### PR TITLE
WIP: First cut at a Zip layer transform

### DIFF
--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/layers/LayerTransformer.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/layers/LayerTransformer.scala
@@ -151,6 +151,14 @@ abstract class LayerTransformer(layerName: String, layerRuntimeInfo: LayerRuntim
   def endLayerForUnparse(s: UState): Unit = () // nothing by default
 }
 
+/**
+ * Converts a Daffodil InputSourceDataInputStream back into a regular java InputStream.
+ * As bytes are pulled from the java InputStream, the corresponding bits are pulled from the
+ * underlying InputSourceDataInputStream.
+ *
+ * @param s - the InputSourceDataInputStream being converted
+ * @param finfo - FormatInfo used for byte order, bit order.
+ */
 class JavaIOInputStream(s: InputSourceDataInputStream, finfo: FormatInfo)
   extends InputStream {
 
@@ -187,6 +195,15 @@ class JavaIOInputStream(s: InputSourceDataInputStream, finfo: FormatInfo)
   override def markSupported() = true
 }
 
+
+/**
+ * Converts a Daffodil DataOutputStream back into a regular java OutputStream.
+ * As bytes are written to the java OutputStream the corresponding bits are written to the
+ * underlying DataOutputStream.
+ *
+ * @param s - the DataOutputStream being converted
+ * @param finfo - FormatInfo used for byte order, bit order.
+ */
 class JavaIOOutputStream(dos: DataOutputStream, finfo: FormatInfo)
   extends OutputStream {
 

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/layers/ZipTransformer.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/layers/ZipTransformer.scala
@@ -1,0 +1,335 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.daffodil.layers
+
+import org.apache.commons.compress.archivers.zip.ZipArchiveEntry
+import org.apache.commons.compress.archivers.zip.ZipArchiveOutputStream
+import org.apache.commons.compress.archivers.zip.ZipFile
+import org.apache.commons.compress.utils.SeekableInMemoryByteChannel
+import org.apache.commons.io.IOUtils
+import org.apache.daffodil.schema.annotation.props.gen.LayerLengthKind
+import org.apache.daffodil.schema.annotation.props.gen.LayerLengthUnits
+import org.apache.daffodil.util.Maybe
+import org.apache.daffodil.processors.LayerLengthInBytesEv
+import org.apache.daffodil.processors.LayerBoundaryMarkEv
+import org.apache.daffodil.processors.LayerCharsetEv
+import org.apache.daffodil.processors.parsers.PState
+import org.apache.daffodil.processors.unparsers.UState
+import org.apache.daffodil.dsom.DPathCompileInfo
+import org.apache.daffodil.exceptions.Assert
+import org.apache.daffodil.io.ExplicitLengthLimitingStream
+
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.InputStream
+import java.io.OutputStream
+import java.io.SequenceInputStream
+import java.nio.charset.StandardCharsets
+import scala.Array.emptyByteArray
+import scala.collection.JavaConverters._
+
+/*
+ * Zip files require seeking to the end of the file. Hence, we need to have an explicit
+ * length for a zip layer to work from.
+ *
+ * When writing out zip file contents, to get the length, one must take the
+ * dfdl:contentLength of an enclosing element that surrounds the entire layer.
+ *
+ * All of this forces buffering. So there's no point in worrying about
+ * somehow avoiding buffering inside the implementation.
+ * That can simplify many things. There's no point, for example, in trying
+ * to not read and buffer all the entries.
+ *
+ */
+
+/**
+ * Zip files are hard to deal with. The entries can be present in the file, but marked deleted
+ * based on information in the master information at the end of the file.
+ *
+ * This requires seeking or buffering. The entries are also compressed (usually, not always)
+ *
+ * Rather than try to cope with zip by describing the zip format in DFDL, which is not really possible,
+ * we instead have a zip layer transformer.
+ *
+ * This uses java zip libraries to cope with the zip file seeking, decryption, decompress, etc.
+ * But enables each entry of the zip file to be presented for Daffodil parsing as something
+ * easier to parse, consisting of the metadata of the zip entry in a straightforward layout,
+ * followed by the contents of the entry, fully decompressed.
+ *
+ * This allows a Daffodil element of complex type that knows this layout to decompose the series of
+ * zip entries into DFDL elements corresponding to those entries.
+ *
+ * If you read, and then write a zip using this layer transformer, the data is canonicalized in that
+ * deleted entries will not be represented in the zip contents any longer, skipped over sections will be
+ * omitted, etc.
+ *
+ * For unparsing the opposite occurs. A standard layout of entries is filled in from Daffodil unparsing,
+ * and this layer then consumes those and creates zip entries from them which are placed into
+ * the zip output stream.
+ */
+final class ZIPTransformer(layerLengthInBytesEv: LayerLengthInBytesEv)
+  extends LayerTransformer() {
+
+  override def wrapLayerDecoder(jis: java.io.InputStream) = {
+    val s = new ZipAllEntriesInputStream(jis)
+    s
+  }
+
+  override def wrapLimitingStream(jis: java.io.InputStream, state: PState) = {
+    val layerLengthInBytes: Int = layerLengthInBytesEv.evaluate(state).toInt
+    val s = new ExplicitLengthLimitingStream(jis, layerLengthInBytes)
+    s
+  }
+
+  override protected def wrapLayerEncoder(jos: java.io.OutputStream): java.io.OutputStream = {
+    val s = new ZipAllEntriesOutputStream(jos)
+    s
+  }
+
+  override protected def wrapLimitingStream(jos: java.io.OutputStream, state: UState): java.io.OutputStream = {
+    jos // just return jis. The way the length will be used/stored is by way of
+    // taking the content length of the enclosing element. That will measure the
+    // length relative to the "ultimate" data output stream.
+  }
+}
+
+final class ZipAllEntriesInputStream(is: InputStream)
+  extends java.io.InputStream {
+
+  private lazy val sbc = new SeekableInMemoryByteChannel(IOUtils.toByteArray(is))
+  private lazy val zf = new ZipFile(sbc)
+  private val emptyByteArray = new Array[Byte](0)
+  private val emptyInputStream = new ByteArrayInputStream(emptyByteArray)
+
+  private lazy val zeis: InputStream = {
+    val entries = zf.getEntries.asScala
+    var priorInputStream: InputStream = emptyInputStream
+    while (entries.hasNext) {
+      //
+      // now we pull all the entry fields off the entry
+      //
+      // we don't bother with getSize() nor getCompressedSize() because
+      // the API says they can return -1, so we can't depend on them being there.
+      //
+      val e: ZipArchiveEntry = entries.next()
+      val comment: String = "" // Option(e.getComment()).getOrElse("")
+      val extra: Array[Byte] = emptyByteArray // Option(e.getExtra()).getOrElse(emptyByteArray)
+      val method: Int = e.getMethod()
+      val name: String = e.getName()
+      val time: Long = 0L // e.getTime() // modification time, or -1 if not specified
+      val isDirectory: Boolean = e.isDirectory()
+      // val crc: Long = e.getCrc()
+
+      val baos = new ByteArrayOutputStream()
+      val jdos = new java.io.DataOutputStream(baos)
+      jdos.writeInt(name.length * 2) // 4 byte length in bytes not characters
+      jdos.writeInt(comment.length * 2) // 4 byte length in bytes not characters
+      jdos.writeInt(extra.length) // 4 byte length in bytes
+      jdos.writeInt(method) // 4 byte value
+      jdos.writeLong(time) // 8 byte value - milliseconds since the epoch.
+      jdos.writeBoolean(isDirectory) // single byte. 1 is true, 0 is false
+
+      // Now we want to write out a 8-byte data length
+      // But because zip entries don't necessarily have the uncompressed data length
+      // ( the getSize() method of ZipEntry is allowed to return -1 for unknown length )
+      // we actually have to compute the length while we consume the data.
+
+      val dataBaos = new ByteArrayOutputStream()
+      val dataInputStream = zf.getInputStream(e)
+      val dataLength = org.apache.commons.io.IOUtils.copyLarge(dataInputStream, dataBaos)
+      dataBaos.close()
+      dataInputStream.close()
+      jdos.writeLong(dataLength) // 8 byte length of uncompressed data (in bytes)
+
+      // That's the end of all the fixed-position parts of the header
+
+      Assert.invariant(jdos.size() == 33) // fixed length part.
+
+      // Now we have all the variable-length parts
+
+      jdos.writeChars(name) // string in utf16 encoding
+      jdos.writeChars(comment) // string in utf16 encoding
+      jdos.write(extra) // byte array
+
+      jdos.close()
+      val entryHeaderInputStream = new ByteArrayInputStream(baos.toByteArray)
+      val dataBais = new ByteArrayInputStream(dataBaos.toByteArray)
+      priorInputStream =
+        new SequenceInputStream(priorInputStream,
+          new SequenceInputStream(entryHeaderInputStream, dataBais))
+    }
+    priorInputStream
+  }
+
+  override def read(): Int = {
+    val res = zeis.read()
+    res
+  }
+}
+
+final class ZipAllEntriesOutputStream(os: OutputStream)
+  extends OutputStream {
+
+  private lazy val sbc = new SeekableInMemoryByteChannel()
+  private lazy val zos = new ZipArchiveOutputStream(sbc)
+
+  private object State extends Enumeration {
+    type State = Value
+    val Header, Name, Comment, Extra, Data = Value
+  }
+
+  import State._
+
+  private val headerLength = 33
+
+  private var state: State = Header
+  private val headerBaos = new ByteArrayOutputStream(headerLength)
+  private var nameLen: Int = 0 // length in bytes
+  private var name: String = null
+  private var commentLen: Int = 0 // length in bytes
+  private var comment: String = null
+  private var extraLen: Int = 0 // length in bytes.
+  private var extra: Array[Byte] = null
+  private var method: Int = 0
+  private var time: Long = 0L
+  private var isDirectory: Boolean = false
+  private var dataLength: Long = 0L
+  private var dataCount: Long = 0L // counts from 0 to dataLength so we know when we've got all the data.
+
+  private val nameBaos = new ByteArrayOutputStream()
+  private val commentBaos = new ByteArrayOutputStream()
+  private val extraBaos = new ByteArrayOutputStream()
+
+  override def write(b: Int) = {
+    var tryAgain = true
+    while (tryAgain) {
+      tryAgain = false // by default we don't go around the loop again
+      state match {
+        case Header => {
+          // accumulating the header
+          if (headerBaos.size() < headerLength) headerBaos.write(b)
+          if (headerBaos.size() == headerLength) {
+            // We have accumulated the whole header
+            val jdis = new java.io.DataInputStream(new ByteArrayInputStream(headerBaos.toByteArray))
+
+            nameLen = jdis.readInt() // 4 byte length
+            commentLen = jdis.readInt() // 4 byte length
+            extraLen = jdis.readInt() // 4 byte length
+            method = jdis.readInt() // 4 byte value
+            time = jdis.readLong() // 8 byte value
+            isDirectory = jdis.readBoolean() // single byte. 1 is true, 0 is false
+            dataLength = jdis.readLong()
+
+            headerBaos.reset()
+            state = Name // transition. Next we accumulate the name.
+          }
+        }
+        case Name => {
+          Assert.invariant(nameLen > 0)
+          if (nameBaos.size < nameLen) nameBaos.write(b)
+          if (nameBaos.size() == nameLen) {
+            name = new String(nameBaos.toByteArray, StandardCharsets.UTF_16BE)
+            if (isDirectory)
+              Assert.invariant(name.endsWith("/")) // TBD: should we even check this?
+            nameBaos.reset()
+            state = Comment
+          }
+        }
+        case Comment if (commentLen == 0) => {
+          state = Extra
+          tryAgain = true
+        } // not isDone
+        case Comment => {
+          if (commentBaos.size() < commentLen) commentBaos.write(b)
+          if (commentBaos.size() == commentLen) {
+            comment = new String(commentBaos.toByteArray, StandardCharsets.UTF_16BE)
+            commentBaos.reset()
+            state = Extra
+          }
+        }
+        case Extra if (extraLen == 0) => {
+          extra = emptyByteArray
+          finishEntry()
+          state = Data
+          tryAgain = true
+        }
+        case Extra => {
+          if (extraBaos.size() < extraLen) extraBaos.write(b)
+          if (extraBaos.size() == extraLen) {
+            extra = extraBaos.toByteArray
+            extraBaos.reset()
+            // Now we can create the entry and write all the fields to it.
+            finishEntry()
+            state = Data
+          }
+        }
+        case Data if (dataLength == 0) => {
+          zos.closeArchiveEntry()
+          state = Header
+          tryAgain = true
+        }
+        case Data => {
+          if (dataCount < dataLength) {
+            zos.write(b)
+            dataCount += 1
+          }
+          if (dataCount == dataLength) {
+            zos.closeArchiveEntry()
+            dataCount = 0
+            state = Header
+          }
+        }
+      }
+    }
+  }
+
+  private def finishEntry() : Unit = {
+    val e = new ZipArchiveEntry(name)
+    // e.setComment("") // comment)
+    // e.setExtra(emptyByteArray) // extra)
+    e.setTime(0L)// time)
+    e.setMethod(method)
+    zos.putArchiveEntry(e)
+  }
+
+  override def close(): Unit = {
+    Assert.usageErrorUnless(state == Header && headerBaos.size() == 0, "Closed in middle of an entry.")
+    zos.close()
+    val rawBytes: Array[Byte] = sbc.array()
+    val sz = sbc.size()
+    os.write(rawBytes, 0, sz.toInt)
+    os.flush()
+    os.close()
+  }
+}
+
+object ZIPTransformerFactory
+  extends LayerTransformerFactory("zip") {
+
+  override def newInstance(
+    maybeLayerCharsetEv: Maybe[LayerCharsetEv],
+    maybeLayerLengthKind: Maybe[LayerLengthKind],
+    maybeLayerLengthInBytesEv: Maybe[LayerLengthInBytesEv],
+    maybeLayerLengthUnits: Maybe[LayerLengthUnits],
+    maybeLayerBoundaryMarkEv: Maybe[LayerBoundaryMarkEv],
+    tci: DPathCompileInfo): LayerTransformer = {
+
+    val xformer = new ZIPTransformer(maybeLayerLengthInBytesEv.get)
+    xformer
+  }
+}

--- a/daffodil-test/src/test/resources/org/apache/daffodil/layers/ziplayer.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/layers/ziplayer.tdml
@@ -1,0 +1,209 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<tdml:testSuite xmlns:tdml="http://www.ibm.com/xmlns/dfdl/testData"
+                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/" xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                xmlns:fn="http://www.w3.org/2005/xpath-functions"
+                xmlns:daf="urn:ogf:dfdl:2013:imp:daffodil.apache.org:2018:ext"
+                xmlns:dfdlx="http://www.ogf.org/dfdl/dfdl-1.0/extensions"
+                xmlns:ex="http://example.com" xmlns:tns="http://example.com" defaultRoundTrip="onePass">
+
+  <tdml:defineSchema name="s1" elementFormDefault="unqualified">
+    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+    <dfdl:defineFormat name="general">
+      <dfdl:format ref="ex:GeneralFormat"/>
+    </dfdl:defineFormat>
+    <dfdl:defineFormat name="zip">
+      <dfdl:format ref="ex:general"
+                   dfdlx:layerTransform="zip"
+                   dfdlx:layerLengthKind="explicit"
+                   dfdlx:layerLengthUnits="bytes"/>
+    </dfdl:defineFormat>
+    <dfdl:format ref="ex:general" representation="binary" byteOrder="bigEndian"
+                 alignment="1" alignmentUnits="bytes" lengthUnits="bytes" encoding="UTF-16BE"/>
+
+    <xs:element name="zipFile">
+      <xs:complexType>
+        <xs:sequence>
+          <xs:element name="zipLength" type="xs:long" dfdl:lengthKind="implicit"
+                      dfdl:outputValueCalc='{ dfdl:contentLength(../zip, "bytes") }'/>
+          <xs:element name="zip" type="tns:zipType"/>
+        </xs:sequence>
+      </xs:complexType>
+    </xs:element>
+
+    <xs:complexType name="zipType">
+      <xs:sequence dfdl:ref="tns:zip" dfdlx:layerLength="{ ../zipLength }">
+        <xs:element name="zipEntries">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="zipEntry" maxOccurs="unbounded" dfdl:occursCountKind="implicit">
+                <xs:complexType>
+                  <xs:sequence>
+                    <xs:element name="nameLen" type="xs:unsignedInt" dfdl:lengthKind="explicit" dfdl:length="4"
+                                dfdl:outputValueCalc='{ dfdl:valueLength(../name, "bytes") }'/>
+                    <xs:element name="commentLen" type="xs:unsignedInt" dfdl:lengthKind="explicit" dfdl:length="4"
+                                dfdl:outputValueCalc='{ dfdl:valueLength(../comment, "bytes") }'/>
+                    <xs:element name="extraLen" type="xs:unsignedInt" dfdl:lengthKind="explicit" dfdl:length="4"
+                                dfdl:outputValueCalc='{ dfdl:valueLength(../extra, "bytes") }'/>
+                    <xs:element name="method" type="xs:unsignedInt" dfdl:lengthKind="explicit" dfdl:length="4"/>
+                    <xs:element name="time" type="xs:long" dfdl:lengthKind="explicit" dfdl:length="8"/>
+                    <xs:element name="isDirectory" type="xs:boolean" dfdl:lengthKind="explicit" dfdl:length="1"
+                                dfdl:binaryBooleanTrueRep="1" dfdl:binaryBooleanFalseRep="0"
+                                dfdl:outputValueCalc='{ fn:ends-with(../name, "/") }'/>
+                    <xs:element name="dataLen" type="xs:unsignedLong" dfdl:lengthKind="explicit" dfdl:length="8"
+                                dfdl:outputValueCalc='{ dfdl:valueLength(../data, "bytes") }'/>
+                    <xs:element name="name" type="xs:string" dfdl:lengthKind="explicit"
+                                dfdl:length="{ ../nameLen }"/>
+                    <xs:element name="comment" type="xs:string" dfdl:lengthKind="explicit"
+                                dfdl:length="{ ../commentLen }"/>
+                    <xs:element name="extra" type="xs:hexBinary" dfdl:lengthKind="explicit"
+                                dfdl:length="{ ../extraLen }"/>
+                    <xs:element name="data" type="xs:hexBinary" dfdl:lengthKind="explicit"
+                                dfdl:length="{ ../dataLen }"/>
+                  </xs:sequence>
+                </xs:complexType>
+              </xs:element>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+      </xs:sequence>
+    </xs:complexType>
+
+  </tdml:defineSchema>
+
+  <tdml:unparserTestCase name="zipLayer1u" model="s1" roundTrip="onePass">
+    <tdml:document>
+      <!--
+      <tdml:documentPart type="byte"><![CDATA[
+00 00 00 00 00 00 00 A4
+50 4b 03 04 0a 03 00 00 00 00 46 71 36 52 b5 37
+3c 98 10 00 00 00 10 00 00 00 07 00 00 00 66 6f
+6f 2e 74 78 74 30 31 32 33 34 35 36 37 38 39 41
+42 43 44 45 46 50 4b 01 02 3f 03 0a 03 00 00 00
+00 46 71 36 52 b5 37 3c 98 10 00 00 00 10 00 00
+00 07 00 24 00 00 00 00 00 00 00 20 80 b4 81 00
+00 00 00 66 6f 6f 2e 74 78 74 0a 00 20 00 00 00
+00 00 01 00 18 00 00 c2 3d 35 f2 f0 d6 01 80 39
+cc 3b f2 f0 d6 01 00 c2 3d 35 f2 f0 d6 01 50 4b
+05 06 00 00 00 00 01 00 01 00 59 00 00 00 35 00
+00 00 00 00                                     ]]>
+      </tdml:documentPart>
+-->
+        <tdml:documentPart type="byte"><![CDATA[
+0000000000000094
+50 4B 03 04 0A 00 00 08 00 00 00 21 00 00 B5 37
+3C 98 10 00 00 00 10 00 00 00 07 00 14 00 66 6F
+6F2E7478740100100010000000000000
+00100000000000000030313233343536
+373839414243444546504B010214000A
+000008000000210000B5373C98100000
+00100000000700000000000000000000
+00000000000000666F6F2E747874504B
+05060000000001000100350000004900
+00000000
+          ]]>
+        </tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <ex:zipFile xmlns:ex="http://example.com">
+          <zipLength>148</zipLength>
+          <zip>
+            <zipEntries>
+              <zipEntry>
+                <nameLen>14</nameLen>
+                <commentLen>0</commentLen>
+                <extraLen>0</extraLen>
+                <method>0</method>
+                <time>0</time>
+                <isDirectory>false</isDirectory>
+                <dataLen>16</dataLen>
+                <name>foo.txt</name>
+                <comment></comment>
+                <extra></extra>
+                <data>30313233343536373839414243444546</data>
+              </zipEntry>
+            </zipEntries>
+          </zip>
+        </ex:zipFile>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:unparserTestCase>
+
+  <tdml:parserTestCase name="zipLayer1p" model="s1" roundTrip="onePass">
+    <tdml:document>
+      <!--
+      <tdml:documentPart type="byte"><![CDATA[
+00 00 00 00 00 00 00 A4
+50 4b 03 04 0a 03 00 00 00 00 46 71 36 52 b5 37
+3c 98 10 00 00 00 10 00 00 00 07 00 00 00 66 6f
+6f 2e 74 78 74 30 31 32 33 34 35 36 37 38 39 41
+42 43 44 45 46 50 4b 01 02 3f 03 0a 03 00 00 00
+00 46 71 36 52 b5 37 3c 98 10 00 00 00 10 00 00
+00 07 00 24 00 00 00 00 00 00 00 20 80 b4 81 00
+00 00 00 66 6f 6f 2e 74 78 74 0a 00 20 00 00 00
+00 00 01 00 18 00 00 c2 3d 35 f2 f0 d6 01 80 39
+cc 3b f2 f0 d6 01 00 c2 3d 35 f2 f0 d6 01 50 4b
+05 06 00 00 00 00 01 00 01 00 59 00 00 00 35 00
+00 00 00 00                                     ]]>
+      </tdml:documentPart>
+      -->
+      <tdml:documentPart type="byte"><![CDATA[
+0000000000000094
+50 4B 03 04 0A 00 00 08 00 00 00 21 00 00 B5 37
+3C 98 10 00 00 00 10 00 00 00 07 00 14 00 66 6F
+6F2E7478740100100010000000000000
+00100000000000000030313233343536
+373839414243444546504B010214000A
+000008000000210000B5373C98100000
+00100000000700000000000000000000
+00000000000000666F6F2E747874504B
+05060000000001000100350000004900
+00000000
+          ]]>
+      </tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <ex:zipFile xmlns:ex="http://example.com">
+          <zipLength>148</zipLength>
+          <zip>
+            <zipEntries>
+              <zipEntry>
+                <nameLen>14</nameLen>
+                <commentLen>0</commentLen>
+                <extraLen>0</extraLen>
+                <method>0</method>
+                <time>0</time>
+                <isDirectory>false</isDirectory>
+                <dataLen>16</dataLen>
+                <name>foo.txt</name>
+                <comment></comment>
+                <extra></extra>
+                <data>30313233343536373839414243444546</data>
+              </zipEntry>
+            </zipEntries>
+          </zip>
+        </ex:zipFile>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+</tdml:testSuite>

--- a/daffodil-test/src/test/scala/org/apache/daffodil/layers/TestZipLayer.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/layers/TestZipLayer.scala
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.daffodil.layers
+
+import org.apache.commons.compress.archivers.zip.ZipArchiveEntry
+import org.apache.commons.compress.archivers.zip.ZipArchiveInputStream
+import org.apache.commons.io.IOUtils
+import org.junit.Test
+import org.apache.daffodil.tdml.Runner
+import org.apache.daffodil.util.Misc
+import org.junit.AfterClass
+import org.junit.Assert.assertEquals
+
+import java.io.BufferedInputStream
+import java.io.ByteArrayInputStream
+import java.nio.charset.StandardCharsets
+
+object TestZipLayer {
+  lazy val testDir = "/org/apache/daffodil/layers/"
+  lazy val runner = Runner(testDir, "ziplayer.tdml")
+
+  @AfterClass def shutDown(): Unit = {
+    runner.reset
+  }
+}
+
+class TestZipLayer {
+
+  import TestZipLayer._
+
+  @Test def test_zip1p(): Unit = { runner.runOneTest("zipLayer1p") }
+
+  @Test def test_zip1u(): Unit = { runner.runOneTest("zipLayer1u") }
+
+  @Test def zip1() : Unit = {
+    val hex = """50 4b 03 04 0a 03 00 00 00 00 46 71 36 52 b5 37
+                |3c 98 10 00 00 00 10 00 00 00 07 00 00 00 66 6f
+                |6f 2e 74 78 74 30 31 32 33 34 35 36 37 38 39 41
+                |42 43 44 45 46 50 4b 01 02 3f 03 0a 03 00 00 00
+                |00 46 71 36 52 b5 37 3c 98 10 00 00 00 10 00 00
+                |00 07 00 24 00 00 00 00 00 00 00 20 80 b4 81 00
+                |00 00 00 66 6f 6f 2e 74 78 74 0a 00 20 00 00 00
+                |00 00 01 00 18 00 00 c2 3d 35 f2 f0 d6 01 80 39
+                |cc 3b f2 f0 d6 01 00 c2 3d 35 f2 f0 d6 01 50 4b
+                |05 06 00 00 00 00 01 00 01 00 59 00 00 00 35 00
+                |00 00 00 00""".stripMargin.replaceAll("\\s", "")
+    val bytes = Misc.hex2Bytes(hex)
+    // println("data length = " + bytes.size)
+    val bais = new BufferedInputStream(new ByteArrayInputStream(bytes))
+    val zis = new ZipArchiveInputStream(bais)
+    var e: ZipArchiveEntry = zis.getNextZipEntry()
+    while (e ne null) {
+      assertEquals("foo.txt", e.getName())
+      val data = IOUtils.toString(zis, StandardCharsets.UTF_8)
+      assertEquals("0123456789ABCDEF", data)
+      e = zis.getNextZipEntry()
+    }
+  }
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -33,6 +33,7 @@ object Dependencies {
     "org.apache.logging.log4j" %% "log4j-api-scala" % "12.0",
     "org.apache.logging.log4j" % "log4j-api" % "2.17.0",
     "org.apache.logging.log4j" % "log4j-core" % "2.17.0" % "it,test",
+    "org.apache.commons" % "commons-compress" % "1.20"
   )
 
   lazy val infoset = Seq(


### PR DESCRIPTION
Minimal testing so far.

This enables a message to contain a bunch of bytes that are the image of a zip file. 

It doesn't use DFDL to parse the zip file. It uses apache commons compress library to parse it as a layer, handing daffodil a known layout structure corresponding to each entry of the zip file containing pretty much just the name and contents (at the moment). 

For unparse, DFDL populates a known structure for each entry of the zip file, and the layer uses apache commons compress library to create a zip archive from those. 

Todo:
Test multiple files in the zip.
Test parsing known-kinds of structure depending on the file extension of the file. 

Known limitations:
Buffers everything into memory. Not suitable for large zip files. 

DAFFODIL-2459