### PR TITLE
ADD test for "%%" to bypass existing test for "%NL"

### DIFF
--- a/daffodil-lib/src/main/scala/org/apache/daffodil/cookers/Cookers.scala
+++ b/daffodil-lib/src/main/scala/org/apache/daffodil/cookers/Cookers.scala
@@ -63,7 +63,7 @@ object InitiatorCooker extends DelimiterCooker("initiator")
 
 object TerminatorCooker extends DelimiterCooker("terminator")
 
-object TerminatorCookerNoES extends DelimiterCookerNoES("terminator")
+object TerminatorDelimitedCooker extends DelimiterCookerNoSoleES("terminator")
 
 object SeparatorCooker extends DelimiterCookerNoES("separator")
 

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/EvDelimiters.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/EvDelimiters.scala
@@ -23,7 +23,7 @@ import org.apache.daffodil.processors.dfa.CreateDelimiterDFA
 import org.apache.daffodil.exceptions.Assert
 import org.apache.daffodil.processors.unparsers.UState
 import org.apache.daffodil.processors.parsers.DelimiterTextType
-import org.apache.daffodil.cookers.TerminatorCookerNoES
+import org.apache.daffodil.cookers.TerminatorDelimitedCooker
 import org.apache.daffodil.cookers.SeparatorCooker
 import org.apache.daffodil.cookers.InitiatorCooker
 import org.apache.daffodil.cookers.TerminatorCooker
@@ -117,13 +117,13 @@ class InitiatorUnparseEv(expr: CompiledExpression[String], outputNewLine: Output
 class TerminatorParseEv(expr: CompiledExpression[String], isLengthKindDelimited: Boolean, ignoreCase: Boolean, tci: DPathCompileInfo)
   extends DelimiterParseEv(DelimiterTextType.Terminator, expr, ignoreCase, tci) {
 
-  override val converter = if (isLengthKindDelimited) TerminatorCookerNoES else TerminatorCooker
+  override val converter = if (isLengthKindDelimited) TerminatorDelimitedCooker else TerminatorCooker
 }
 
 class TerminatorUnparseEv(expr: CompiledExpression[String], isLengthKindDelimited: Boolean, outputNewLine: OutputNewLineEv, tci: DPathCompileInfo)
   extends DelimiterUnparseEv(DelimiterTextType.Terminator, expr, outputNewLine, tci) {
 
-  override val converter = if (isLengthKindDelimited) TerminatorCookerNoES else TerminatorCooker
+  override val converter = if (isLengthKindDelimited) TerminatorDelimitedCooker else TerminatorCooker
 }
 
 class SeparatorParseEv(expr: CompiledExpression[String], ignoreCase: Boolean, tci: DPathCompileInfo)

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/Entities.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/Entities.tdml
@@ -1236,7 +1236,7 @@ is multiple bytes in UTF-8 encoding that is used"
     <tdml:errors>
       <tdml:error>Schema Definition Error</tdml:error>
       <tdml:error>dfdl:terminator</tdml:error>
-      <tdml:error>cannot contain %ES;</tdml:error>
+      <tdml:error>ES entity cannot appear on its own</tdml:error>
       <tdml:error>dfdl:lengthKind="delimited"</tdml:error>
     </tdml:errors>
   </tdml:parserTestCase>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/entities_01.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/entities_01.tdml
@@ -46,8 +46,8 @@
     </tdml:document>
     <tdml:errors>
       <tdml:error>Separator</tdml:error>
-      <tdml:error>cannot</tdml:error>
-      <tdml:error>contain</tdml:error>
+      <tdml:error>contains</tdml:error>
+      <tdml:error>disallowed</tdml:error>
       <tdml:error>ES</tdml:error>
     </tdml:errors>
   </tdml:parserTestCase>
@@ -267,8 +267,8 @@
     <tdml:errors>
       <tdml:error>Schema definition error</tdml:error>
       <tdml:error>nilValue</tdml:error>
-      <tdml:error>cannot</tdml:error>
-      <tdml:error>contain</tdml:error>
+      <tdml:error>contains</tdml:error>
+      <tdml:error>disallowed</tdml:error>
       <tdml:error>NL</tdml:error>
     </tdml:errors>
   </tdml:parserTestCase>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section12/delimiter_properties/DelimiterPropertiesUnparse.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section12/delimiter_properties/DelimiterPropertiesUnparse.tdml
@@ -253,7 +253,7 @@
       <tdml:error>Schema Definition Error</tdml:error>
       <tdml:error>dfdl:terminator</tdml:error>
       <tdml:error>cannot</tdml:error>
-      <tdml:error>contain</tdml:error>
+      <tdml:error>own</tdml:error>
       <tdml:error>ES</tdml:error>
     </tdml:errors>
   </tdml:unparserTestCase>
@@ -331,8 +331,8 @@
   <tdml:errors>
     <tdml:error>Schema Definition Error</tdml:error>
     <tdml:error>Separator</tdml:error>
-    <tdml:error>cannot</tdml:error>
-    <tdml:error>contain</tdml:error>
+    <tdml:error>contains</tdml:error>
+    <tdml:error>disallowed</tdml:error>
     <tdml:error>ES</tdml:error>
   </tdml:errors>
 

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section13/nillable/literal-character-nils.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section13/nillable/literal-character-nils.tdml
@@ -230,8 +230,8 @@
     <tdml:errors>
       <tdml:error>Schema Definition Error</tdml:error>
       <tdml:error>nilValue</tdml:error>
-      <tdml:error>cannot</tdml:error>
-      <tdml:error>contain</tdml:error>
+      <tdml:error>contains</tdml:error>
+      <tdml:error>disallowed</tdml:error>
       <tdml:error>WSP*</tdml:error>
     </tdml:errors>
   </tdml:parserTestCase>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section13/text_number_props/TextNumberProps.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section13/text_number_props/TextNumberProps.tdml
@@ -1459,7 +1459,7 @@
     </tdml:document>
     <tdml:errors>
       <tdml:error>Schema Definition Error</tdml:error>
-      <tdml:error>textStandardDecimalSeparator cannot contain %WSP;</tdml:error>
+      <tdml:error>textStandardDecimalSeparator contains disallowed character class(es): %WSP;</tdml:error>
     </tdml:errors>
 
   </tdml:parserTestCase>
@@ -1889,7 +1889,7 @@
     </tdml:document>
     <tdml:errors>
       <tdml:error>Schema Definition Error</tdml:error>
-      <tdml:error>textStandardGroupingSeparator cannot contain %NL;</tdml:error>
+      <tdml:error>textStandardGroupingSeparator contains disallowed character class(es): %NL;</tdml:error>
     </tdml:errors>
   </tdml:parserTestCase>
   
@@ -3621,8 +3621,8 @@
   <tdml:errors>
     <tdml:error>Schema Definition Error</tdml:error>
     <tdml:error>textStandardDecimalSeparator</tdml:error>
-    <tdml:error>cannot</tdml:error>
-    <tdml:error>contain</tdml:error>
+    <tdml:error>contains</tdml:error>
+    <tdml:error>disallowed</tdml:error>
     <tdml:error>%NL;</tdml:error>
   </tdml:errors>
   </tdml:parserTestCase>
@@ -3645,8 +3645,8 @@
     <tdml:errors>
       <tdml:error>Schema Definition Error</tdml:error>
       <tdml:error>textStandardGroupingSeparator</tdml:error>
-      <tdml:error>cannot</tdml:error>
-      <tdml:error>contain</tdml:error>
+      <tdml:error>contains</tdml:error>
+      <tdml:error>disallowed</tdml:error>
       <tdml:error>%WSP+;</tdml:error>
     </tdml:errors>
   </tdml:parserTestCase>
@@ -3816,7 +3816,7 @@
 
     <tdml:errors>
       <tdml:error>Schema Definition Error</tdml:error>
-      <tdml:error>textStandardExponentRep cannot contain %NL;</tdml:error>
+      <tdml:error>textStandardExponentRep contains disallowed character class(es): %NL;</tdml:error>
     </tdml:errors>
 
   </tdml:parserTestCase>
@@ -4090,7 +4090,7 @@
 
     <tdml:errors>
       <tdml:error>Schema Definition Error</tdml:error>
-      <tdml:error>textStandardNaNRep cannot contain %NL;</tdml:error>
+      <tdml:error>textStandardNaNRep contains disallowed character class(es): %NL;</tdml:error>
     </tdml:errors>
 
   </tdml:parserTestCase>
@@ -4120,7 +4120,7 @@
 
     <tdml:errors>
       <tdml:error>Schema Definition Error</tdml:error>
-      <tdml:error>textStandardInfinityRep cannot contain %NL;</tdml:error>
+      <tdml:error>textStandardInfinityRep contains disallowed character class(es): %NL;</tdml:error>
     </tdml:errors>
 
   </tdml:parserTestCase>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section13/text_number_props/TextNumberPropsUnparse.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section13/text_number_props/TextNumberPropsUnparse.tdml
@@ -470,7 +470,7 @@
     </tdml:infoset>
     <tdml:errors>
       <tdml:error>Schema Definition Error</tdml:error>
-      <tdml:error>textStringPadCharacter cannot contain %WSP+;</tdml:error>
+      <tdml:error>textStringPadCharacter contains disallowed character class(es): %WSP+;</tdml:error>
     </tdml:errors>
   </tdml:unparserTestCase>
 
@@ -489,8 +489,8 @@
   <tdml:errors>
     <tdml:error>Schema Definition Error</tdml:error>
     <tdml:error>textStringPadCharacter</tdml:error>
-    <tdml:error>cannot</tdml:error>
-    <tdml:error>contain</tdml:error>
+    <tdml:error>contains</tdml:error>
+    <tdml:error>disallowed</tdml:error>
     <tdml:error>NL</tdml:error>
   </tdml:errors>
   </tdml:unparserTestCase>
@@ -510,8 +510,8 @@
   <tdml:errors>
     <tdml:error>Schema Definition Error</tdml:error>
     <tdml:error>textStringPadCharacter</tdml:error>
-    <tdml:error>cannot</tdml:error>
-    <tdml:error>contain</tdml:error>
+    <tdml:error>contains</tdml:error>
+    <tdml:error>disallowed</tdml:error>
     <tdml:error>ES</tdml:error>
   </tdml:errors>
   </tdml:unparserTestCase>


### PR DESCRIPTION
Add an if test to the noCharClassEntities function to not throw an SDE when the passed string
contains "%%NL"

daffodil-774