### PR TITLE
Fix hang caused by a zero-length first separated infix element

### DIFF
--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/SequenceParserBases.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/SequenceParserBases.scala
@@ -183,21 +183,21 @@ abstract class SequenceParserBase(
             if (ais ne Done) {
               pstate.mpstate.moveOverOneArrayIndexOnly()
             }
+
             if (currentPos > priorPos ||
-              ((resultOfTry eq AbsentRep) && pstate.isSuccess
-                && parser.isPositional) ||
+              ((resultOfTry eq AbsentRep) && pstate.isSuccess) ||
                 resultOfTry.isInstanceOf[SuccessParseAttemptStatus]) {
-              // we moved past something, so we're definitely not first
-              // in the group any more.
+              // If we consumed some bits, then we moved past something, and so
+              // we're definitely not first in the group any more.
               //
-              // Or if AbsentRep, and we're positional. Then also we
-              // move on in the group.
+              // Or if AbsentRep, that means we sucessfully parsed a
+              // zero-length separated element. Even though this element may
+              // not end up in the infoset due to separator suppression, we
+              // must still increment the group index since that is used to
+              // determine when to consume infix separators
               //
-              // But if not, if we're still at position zero, then
-              // whatever is next could still be first in the group
-              // and not get an infix separator. So we have to conditionally
-              // not move the group index unless we really did parse something.
-              //
+              // Otherwise, the parse failed or nothing was consumed and we do
+              // should not increment the group index.
               pstate.mpstate.moveOverOneGroupIndexOnly()
             }
 

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section14/sequence_groups/SequenceGroupNestedArray.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section14/sequence_groups/SequenceGroupNestedArray.tdml
@@ -196,7 +196,7 @@ jones,arya,cat,1986-02-19
     <tdml:document><![CDATA[last,first,middle,DOB
 ,preceded by an empty field,
 ,,preceded by two empty fields,
-notice lines of all commas are skipped
+notice lines of all commas create an empty record
 ,,,,,,,
 notice blank lines are skipped
 
@@ -217,8 +217,9 @@ notice blank lines are skipped
             <ex:item>preceded by two empty fields</ex:item>
           </ex:record>
           <ex:record>
-            <ex:item>notice lines of all commas are skipped</ex:item>
+            <ex:item>notice lines of all commas create an empty record</ex:item>
           </ex:record>
+          <ex:record />
           <ex:record>
             <ex:item>notice blank lines are skipped</ex:item>
           </ex:record>

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section14/sequence_groups/TestSequenceGroupNestedArray.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section14/sequence_groups/TestSequenceGroupNestedArray.scala
@@ -39,9 +39,7 @@ class TestSequenceGroupNestedArray {
 
   @Test def test_csv_nohang_1(): Unit = { runner.runOneTest("csv_nohang_1") }
   // DAFFODIL-2487 hang when minOccurs="0"
-  // @Test def test_csv_hang_1(): Unit = { runner.runOneTest("csv_hang_1") }
-  // @Test def test_csv_hang_2(): Unit = { runner.runOneTest("csv_hang_2") }
-  // @Test def test_csv_hang_3(): Unit = { runner.runOneTest("csv_hang_3") }
-
-
+  @Test def test_csv_hang_1(): Unit = { runner.runOneTest("csv_hang_1") }
+  @Test def test_csv_hang_2(): Unit = { runner.runOneTest("csv_hang_2") }
+  @Test def test_csv_hang_3(): Unit = { runner.runOneTest("csv_hang_3") }
 }


### PR DESCRIPTION
With infix separators, we only consume a separator after we have parsed
the first field, i.e. when groupPos > 1. The sequence logic has a
condition that prevents groupPos from being incremented when a
zero-length field is parsed when the field was positional. But this
means that if the first field is zero-length, and this condition was
hit, we do not increment groupPos, we never consume the first infix
separator, and thus we parse the same zero-length data infinitely,
causing a hang.

To fix this, we need to remove the isPositional condition that prevented
the groupPos from being incremented when zero length separated field was
parsed. Whether or not the field is positional should not matter--if a
separated field was successfully parsed, even if it was zero length, we
must still increment groupPos for the following separators to be parsed
correctly.

DAFFODIL-2487