### PR TITLE
WIP: Attempt to compile with scala 2.13.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -104,7 +104,7 @@ lazy val commonSettings = Seq(
   organization := "org.apache.daffodil",
   version := "2.4.0-SNAPSHOT",
   scalaVersion := "2.12.6",
-  crossScalaVersions := Seq("2.12.6", "2.11.12"),
+  crossScalaVersions := Seq("2.13.0", "2.12.6", "2.11.12"),
   scalacOptions ++= Seq(
     "-feature",
     "-deprecation",

--- a/daffodil-japi/build.sbt
+++ b/daffodil-japi/build.sbt
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-addCompilerPlugin("com.typesafe.genjavadoc" %% "genjavadoc-plugin" % "0.11" cross CrossVersion.full)
+addCompilerPlugin("com.typesafe.genjavadoc" %% "genjavadoc-plugin" % "0.13" cross CrossVersion.full)
 
 
 lazy val JavaDoc = config("genjavadoc") extend Compile

--- a/daffodil-propgen/src/main/scala/UpdateEclipseClasspaths.scala
+++ b/daffodil-propgen/src/main/scala/UpdateEclipseClasspaths.scala
@@ -138,7 +138,7 @@ trait UpdateEclipseClasspaths {
     xmlNodes.toSeq
   }
 
-  def updateOneClasspathFile(cpf: java.io.File) {
+  def updateOneClasspathFile(cpf: java.io.File): Unit = {
     val cpNode = scala.xml.XML.loadFile(cpf)
     val cpes = (cpNode \\ "classpathentry")
     val nonLibChildren = cpes.filterNot { e => (e \\ "@kind").text == "lib" }

--- a/daffodil-propgen/src/main/scala/org/apache/daffodil/propGen/PropertyGenerator.scala
+++ b/daffodil-propgen/src/main/scala/org/apache/daffodil/propGen/PropertyGenerator.scala
@@ -86,7 +86,7 @@ class PropertyGenerator(arg: Node) {
   //  }
 
   def genAll(): Seq[String] = {
-    val allTopLevel = dfdlSchema.child
+    val allTopLevel = dfdlSchema.child.toSeq
     //      val allNamed = allTopLevel.filter(st => {
     //      val name = attr(st, "name")
     //        name != None
@@ -642,12 +642,12 @@ object Currency {
     stripLast
   }
 
-  def initialUpperCase(s: String): String = s.head.toUpper + s.substring(1)
+  def initialUpperCase(s: String): String = Character.toString(s.head.toUpper) + s.substring(1)
   def initialLowerCase(s: String): String = {
     // special case for the way we lowercase the utf16Width property.
     if (s == "UTF16Width") "utf16Width"
     else
-      s.head.toLower + s.substring(1)
+      Character.toString(s.head.toLower) + s.substring(1)
   }
 
 } // end trait
@@ -694,7 +694,7 @@ import org.apache.daffodil.exceptions.ThrowsSDE
 
 """
 
-  def writeGeneratedCode(thunks: Seq[String], ow: java.io.FileWriter) {
+  def writeGeneratedCode(thunks: Seq[String], ow: java.io.FileWriter) : Unit = {
     ow.write(preamble)
     for (thunk <- thunks) {
       ow.write(thunk)
@@ -715,14 +715,14 @@ import org.apache.daffodil.exceptions.ThrowsSDE
   def getGeneratedFilePath(rootDir: String, pkg: String, filename: String): String = {
     val outDir = new java.io.File(rootDir + "/" + pkg.split('.').reduceLeft(_ + "/" + _))
     outDir.mkdirs()
-    val outPath = outDir + "/" + filename
+    val outPath = outDir.toString() + "/" + filename
     outPath
   }
 
   /**
    * Main - run as a scala application to actually create a new GeneratedCode.scala file in the gen directory.
    */
-  def main(args: Array[String]) {
+  def main(args: Array[String]) : Unit = {
     if (args.length != 1) {
       System.exit(1);
     }

--- a/daffodil-propgen/src/main/scala/org/apache/daffodil/propGen/TunableGenerator.scala
+++ b/daffodil-propgen/src/main/scala/org/apache/daffodil/propGen/TunableGenerator.scala
@@ -133,7 +133,7 @@ class TunableGenerator(schemaRootConfig: scala.xml.Node, schemaRootExt: scala.xm
     .filter { st => (st \@ "name").startsWith("Tunable") }
     .filter { st => !excludedSimpleTypes.contains(st \@ "name") }
 
-  def writeGeneratedCode(w: java.io.FileWriter) {
+  def writeGeneratedCode(w: java.io.FileWriter): Unit = {
     val tunables =
       tunableNodes.map { tunableNode =>
         val schemaName = tunableNode \@ "name"
@@ -225,7 +225,7 @@ class EnumListTunable(name: String, schemaType: String, schemaDefault: String, l
     if (trimmedDefault == "") {
       "Nil"
     } else {
-      val defaultSeq = trimmedDefault.split("\\s+").map(d => s"${listType}.${d.head.toUpper + d.tail}")
+      val defaultSeq = trimmedDefault.split("\\s+").map(d => s"${listType}.${"$d.head.toUpper$d.tail"}")
       s"""Seq(${defaultSeq.mkString(", ")})"""
     }
 
@@ -245,7 +245,7 @@ class EnumListTunable(name: String, schemaType: String, schemaDefault: String, l
 
 class TunableEnumDefinition(schemaRootConfig: scala.xml.Node, schemaRootExt: scala.xml.Node, simpleTypeNode: scala.xml.Node) {
   private val nodeName = (simpleTypeNode \@ "name").stripPrefix("Tunable")
-  private val scalaType = nodeName.head.toUpper + nodeName.tail
+  private val scalaType = "$nodeName.head.toUpper$nodeName.tail"
 
   /**
    * Returns a list of all string values of enumerations. If a simpletype is a
@@ -281,7 +281,7 @@ class TunableEnumDefinition(schemaRootConfig: scala.xml.Node, schemaRootExt: sca
 """.trim.stripMargin
 
   private val scalaEnums = {
-    val scalaEnumValues = allEnumerationValues.map { e => e.head.toUpper + e.tail }
+    val scalaEnumValues = allEnumerationValues.map { e => "$e.head.toUpper$e.tail" }
     scalaEnumValues.map { e => s"""  case object ${e} extends ${scalaType}; forceConstruction(${e})""" }
   }
 

--- a/daffodil-propgen/src/main/scala/org/apache/daffodil/propGen/WarnIDGenerator.scala
+++ b/daffodil-propgen/src/main/scala/org/apache/daffodil/propGen/WarnIDGenerator.scala
@@ -68,13 +68,13 @@ class WarnIDGenerator(schema: scala.xml.Node) {
   val ssdwNode = (schema \ "simpleType").find( _ \@ "name" == "TunableSuppressSchemaDefinitionWarnings").get
   val enumerationNodes = (ssdwNode \\ "enumeration")
 
-  def writeGeneratedCode(w: java.io.FileWriter) {
+  def writeGeneratedCode(w: java.io.FileWriter) : Unit = {
     w.write(top)
     w.write("\n")
 
     enumerationNodes.foreach { node =>
       val enumName = node \@ "value"
-      val scalaName = enumName.head.toUpper + enumName.tail
+      val scalaName = "$enumName.head.toUpper$enumName.tail"
       w.write(s"  case object ${scalaName} extends WarnID; forceConstruction($scalaName)\n")
     }
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -22,8 +22,8 @@ object Dependencies {
   lazy val common = core ++ infoset ++ test
 
   lazy val core = Seq(
-    "org.scala-lang.modules" %% "scala-xml" % "1.1.0",
-    "org.scala-lang.modules" %% "scala-parser-combinators" % "1.1.1",
+    "org.scala-lang.modules" %% "scala-xml" % "1.2.0",
+    "org.scala-lang.modules" %% "scala-parser-combinators" % "1.1.2",
     "com.ibm.icu" % "icu4j" % "62.1",
     "xerces" % "xercesImpl" % "2.12.0",
     "xml-resolver" % "xml-resolver" % "1.2",
@@ -39,7 +39,7 @@ object Dependencies {
    
   lazy val cli = Seq( 
     "org.fusesource.jansi" % "jansi" % "1.17.1",
-    "org.rogach" %% "scallop" % "3.1.3",
+    "org.rogach" %% "scallop" % "3.3.1",
     "net.sf.expectit" % "expectit-core" % "0.9.0" % "it,test"
   )
 


### PR DESCRIPTION
This branch contains changes to enable cross compilation with scala 2.13.0, but currently has quiet a few compilation errors if attempted to cross compile with scala 2.13.0.
Two major changes noted with the new version of scala is that:
1) the returned type of every method must explicitly be declared else it produces a syntax error that’s including void methods. Currently there are 92 compilations errors and almost if not half of them has to do with this new syntax requirements of void methods.
2)  scala has a predefined Node class which has a child method which previously used to return a mutable seq of all the child of that particular node, but in scala 2.13.0 that returned type is now immutable which causes type mismatch in at least one instance so far so to get around “toSeq” function on the child call to turn that seq back to a mutable seq as it was in the previous version.
Other changes noted with scala 2.13.0 include:
a)	Deprecation of the any2Stringadd object predefinition as well as the implicit injection of the + sign. This now causes problem when adding a file name which is a string to a Path without calling the toString method on the path because it’s no longer implied now.
b)	Stricter type checking when adding a character to a string you need to either use the Character.toString() method on the character or use string interpolation to add the two. In some instances, the string interpolation causes some issues when that value is passed to a regex and cause some illegalArgumentException.
