### PR TITLE
Add debugger "info suspensions" and "set diffExcludes" commands

### DIFF
--- a/daffodil-cli/src/it/resources/org/apache/daffodil/CLI/input/input1.txt.xml
+++ b/daffodil-cli/src/it/resources/org/apache/daffodil/CLI/input/input1.txt.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<tns:matrix xmlns:tns="http://www.example.org/example1/">
+  <tns:row>
+    <tns:cell>0</tns:cell>
+    <tns:cell>1</tns:cell>
+    <tns:cell>2</tns:cell>
+  </tns:row>
+</tns:matrix>

--- a/daffodil-cli/src/it/resources/org/apache/daffodil/CLI/input/input9.txt.xml
+++ b/daffodil-cli/src/it/resources/org/apache/daffodil/CLI/input/input9.txt.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<ex:list xmlns:ex="http://example.com">
+  <ex:Item>
+    <ex:description>Shirts</ex:description>
+    <ex:comment>Sold on Monday</ex:comment>
+    <ex:quantity>30</ex:quantity>
+    <ex:price>17.99</ex:price>
+  </ex:Item>
+  <ex:Item>
+    <ex:description>Shoes</ex:description>
+    <ex:comment>Sold on Tuesday</ex:comment>
+    <ex:quantity>23</ex:quantity>
+    <ex:price>89.99</ex:price>
+  </ex:Item>
+</ex:list>

--- a/daffodil-cli/src/it/scala/org/apache/daffodil/CLI/Util.scala
+++ b/daffodil-cli/src/it/scala/org/apache/daffodil/CLI/Util.scala
@@ -150,6 +150,14 @@ object Util {
     }
   }
 
+  def devNull(): String = {
+    if (isWindows) {
+      "NUL"
+    } else {
+      "/dev/null"
+    }
+  }
+
   def makeMultipleCmds(cmds: Array[String]): String = {
     if (isWindows) {
       cmds.mkString(" & ")

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/ProcessorStateBases.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/ProcessorStateBases.scala
@@ -80,6 +80,7 @@ trait StateForDebugger {
   def variableMap: VariableMap
   def delimitedParseResult: Maybe[dfa.ParseResult]
   def withinHiddenNest: Boolean
+  def suspensions: Seq[Suspension]
 }
 
 case class TupleForDebugger(
@@ -91,7 +92,8 @@ case class TupleForDebugger(
   val arrayPos: Long,
   val variableMap: VariableMap,
   val delimitedParseResult: Maybe[dfa.ParseResult],
-  val withinHiddenNest: Boolean)
+  val withinHiddenNest: Boolean,
+  val suspensions: Seq[Suspension])
   extends StateForDebugger
 
 trait SetProcessorMixin {
@@ -440,6 +442,7 @@ abstract class ParseOrUnparseState protected (
       variableMap.copy(), // deep copy since variableMap is mutable
       delimitedParseResult,
       withinHiddenNest,
+      suspensions,
     )
   }
 
@@ -571,6 +574,7 @@ final class CompileState(tci: DPathCompileInfo, maybeDataProc: Maybe[DataProcess
   def groupPos: Long = 0L
   def hasInfoset: Boolean = infoset_.isDefined
   def delimitedParseResult = Nope
+  def suspensions = Seq.empty
 
   private lazy val infoset_ : Maybe[DIElement] = Nope
 

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/SuspensionTracker.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/SuspensionTracker.scala
@@ -30,6 +30,8 @@ class SuspensionTracker(suspensionWaitYoung: Int, suspensionWaitOld: Int)
   private val suspensionsYoung = new Queue[Suspension]
   private val suspensionsOld = new Queue[Suspension]
 
+  def suspensions: Seq[Suspension] = suspensionsYoung.toSeq ++ suspensionsOld.toSeq
+
   private var count: Int = 0
 
   private var suspensionStatTracked: Int = 0

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/PState.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/PState.scala
@@ -525,6 +525,8 @@ final class PState private (
       }
     }
   }
+
+  def suspensions = Seq.empty
 }
 
 object PState {

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/unparsers/UState.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/unparsers/UState.scala
@@ -385,6 +385,8 @@ final class UStateForSuspension(
   override def getDecoder(cs: BitsCharset): BitsCharsetDecoder = mainUState.getDecoder(cs)
   override def getEncoder(cs: BitsCharset): BitsCharsetEncoder = mainUState.getEncoder(cs)
 
+  override def suspensions = mainUState.suspensions
+
   // override def charBufferDataOutputStream = mainUState.charBufferDataOutputStream
   override def withUnparserDataInputStream = mainUState.withUnparserDataInputStream
   override def withByteArrayOutputStream = mainUState.withByteArrayOutputStream
@@ -631,6 +633,8 @@ final class UStateMain private (
     suspensionTracker.evalSuspensions()
     if (isFinal) suspensionTracker.requireFinal()
   }
+
+  def suspensions = suspensionTracker.suspensions
 
   final override def pushTRD(trd: TermRuntimeData) =
     inputter.pushTRD(trd)


### PR DESCRIPTION
- Add new trait for info commands that are Seq's rather than simple
  values, implementing act() and diff() functions
- Use this new trait to create a new "info suspensions" command to list
  the current suspensions. For example:

      (debug) info suspensions
        suspensions:
          SuppressableSeparatorUnparserSuspendableOperation for title
          RegionSplitSuspendableOperation for title
          SuppressableSeparatorUnparserSuspendableOperation for title
      (debug) info diff
        suspensions:
          + SuppressableSeparatorUnparserSuspendableOperation for title

- Add a new "set diffExcludes" command to exclude info commands from
  showing up in "info diff". This can be useful if there are certain
  diffs that happen all the time that the user doesn't care about. For
  example:

      (debug) set diffExcludes bitPosition bitLimit suspensions

- Skip debug steps during suspensions. This currently causes an abort
  (some suspension state should never be accessed), but also can cause
  confusing during debugging, especially related to diffs, since
  Daffodil temporarily time travel when evaluating suspensions. More
  thought is needed to figure out best how to debug suspensions so the
  time travel aspect is obvious and understandable.

DAFFODIL-758