### PR TITLE
Patterns to match strings with newlines.

### DIFF
--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/Facets.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/Facets.scala
@@ -44,7 +44,8 @@ trait Facets { self: Restriction =>
 
   private def retrieveFacetValuesFromRestrictionBase(xml: Node, facetName: Facet.Type): Seq[String] = {
     val res = xml \\ "restriction" \ facetName.toString() \\ "@value"
-    if (res.length > 0) res.map(n => n.text).toList else List.empty
+    val ret = if (res.length > 0) res.map(n => n.text).toList else List.empty
+    ret
   }
   private def enumeration(xml: Node): Seq[String] = { retrieveFacetValuesFromRestrictionBase(xml, Facet.enumeration) }
   private def fractionDigits(xml: Node): String = { retrieveFacetValueFromRestrictionBase(xml, Facet.fractionDigits) }
@@ -56,7 +57,8 @@ trait Facets { self: Restriction =>
   private def minLength(xml: Node): String = { retrieveFacetValueFromRestrictionBase(xml, Facet.minLength) }
   private def pattern(xml: Node): Seq[String] = {
     // Patterns are OR'd locally, AND'd remotely
-    retrieveFacetValuesFromRestrictionBase(xml, Facet.pattern).map(p => p)
+    val res = retrieveFacetValuesFromRestrictionBase(xml, Facet.pattern).map(p => p)
+    res
   }
   private def totalDigits(xml: Node): String = { retrieveFacetValueFromRestrictionBase(xml, Facet.totalDigits) }
   private def whitespace(xml: Node): String = { retrieveFacetValueFromRestrictionBase(xml, Facet.whiteSpace) }
@@ -128,10 +130,10 @@ trait Facets { self: Restriction =>
   final lazy val hasFractionDigits: Boolean = (localFractionDigitsValue != "") || (getRemoteFacetValues(Facet.fractionDigits).size > 0)
 
   final lazy val patternValues: Seq[FacetValueR] = {
-    val values = combinedBaseFacets.filter { case (f, _) => f == Facet.pattern }
+    val values: Seq[(Facet.Type, Values)] = combinedBaseFacets.filter { case (f, _) => f == Facet.pattern }
     if (values.size > 0) {
       val res: Seq[FacetValueR] = values.map {
-        case (f, v) => {
+        case (f, v: String) => {
           //
           // The DFDL Infoset can contain strings which hold characters
           // that are not allowed in XML at all.
@@ -160,7 +162,7 @@ trait Facets { self: Restriction =>
           // The XSD numeric character entity &#xE000; can be used to match ASCII NUL
           // (char code 0).
           //
-          val remapped = XMLUtils.remapPUAToXMLIllegalCharacters(v)
+          val remapped: String = XMLUtils.remapPUAToXMLIllegalCharacters(v)
           (f, remapped.r)
         }
       }

--- a/daffodil-lib/src/test/scala/org/apache/daffodil/xml/test/unit/TestXMLUtils.scala
+++ b/daffodil-lib/src/test/scala/org/apache/daffodil/xml/test/unit/TestXMLUtils.scala
@@ -106,9 +106,9 @@ class TestXMLUtils {
   }
 
   @Test def testRemapPUAToXMLIllegalChar(): Unit = {
-    val ec = XMLUtils.remapPUAToXMLIllegalChar(false)(0xE000)
+    val ec = XMLUtils.remapPUAToXMLIllegalChar(0xE000)
     assertEquals(0x0, ec)
-    val ed = XMLUtils.remapPUAToXMLIllegalChar(false)(0xE880)
+    val ed = XMLUtils.remapPUAToXMLIllegalChar(0xE880)
     assertEquals(0xD880, ed)
   }
 
@@ -326,7 +326,6 @@ class TestXMLUtils {
     val path1 = createBlobFile(("00" * 1024) + ("A1" * 41))
     val path2 = createBlobFile(("00" * 1024))
     val diff = XMLUtils.computeBlobDiff("path", path1.toUri.toString, path2.toUri.toString)
-    println(diff)
     assertEquals("path.bytesAt(1025)", diff(0)._1)
     assertEquals("A1" * 40, diff(0)._2)
     assertEquals("", diff(0)._3)

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/RuntimeData.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/RuntimeData.scala
@@ -18,7 +18,6 @@
 package org.apache.daffodil.processors
 
 import scala.xml.NamespaceBinding
-
 import org.apache.daffodil.Implicits.ImplicitsSuppressUnusedImportWarning
 import org.apache.daffodil.dpath.NodeInfo
 import org.apache.daffodil.dpath.NodeInfo.PrimType
@@ -46,7 +45,10 @@ import org.apache.daffodil.xml.NS
 import org.apache.daffodil.xml.NamedQName
 import org.apache.daffodil.xml.QNameBase
 import org.apache.daffodil.xml.RefQName
-import org.apache.daffodil.xml.StepQName; object NoWarn { ImplicitsSuppressUnusedImportWarning() }
+import org.apache.daffodil.xml.StepQName
+import org.apache.daffodil.xml.XMLUtils
+
+import scala.util.matching.Regex; object NoWarn { ImplicitsSuppressUnusedImportWarning() }
 import java.util.regex.Matcher
 
 import org.apache.daffodil.api.UnqualifiedPathStepPolicy
@@ -305,7 +307,8 @@ final class SimpleTypeRuntimeData(
     if (e.patternValues.isDefinedAt(0)) {
       val check = checkPatterns(currentElement, patternMatchers)
       if (!check) {
-        val patternStrings = e.patternValues.map { case (_, pattern) => pattern }.mkString(",")
+        // The escaping is important here as error messages were impossible to figure out when control chars were involved.
+        val patternStrings = e.patternValues.map { case (_, r: Regex) => XMLUtils.escape(r.pattern.pattern()) }.mkString(",")
         return Error("facet pattern(s): %s".format(patternStrings))
       }
     }

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section05/facets/PatternRanges.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section05/facets/PatternRanges.tdml
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<tdml:testSuite
+  xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/"
+  xmlns:dfdlx="http://www.ogf.org/dfdl/dfdl-1.0/extensions"
+  xmlns:tdml="http://www.ibm.com/xmlns/dfdl/testData"
+  xmlns:ex="http://example.com"
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  defaultRoundTrip="onePass"
+  defaultValidation="on">
+
+  <tdml:defineSchema name="s">
+    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+
+    <dfdl:format ref="ex:GeneralFormat"/>
+
+    <xs:simpleType name="singleByteCharsWithCodepointLessThan1F"
+                    dfdl:encoding="iso-8859-1">
+      <xs:restriction base="xs:string">
+        <!--
+          We cannot depend on Daffodil's mapping from E009 to 9, E00A to A, and E00D to D.
+          Because that won't work in Xerces with "full" validation.
+          We can't use numeric entities for the tab, LF, or CR, because those aren't allowed in attribute
+          values (XML attribute normalization converts tabs, and line endings to spaces.)
+          So we use \t, \n, and \r for those control characters.
+
+          The result is this somewhat clumsy pattern is what is needed in DFDL to say you want only
+          code points in the original data of 0x00 to 0x1F to be valid.
+          -->
+        <xs:pattern value="[&#xE000;-&#xE008;\t\n&#xE00B;&#xE00C;\r&#xE00E;-&#xE01F;&#x20;-&#x7F;]*"/>
+      </xs:restriction>
+    </xs:simpleType>
+
+
+    <!-- note this is delimited, but there is no terminator. So End-of-Data
+         becomes the delimiter -->
+    <xs:element name="str" type="ex:singleByteCharsWithCodepointLessThan1F"
+       dfdl:lengthKind="delimited"/>
+
+
+  </tdml:defineSchema>
+
+  <tdml:parserTestCase name="patternRanges1" model="s"
+                       validation="limited" roundTrip="none">
+    <tdml:document>
+      <tdml:documentPart type="byte">00 01 09 0A 0B 0D 0E 1F 20 7F</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <!-- in the infoset note that 0A becomes &#x0A; in the below. But the CR (0D above)
+             also becomes &#x0A; because XML normalizes isolated CR to LF.
+             This can affect round-tripping of data, because information is actually lost here.
+             Some LFs come from LFs, and some LFs come from CRs, and we lose which is which.
+             If, however, all line endings are LF, or CRLF, then you can use dfdl:outputNewLine
+             to do the right thing.
+             -->
+        <ex:str>&#xE000;&#xE001;&#x09;&#x0A;&#xE00B;&#x0A;&#xE00E;&#xE01F;&#x20;&#x7F;</ex:str>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="patternRanges2" model="s"
+                       validation="limited" roundTrip="none">
+    <tdml:document>
+      <tdml:documentPart type="byte">00 01 09 0A 0B 0D 0E 1F 20 7F 80</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <!-- similar to patternRanges1 test, but has an out-of-range character -->
+        <ex:str>&#xE000;&#xE001;&#x09;&#x0A;&#xE00B;&#x0A;&#xE00E;&#xE01F; &#x7F;&#x80;</ex:str>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+    <tdml:validationErrors>
+      <tdml:error>ex:str failed facet checks</tdml:error>
+    </tdml:validationErrors>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="patternRangesXerces1" model="s"
+                       validation="on" roundTrip="none">
+    <tdml:document>
+      <tdml:documentPart type="byte">00 01 09 0A 0B 0D 0E 1F 20 7F</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <ex:str>&#xE000;&#xE001;&#x09;&#x0A;&#xE00B;&#x0A;&#xE00E;&#xE01F;&#x20;&#x7F;</ex:str>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="patternRangesXerces2" model="s"
+                       validation="on" roundTrip="none">
+    <tdml:document>
+      <tdml:documentPart type="byte">00 01 09 0A 0B 0D 0E 1F 20 7F 80</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <!-- similar to patternRanges1 test, but has an out-of-range character -->
+        <ex:str>&#xE000;&#xE001;&#x09;&#x0A;&#xE00B;&#x0A;&#xE00E;&#xE01F; &#x7F;&#x80;</ex:str>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+    <tdml:validationErrors>
+      <tdml:error>ex:str failed facet checks</tdml:error>
+    </tdml:validationErrors>
+  </tdml:parserTestCase>
+</tdml:testSuite>

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section05/facets/TestPatternRanges.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section05/facets/TestPatternRanges.scala
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.daffodil.section05.facets
+
+import org.apache.daffodil.tdml.Runner
+import org.junit.AfterClass
+import org.junit.Test
+
+object TestPatternRanges {
+  lazy val runner = Runner("/org/apache/daffodil/section05/facets", "PatternRanges.tdml")
+
+  @AfterClass def shutDown = {
+    runner.reset
+  }
+}
+
+class TestPatternRanges {
+  import org.apache.daffodil.section05.facets.TestPatternRanges._
+
+  @Test def test_patternRanges1() = { runner.runOneTest("patternRanges1") }
+  @Test def test_patternRanges2() = { runner.runOneTest("patternRanges2") }
+  @Test def test_patternRangesXerces1() = { runner.runOneTest("patternRangesXerces1") }
+  @Test def test_patternRangesXerces2() = { runner.runOneTest("patternRangesXerces2") }
+
+}


### PR DESCRIPTION
Tests added illustrating this.

Diagnostic messages about pattern facets improved
to include things like &#xE000; when that's part of the pattern facet.

Some cleanup of XMLUtils which was unclear to me whether it was doing the right thing. (It was)

DAFFODIL-2474 

https://issues.apache.org/jira/browse/DAFFODIL-2474