### PR TITLE
WIP: Changeover most DFDLTestSuite invocations to Runner

### DIFF
--- a/daffodil-cli/src/main/scala/org/apache/daffodil/Main.scala
+++ b/daffodil-cli/src/main/scala/org/apache/daffodil/Main.scala
@@ -82,7 +82,7 @@ import org.apache.daffodil.processors.DataLoc
 import org.apache.daffodil.processors.DataProcessor
 import org.apache.daffodil.processors.HasSetDebugger
 import org.apache.daffodil.schema.annotation.props.gen.BitOrder
-import org.apache.daffodil.tdml.DFDLTestSuite
+import org.apache.daffodil.tdml.Runner
 import org.apache.daffodil.tdml.TDMLException
 import org.apache.daffodil.tdml.TDMLTestNotCompatibleException
 import org.apache.daffodil.udf.UserDefinedFunctionFatalErrorException
@@ -1228,7 +1228,7 @@ object Main extends Logging {
         val testOpts = conf.test
 
         val tdmlFile = testOpts.tdmlfile()
-        val tdmlRunner = new DFDLTestSuite(new java.io.File(tdmlFile))
+        val tdmlRunner = Runner("", tdmlFile)
         setupDebugOrTrace(tdmlRunner, conf)
 
         val tests = {

--- a/daffodil-tdml-lib/src/main/scala/org/apache/daffodil/tdml/RunnerFactory.scala
+++ b/daffodil-tdml-lib/src/main/scala/org/apache/daffodil/tdml/RunnerFactory.scala
@@ -100,6 +100,17 @@ class RunnerOpts(
  * defaultRoundTripDefaultDefault
  */
 object Runner {
+
+def apply(dir: String, file: String,
+    validateTDMLFile: Boolean = true,
+    validateDFDLSchemas: Boolean = true,
+    compileAllTopLevel: Boolean = false,
+    defaultRoundTripDefault: RoundTrip = RunnerOpts.defaultRoundTripDefaultDefault,
+    defaultValidationDefault: String = RunnerOpts.defaultValidationDefaultDefault,
+    defaultImplementationsDefault: Seq[String] = RunnerOpts.defaultImplementationsDefaultDefault): Runner =
+    new Runner(elem = null, dir, file, validateTDMLFile, validateDFDLSchemas, compileAllTopLevel,
+      defaultRoundTripDefault, defaultValidationDefault, defaultImplementationsDefault)
+
   def apply(dir: String, file: String): Runner =
     new Runner(dir, file, RunnerOpts())
 
@@ -111,6 +122,9 @@ object Runner {
 
   def apply(elem: scala.xml.Elem, options: RunnerOpts): Runner =
     new Runner(elem, options)
+
+  def apply(elem: scala.xml.Elem, validateTDMLFile: Boolean): Runner =
+    new Runner(elem, dir = null, file = null, validateTDMLFile)
 }
 
 /**
@@ -121,6 +135,22 @@ object Runner {
  */
 class Runner private (elem: scala.xml.Elem, dir: String, file: String, options: RunnerOpts) 
 extends HasSetDebugger {
+
+  def this (elem: scala.xml.Elem, 
+    dir: String, 
+    file: String,
+    validateTDMLFile: Boolean = true,
+    validateDFDLSchemas: Boolean = true,
+    compileAllTopLevel: Boolean = false,
+    defaultRoundTripDefault: RoundTrip = RunnerOpts.defaultRoundTripDefaultDefault,
+    defaultValidationDefault: String = RunnerOpts.defaultValidationDefaultDefault,
+    defaultImplementationsDefault: Seq[String] = RunnerOpts.defaultImplementationsDefaultDefault) = 
+      this(elem, dir, file, RunnerOpts(validateTDMLFile,
+        validateDFDLSchemas,
+        compileAllTopLevel,
+        defaultRoundTripDefault,
+        defaultValidationDefault,
+        defaultImplementationsDefault))
 
   /*
    * these constructors are for use by Java programs

--- a/daffodil-tdml-lib/src/main/scala/org/apache/daffodil/tdml/TDMLRunner.scala
+++ b/daffodil-tdml-lib/src/main/scala/org/apache/daffodil/tdml/TDMLRunner.scala
@@ -201,11 +201,11 @@ class DFDLTestSuite private[tdml] (
     validateTDMLFile: Boolean = true,
     validateDFDLSchemas: Boolean = true,
     compileAllTopLevel: Boolean = false,
-    defaultRoundTripDefault: RoundTrip = Runner.defaultRoundTripDefaultDefault,
-    defaultValidationDefault: String = Runner.defaultValidationDefaultDefault,
-    defaultImplementationsDefault: Seq[String] = Runner.defaultImplementationsDefaultDefault,
-    shouldDoErrorComparisonOnCrossTests: Boolean = Runner.defaultShouldDoErrorComparisonOnCrossTests,
-    shouldDoWarningComparisonOnCrossTests: Boolean = Runner.defaultShouldDoWarningComparisonOnCrossTests) =
+    defaultRoundTripDefault: RoundTrip = RunnerOpts.defaultRoundTripDefaultDefault,
+    defaultValidationDefault: String = RunnerOpts.defaultValidationDefaultDefault,
+    defaultImplementationsDefault: Seq[String] = RunnerOpts.defaultImplementationsDefaultDefault,
+    shouldDoErrorComparisonOnCrossTests: Boolean = RunnerOpts.defaultShouldDoErrorComparisonOnCrossTests,
+    shouldDoWarningComparisonOnCrossTests: Boolean = RunnerOpts.defaultShouldDoWarningComparisonOnCrossTests) =
     this(null, aNodeFileOrURL, validateTDMLFile, validateDFDLSchemas, compileAllTopLevel,
       defaultRoundTripDefault,
       defaultValidationDefault,

--- a/daffodil-tdml-processor/src/test/java/org/apache/daffodil/tdml/TestRunnerFactory.java
+++ b/daffodil-tdml-processor/src/test/java/org/apache/daffodil/tdml/TestRunnerFactory.java
@@ -33,8 +33,8 @@ public class TestRunnerFactory {
 
   @Test
   public void testPrimaryConstructor() {
-    Runner runner = new Runner(null, testDir, testTdmlFile, true, true, false, NoRoundTrip$.MODULE$,
-        "off", JavaConverters.asScalaBufferConverter(Arrays.asList("daffodil", "ibm")).asScala());
+    Runner runner = new Runner(testDir, testTdmlFile, new RunnerOpts(true, true, false, NoRoundTrip$.MODULE$,
+        "off", JavaConverters.asScalaBufferConverter(Arrays.asList("daffodil", "ibm")).asScala(), false, false));
     runner.runOneTest("testPass");
   }
 

--- a/daffodil-tdml-processor/src/test/scala/org/apache/daffodil/tdml/TestTDMLCrossTest.scala
+++ b/daffodil-tdml-processor/src/test/scala/org/apache/daffodil/tdml/TestTDMLCrossTest.scala
@@ -50,7 +50,7 @@ class TestTDMLCrossTest {
           <ts:document>foo</ts:document>
         </ts:parserTestCase>
       </ts:testSuite>
-    lazy val ts = new DFDLTestSuite(testSuite)
+    lazy val ts = Runner(testSuite)
     val e = intercept[TDMLException] {
       ts.runOneTest("test1")
     }

--- a/daffodil-tdml-processor/src/test/scala/org/apache/daffodil/tdml/TestTDMLRoundTrips.scala
+++ b/daffodil-tdml-processor/src/test/scala/org/apache/daffodil/tdml/TestTDMLRoundTrips.scala
@@ -60,7 +60,7 @@ class TestTDMLRoundTrips {
                         <ts:document>foo,bar</ts:document>
                       </ts:parserTestCase>
                     </ts:testSuite>
-    lazy val ts = new DFDLTestSuite(testSuite)
+    lazy val ts = Runner(testSuite)
     ts.runOneTest("test1")
   }
 
@@ -98,7 +98,7 @@ class TestTDMLRoundTrips {
                         <ts:document>foo,bar</ts:document>
                       </ts:parserTestCase>
                     </ts:testSuite>
-    lazy val ts = new DFDLTestSuite(testSuite)
+    lazy val ts = Runner(testSuite)
     val e = intercept[TDMLException] {
       ts.runOneTest("test1")
     }
@@ -140,7 +140,7 @@ class TestTDMLRoundTrips {
   @Test def testTwoPass1(): Unit = {
 
     val testSuite = needsTwoPassesOnlyTDML("twoPass")
-    lazy val ts = new DFDLTestSuite(testSuite)
+    lazy val ts = Runner(testSuite)
     ts.runOneTest("test1")
   }
   /**
@@ -190,7 +190,7 @@ New Line]]></bar>
           </ts:infoset>
         </ts:parserTestCase>
       </ts:testSuite>
-    lazy val ts = new DFDLTestSuite(testSuite)
+    lazy val ts = Runner(testSuite)
     ts.runOneTest("test1")
   }
 
@@ -240,7 +240,7 @@ New Line]]></bar>
                         </ts:infoset>
                       </ts:parserTestCase>
                     </ts:testSuite>
-    lazy val ts = new DFDLTestSuite(testSuite)
+    lazy val ts = Runner(testSuite)
     ts.runOneTest("test1")
   }
 
@@ -280,7 +280,7 @@ New Line]]></bar>
    */
   @Test def testTwoPassNotNeeded1(): Unit = {
     val testSuite = nPassNotNeededTDML("twoPass")
-    lazy val ts = new DFDLTestSuite(testSuite)
+    lazy val ts = Runner(testSuite)
     val e = intercept[TDMLException] {
       ts.runOneTest("test1")
     }
@@ -327,7 +327,7 @@ New Line]]></bar>
                         <ts:document>foo,nil,</ts:document>
                       </ts:parserTestCase>
                     </ts:testSuite>
-    lazy val ts = new DFDLTestSuite(testSuite)
+    lazy val ts = Runner(testSuite)
     // ts.areTracing = true
     ts.runOneTest("test1")
   }
@@ -339,7 +339,7 @@ New Line]]></bar>
    */
   @Test def testThreePassNotNeeded1(): Unit = {
     val testSuite = nPassNotNeededTDML("threePass")
-    lazy val ts = new DFDLTestSuite(testSuite)
+    lazy val ts = Runner(testSuite)
     val e = intercept[TDMLException] {
       ts.runOneTest("test1")
     }
@@ -363,7 +363,7 @@ New Line]]></bar>
   //  @Test def testThreePassNotNeeded2() {
   //
   //    val testSuite = needsTwoPassesOnlyTDML("threePass")
-  //    lazy val ts = new DFDLTestSuite(testSuite)
+  //    lazy val ts = Runner(testSuite)
   //    val e = intercept[TDMLException] {
   //      ts.runOneTest("test1")
   //    }

--- a/daffodil-tdml-processor/src/test/scala/org/apache/daffodil/tdml/TestTDMLRunner.scala
+++ b/daffodil-tdml-processor/src/test/scala/org/apache/daffodil/tdml/TestTDMLRunner.scala
@@ -76,7 +76,7 @@ class TestTDMLRunner {
     }
 
     // compileAllTopLevel must be true to enable caching
-    lazy val ts = new DFDLTestSuite(testSuite, true, true, true)
+    lazy val ts = Runner(testSuite, RunnerOpts(validateTDMLFile = true, validateDFDLSchemas = true, compileAllTopLevel = true))
 
     // Run the non-validation test first, this will compile, serialize, and
     // cache the schema
@@ -106,7 +106,7 @@ class TestTDMLRunner {
                         </ts:infoset>
                       </ts:parserTestCase>
                     </ts:testSuite>
-    val ts = new DFDLTestSuite(testSuite)
+    val ts = Runner(testSuite)
     ts.runOneTest("testTDMLParseSuccess", Some(testSchema))
   }
 
@@ -121,7 +121,7 @@ class TestTDMLRunner {
                         </ts:errors>
                       </ts:parserTestCase>
                     </ts:testSuite>
-    lazy val ts = new DFDLTestSuite(testSuite)
+    lazy val ts = Runner(testSuite)
     ts.runOneTest("testTDMLParseDetectsErrorWithSpecificMessage", Some(testSchema))
   }
 
@@ -136,7 +136,7 @@ class TestTDMLRunner {
                         </ts:errors>
                       </ts:parserTestCase>
                     </ts:testSuite>
-    lazy val ts = new DFDLTestSuite(testSuite)
+    lazy val ts = Runner(testSuite)
     val exc = intercept[Exception] {
       ts.runOneTest("testTDMLParseDetectsErrorWithPartMessage", Some(testSchema))
     }
@@ -153,7 +153,7 @@ class TestTDMLRunner {
                         </ts:errors>
                       </ts:parserTestCase>
                     </ts:testSuite>
-    lazy val ts = new DFDLTestSuite(testSuite)
+    lazy val ts = Runner(testSuite)
     ts.runOneTest("testTDMLParseDetectsErrorAnyMessage", Some(testSchema))
   }
 
@@ -167,7 +167,7 @@ class TestTDMLRunner {
                         </ts:errors>
                       </ts:parserTestCase>
                     </ts:testSuite>
-    lazy val ts = new DFDLTestSuite(testSuite)
+    lazy val ts = Runner(testSuite)
     val exc = intercept[Exception] {
       ts.runOneTest("testTDMLParseDetectsNoError", Some(testSchema))
     }
@@ -192,7 +192,7 @@ class TestTDMLRunner {
   //                        </ts:warnings>
   //                      </ts:parserTestCase>
   //                    </ts:testSuite>
-  //    lazy val ts = new DFDLTestSuite(testSuite)
+  //    lazy val ts = new Runner(testSuite)
   //    val exc = intercept[Exception] {
   //      ts.runOneTest("testTDMLParseDetectsNoWarning", Some(testSchema))
   //    }
@@ -218,7 +218,7 @@ class TestTDMLRunner {
                         </infoset>
                       </parserTestCase>
                     </testSuite>
-    lazy val ts = new DFDLTestSuite(testSuite)
+    lazy val ts = Runner(testSuite)
     ts.runAllTests(Some(testSchema))
   }
 
@@ -233,7 +233,7 @@ class TestTDMLRunner {
                   </infoset>
                 </parserTestCase>
               </testSuite>
-    val ts = new DFDLTestSuite(xml)
+    val ts = Runner(xml)
     val ptc = ts.parserTestCases(0)
     val infoset = ptc.optExpectedOrInputInfoset.get
     val actual = infoset.contents
@@ -259,7 +259,7 @@ class TestTDMLRunner {
       fileWriter =>
         fileWriter.write(testSchema.toString())
     }
-    lazy val ts = new DFDLTestSuite(testSuite)
+    lazy val ts = Runner(testSuite)
     ts.runOneTest("testRunModelFile")
   }
 
@@ -285,7 +285,7 @@ class TestTDMLRunner {
         fw =>
           fw.write(testSuite.toString())
       }
-      lazy val ts = new DFDLTestSuite(new java.io.File(tmpTDMLFileName))
+      lazy val ts = Runner("",tmpTDMLFileName)
       ts.runAllTests()
     } finally {
       try {
@@ -317,7 +317,7 @@ class TestTDMLRunner {
 
   @Test def testEmbeddedSchemaWorks(): Unit = {
     val testSuite = tdmlWithEmbeddedSchema
-    lazy val ts = new DFDLTestSuite(testSuite)
+    lazy val ts = Runner(testSuite)
     ts.runOneTest("testEmbeddedSchemaWorks")
   }
 
@@ -329,7 +329,7 @@ class TestTDMLRunner {
         fw =>
           fw.write(testSuite.toString())
       }
-      lazy val ts = new DFDLTestSuite(new java.io.File(tmpTDMLFileName))
+      lazy val ts = Runner("", tmpTDMLFileName)
       assertTrue(ts.isTDMLFileValid)
       ts.runAllTests()
     } finally {
@@ -357,7 +357,7 @@ class TestTDMLRunner {
 
   @Test def testMultiByteUnicodeWorks(): Unit = {
     val testSuite = tdmlWithUnicode2028
-    lazy val ts = new DFDLTestSuite(testSuite)
+    lazy val ts = Runner(testSuite)
     ts.runOneTest("testMultiByteUnicodeWorks")
   }
 
@@ -380,7 +380,7 @@ class TestTDMLRunner {
 
   @Test def testMultiByteUnicodeWithCDATAWorks(): Unit = {
     val testSuite = tdmlWithUnicode5E74AndCDATA
-    lazy val ts = new DFDLTestSuite(testSuite)
+    lazy val ts = Runner(testSuite)
     ts.runOneTest("testMultiByteUnicodeWithCDATAWorks")
   }
 
@@ -402,7 +402,7 @@ class TestTDMLRunner {
         </tdml:parserTestCase>
       </tdml:testSuite>
 
-    lazy val ts = new DFDLTestSuite(testSuite)
+    lazy val ts = Runner(testSuite)
     ts.runOneTest("testNilCompare")
   }
 
@@ -424,7 +424,7 @@ class TestTDMLRunner {
         </tdml:parserTestCase>
       </tdml:testSuite>
 
-    lazy val ts = new DFDLTestSuite(testSuite)
+    lazy val ts = Runner(testSuite)
     val e = intercept[Exception] {
       ts.runOneTest("testNilCompare")
     }
@@ -476,7 +476,7 @@ f0 f1 f2 f3 f4 f5 f6 f7 f8 f9 fa fb fc fd fe ff
         </tdml:parserTestCase>
       </tdml:testSuite>
 
-    lazy val ts = new DFDLTestSuite(testSuite)
+    lazy val ts = Runner(testSuite)
     val bytes = ts.parserTestCases(0).document.get.documentBytes
     assertEquals(252, bytes.length)
     val tsData = (testSuite \\ "data").text
@@ -511,7 +511,7 @@ f0 f1 f2 f3 f4 f5 f6 f7 f8 f9 fa fb fc fd fe ff
         </tdml:parserTestCase>
       </tdml:testSuite>
 
-    lazy val ts = new DFDLTestSuite(testSuite)
+    lazy val ts = Runner(testSuite)
     val bytes = ts.parserTestCases(0).document.get.documentBytes
     assertEquals(9, bytes.length)
     ts.runOneTest("testNilCompare")
@@ -519,8 +519,7 @@ f0 f1 f2 f3 f4 f5 f6 f7 f8 f9 fa fb fc fd fe ff
 
   @Test def test_tdmlNamespaces1(): Unit = {
     val testDir = "/test/tdml/"
-    val t0 = testDir + "tdmlNamespaces.tdml"
-    lazy val r = new DFDLTestSuite(Misc.getRequiredResource(t0))
+    lazy val r = Runner(testDir, "tdmlNamespaces.tdml")
     //
     // This is going to write in the default charset.
     //
@@ -561,7 +560,7 @@ f0 f1 f2 f3 f4 f5 f6 f7 f8 f9 fa fb fc fd fe ff
                         </ts:infoset>
                       </ts:parserTestCase>
                     </ts:testSuite>
-    val ts = new DFDLTestSuite(testSuite)
+    val ts = Runner(testSuite)
     ts.runOneTest("testTDMLHexBinaryTypeAwareSuccess", Some(testHexBinarySchema))
   }
 
@@ -580,7 +579,7 @@ f0 f1 f2 f3 f4 f5 f6 f7 f8 f9 fa fb fc fd fe ff
                         </ts:infoset>
                       </ts:parserTestCase>
                     </ts:testSuite>
-    val ts = new DFDLTestSuite(testSuite)
+    val ts = Runner(testSuite)
     ts.runOneTest("testTDMLHexBinaryTypeAwareSuccess", Some(testHexBinarySchema))
   }
 
@@ -598,7 +597,7 @@ f0 f1 f2 f3 f4 f5 f6 f7 f8 f9 fa fb fc fd fe ff
                         </ts:infoset>
                       </ts:parserTestCase>
                     </ts:testSuite>
-    val ts = new DFDLTestSuite(testSuite)
+    val ts = Runner(testSuite)
     val e = intercept[Exception] {
       ts.runOneTest("testTDMLHexBinaryTypeAwareFailure", Some(testHexBinarySchema))
     }
@@ -630,7 +629,7 @@ f0 f1 f2 f3 f4 f5 f6 f7 f8 f9 fa fb fc fd fe ff
                         </ts:infoset>
                       </ts:parserTestCase>
                     </ts:testSuite>
-    val ts = new DFDLTestSuite(testSuite)
+    val ts = Runner(testSuite)
     ts.runOneTest("testTDMLDateTimeTypeAwareSuccess", Some(testDateTimeSchema))
   }
 
@@ -647,7 +646,7 @@ f0 f1 f2 f3 f4 f5 f6 f7 f8 f9 fa fb fc fd fe ff
                         </ts:infoset>
                       </ts:parserTestCase>
                     </ts:testSuite>
-    val ts = new DFDLTestSuite(testSuite)
+    val ts = Runner(testSuite)
     ts.runOneTest("testTDMLDateTimeTypeAwareSuccess", Some(testDateTimeSchema))
   }
 
@@ -664,7 +663,7 @@ f0 f1 f2 f3 f4 f5 f6 f7 f8 f9 fa fb fc fd fe ff
                         </ts:infoset>
                       </ts:parserTestCase>
                     </ts:testSuite>
-    val ts = new DFDLTestSuite(testSuite)
+    val ts = Runner(testSuite)
     ts.runOneTest("testTDMLDateTimeTypeAwareSuccess", Some(testDateTimeSchema))
   }
 
@@ -681,7 +680,7 @@ f0 f1 f2 f3 f4 f5 f6 f7 f8 f9 fa fb fc fd fe ff
                         </ts:infoset>
                       </ts:parserTestCase>
                     </ts:testSuite>
-    val ts = new DFDLTestSuite(testSuite)
+    val ts = Runner(testSuite)
     ts.runOneTest("testTDMLDateTimeTypeAwareSuccess", Some(testDateTimeSchema))
   }
 
@@ -697,7 +696,7 @@ f0 f1 f2 f3 f4 f5 f6 f7 f8 f9 fa fb fc fd fe ff
                         </ts:infoset>
                       </ts:parserTestCase>
                     </ts:testSuite>
-    val ts = new DFDLTestSuite(testSuite)
+    val ts = Runner(testSuite)
     val e = intercept[Exception] {
       ts.runOneTest("testTDMLDateTimeTypeAwareFailure", Some(testDateTimeSchema))
     }

--- a/daffodil-tdml-processor/src/test/scala/org/apache/daffodil/tdml/TestTDMLRunner2.scala
+++ b/daffodil-tdml-processor/src/test/scala/org/apache/daffodil/tdml/TestTDMLRunner2.scala
@@ -441,7 +441,7 @@ abc # a comment
         </tdml:parserTestCase>
       </tdml:testSuite>
 
-    val runner = Runner(testSuite, validateTDMLFile = false)
+    val runner = Runner(testSuite, RunnerOpts(validateTDMLFile = false))
     runner.runOneTest("test1")
     runner.reset
   }
@@ -500,7 +500,7 @@ abc # a comment
         fw =>
           fw.write(testSuite.toString())
       }
-      val ts = new DFDLTestSuite(new java.io.File(tmpTDMLFileName))
+      val ts = Runner("",tmpTDMLFileName)
       ts.trace
       ts.runAllTests()
     } finally {

--- a/daffodil-tdml-processor/src/test/scala/org/apache/daffodil/tdml/TestTDMLRunnerCommentSyntax.scala
+++ b/daffodil-tdml-processor/src/test/scala/org/apache/daffodil/tdml/TestTDMLRunnerCommentSyntax.scala
@@ -87,7 +87,7 @@ class TestTDMLRunnerCommentSyntax {
         <!-- comment -->
       </tdml:testSuite>
 
-    lazy val ts = new DFDLTestSuite(testSuite)
+    lazy val ts = Runner(testSuite)
     ts.runOneTest("test1")
     // if we don't throw/fail when running then pass this test.
   }

--- a/daffodil-tdml-processor/src/test/scala/org/apache/daffodil/tdml/TestTDMLRunnerConfig.scala
+++ b/daffodil-tdml-processor/src/test/scala/org/apache/daffodil/tdml/TestTDMLRunnerConfig.scala
@@ -52,7 +52,7 @@ class TestTDMLRunnerConfig {
         </tdml:parserTestCase>
       </tdml:testSuite>
 
-    lazy val ts = new DFDLTestSuite(testSuite)
+    lazy val ts = Runner(testSuite)
     val e = intercept[Exception] {
       ts.runOneTest("test1")
     }
@@ -80,7 +80,7 @@ class TestTDMLRunnerConfig {
         </tdml:parserTestCase>
       </tdml:testSuite>
 
-    lazy val ts = new DFDLTestSuite(testSuite)
+    lazy val ts = Runner(testSuite)
     val e = intercept[Exception] {
       ts.runOneTest("test1")
     }
@@ -113,7 +113,7 @@ class TestTDMLRunnerConfig {
         </tdml:parserTestCase>
       </tdml:testSuite>
 
-    lazy val ts = new DFDLTestSuite(testSuite)
+    lazy val ts = Runner(testSuite)
     val e = intercept[Exception] {
       ts.runOneTest("test1")
     }
@@ -145,7 +145,7 @@ class TestTDMLRunnerConfig {
         </tdml:parserTestCase>
       </tdml:testSuite>
 
-    lazy val ts = new DFDLTestSuite(testSuite)
+    lazy val ts = Runner(testSuite)
     ts.runOneTest("test1")
   }
 
@@ -171,7 +171,7 @@ class TestTDMLRunnerConfig {
         </tdml:parserTestCase>
       </tdml:testSuite>
 
-    lazy val ts = new DFDLTestSuite(testSuite)
+    lazy val ts = Runner(testSuite)
     ts.runOneTest("test1")
   }
 
@@ -198,7 +198,7 @@ class TestTDMLRunnerConfig {
         </tdml:parserTestCase>
       </tdml:testSuite>
 
-    lazy val ts = new DFDLTestSuite(testSuite)
+    lazy val ts = Runner(testSuite)
     val e = intercept[Exception] {
       ts.runOneTest("test1")
     }

--- a/daffodil-tdml-processor/src/test/scala/org/apache/daffodil/tdml/TestTDMLRunnerTutorial.scala
+++ b/daffodil-tdml-processor/src/test/scala/org/apache/daffodil/tdml/TestTDMLRunnerTutorial.scala
@@ -96,13 +96,13 @@ class TestTDMLRunnerTutorial {
 
   @Test def testTutorialElementsParse(): Unit = {
     val testSuite = tdmlWithTutorial
-    lazy val ts = new DFDLTestSuite(testSuite)
+    lazy val ts = Runner(testSuite)
     ts.runOneTest("testTutorialElementsParse")
   }
 
   @Test def testTutorialElementsUnparse(): Unit = {
     val testSuite = tdmlWithTutorial
-    lazy val ts = new DFDLTestSuite(testSuite)
+    lazy val ts = Runner(testSuite)
     ts.runOneTest("testTutorialElementsUnparse")
   }
 }

--- a/daffodil-tdml-processor/src/test/scala/org/apache/daffodil/tdml/TestTDMLRunnerWarnings.scala
+++ b/daffodil-tdml-processor/src/test/scala/org/apache/daffodil/tdml/TestTDMLRunnerWarnings.scala
@@ -87,7 +87,7 @@ class TestTDMLRunnerWarnings {
         </tdml:parserTestCase>
       </tdml:testSuite>
 
-    lazy val ts = new DFDLTestSuite(testSuite)
+    lazy val ts = Runner(testSuite)
     val e = intercept[Exception] {
       ts.runOneTest("warningWhenExpectingSuccess")
     }
@@ -136,7 +136,7 @@ class TestTDMLRunnerWarnings {
         </tdml:parserTestCase>
       </tdml:testSuite>
 
-    lazy val ts = new DFDLTestSuite(testSuite)
+    lazy val ts = Runner(testSuite)
     val e = intercept[Exception] {
       ts.runOneTest("warningWhenExpectingError")
     }
@@ -183,7 +183,7 @@ class TestTDMLRunnerWarnings {
         </tdml:unparserTestCase>
       </tdml:testSuite>
 
-    lazy val ts = new DFDLTestSuite(testSuite)
+    lazy val ts = Runner(testSuite)
     val e = intercept[Exception] {
       ts.runOneTest("unparserWarningWhenExpectingSuccess")
     }
@@ -236,7 +236,7 @@ class TestTDMLRunnerWarnings {
         </tdml:unparserTestCase>
       </tdml:testSuite>
 
-    lazy val ts = new DFDLTestSuite(testSuite)
+    lazy val ts = Runner(testSuite)
     val e = intercept[Exception] {
       ts.runOneTest("unparserWarningWhenExpectingError")
     }

--- a/daffodil-tdml-processor/src/test/scala/org/apache/daffodil/tdml/TestTDMLUnparseCases.scala
+++ b/daffodil-tdml-processor/src/test/scala/org/apache/daffodil/tdml/TestTDMLUnparseCases.scala
@@ -48,7 +48,7 @@ class TestTDMLUnparseCases {
                         <ts:document>Hello</ts:document>
                       </ts:unparserTestCase>
                     </ts:testSuite>
-    lazy val ts = new DFDLTestSuite(testSuite)
+    lazy val ts = Runner(testSuite)
     val tc: UnparserTestCase = ts.unparserTestCases.find { utc => utc.tcName == "test1" }.get
     // println(tc)
     tc.document
@@ -61,5 +61,4 @@ class TestTDMLUnparseCases {
     // ts.trace
     ts.runOneTest("test1")
   }
-
 }

--- a/daffodil-test-ibm1/src/test/scala/org/apache/daffodil/IBMTests.scala
+++ b/daffodil-test-ibm1/src/test/scala/org/apache/daffodil/IBMTests.scala
@@ -17,18 +17,16 @@
 
 package org.apache.daffodil
 
-import org.apache.daffodil.tdml.DFDLTestSuite
-import org.apache.daffodil.util.Misc
 import org.junit.Test
 import org.junit.Test
+import org.apache.daffodil.tdml.Runner
+import org.apache.daffodil.tdml.RunnerOpts
 
 object IBMTestsThatPass {
 
   val testDir = "/test-suite/ibm-contributed/"
-  val tdml1 = testDir + "dpaext1.tdml"
-  val tdml2 = testDir + "dpaext2.tdml"
-  lazy val runner1 = new DFDLTestSuite(Misc.getRequiredResource(tdml1), validateTDMLFile = true, validateDFDLSchemas = false)
-  lazy val runner2 = new DFDLTestSuite(Misc.getRequiredResource(tdml2))
+  lazy val runner1 = Runner(testDir, "dpaext1.tdml", RunnerOpts(validateTDMLFile = true, validateDFDLSchemas = false))
+  lazy val runner2 = Runner(testDir, "dpaext2.tdml")
 }
 
 class IBMTestsThatPass {

--- a/daffodil-test-ibm1/src/test/scala/org/apache/daffodil/IBMTests3.scala
+++ b/daffodil-test-ibm1/src/test/scala/org/apache/daffodil/IBMTests3.scala
@@ -17,17 +17,14 @@
 
 package org.apache.daffodil
 
-import org.apache.daffodil.tdml.DFDLTestSuite
-import org.apache.daffodil.util.Misc
+import org.apache.daffodil.tdml.Runner
 import org.junit.Test
 
 object IBMTestsThatPass2 {
 
-  val testDir = "/test-suite/ibm-contributed/"
-  val tdml1 = testDir + "dpaext1.tdml"
-  val tdml2 = testDir + "dpaext2.tdml"
-  lazy val runner1 = new DFDLTestSuite(Misc.getRequiredResource(tdml1))
-  lazy val runner2 = new DFDLTestSuite(Misc.getRequiredResource(tdml2))
+  val testDir : String = "/test-suite/ibm-contributed/"
+  lazy val runner1 = Runner(testDir, "dpaext1.tdml")
+  lazy val runner2 = Runner(testDir, "dpaext2.tdml")
 }
 
 class IBMTestsThatPass2 {

--- a/daffodil-test-ibm1/src/test/scala/org/apache/daffodil/TresysTests.scala
+++ b/daffodil-test-ibm1/src/test/scala/org/apache/daffodil/TresysTests.scala
@@ -17,10 +17,9 @@
 
 package org.apache.daffodil
 
-import org.apache.daffodil.tdml.DFDLTestSuite
-import org.apache.daffodil.util.Misc
 import org.junit.{ AfterClass, Test }
 import org.apache.daffodil.tdml.Runner
+import org.apache.daffodil.tdml.RunnerOpts
 
 object TresysTests {
 
@@ -34,69 +33,72 @@ object TresysTests {
 
   lazy val runnerDelimited = Runner(testDir, "delimTests.tdml")
 
-  lazy val runnerMD = Runner(testDir, "multiple-diagnostics.tdml", compileAllTopLevel = true)
-  lazy val runnerMD_NV = Runner(testDir, "multiple-diagnostics.tdml", compileAllTopLevel = true, validateDFDLSchemas = false)
+  lazy val runnerMD = Runner(testDir, "multiple-diagnostics.tdml", RunnerOpts(compileAllTopLevel = true))
+  lazy val runnerMD_NV = Runner(testDir, "multiple-diagnostics.tdml", RunnerOpts(compileAllTopLevel = true, validateDFDLSchemas = false))
   
-  val bb = testDir + "BB.tdml"
-  lazy val runnerBB = new DFDLTestSuite(Misc.getRequiredResource(bb))
-  val be = testDir + "BE.tdml"
-  lazy val runnerBE = new DFDLTestSuite(Misc.getRequiredResource(be))
-  val bf = testDir + "BF.tdml"
-  lazy val runnerBF1 = new DFDLTestSuite(Misc.getRequiredResource(bf))
-  val bg = testDir + "BG.tdml"
-  lazy val runnerBG = new DFDLTestSuite(Misc.getRequiredResource(bg))
-  val mb = testDir + "mixed-binary-text.tdml"
-  lazy val runnerMB = new DFDLTestSuite(Misc.getRequiredResource(mb))
+  lazy val runnerBB = Runner(testDir, "BB.tdml")
+  lazy val runnerBE = Runner(testDir, "BE.tdml")
+  lazy val runnerBF1 = Runner(testDir, "BF.tdml")
+  lazy val runnerBG = Runner(testDir, "BG.tdml")
+  lazy val runnerMB = Runner(testDir, "mixed-binary-text.tdml")
 
-  val ap = testDir + "AP.tdml"
-  lazy val runnerAP = new DFDLTestSuite(Misc.getRequiredResource(ap))
-  val ax = testDir + "AX.tdml"
-  lazy val runnerAX = new DFDLTestSuite(Misc.getRequiredResource(ax))
-  val av0 = testDir + "AV000.tdml"
-  lazy val runnerAV000 = new DFDLTestSuite(Misc.getRequiredResource(av0))
-  val av1 = testDir + "AV001.tdml"
-  lazy val runnerAV001 = new DFDLTestSuite(Misc.getRequiredResource(av1))
-  val av2 = testDir + "AV002.tdml"
-  lazy val runnerAV002 = new DFDLTestSuite(Misc.getRequiredResource(av2))
-  val av3 = testDir + "AV003.tdml"
-  lazy val runnerAV003 = new DFDLTestSuite(Misc.getRequiredResource(av3))
-  val nsd = testDir + "nested-separator-delimited.tdml"
-  lazy val runnerNSD = new DFDLTestSuite(Misc.getRequiredResource(nsd))
+  lazy val runnerAP = Runner(testDir, "AP.tdml")
+  lazy val runnerAX = Runner(testDir, "AX.tdml")
+  lazy val runnerAV000 = Runner(testDir, "AV000.tdml")
+  lazy val runnerAV001 = Runner(testDir, "AV001.tdml")
+  lazy val runnerAV002 = Runner(testDir, "AV002.tdml")
+  lazy val runnerAV003 = Runner(testDir, "AV003.tdml")
+  lazy val runnerNSD = Runner(testDir, "nested-separator-delimited.tdml")
 
+  lazy val runnerRD = Runner(testDir, "runtime-diagnostics.tdml", RunnerOpts(compileAllTopLevel = true, validateTDMLFile = false))
 
-  lazy val runnerRD = Runner(testDir, "runtime-diagnostics.tdml", compileAllTopLevel = true, validateTDMLFile = false)
+  lazy val runnerSQ = Runner(testDir, "sequence.tdml")
 
-  val sq = testDir + "sequence.tdml"
-  lazy val runnerSQ = new DFDLTestSuite(Misc.getRequiredResource(sq))
+  lazy val runnerNG = Runner(testDir, "nested_group_ref.tdml")
 
-  lazy val runnerNG = new DFDLTestSuite(Misc.getRequiredResource(testDir + "nested_group_ref.tdml"))
-  val af = testDir + "AF.tdml"
-  lazy val runnerAF = new DFDLTestSuite(Misc.getRequiredResource(af))
-  val ag = testDir + "AG.tdml"
-  lazy val runnerAG = new DFDLTestSuite(Misc.getRequiredResource(ag))
+  lazy val runnerAF = Runner(testDir, "AF.tdml")
 
-  val aw = testDir + "AW.tdml"
-  lazy val runnerAW = new DFDLTestSuite(Misc.getRequiredResource(aw))
+  lazy val runnerAG = Runner(testDir, "AG.tdml")
 
-  val ay = testDir + "AY.tdml"
-  lazy val runnerAY = new DFDLTestSuite(Misc.getRequiredResource(ay))
+  lazy val runnerAW = Runner(testDir, "AW.tdml")
 
-  val az = testDir + "AZ.tdml"
-  lazy val runnerAZ = new DFDLTestSuite(Misc.getRequiredResource(az))
+  lazy val runnerAY = Runner(testDir, "AY.tdml")
 
-  val ba = testDir + "BA.tdml"
-  lazy val runnerBA = new DFDLTestSuite(Misc.getRequiredResource(ba))
+  lazy val runnerAZ = Runner(testDir, "AZ.tdml")
 
-  val bc = testDir + "BC.tdml"
-  lazy val runnerBC = new DFDLTestSuite(Misc.getRequiredResource(bc))
-  val bd = testDir + "BD.tdml"
-  lazy val runnerBD = new DFDLTestSuite(Misc.getRequiredResource(bd))
+  lazy val runnerBA = Runner(testDir, "BA.tdml")
+
+  lazy val runnerBC = Runner(testDir, "BC.tdml")
+
+  lazy val runnerBD = Runner(testDir, "BD.tdml")
 
   @AfterClass def shutDown: Unit = {
     runnerDelimited.reset
     runnerMD.reset
     runnerMD_NV.reset
+    runnerBB.reset
+    runnerBE.reset
+    runnerBF1.reset
+    runnerBG.reset
+    runnerMB.reset
+    runnerAP.reset
+    runnerAX.reset
+    runnerAV000.reset
+    runnerAV001.reset
+    runnerAV002.reset
+    runnerAV003.reset
+    runnerNSD.reset
     runnerRD.reset
+    runnerSQ.reset
+    runnerNG.reset
+    runnerAF.reset
+    runnerAG.reset
+    runnerAW.reset
+    runnerAY.reset
+    runnerAZ.reset
+    runnerBA.reset
+    runnerBC.reset
+    runnerBD.reset
   }
 }
 

--- a/daffodil-test-ibm1/src/test/scala/org/apache/daffodil/TresysTests3.scala
+++ b/daffodil-test-ibm1/src/test/scala/org/apache/daffodil/TresysTests3.scala
@@ -18,21 +18,22 @@
 package org.apache.daffodil
 
 import org.apache.daffodil.tdml.Runner
+import org.apache.daffodil.tdml.RunnerOpts
 import org.junit.{ AfterClass, Test }
 
 object TresysTests3 {
   val testDir = "/test-suite/tresys-contributed/"
 
   lazy val runnerBF = Runner(testDir, "bitFlagExpression.tdml",
-    compileAllTopLevel = false) // test has elements that have upward paths past root.
+    RunnerOpts(compileAllTopLevel = false)) // test has elements that have upward paths past root.
 
-  lazy val runnerAH = Runner(testDir, "AH.tdml", compileAllTopLevel = true)
+  lazy val runnerAH = Runner(testDir, "AH.tdml", RunnerOpts(compileAllTopLevel = true))
 
-  lazy val runnerAM = Runner(testDir, "AM.tdml", validateTDMLFile = true, validateDFDLSchemas = false,
-    compileAllTopLevel = true)
+  lazy val runnerAM = Runner(testDir, "AM.tdml", RunnerOpts(validateTDMLFile = true, validateDFDLSchemas = false,
+    compileAllTopLevel = true))
 
-  lazy val runnerAU = Runner(testDir, "AU.tdml", validateTDMLFile = true, validateDFDLSchemas = false,
-    compileAllTopLevel = true)
+  lazy val runnerAU = Runner(testDir, "AU.tdml", RunnerOpts(validateTDMLFile = true, validateDFDLSchemas = false,
+    compileAllTopLevel = true))
 
   lazy val runnerBC = Runner(testDir, "BC.tdml")
   lazy val runnerBD = Runner(testDir, "BD.tdml")

--- a/daffodil-test/src/test/scala/org/apache/daffodil/extensions/TestChoiceBranchKeyRanges.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/extensions/TestChoiceBranchKeyRanges.scala
@@ -17,13 +17,14 @@
 package org.apache.daffodil.extensions
 
 import org.apache.daffodil.tdml.Runner
+import org.apache.daffodil.tdml.RunnerOpts
 import org.junit.AfterClass
 import org.junit.Test
 
 object TestChoiceBranchKeyRanges {
   val testDir = "/org/apache/daffodil/extensions/choiceBranchRanges/"
 
-  val runner = Runner(testDir, "choiceBranchKeyRanges.tdml", validateTDMLFile = true)
+  val runner = Runner(testDir, "choiceBranchKeyRanges.tdml", RunnerOpts(validateTDMLFile = true))
 
   @AfterClass def shutDown: Unit = {
     runner.reset

--- a/daffodil-test/src/test/scala/org/apache/daffodil/extensions/TestInputTypeValueCalc.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/extensions/TestInputTypeValueCalc.scala
@@ -19,15 +19,16 @@ package org.apache.daffodil.extensions
 
 import org.junit.Test
 import org.apache.daffodil.tdml.Runner
+import org.apache.daffodil.tdml.RunnerOpts
 import org.junit.AfterClass
 
 object TestInputTypeValueCalc {
   val testDir = "/org/apache/daffodil/extensions/type_calc/"
 
-  val runner = Runner(testDir, "inputTypeCalc.tdml", validateTDMLFile = false)
-  val exprRunner = Runner(testDir, "inputTypeCalcExpression.tdml", validateTDMLFile = false)
-  val fnRunner = Runner(testDir, "typeCalcFunctions.tdml", validateTDMLFile = false)
-  val fnErrRunner = Runner(testDir, "typeCalcFunctionErrors.tdml", validateTDMLFile = false)
+  val runner = Runner(testDir, "inputTypeCalc.tdml", RunnerOpts(validateTDMLFile = false))
+  val exprRunner = Runner(testDir, "inputTypeCalcExpression.tdml", RunnerOpts(validateTDMLFile = false))
+  val fnRunner = Runner(testDir, "typeCalcFunctions.tdml", RunnerOpts(validateTDMLFile = false))
+  val fnErrRunner = Runner(testDir, "typeCalcFunctionErrors.tdml", RunnerOpts(validateTDMLFile = false))
 
   @AfterClass def shutDown: Unit = {
     runner.reset

--- a/daffodil-test/src/test/scala/org/apache/daffodil/extensions/TestLookAhead.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/extensions/TestLookAhead.scala
@@ -17,13 +17,14 @@
 package org.apache.daffodil.extensions
 
 import org.apache.daffodil.tdml.Runner
+import org.apache.daffodil.tdml.RunnerOpts
 import org.junit.AfterClass
 import org.junit.Test
 
 object TestLookAhead {
   val testDir = "/org/apache/daffodil/extensions/lookAhead/"
 
-  val runner = Runner(testDir, "lookAhead.tdml", validateTDMLFile = true)
+  val runner = Runner(testDir, "lookAhead.tdml", RunnerOpts(validateTDMLFile = true))
 
   @AfterClass def shutDown: Unit = {
     runner.reset

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section02/processing_errors/ProcessingErrors.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section02/processing_errors/ProcessingErrors.scala
@@ -19,15 +19,16 @@ package org.apache.daffodil.section02.processing_errors
 
 import org.junit.Test
 import org.apache.daffodil.tdml.Runner
+import org.apache.daffodil.tdml.RunnerOpts
 import org.junit.AfterClass
 
 object TestProcessingErrors {
   val testDir = "/org/apache/daffodil/section02/processing_errors/"
 
-  val runner = Runner(testDir, "dfdl-schema-validation-diagnostics.tdml", validateTDMLFile = false)
+  val runner = Runner(testDir, "dfdl-schema-validation-diagnostics.tdml", RunnerOpts(validateTDMLFile = false))
 
-  val runner02 = Runner(testDir, "ProcessingErrors.tdml", validateTDMLFile = false, validateDFDLSchemas = false)
-  val runner02Validate = Runner(testDir, "ProcessingErrors.tdml", validateTDMLFile = true, validateDFDLSchemas = true)
+  val runner02 = Runner(testDir, "ProcessingErrors.tdml", RunnerOpts(validateTDMLFile = false, validateDFDLSchemas = false))
+  val runner02Validate = Runner(testDir, "ProcessingErrors.tdml", RunnerOpts(validateTDMLFile = true, validateDFDLSchemas = true))
 
   @AfterClass def shutDown: Unit = {
     runner.reset

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section02/processing_errors/ProcessingErrorsUnparse.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section02/processing_errors/ProcessingErrorsUnparse.scala
@@ -19,14 +19,15 @@ package org.apache.daffodil.section02.processing_errors
 
 import org.junit.Test
 import org.apache.daffodil.tdml.Runner
+import org.apache.daffodil.tdml.RunnerOpts
 import org.junit.AfterClass
 
 object TestProcessingErrorsUnparse {
   val testDir = "/org/apache/daffodil/section02/processing_errors/"
 
-  val runner02 = Runner(testDir, "ProcessingErrorsUnparse.tdml", validateTDMLFile = false, validateDFDLSchemas = false)
-  val runner02Validate = Runner(testDir, "ProcessingErrorsUnparse.tdml", validateTDMLFile = true, validateDFDLSchemas = true,
-    compileAllTopLevel = true)
+  val runner02 = Runner(testDir, "ProcessingErrorsUnparse.tdml", RunnerOpts(validateTDMLFile = false, validateDFDLSchemas = false))
+  val runner02Validate = Runner(testDir, "ProcessingErrorsUnparse.tdml", RunnerOpts(validateTDMLFile = true, validateDFDLSchemas = true,
+    compileAllTopLevel = true))
 
   @AfterClass def shutDown: Unit = {
     runner02.reset

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section02/schema_definition_errors/TestSDENew.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section02/schema_definition_errors/TestSDENew.scala
@@ -18,13 +18,11 @@
 package org.apache.daffodil.section02.schema_definition_errors
 
 import org.junit.Test
-import org.apache.daffodil.util._
-import org.apache.daffodil.tdml.DFDLTestSuite
+import org.apache.daffodil.tdml.Runner
 
 class TestSDENew {
   val testDir = "/org/apache/daffodil/section02/schema_definition_errors/"
-  val aa = testDir + "SchemaDefinitionErrors.tdml"
-  lazy val runner = new DFDLTestSuite(Misc.getRequiredResource(aa))
+  lazy val runner = Runner(testDir, "SchemaDefinitionErrors.tdml")
 
   @Test def test_schema_component_err(): Unit = { runner.runOneTest("schema_component_err") }
 

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section02/validation_errors/TestValidationErrNew.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section02/validation_errors/TestValidationErrNew.scala
@@ -17,12 +17,10 @@
 
 package org.apache.daffodil.section02.validation_errors
 
-import org.apache.daffodil.util._
-import org.apache.daffodil.tdml.DFDLTestSuite
+import org.apache.daffodil.tdml.Runner
 
 class TestValidationErrNew {
   val testDir = "/org/apache/daffodil/section02/validation_errors/"
-  val aa = testDir + "Validation.tdml"
-  lazy val runner = new DFDLTestSuite(Misc.getRequiredResource(aa))
+  lazy val runner = Runner(testDir, "Validation.tdml")
 
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section05/dfdl_xsdl_subset/TestDFDLSubset.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section05/dfdl_xsdl_subset/TestDFDLSubset.scala
@@ -19,13 +19,14 @@ package org.apache.daffodil.section05.dfdl_xsdl_subset
 
 import org.junit.Test
 import org.apache.daffodil.tdml.Runner
+import org.apache.daffodil.tdml.RunnerOpts
 import org.junit.AfterClass
 
 object TestDFDLSubset {
 
   val testDir = "/org/apache/daffodil/section05/dfdl_xsdl_subset/"
   val runner = Runner(testDir, "DFDLSubset.tdml")
-  val runnerNV = Runner(testDir, "DFDLSubset.tdml", validateDFDLSchemas=false)
+  val runnerNV = Runner(testDir, "DFDLSubset.tdml", RunnerOpts(validateDFDLSchemas=false))
 
   @AfterClass def tearDown(): Unit = {
     runner.reset

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section05/facets/TestFacets.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section05/facets/TestFacets.scala
@@ -20,13 +20,14 @@ package org.apache.daffodil.section05.facets
 import org.junit.Test
 import org.junit._
 import org.apache.daffodil.tdml.Runner
+import org.apache.daffodil.tdml.RunnerOpts
 import org.junit.AfterClass
 
 object TestFacets {
 
   val testDir = "/org/apache/daffodil/section05/facets/"
-  val runner = Runner(testDir, "Facets.tdml", validateTDMLFile = false, validateDFDLSchemas = false)
-  val runnerV = Runner(testDir, "Facets.tdml", validateTDMLFile = false, validateDFDLSchemas = true)
+  val runner = Runner(testDir, "Facets.tdml", RunnerOpts(validateTDMLFile = false, validateDFDLSchemas = false))
+  val runnerV = Runner(testDir, "Facets.tdml", RunnerOpts(validateTDMLFile = false, validateDFDLSchemas = true))
 
   @AfterClass def tearDown(): Unit = {
     runner.reset

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section05/facets/TestFacetsNew.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section05/facets/TestFacetsNew.scala
@@ -17,12 +17,10 @@
 
 package org.apache.daffodil.section05.facets
 
-import org.apache.daffodil.util._
-import org.apache.daffodil.tdml.DFDLTestSuite
+import org.apache.daffodil.tdml.Runner
 
 class TestFacetsNew {
   val testDir = "/org/apache/daffodil/section05/facets/"
-  val aa = testDir + "Facets.tdml"
-  lazy val runner = new DFDLTestSuite(Misc.getRequiredResource(aa))
+  lazy val runner = Runner(testDir, "Facets.tdml")
 
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section06/entities/TestEntitiesNew.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section06/entities/TestEntitiesNew.scala
@@ -17,16 +17,15 @@
 
 package org.apache.daffodil.section06.entities
 
-import org.apache.daffodil.util._
-import org.apache.daffodil.tdml.DFDLTestSuite
+import org.apache.daffodil.tdml.Runner
 
 class TestEntitiesNew {
   val testDir = "/org/apache/daffodil/section06/entities/"
 
   val tdml_01 = testDir + "InvalidEntities.tdml"
-  lazy val runner = new DFDLTestSuite(Misc.getRequiredResource(tdml_01))
+  lazy val runner = Runner(testDir, "InvalidEntities.tdml")
 
   val tdml_02 = testDir + "Entities.tdml"
-  lazy val runner_01 = new DFDLTestSuite(Misc.getRequiredResource(tdml_02))
+  lazy val runner_01 = Runner(testDir, "Entities.tdml")
 
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section06/namespaces/TestNamespaces.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section06/namespaces/TestNamespaces.scala
@@ -20,18 +20,19 @@ package org.apache.daffodil.section06.namespaces
 import org.junit.Test
 import org.junit.AfterClass
 import org.apache.daffodil.tdml.Runner
+import org.apache.daffodil.tdml.RunnerOpts
 import org.apache.daffodil.util.LoggingDefaults
 import org.apache.daffodil.util.LogLevel
 
 object TestNamespaces {
   val testDir = "/org/apache/daffodil/section06/namespaces/"
 
-  val runner = Runner(testDir, "namespaces.tdml", validateTDMLFile = true, validateDFDLSchemas = false)
-  val runnerV = Runner(testDir, "namespaces.tdml", validateTDMLFile = true, validateDFDLSchemas = true)
+  val runner = Runner(testDir, "namespaces.tdml", RunnerOpts(validateTDMLFile = true, validateDFDLSchemas = false))
+  val runnerV = Runner(testDir, "namespaces.tdml", RunnerOpts(validateTDMLFile = true, validateDFDLSchemas = true))
 
-  val runner2 = Runner(testDir, "multiFile.tdml", validateTDMLFile = false, validateDFDLSchemas = false)
+  val runner2 = Runner(testDir, "multiFile.tdml", RunnerOpts(validateTDMLFile = false, validateDFDLSchemas = false))
   val runner3 = Runner(testDir, "includeImport.tdml")
-  val runnerWithSchemaValidation = Runner(testDir, "multiFile.tdml", validateTDMLFile = true, validateDFDLSchemas = true)
+  val runnerWithSchemaValidation = Runner(testDir, "multiFile.tdml", RunnerOpts(validateTDMLFile = true, validateDFDLSchemas = true))
 
   @AfterClass def shutDown: Unit = {
     runner.reset

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section06/namespaces/TestNamespacesNew.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section06/namespaces/TestNamespacesNew.scala
@@ -18,11 +18,10 @@
 package org.apache.daffodil.section06.namespaces
 
 import org.apache.daffodil.util._
-import org.apache.daffodil.tdml.DFDLTestSuite
+import org.apache.daffodil.tdml.Runner
 
 class TestNamespacesNew extends Logging {
   val testDir = "/org/apache/daffodil/section06/namespaces/"
-  val aa = testDir + "namespaces.tdml"
-  lazy val runner = new DFDLTestSuite(Misc.getRequiredResource(aa))
+  lazy val runner = Runner(testDir, "namespaces.tdml")
 
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section07/annotations/TestAnnotations.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section07/annotations/TestAnnotations.scala
@@ -19,11 +19,12 @@ package org.apache.daffodil.section07.annotations
 
 import org.junit.Test
 import org.apache.daffodil.tdml.Runner
+import org.apache.daffodil.tdml.RunnerOpts
 import org.junit.AfterClass
 
 object TestAnnotations {
   val testDir = "/org/apache/daffodil/section07/annotations/"
-  val runner = Runner(testDir, "annotations.tdml", validateTDMLFile = false)
+  val runner = Runner(testDir, "annotations.tdml", RunnerOpts(validateTDMLFile = false))
 
   @AfterClass def tearDown: Unit = {
     runner.reset

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section07/assertions/TestAssertions.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section07/assertions/TestAssertions.scala
@@ -19,11 +19,12 @@ package org.apache.daffodil.section07.assertions
 
 import org.junit.Test
 import org.apache.daffodil.tdml.Runner
+import org.apache.daffodil.tdml.RunnerOpts
 import org.junit.AfterClass
 
 object TestAssertions {
   val testDir = "/org/apache/daffodil/section07/assertions/"
-  val runner = Runner(testDir, "assert.tdml", validateTDMLFile = false)
+  val runner = Runner(testDir, "assert.tdml", RunnerOpts(validateTDMLFile = false))
 
   @AfterClass def tearDown: Unit = {
     runner.reset

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section07/escapeScheme/TestEscapeScheme.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section07/escapeScheme/TestEscapeScheme.scala
@@ -19,13 +19,14 @@ package org.apache.daffodil.section07.escapeScheme
 
 import org.junit._
 import org.apache.daffodil.tdml.Runner
+import org.apache.daffodil.tdml.RunnerOpts
 import org.junit.AfterClass
 
 object TestEscapeScheme {
   val testDir = "/org/apache/daffodil/section07/escapeScheme/"
-  val runner = Runner(testDir, "escapeScheme.tdml", validateTDMLFile = false)
-  val runnerNeg = Runner(testDir, "escapeSchemeNeg.tdml", validateTDMLFile = false)
-  val runner2 = Runner(testDir, "escapeScenarios.tdml", validateTDMLFile = false)
+  val runner = Runner(testDir, "escapeScheme.tdml", RunnerOpts(validateTDMLFile = false))
+  val runnerNeg = Runner(testDir, "escapeSchemeNeg.tdml", RunnerOpts(validateTDMLFile = false))
+  val runner2 = Runner(testDir, "escapeScenarios.tdml", RunnerOpts(validateTDMLFile = false))
 
   @AfterClass def shutDown(): Unit = {
     runner.reset

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section07/external_variables/TestExternalVariablesNew.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section07/external_variables/TestExternalVariablesNew.scala
@@ -17,16 +17,14 @@
 
 package org.apache.daffodil.section07.external_variables
 
-import org.apache.daffodil.tdml.DFDLTestSuite
+import org.apache.daffodil.tdml.Runner
 import org.junit.Test
-import org.apache.daffodil.util._
 
 class TestExternalVariablesNew {
 
   val testDir = "/org/apache/daffodil/section07/external_variables/"
-  val tdml = testDir + "external_variables.tdml"
 
-  lazy val runner = new DFDLTestSuite(Misc.getRequiredResource(tdml))
+  lazy val runner = Runner(testDir, "external_variables.tdml")
 
   // It's important to note here that external variables
   // via the TDMLRunner are currently passed in during

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section07/property_syntax/TestPropertySyntax.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section07/property_syntax/TestPropertySyntax.scala
@@ -19,12 +19,13 @@ package org.apache.daffodil.section07.property_syntax
 
 import org.junit.Test
 import org.apache.daffodil.tdml.Runner
+import org.apache.daffodil.tdml.RunnerOpts
 import org.junit.AfterClass
 
 object TestPropertySyntax {
   val testDir1 = "/org/apache/daffodil/section07/property_syntax/"
-  val runner1 = Runner(testDir1, "PropertySyntax.tdml", validateTDMLFile = false, validateDFDLSchemas = false)
-  val runner1V = Runner(testDir1, "PropertySyntax.tdml", validateTDMLFile = false)
+  val runner1 = Runner(testDir1, "PropertySyntax.tdml", RunnerOpts(validateTDMLFile = false, validateDFDLSchemas = false))
+  val runner1V = Runner(testDir1, "PropertySyntax.tdml", RunnerOpts(validateTDMLFile = false))
 
   @AfterClass def shutDown: Unit = {
     runner1.reset

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section07/property_syntax/TestPropertySyntaxNew.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section07/property_syntax/TestPropertySyntaxNew.scala
@@ -19,12 +19,13 @@ package org.apache.daffodil.section07.property_syntax
 
 import org.junit.Test
 import org.apache.daffodil.tdml.Runner
+import org.apache.daffodil.tdml.RunnerOpts
 import org.junit.AfterClass
 
 object TestPropertySyntax2 {
 
   val testDir1 = "/org/apache/daffodil/section07/property_syntax/"
-  val runner = Runner(testDir1, "PropertySyntax.tdml", false, false)
+  val runner = Runner(testDir1, "PropertySyntax.tdml", RunnerOpts(validateTDMLFile=false, validateDFDLSchemas=false))
 
   @AfterClass def shutDown: Unit = {
     runner.reset

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section07/variables/TestVariables.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section07/variables/TestVariables.scala
@@ -20,7 +20,6 @@ package org.apache.daffodil.section07.variables
 import org.junit.Test
 import org.apache.daffodil.xml.XMLUtils
 import org.apache.daffodil.Implicits._
-import org.apache.daffodil.tdml.DFDLTestSuite
 import scala.math.Pi
 import org.apache.daffodil.tdml.Runner
 import org.junit.AfterClass
@@ -137,7 +136,7 @@ class TestVariables {
 
   @Test def test_variables2(): Unit = {
     val testSuite = variables2
-    lazy val ts = new DFDLTestSuite(testSuite)
+    lazy val ts = Runner(testSuite)
     ts.runOneTest("variables2")
   }
 
@@ -175,7 +174,7 @@ class TestVariables {
   @Test def test_variables3(): Unit = {
     // Debugger.setDebugging(true)
     val testSuite = variables3
-    lazy val ts = new DFDLTestSuite(testSuite)
+    lazy val ts = Runner(testSuite)
     ts.runOneTest("variables3")
   }
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section07/variables/TestVariables2.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section07/variables/TestVariables2.scala
@@ -17,15 +17,12 @@
 
 package org.apache.daffodil.section07.variables
 
-import org.apache.daffodil.tdml.DFDLTestSuite
-import org.apache.daffodil.util._
+import org.apache.daffodil.tdml.Runner
 
 class TestVariables2 {
   val testDir = "/org/apache/daffodil/section07/variables/"
-  val tdml = testDir + "variables.tdml"
-  lazy val runner = new DFDLTestSuite(Misc.getRequiredResource(tdml))
+  lazy val runner = Runner(testDir, "variables.tdml")
 
-  val tdml_01 = testDir + "variables_01.tdml"
-  lazy val runner_01 = new DFDLTestSuite(Misc.getRequiredResource(tdml_01))
+  lazy val runner_01 = Runner(testDir, "variables_01.tdml")
 
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section08/property_scoping/TestPropertyScopingNew.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section08/property_scoping/TestPropertyScopingNew.scala
@@ -17,12 +17,10 @@
 
 package org.apache.daffodil.section08.property_scoping
 
-import org.apache.daffodil.util._
-import org.apache.daffodil.tdml.DFDLTestSuite
+import org.apache.daffodil.tdml.Runner
 
 class TestPropertyScopingNew {
   val testDir = "/org/apache/daffodil/section08/property_scoping/"
-  val aa = testDir + "PropertyScoping.tdml"
-  lazy val runner = new DFDLTestSuite(Misc.getRequiredResource(aa))
+  lazy val runner = Runner(testDir, "PropertyScoping.tdml")
 
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section12/lengthKind/TestLengthKindPattern2.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section12/lengthKind/TestLengthKindPattern2.scala
@@ -17,12 +17,16 @@
 
 package org.apache.daffodil.section12.lengthKind
 
-import org.apache.daffodil.util._
-import org.apache.daffodil.tdml.DFDLTestSuite
+import org.apache.daffodil.tdml.Runner
+import org.junit.AfterClass
 
 class TestLengthKindPattern2 {
   val testDir = "/org/apache/daffodil/section12/lengthKind/"
   val aa = testDir + "PatternTests.tdml"
-  lazy val runner = new DFDLTestSuite(Misc.getRequiredResource(aa))
+  lazy val runner = Runner(testDir, "PatternTests.tdml")
+
+  @AfterClass def shutdown: Unit = {
+    runner.reset
+  }
 
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section12/lengthKind/TestLengthKindPrefixed.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section12/lengthKind/TestLengthKindPrefixed.scala
@@ -19,12 +19,13 @@ package org.apache.daffodil.section12.lengthKind
 
 import org.junit.Test
 import org.apache.daffodil.tdml.Runner
+import org.apache.daffodil.tdml.RunnerOpts
 import org.junit.AfterClass
 
 object TestLengthKindPrefixed {
   private val testDir = "/org/apache/daffodil/section12/lengthKind/"
 
-  val runner = Runner(testDir, "PrefixedTests.tdml", validateTDMLFile = false, validateDFDLSchemas = false)
+  val runner = Runner(testDir, "PrefixedTests.tdml", RunnerOpts(validateTDMLFile = false, validateDFDLSchemas = false))
 
   @AfterClass def shutDown: Unit = {
     runner.reset

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section13/text_number_props/TestTextNumberPropertiesNew.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section13/text_number_props/TestTextNumberPropertiesNew.scala
@@ -17,15 +17,17 @@
 
 package org.apache.daffodil.section13.text_number_props
 
-import org.apache.daffodil.util._
-import org.apache.daffodil.tdml.DFDLTestSuite
+import org.apache.daffodil.tdml.Runner
 
-import org.junit.Test
+import org.junit.{ AfterClass, Test }
 
 class TestTextNumberPropsNew {
   val testDir = "/org/apache/daffodil/section13/text_number_props/"
-  val aa = testDir + "TextNumberProps.tdml"
-  lazy val runner = new DFDLTestSuite(Misc.getRequiredResource(aa))
+  lazy val runner = Runner(testDir, "TextNumberProps.tdml")
+
+  @AfterClass def shutdown: Unit = {
+    runner.reset
+  }
 
   // DFDL-861
   @Test def test_standardZeroRep03(): Unit = { runner.runOneTest("standardZeroRep03") }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section13/text_number_props/TestTextStandardBase.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section13/text_number_props/TestTextStandardBase.scala
@@ -20,10 +20,11 @@ package org.apache.daffodil.section13.text_standard_base
 import org.junit.Test
 import org.junit.AfterClass
 import org.apache.daffodil.tdml.Runner
+import org.apache.daffodil.tdml.RunnerOpts
 
 object TestTextStandardBase {
   val testDir = "/org/apache/daffodil/section13/text_number_props/"
-  val runner = Runner(testDir, "TextStandardBase.tdml", validateTDMLFile = false, validateDFDLSchemas = false)
+  val runner = Runner(testDir, "TextStandardBase.tdml", RunnerOpts(validateTDMLFile = false, validateDFDLSchemas = false))
 
   @AfterClass def shutDown(): Unit = {
     runner.reset

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section13/validation_errors/PadCharacter.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section13/validation_errors/PadCharacter.scala
@@ -18,6 +18,7 @@
 package org.apache.daffodil.section13.validation_errors
 
 import org.apache.daffodil.tdml.Runner
+import org.apache.daffodil.tdml.RunnerOpts
 import org.apache.daffodil.xml.XMLUtils
 import org.junit.Test
 
@@ -51,7 +52,7 @@ class PadCharacter {
         </tdml:parserTestCase>
       </tdml:testSuite>
 
-    val runner = Runner(testSuite, validateTDMLFile = false)
+    val runner = Runner(testSuite, RunnerOpts(validateTDMLFile = false))
     runner.runOneTest("short_form_pad_char")
     runner.reset
   }
@@ -85,7 +86,7 @@ class PadCharacter {
         </tdml:parserTestCase>
       </tdml:testSuite>
 
-    val runner = Runner(testSuite, validateTDMLFile = false)
+    val runner = Runner(testSuite, RunnerOpts(validateTDMLFile = false))
     runner.runOneTest("long_form_pad_char")
     runner.reset
   }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section14/sequence_groups/TestHiddenSequences.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section14/sequence_groups/TestHiddenSequences.scala
@@ -19,13 +19,14 @@ package org.apache.daffodil.section14.sequence_groups
 
 import org.junit.Test
 import org.apache.daffodil.tdml.Runner
+import org.apache.daffodil.tdml.RunnerOpts
 import org.junit.AfterClass
 
 object TestHiddenSequences {
 
   val testDir = "/org/apache/daffodil/section14/sequence_groups/"
 
-  val runner = Runner(testDir, "HiddenSequences.tdml", validateTDMLFile = true)
+  val runner = Runner(testDir, "HiddenSequences.tdml", RunnerOpts(validateTDMLFile = true))
 
   @AfterClass def shutDown: Unit = {
     runner.reset
@@ -36,7 +37,6 @@ object TestHiddenSequences {
 class TestHiddenSequences {
 
   import TestHiddenSequences._
-
 
   @Test def test_parseHiddenGroupRef(): Unit = { runner.runOneTest("parseHiddenGroupRef") }
   @Test def test_parseRegularGroupRef(): Unit = { runner.runOneTest("parseRegularGroupRef") }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section14/sequence_groups/TestSequenceGroupUnparse.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section14/sequence_groups/TestSequenceGroupUnparse.scala
@@ -18,15 +18,12 @@
 package org.apache.daffodil.section14.sequence_groups
 
 import org.junit.Test
-import org.apache.daffodil.util.Misc
-import org.apache.daffodil.tdml.DFDLTestSuite
+import org.apache.daffodil.tdml.Runner
 import org.junit.AfterClass
 
 object TestSequenceGroupUnparse {
   val testDir = "org/apache/daffodil/section14/sequence_groups/"
-  val aa = testDir + "SequenceGroupUnparse.tdml"
-  val res = Misc.getRequiredResource(aa)
-  var runner = new DFDLTestSuite(res)
+  var runner = Runner(testDir, "SequenceGroupUnparse.tdml")
   @AfterClass def shutDown: Unit = {
     runner = null
   }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section14/sequence_groups/TestSequenceGroups.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section14/sequence_groups/TestSequenceGroups.scala
@@ -19,6 +19,7 @@ package org.apache.daffodil.section14.sequence_groups
 
 import org.junit.Test
 import org.apache.daffodil.tdml.Runner
+import org.apache.daffodil.tdml.RunnerOpts
 import org.junit.AfterClass
 
 object TestSequenceGroups {
@@ -26,7 +27,7 @@ object TestSequenceGroups {
   val testDir_01 = "/org/apache/daffodil/section14/sequence_groups/"
 
   val runner_01 = Runner(testDir_01, "SequenceGroupDelimiters.tdml")
-  var runner_02 = Runner(testDir_01, "SequenceGroup.tdml", validateTDMLFile = false)
+  var runner_02 = Runner(testDir_01, "SequenceGroup.tdml", RunnerOpts(validateTDMLFile = false))
 
   @AfterClass def shutDown: Unit = {
     runner_01.reset
@@ -38,9 +39,6 @@ object TestSequenceGroups {
 class TestSequenceGroups {
 
   import TestSequenceGroups._
-
-
-
 
   @Test def test_SeqGrp_01(): Unit = { runner_01.runOneTest("SeqGrp_01") }
   @Test def test_SeqGrp_02(): Unit = { runner_01.runOneTest("SeqGrp_02") }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section14/sequence_groups/TestSequenceGroups3.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section14/sequence_groups/TestSequenceGroups3.scala
@@ -19,6 +19,7 @@ package org.apache.daffodil.section14.sequence_groups
 
 import org.junit.Test
 import org.apache.daffodil.tdml.Runner
+import org.apache.daffodil.tdml.RunnerOpts
 import org.junit.AfterClass
 
 object TestSequenceGroups3 {
@@ -26,7 +27,7 @@ object TestSequenceGroups3 {
   val testDir_01 = "/org/apache/daffodil/section14/sequence_groups/"
 
   val runner_01 = Runner(testDir_01, "SequenceGroupDelimiters.tdml")
-  val runner_02 = Runner(testDir_01, "SequenceGroup.tdml", validateTDMLFile = false)
+  val runner_02 = Runner(testDir_01, "SequenceGroup.tdml", RunnerOpts(validateTDMLFile = false))
 
   @AfterClass def shutDown: Unit = {
     runner_01.reset

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section15/choice_groups/TestHiddenChoices.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section15/choice_groups/TestHiddenChoices.scala
@@ -19,13 +19,14 @@ package org.apache.daffodil.section15.choice_groups
 
 import org.junit.Test
 import org.apache.daffodil.tdml.Runner
+import org.apache.daffodil.tdml.RunnerOpts
 import org.junit.AfterClass
 
 object TestHiddenChoices {
 
   val testDir = "/org/apache/daffodil/section15/choice_groups/"
 
-  val runner = Runner(testDir, "HiddenChoices.tdml", validateTDMLFile = true)
+  val runner = Runner(testDir, "HiddenChoices.tdml", RunnerOpts(validateTDMLFile = true))
 
   @AfterClass def shutDown: Unit = {
     runner.reset

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section15/choice_groups/TestUnparseChoiceNew.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section15/choice_groups/TestUnparseChoiceNew.scala
@@ -19,13 +19,11 @@ package org.apache.daffodil.section15.choice_groups
 
 import org.junit.Test
 import org.junit.AfterClass
-import org.apache.daffodil.util._
-import org.apache.daffodil.tdml.DFDLTestSuite
+import org.apache.daffodil.tdml.Runner
 
 object TestUnparseChoiceNew {
   val testDir = "/org/apache/daffodil/section15/choice_groups/"
-  val aa = testDir + "choice-unparse.tdml"
-  var runnerCH = new DFDLTestSuite(Misc.getRequiredResource(aa))
+  var runnerCH = Runner(testDir, "choice-unparse.tdml")
 
   @AfterClass def tearDown(): Unit = {
     runnerCH = null

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section16/array_optional_elem/TestArrayOptionalElem.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section16/array_optional_elem/TestArrayOptionalElem.scala
@@ -19,6 +19,7 @@ package org.apache.daffodil.section16.array_optional_elem
 
 import org.junit.Test
 import org.apache.daffodil.tdml.Runner
+import org.apache.daffodil.tdml.RunnerOpts
 import org.junit.AfterClass
 
 object TestArrayOptionalElem {
@@ -26,7 +27,7 @@ object TestArrayOptionalElem {
   private val testDir01 = "/org/apache/daffodil/section05/facets/"
 
   val runner = Runner(testDir, "ArrayOptionalElem.tdml")
-  val runner01 = Runner(testDir01, "Facets.tdml", validateTDMLFile = false)
+  val runner01 = Runner(testDir01, "Facets.tdml", RunnerOpts(validateTDMLFile = false))
   val rBack = Runner(testDir, "backtracking.tdml")
   val runnerAC = Runner(testDir, "ArrayComb.tdml")
 

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section16/array_optional_elem/TestUnparseArrayImplicitOptionalElemNew.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section16/array_optional_elem/TestUnparseArrayImplicitOptionalElemNew.scala
@@ -16,14 +16,15 @@
  */
 
 package org.apache.daffodil.section16.array_optional_elem
-
-import org.apache.daffodil.util._
-import org.apache.daffodil.tdml.DFDLTestSuite
+import org.junit.{ AfterClass }
+import org.apache.daffodil.tdml.Runner
 
 class TestUnparseArrayImplicitOptionalElemNew {
   val testDir = "/org/apache/daffodil/section16/array_optional_elem/"
-  val aa = testDir + "UnparseArrayImplicitOptionalElem.tdml"
 
-  lazy val runner = new DFDLTestSuite(Misc.getRequiredResource(aa))
+  var runner = Runner(testDir, "UnparseArrayImplicitOptionalElem.tdml")
 
+  @AfterClass def shutdown: Unit = {
+    runner.reset
+  }
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section16/array_optional_elem/TestUnparseArrayParsedOptionalElemNew.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section16/array_optional_elem/TestUnparseArrayParsedOptionalElemNew.scala
@@ -17,13 +17,15 @@
 
 package org.apache.daffodil.section16.array_optional_elem
 
-import org.apache.daffodil.util._
-import org.apache.daffodil.tdml.DFDLTestSuite
+import org.apache.daffodil.tdml.Runner
+import org.junit.{ AfterClass }
 
 class TestUnparseArrayParsedOptionalElemNew {
   val testDir = "/org/apache/daffodil/section16/array_optional_elem/"
-  val aa = testDir + "UnparseArrayParsedOptionalElem.tdml"
 
-  lazy val runner = new DFDLTestSuite(Misc.getRequiredResource(aa))
+  var runner = Runner(testDir, "UnparseArrayParsedOptionalElem.tdml")
 
+  @AfterClass def tearDown(): Unit = {
+    runner = null
+  }
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section17/calc_value_properties/TestInputValueCalc.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section17/calc_value_properties/TestInputValueCalc.scala
@@ -19,12 +19,13 @@ package org.apache.daffodil.section17.calc_value_properties
 
 import org.junit.Test
 import org.apache.daffodil.tdml.Runner
+import org.apache.daffodil.tdml.RunnerOpts
 import org.junit.AfterClass
 
 object TestInputValueCalc {
   val testDir = "/org/apache/daffodil/section17/calc_value_properties/"
 
-  val runner = Runner(testDir, "inputValueCalc.tdml", validateTDMLFile = false)
+  val runner = Runner(testDir, "inputValueCalc.tdml", RunnerOpts(validateTDMLFile = false))
   val runnerAR = Runner(testDir, "AR.tdml")
   val runnerAQ = Runner(testDir, "AQ.tdml")
   val runnerAA = Runner(testDir, "AA.tdml")

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section23/dfdl_expressions/TestDFDLExpressions.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section23/dfdl_expressions/TestDFDLExpressions.scala
@@ -19,6 +19,7 @@ package org.apache.daffodil.section23.dfdl_expressions
 
 import org.junit._
 import org.apache.daffodil.tdml.Runner
+import org.apache.daffodil.tdml.RunnerOpts
 
 object TestDFDLExpressions {
   val testDir = "/org/apache/daffodil/section23/dfdl_expressions/"
@@ -32,19 +33,19 @@ object TestDFDLExpressions {
   val testDir4 = "/org/apache/daffodil/section23/runtime_properties/"
 
   val runner = Runner(testDir, "expressions.tdml")
-  val runnerNV = Runner(testDir, "expressions.tdml", validateDFDLSchemas = false)
+  val runnerNV = Runner(testDir, "expressions.tdml", RunnerOpts(validateDFDLSchemas = false))
   val runner2 = Runner(testDir2, "Functions.tdml")
   val runner2_utf8 = Runner(testDir2, "Functions_UTF8.tdml")
   val runner2b = Runner(testDir2, "Functions-neg.tdml")
-  val runner3 = Runner(testDir, "expression_fail.tdml", validateTDMLFile = false)
-  val runner4 = Runner(testDir4, "runtime-properties.tdml", validateTDMLFile = true, validateDFDLSchemas = false)
+  val runner3 = Runner(testDir, "expression_fail.tdml", RunnerOpts(validateTDMLFile = false))
+  val runner4 = Runner(testDir4, "runtime-properties.tdml", RunnerOpts(validateTDMLFile = true, validateDFDLSchemas = false))
   val runner_fun = Runner(testDir, "functions.tdml")
   val runner5 = Runner(testDir, "valueLength.tdml")
 
   val testDir6 = "/org/apache/daffodil/section23/dfdl_expressions/"
   val runner6 = Runner(testDir6, "expressions.tdml")
 
-  val runner7 = Runner(testDir, "expressions2.tdml", compileAllTopLevel = true)
+  val runner7 = Runner(testDir, "expressions2.tdml", RunnerOpts(compileAllTopLevel = true))
 
   @AfterClass def shutDown(): Unit = {
     runner.reset

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section23/dfdl_expressions/TestDFDLExpressions2.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section23/dfdl_expressions/TestDFDLExpressions2.scala
@@ -19,6 +19,7 @@ package org.apache.daffodil.section23.dfdl_expressions
 
 import org.junit.Test
 import org.apache.daffodil.tdml.Runner
+import org.apache.daffodil.tdml.RunnerOpts
 import org.junit.AfterClass
 
 object TestDFDLExpressions2 {
@@ -40,7 +41,7 @@ object TestDFDLExpressions2 {
 
   val runner6 = Runner(testDir, "valueLength.tdml")
 
-  val runner7 = Runner(testDir4, "expressions2.tdml", compileAllTopLevel = true)
+  val runner7 = Runner(testDir4, "expressions2.tdml", RunnerOpts(compileAllTopLevel = true))
 
   @AfterClass def shutdown = {
     runner.reset

--- a/daffodil-test/src/test/scala/org/apache/daffodil/udf/TestUdfsInSchemas.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/udf/TestUdfsInSchemas.scala
@@ -17,13 +17,14 @@
 package org.apache.daffodil.udf
 
 import org.apache.daffodil.tdml.Runner
+import org.apache.daffodil.tdml.RunnerOpts
 import org.junit.AfterClass
 import org.junit.Test
 
 object TestUdfsInSchemas {
   val testDir = "/org/apache/daffodil/udf/"
 
-  val runner = Runner(testDir, "udfs.tdml", validateTDMLFile = true)
+  val runner = Runner(testDir, "udfs.tdml", RunnerOpts(validateTDMLFile = true))
 
   @AfterClass def shutDown: Unit = {
     runner.reset

--- a/daffodil-test/src/test/scala/org/apache/daffodil/unparser/TestOVCAndLength.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/unparser/TestOVCAndLength.scala
@@ -19,13 +19,12 @@ package org.apache.daffodil.unparser
 
 import org.junit.Test
 import org.junit.AfterClass
-import org.apache.daffodil.util._
-import org.apache.daffodil.tdml.DFDLTestSuite
+import org.apache.daffodil.tdml.Runner
 
 object TestOVCAndLength {
   val testDir = "/org/apache/daffodil/unparser/"
   val aa = testDir + "OVCAndLengthTest.tdml"
-  var runner = new DFDLTestSuite(Misc.getRequiredResource(aa))
+  var runner = Runner(testDir, "OVCAndLengthTest.tdml")
 
   @AfterClass def tearDown(): Unit = {
     runner = null

--- a/daffodil-test/src/test/scala/org/apache/daffodil/unparser/TestParseUnparseMode.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/unparser/TestParseUnparseMode.scala
@@ -19,12 +19,13 @@ package org.apache.daffodil.unparser
 
 import org.junit.Test
 import org.apache.daffodil.tdml.Runner
+import org.apache.daffodil.tdml.RunnerOpts
 import org.junit.AfterClass
 
 object TestParseUnparseMode {
   val testDir = "/org/apache/daffodil/unparser/"
   val runner = Runner(testDir, "parseUnparseModeTest.tdml",
-    validateDFDLSchemas = false) // there are UPA errors in some test schemas
+    RunnerOpts(validateDFDLSchemas = false)) // there are UPA errors in some test schemas
 
   @AfterClass def shutDown: Unit = {
     runner.reset

--- a/daffodil-test/src/test/scala/org/apache/daffodil/unparser/TestUnparseNegInfoset.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/unparser/TestUnparseNegInfoset.scala
@@ -19,13 +19,12 @@ package org.apache.daffodil.unparser
 
 import org.junit.Test
 import org.junit.AfterClass
-import org.apache.daffodil.util._
-import org.apache.daffodil.tdml.DFDLTestSuite
+import org.apache.daffodil.tdml.Runner
+import org.apache.daffodil.tdml.RunnerOpts
 
 object TestUnparseNegInfoset {
   val testDir = "/org/apache/daffodil/unparser/"
-  val aa = testDir + "unparseNegInfosetTest.tdml"
-  var runner = new DFDLTestSuite(Misc.getRequiredResource(aa), validateTDMLFile = false)
+  var runner = Runner(testDir, "unparseNegInfosetTest.tdml", RunnerOpts(validateTDMLFile = false))
 
   @AfterClass def tearDown(): Unit = {
     runner = null


### PR DESCRIPTION
Tweak the interface to the Runner object, as well as
creating a RunnerOpts object to handle the multiple
combinations of parameters used by various tests without
compromising the ability to default parameters
not under test.

DAFFODIL-1300