### PR TITLE
WIP on doctype restriction 

### DIFF
--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/DFDLSchemaFile.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/DFDLSchemaFile.scala
@@ -145,7 +145,6 @@ final class DFDLSchemaFile(
       val ldr = new DaffodilXMLLoader(this)
       ldr.setValidation(true)
       try {
-        ldr.load(schemaSource) // validate as XML file with XML Schema for DFDL Schemas
         ldr.validateSchema(schemaSource) // validate as XSD (catches UPA errors for example)
       } catch {
         // ok to absorb SAX Parse Exception as we've captured those errors in error handling

--- a/daffodil-core/src/test/scala/org/apache/daffodil/processor/TestSAXParseUnparseAPI.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/processor/TestSAXParseUnparseAPI.scala
@@ -51,6 +51,7 @@ class TestSAXParseUnparseAPI {
 
     val unparseXMLReader = SAXParserFactory.newInstance().newSAXParser().getXMLReader
     unparseXMLReader.setFeature(XMLUtils.SAX_NAMESPACES_FEATURE, true)
+    XMLUtils.setSecureDefaults(unparseXMLReader)
     val baosUnparse = new ByteArrayOutputStream()
     val wbcUnparse = java.nio.channels.Channels.newChannel(baosUnparse)
     val unparseContentHandler = dp.newContentHandlerInstance(wbcUnparse)
@@ -78,6 +79,7 @@ class TestSAXParseUnparseAPI {
 
     val unparseXMLReader = SAXParserFactory.newInstance().newSAXParser().getXMLReader
     unparseXMLReader.setFeature(XMLUtils.SAX_NAMESPACES_FEATURE, true)
+    XMLUtils.setSecureDefaults(unparseXMLReader)
     val baosUnparse = new ByteArrayOutputStream()
     val wbcUnparse = java.nio.channels.Channels.newChannel(baosUnparse)
     val unparseContentHandler = dp.newContentHandlerInstance(wbcUnparse)
@@ -101,6 +103,7 @@ class TestSAXParseUnparseAPI {
     val wbcUnparse = java.nio.channels.Channels.newChannel(baosUnparse)
     val unparseContentHandler = dp.newContentHandlerInstance(wbcUnparse)
     unparseXMLReader.setContentHandler(unparseContentHandler)
+    XMLUtils.setSecureDefaults(unparseXMLReader)
     val baisUnparse = new ByteArrayInputStream(testInfosetString.getBytes)
     val inputSourceUnparse = new InputSource(baisUnparse)
     unparseXMLReader.parse(inputSourceUnparse)
@@ -130,6 +133,7 @@ class TestSAXParseUnparseAPI {
     val wbcUnparse = java.nio.channels.Channels.newChannel(baosUnparse)
     val unparseContentHandler = dp.newContentHandlerInstance(wbcUnparse)
     unparseXMLReader.setContentHandler(unparseContentHandler)
+    XMLUtils.setSecureDefaults(unparseXMLReader)
     val baisUnparse = new ByteArrayInputStream(testInfosetString.getBytes)
     val inputSourceUnparse = new InputSource(baisUnparse)
     unparseXMLReader.parse(inputSourceUnparse)

--- a/daffodil-core/src/test/scala/org/apache/daffodil/util/TestUtils.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/util/TestUtils.scala
@@ -85,6 +85,17 @@ object TestUtils {
     runSchemaOnRBC(testSchema, Misc.stringToReadableByteChannel(data), areTracing)
   }
 
+  /**
+   * Exposes the data processor object so that you can test its API conveniently.
+   */
+  def dataProcessorForTestString(testSchema: Node, data: String): (DataProcessor, InputStream) = {
+    val rbc = Misc.stringToReadableByteChannel(data)
+    val is = Channels.newInputStream(rbc)
+    val p = compileSchema(testSchema)
+    (p, is)
+    // runDataProcessorOnInputStream(p, is, areTracing)
+  }
+
   def testBinary(testSchema: Node, hexData: String, areTracing: Boolean = false): (DFDL.ParseResult, Node) = {
     val b = Misc.hex2Bytes(hexData)
     testBinary(testSchema, b, areTracing)

--- a/daffodil-japi/src/test/java/org/apache/daffodil/example/TestJavaAPI.java
+++ b/daffodil-japi/src/test/java/org/apache/daffodil/example/TestJavaAPI.java
@@ -40,6 +40,7 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.daffodil.japi.*;
 import org.apache.daffodil.japi.infoset.XMLTextInfosetOutputter;
+import org.apache.daffodil.xml.XMLUtils;
 import org.jdom2.output.Format;
 import org.junit.Test;
 
@@ -1008,6 +1009,7 @@ public class TestJavaAPI {
         try {
             org.xml.sax.XMLReader unparseXMLReader = javax.xml.parsers.SAXParserFactory.newInstance()
                     .newSAXParser().getXMLReader();
+            XMLUtils.setSecureDefaults(unparseXMLReader);
             unparseXMLReader.setContentHandler(unparseContentHandler);
             unparseXMLReader.setErrorHandler(errorHandler);
             unparseXMLReader.setFeature(SAX_NAMESPACES_FEATURE, true);
@@ -1143,6 +1145,7 @@ public class TestJavaAPI {
         try {
             org.xml.sax.XMLReader unparseXMLReader = javax.xml.parsers.SAXParserFactory.newInstance()
                     .newSAXParser().getXMLReader();
+            XMLUtils.setSecureDefaults(unparseXMLReader);
             unparseXMLReader.setContentHandler(unparseContentHandler);
             unparseXMLReader.setFeature(SAX_NAMESPACES_FEATURE, true);
             unparseXMLReader.setFeature(SAX_NAMESPACE_PREFIXES_FEATURE, true);

--- a/daffodil-lib/src/main/scala/org/apache/daffodil/api/DaffodilSchemaSource.scala
+++ b/daffodil-lib/src/main/scala/org/apache/daffodil/api/DaffodilSchemaSource.scala
@@ -17,15 +17,19 @@
 
 package org.apache.daffodil.api
 import org.xml.sax.InputSource
+
 import java.net.URI
 import scala.xml.Node
 import java.io.FileInputStream
 import org.apache.daffodil.xml.XMLUtils
 import org.apache.commons.io.input.XmlStreamReader
+
 import java.io.File
 import java.nio.file.Paths
 import org.apache.daffodil.exceptions.Assert
 import org.apache.daffodil.equality._
+
+import java.io.ByteArrayInputStream
 import java.nio.file.FileSystemNotFoundException
 
 /**
@@ -107,6 +111,27 @@ class URISchemaSource protected (val fileOrResource: URI) extends DaffodilSchema
       else false
     } else false
   }
+}
+
+/**
+ * Convenient for testing. Allows creating XML strings for loading that contain things
+ * not supported by scala XML syntax like DOCTYPE decls.
+ *
+ * @param str - string that is loaded as XML.
+ */
+case class StringSchemaSource(str: String)
+extends DaffodilSchemaSource {
+
+  private val delegate = InputStreamSchemaSource(new ByteArrayInputStream(str.getBytes()), None, "string", "")
+  /**
+   * Use to get a org.xml.sax.InputSource for use by Xerces
+   */
+  override def newInputSource() = delegate.newInputSource()
+
+  /**
+   * Use to get the URI that can be used to load the xml.
+   */
+  override def uriForLoading = delegate.uriForLoading
 }
 
 /**

--- a/daffodil-lib/src/main/scala/org/apache/daffodil/xml/DaffodilConstructingLoader.scala
+++ b/daffodil-lib/src/main/scala/org/apache/daffodil/xml/DaffodilConstructingLoader.scala
@@ -86,6 +86,14 @@ class DaffodilConstructingLoader(uri: URI, errorHandler: org.xml.sax.ErrorHandle
     Source.fromInputStream(is, enc)
   }, true) {
 
+  /**
+   * Ensures that DOCTYPES aka DTDs, if encountered, are rejected.
+   */
+  override def parseDTD(): Unit = {
+    val e = makeSAXParseException(pos, "DOCTYPE is disallowed.")
+    throw e
+  }
+
   // This one line is a bit of a hack to get consistent line numbers. The
   // scala-xml libary reads XML from a scala.io.Source which maintains private
   // line/col information about where in the Source we are reading from (i.e.

--- a/daffodil-lib/src/main/scala/org/apache/daffodil/xml/XMLUtils.scala
+++ b/daffodil-lib/src/main/scala/org/apache/daffodil/xml/XMLUtils.scala
@@ -21,13 +21,11 @@ import java.io.File
 import java.nio.file.Files
 import java.nio.file.Paths
 import java.nio.file.StandardOpenOption
-
 import scala.annotation.tailrec
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuilder
 import scala.xml.NamespaceBinding
 import scala.xml._
-
 import org.apache.commons.io.IOUtils
 import org.apache.daffodil.calendar.DFDLDateConversion
 import org.apache.daffodil.calendar.DFDLDateTimeConversion
@@ -36,6 +34,8 @@ import org.apache.daffodil.exceptions._
 import org.apache.daffodil.schema.annotation.props.LookupLocation
 import org.apache.daffodil.util.Maybe
 import org.apache.daffodil.util.Misc
+import org.xml.sax.SAXNotRecognizedException
+import org.xml.sax.XMLReader
 
 /**
  * Utilities for handling XML
@@ -450,6 +450,64 @@ object XMLUtils {
   val SAX_NAMESPACES_FEATURE = "http://xml.org/sax/features/namespaces"
   val SAX_NAMESPACE_PREFIXES_FEATURE = "http://xml.org/sax/features/namespace-prefixes"
 
+  /**
+   * Always enable this feature (which disables doctypes).
+   */
+  val XML_DISALLOW_DOCTYPE_FEATURE = "http://apache.org/xml/features/disallow-doctype-decl"
+
+  /**
+   * Always disable this. Might not be necessary if doctypes are disallowed.
+   */
+  val XML_EXTERNAL_PARAMETER_ENTITIES_FEATURE = "http://xml.org/sax/features/external-parameter-entities"
+
+  /**
+   * Always disable this. Might not be necessary if doctypes are disallowed.
+   */
+  val XML_EXTERNAL_GENERAL_ENTITIES_FEATURE = "http://xml.org/sax/features/external-general-entities"
+
+  /**
+   * Sets properties that disable insecure XML reader behaviors.
+   * @param xmlReader - the reader to change feature settings on.
+   */
+  def setSecureDefaults(xmlReader: XMLReader) : Unit = {
+    try {
+      xmlReader.setFeature(XMLUtils.XML_DISALLOW_DOCTYPE_FEATURE, true)
+      xmlReader.setFeature(XMLUtils.XML_EXTERNAL_PARAMETER_ENTITIES_FEATURE, false)
+      xmlReader.setFeature(XMLUtils.XML_EXTERNAL_GENERAL_ENTITIES_FEATURE, false)
+      // System.err.println("SAX XMLReader supports disallow properties: " + xmlReader)
+    } catch {
+      case e: SAXNotRecognizedException => {
+        // System.err.println("xmlReader: " + e.getMessage()) // good place for a breakpoint
+        throw e
+      }
+    }
+  }
+
+//  def setSecureDefaults(schemaFactory: org.apache.xerces.jaxp.validation.XMLSchemaFactory) : Unit = {
+//    try {
+//      schemaFactory.setFeature(XMLUtils.XML_DISALLOW_DOCTYPE_FEATURE, true)
+//      schemaFactory.setFeature(XMLUtils.XML_EXTERNAL_PARAMETER_ENTITIES_FEATURE, false)
+//      schemaFactory.setFeature(XMLUtils.XML_EXTERNAL_GENERAL_ENTITIES_FEATURE, false)
+//      System.err.println("SAX SchemaFactory supports disallow properties: " + schemaFactory)
+//    } catch {
+//      case e: SAXNotRecognizedException => {
+//        System.err.println("schemaFactory: " + e.getMessage())
+//      }
+//    }
+//  }
+
+//  def setSecureDefaults(saxParser: SAXParser) : Unit = {
+//    try {
+//    saxParser.setProperty(XMLUtils.XML_DISALLOW_DOCTYPE_FEATURE, true)
+//    saxParser.setProperty(XMLUtils.XML_EXTERNAL_PARAMETER_ENTITIES_FEATURE, false)
+//    saxParser.setProperty(XMLUtils.XML_EXTERNAL_GENERAL_ENTITIES_FEATURE, false)
+//      System.err.println("SAX parser supports disallow properties: " + saxParser)
+//    } catch {
+//      case e: SAXNotRecognizedException => {
+//        System.err.println("saxParser: " + e.getMessage())
+//      }
+//    }
+//  }
 
   val FILE_ATTRIBUTE_NAME = "file"
   val LINE_ATTRIBUTE_NAME = "line"

--- a/daffodil-lib/src/test/scala/org/apache/daffodil/xml/test/unit/TestXMLLoader.scala
+++ b/daffodil-lib/src/test/scala/org/apache/daffodil/xml/test/unit/TestXMLLoader.scala
@@ -17,8 +17,12 @@
 
 package org.apache.daffodil.xml.test.unit
 
+import org.apache.daffodil.Implicits.intercept
+import org.apache.daffodil.api.StringSchemaSource
+import org.apache.daffodil.xml.DaffodilXMLLoader
 import org.junit.Assert._
 import org.junit.Test
+import org.xml.sax.SAXParseException
 
 class TestXMLLoader {
 
@@ -57,4 +61,28 @@ b&"<>]]>"""))
 
   }
 
+  /**
+   * Verify that we don't accept doctype decls in our XML.
+   *
+   * Part of fixing DAFFODIL-1422, DAFFODIL-1659.
+   */
+  @Test
+  def testNoDoctypeAllowed() : Unit = {
+
+    val data = """<?xml version="1.0" ?>
+      <!DOCTYPE root_element [
+        Document Type Definition (DTD):
+        elements/attributes/entities/notations/
+          processing instructions/comments/PE references
+    ]>
+    <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"/>
+    """
+    val loader = new DaffodilXMLLoader()
+    val ss = StringSchemaSource(data)
+    val e = intercept[SAXParseException] {
+      loader.load(ss)
+    }
+    val m = e.getMessage()
+    assertTrue(m.contains("DOCTYPE is disallowed"))
+  }
 }

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/externalvars/ExternalVariablesLoader.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/externalvars/ExternalVariablesLoader.scala
@@ -17,16 +17,18 @@
 
 package org.apache.daffodil.externalvars
 
-import scala.xml.parsing.ConstructingParser
+import org.apache.daffodil.api.URISchemaSource
+
 import java.io.File
 import java.net.URI
-
 import scala.xml.Node
 import scala.io.Codec.string2codec
-import org.apache.daffodil.processors.{ VariableUtils, VariableMap }
+import org.apache.daffodil.processors.VariableMap
+import org.apache.daffodil.processors.VariableUtils
 import org.apache.daffodil.exceptions.Assert
 import org.apache.daffodil.util.Misc._
 import org.apache.daffodil.exceptions.ThrowsSDE
+import org.apache.daffodil.xml.DaffodilXMLLoader
 
 import scala.collection.immutable.Queue
 
@@ -66,13 +68,15 @@ object ExternalVariablesLoader {
 
   def fileToBindings(file: File): Queue[Binding] = {
     Assert.usage(file ne null)
-    ExternalVariablesValidator.validate(file) match {
+    val validatorResult = ExternalVariablesValidator.validate(file)
+    validatorResult match {
       case Left(ex) => Assert.abort(ex)
       case Right(_) => // Success
     }
     val enc = determineEncoding(file) // The encoding is needed for ConstructingParser
     val input = scala.io.Source.fromURI(file.toURI)(enc)
-    val node = ConstructingParser.fromSource(input, true).document.docElem
+    val ldr = new DaffodilXMLLoader()
+    val node = ldr.load(URISchemaSource(file.toURI))
     nodeToBindings(node)
   }
 

--- a/daffodil-sapi/src/test/scala/org/apache/daffodil/example/TestScalaAPI.scala
+++ b/daffodil-sapi/src/test/scala/org/apache/daffodil/example/TestScalaAPI.scala
@@ -47,6 +47,7 @@ import org.apache.daffodil.sapi.DaffodilUnhandledSAXException
 import org.apache.daffodil.sapi.DaffodilUnparseErrorSAXException
 import org.apache.daffodil.sapi.SAXErrorHandlerForSAPITest
 import org.apache.daffodil.sapi.infoset.XMLTextInfosetOutputter
+import org.apache.daffodil.xml.XMLUtils
 
 import java.nio.ByteBuffer
 
@@ -1027,6 +1028,7 @@ class TestScalaAPI {
     // prep for SAX unparse
     val unparseContentHandler = dp.newContentHandlerInstance(wbc)
     val unparseXMLReader = javax.xml.parsers.SAXParserFactory.newInstance.newSAXParser.getXMLReader
+    XMLUtils.setSecureDefaults(unparseXMLReader)
     unparseXMLReader.setContentHandler(unparseContentHandler)
     unparseXMLReader.setErrorHandler(errorHandler)
     unparseXMLReader.setFeature(SAX_NAMESPACES_FEATURE, true)
@@ -1107,6 +1109,7 @@ class TestScalaAPI {
     val unparseContentHandler = dp.newContentHandlerInstance(wbc)
     val errorHandler = new SAXErrorHandlerForSAPITest()
     val unparseXMLReader = javax.xml.parsers.SAXParserFactory.newInstance.newSAXParser.getXMLReader
+    XMLUtils.setSecureDefaults(unparseXMLReader)
     unparseXMLReader.setContentHandler(unparseContentHandler)
     unparseXMLReader.setErrorHandler(errorHandler)
     unparseXMLReader.setFeature(SAX_NAMESPACES_FEATURE, true)

--- a/daffodil-schematron/src/main/scala/org/apache/daffodil/validation/schematron/Schematron.scala
+++ b/daffodil-schematron/src/main/scala/org/apache/daffodil/validation/schematron/Schematron.scala
@@ -19,7 +19,6 @@ package org.apache.daffodil.validation.schematron
 
 import java.io.InputStream
 import java.io.StringWriter
-
 import javax.xml.parsers.ParserConfigurationException
 import javax.xml.parsers.SAXParserFactory
 import javax.xml.transform.Templates
@@ -27,6 +26,7 @@ import javax.xml.transform.URIResolver
 import javax.xml.transform.sax.SAXSource
 import javax.xml.transform.stream.StreamResult
 import org.apache.daffodil.api.ValidatorInitializationException
+import org.apache.daffodil.xml.XMLUtils
 import org.xml.sax.InputSource
 import org.xml.sax.SAXException
 import org.xml.sax.XMLReader
@@ -59,7 +59,9 @@ object Schematron {
           throw ValidatorInitializationException(s"Error setting feature on parser: ${ex.getMessage}")
       }
       f.setValidating(false)
-      f.newSAXParser.getXMLReader
+      val xr = f.newSAXParser.getXMLReader
+      XMLUtils.setSecureDefaults(xr)
+      xr
     }
   }
 

--- a/daffodil-tdml-lib/src/main/scala/org/apache/daffodil/tdml/TDMLRunner.scala
+++ b/daffodil-tdml-lib/src/main/scala/org/apache/daffodil/tdml/TDMLRunner.scala
@@ -2301,7 +2301,8 @@ case class DFDLInfoset(di: Node, parent: Infoset) {
         val path = di.text.trim()
         val maybeURI = parent.parent.parent.findTDMLResource(path)
         val uri = maybeURI.getOrElse(throw new FileNotFoundException("TDMLRunner: infoset file '" + path + "' was not found"))
-        val elem = scala.xml.XML.load(uri.toURL)
+        val loader = new DaffodilXMLLoader()
+        val elem = loader.load(URISchemaSource(uri))
         elem
       }
       case value => Assert.abort("Uknown value for type attribute on dfdlInfoset: " + value)

--- a/daffodil-tdml-processor/src/main/scala/org/apache/daffodil/tdml/processor/DaffodilTDMLDFDLProcessor.scala
+++ b/daffodil-tdml-processor/src/main/scala/org/apache/daffodil/tdml/processor/DaffodilTDMLDFDLProcessor.scala
@@ -346,6 +346,7 @@ class DaffodilTDMLDFDLProcessor private (private var dp: DataProcessor) extends 
     val unparseContentHandler = dp.newContentHandlerInstance(saxOutputChannel)
     unparseContentHandler.enableInputterResolutionOfRelativeInfosetBlobURIs()
     val xmlReader = SAXParserFactory.newInstance.newSAXParser.getXMLReader
+    XMLUtils.setSecureDefaults(xmlReader)
     xmlReader.setContentHandler(unparseContentHandler)
     xmlReader.setFeature(XMLUtils.SAX_NAMESPACES_FEATURE, true)
     xmlReader.setFeature(XMLUtils.SAX_NAMESPACE_PREFIXES_FEATURE, true)

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section00/general/disallowDocTypes.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section00/general/disallowDocTypes.tdml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<tdml:testSuite
+  xmlns:tdml="http://www.ibm.com/xmlns/dfdl/testData"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/"
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns:fn="http://www.w3.org/2005/xpath-functions"
+  xmlns:daf="urn:ogf:dfdl:2013:imp:daffodil.apache.org:2018:ext"
+  xmlns:dfdlx="http://www.ogf.org/dfdl/dfdl-1.0/extensions"
+  xmlns:ex="http://example.com"
+  xmlns:tns="http://example.com">
+
+  <tdml:defineSchema name="s1">
+    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+    <dfdl:format ref="ex:GeneralFormat" lengthKind="delimited"/>
+    <xs:element name="root" type="xs:string"/>
+  </tdml:defineSchema>
+
+  <tdml:parserTestCase name="configMustNotHaveDocType" root="root" model="s1"
+    config="hasDocType.cfg">
+    <tdml:document/>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <ex:root/>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="dfdlSchemaMustNotHaveDocType" root="root"
+                       model="hasDocType.dfdl.xsd">
+    <tdml:document/>
+    <tdml:errors>
+      <tdml:error>Schema Definition Error</tdml:error>
+      <tdml:error>org.xml.sax.SAXParseException</tdml:error>
+      <tdml:error>hasDocType.dfdl.xsd</tdml:error>
+      <tdml:error>DOCTYPE is disallowed</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="dfdlSchemaMustNotHaveDocTypeViaInclude" root="root"
+                       model="hasDocType-via-include.dfdl.xsd">
+    <tdml:document/>
+    <tdml:errors>
+      <tdml:error>Schema Definition Error</tdml:error>
+      <tdml:error>org.xml.sax.SAXParseException</tdml:error>
+      <tdml:error>hasDocType-include.dfdl.xsd</tdml:error>
+      <tdml:error>DOCTYPE is disallowed</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="dfdlSchemaMustNotHaveDocTypeViaImport" root="root"
+                       model="hasDocType-via-import.dfdl.xsd">
+    <tdml:document/>
+    <tdml:errors>
+      <tdml:error>Schema Definition Error</tdml:error>
+      <tdml:error>org.xml.sax.SAXParseException</tdml:error>
+      <tdml:error>hasDocType-import.dfdl.xsd</tdml:error>
+      <tdml:error>DOCTYPE is disallowed</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="infosetFileMustNotHaveDocType" root="root"
+                       model="s1">
+    <tdml:document/>
+    <tdml:infoset>
+      <tdml:dfdlInfoset type="file">hasDocType-infoset.xml</tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+
+</tdml:testSuite>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section00/general/hasDocType-external-vars.xml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section00/general/hasDocType-external-vars.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<!--
+  This file has a DOCTYPE. The purpose is to show we disallow these.
+-->
+<!DOCTYPE exter [
+  <!ENTITY nbsp "&#xA0;">
+  <!ENTITY writer "Writer: Donald Duck.">
+  <!ENTITY copyright "Copyright: W3Schools.">
+  ]>
+<daf:externalVariableBindings
+  xmlns:ex="http://example.com"
+  xmlns:daf="urn:ogf:dfdl:2013:imp:daffodil.apache.org:2018:ext">
+  <daf:bind name="ex:var1">externallySet</daf:bind>
+</daf:externalVariableBindings>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section00/general/hasDocType-import.dfdl.xsd
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section00/general/hasDocType-import.dfdl.xsd
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<!--
+  This file has a DOCTYPE. The purpose is to show we don't allow them.
+  -->
+<!DOCTYPE schema [
+  <!ENTITY nbsp "&#xA0;">
+  <!ENTITY writer "Writer: Donald Duck.">
+  <!ENTITY copyright "Copyright: W3Schools.">
+  ]>
+<xs:schema
+  xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/"
+  xmlns:xs="http://www.w3.org/2001/XMLSchema">
+    
+  <xs:element name="imported" type="xs:string"/>
+</xs:schema>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section00/general/hasDocType-include.dfdl.xsd
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section00/general/hasDocType-include.dfdl.xsd
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<!--
+  This file has a DOCTYPE. The purpose is to show we don't allow them.
+  -->
+<!DOCTYPE schema [
+  <!ENTITY nbsp "&#xA0;">
+  <!ENTITY writer "Writer: Donald Duck.">
+  <!ENTITY copyright "Copyright: W3Schools.">
+  ]>
+<xs:schema
+  xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/"
+  xmlns:xs="http://www.w3.org/2001/XMLSchema">
+    
+  <xs:element name="included" type="xs:string"/>
+</xs:schema>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section00/general/hasDocType-infoset.xml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section00/general/hasDocType-infoset.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<!--
+  This file has a DOCTYPE. The purpose is to show we don't allow them.
+  -->
+<!DOCTYPE root [
+  <!ENTITY nbsp "&#xA0;">
+  <!ENTITY writer "Writer: Donald Duck.">
+  <!ENTITY copyright "Copyright: W3Schools.">
+  ]>
+<ex:root xmlns:ex="http://example.com"/>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section00/general/hasDocType-via-import.dfdl.xsd
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section00/general/hasDocType-via-import.dfdl.xsd
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<!--
+  This file includes another schema file where it has a DOCTYPE
+  -->
+<xs:schema
+  xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/"
+  xmlns:xs="http://www.w3.org/2001/XMLSchema">
+
+  <xs:import schemaLocation="hasDocType-import.dfdl.xsd"/>
+    
+  <xs:element name="root" type="xs:string"/>
+</xs:schema>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section00/general/hasDocType-via-include.dfdl.xsd
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section00/general/hasDocType-via-include.dfdl.xsd
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<!--
+  This file includes another schema file where it has a DOCTYPE
+  -->
+<xs:schema
+  xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/"
+  xmlns:xs="http://www.w3.org/2001/XMLSchema">
+
+  <xs:include schemaLocation="hasDocType-include.dfdl.xsd"/>
+    
+  <xs:element name="root" type="xs:string"/>
+</xs:schema>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section00/general/hasDocType.cfg
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section00/general/hasDocType.cfg
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<!--
+  This file has a DOCTYPE. The purpose is to show we disallow these.
+-->
+<!DOCTYPE dfdlConfig [
+  <!ENTITY nbsp "&#xA0;">
+  <!ENTITY writer "Writer: Donald Duck.">
+  <!ENTITY copyright "Copyright: W3Schools.">
+  ]>
+<daf:dfdlConfig
+	xmlns:daf="urn:ogf:dfdl:2013:imp:daffodil.apache.org:2018:ext">
+    <daf:tunables>
+      <daf:suppressSchemaDefinitionWarnings>
+        encodingErrorPolicyError
+      </daf:suppressSchemaDefinitionWarnings>
+    </daf:tunables>
+</daf:dfdlConfig>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section00/general/hasDocType.dfdl.xsd
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section00/general/hasDocType.dfdl.xsd
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<!--
+  This file has a DOCTYPE. The purpose is to show we don't allow them.
+  -->
+<!DOCTYPE schema [
+  <!ENTITY nbsp "&#xA0;">
+  <!ENTITY writer "Writer: Donald Duck.">
+  <!ENTITY copyright "Copyright: W3Schools.">
+  ]>
+<xs:schema
+  xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/"
+  xmlns:xs="http://www.w3.org/2001/XMLSchema">
+    
+  <xs:element name="root" type="xs:string"/>
+</xs:schema>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section00/general/hasDocType.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section00/general/hasDocType.tdml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<!--
+  This TDML file has a DOCTYPE. The purpose is to show we disallow these.
+-->
+<!DOCTYPE testSuite [
+  <!ENTITY nbsp "&#xA0;">
+  <!ENTITY writer "Writer: Donald Duck.">
+  <!ENTITY copyright "Copyright: W3Schools.">
+  ]>
+<tdml:testSuite
+  xmlns:tdml="http://www.ibm.com/xmlns/dfdl/testData"/>
+

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section00/general/TestDisallowDocType.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section00/general/TestDisallowDocType.scala
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.daffodil.section00.general
+
+/* This section00 is for testing general features of DFDL that are
+ * not related to any specific requirement
+ */
+
+import org.apache.daffodil.Implicits.intercept
+import org.apache.daffodil.processors.DataProcessor
+import org.junit.Test
+import org.apache.daffodil.tdml.Runner
+import org.apache.daffodil.util.Misc
+import org.apache.daffodil.util.SchemaUtils
+import org.apache.daffodil.util.TestUtils.compileSchema
+import org.junit.AfterClass
+import org.junit.Assert.assertTrue
+import org.xml.sax.SAXParseException
+
+import java.nio.file.Paths
+
+object TestDisallowDocType {
+  lazy val testDir = "/org/apache/daffodil/section00/general"
+
+  // This TDML file has a DOCTYPE declaration, so we should fail to
+  // load it. However, that happens lazily.
+  lazy val runner1 = Runner(testDir, "hasDocType.tdml")
+
+  lazy val runner2 = Runner(testDir, "disallowDocTypes.tdml")
+
+  @AfterClass def shutDown(): Unit = {
+    runner1.reset
+    runner2.reset
+
+  }
+}
+
+class TestDisallowDocType {
+
+  import TestDisallowDocType._
+
+  @Test def test_TDMLFileMustNotHaveDocType(): Unit = {
+    val e = intercept[org.xml.sax.SAXParseException] {
+      runner1.runOneTest("ignored")
+    }
+    assertTrue(e.getMessage().contains("DOCTYPE is disallowed"))
+    assertTrue(e.getSystemId().contains("hasDocType.tdml"))
+  }
+
+  @Test def test_configMustNotHaveDocType(): Unit = {
+    val e = intercept[org.xml.sax.SAXParseException] {
+      runner2.runOneTest("configMustNotHaveDocType")
+    }
+    assertTrue(e.getMessage().contains("DOCTYPE is disallowed"))
+    assertTrue(e.getSystemId().contains("hasDocType.cfg"))
+  }
+
+  @Test def test_dfdlSchemaMustNotHaveDocType(): Unit = {
+      runner2.runOneTest("dfdlSchemaMustNotHaveDocType")
+  }
+
+  @Test def test_dfdlSchemaMustNotHaveDocTypeViaInclude(): Unit = {
+    runner2.runOneTest("dfdlSchemaMustNotHaveDocTypeViaInclude")
+  }
+
+  @Test def test_dfdlSchemaMustNotHaveDocTypeViaImport(): Unit = {
+    runner2.runOneTest("dfdlSchemaMustNotHaveDocTypeViaImport")
+  }
+
+
+  @Test def test_infosetFileMustNotHaveDocType(): Unit = {
+    val e = intercept[org.xml.sax.SAXParseException] {
+      runner2.runOneTest("infosetFileMustNotHaveDocType")
+    }
+    val msg = e.getMessage()
+    assertTrue(msg.contains("DOCTYPE is disallowed"))
+    assertTrue(e.getSystemId.contains("hasDocType-infoset.xml"))
+  }
+
+  @Test
+  def testExternalVariablesFileMustNotHaveDocType(): Unit = {
+    val testSchema = SchemaUtils.dfdlTestSchema(
+      <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
+      <dfdl:format ref="tns:GeneralFormat" lengthKind="delimited"/>,
+      <xs:element name="e1" type="xs:string"/>)
+    val schString = testSchema.toString()
+    var dp: DataProcessor = compileSchema(testSchema)
+    val extVarURI = Misc.getRequiredResource(
+      "org/apache/daffodil/section00/general/hasDocType-external-vars.xml")
+    val extVarFile = Paths.get(extVarURI).toFile
+    assertTrue(extVarFile.exists)
+    val e = intercept[SAXParseException] {
+      dp.withExternalVariables(extVarFile)
+    }
+    println(e.toString())
+    val m = e.getMessage()
+    val f = e.getSystemId()
+    assertTrue(m.contains("DOCTYPE is disallowed"))
+    assertTrue(f.contains("hasDocType-external-vars.xml"))
+  }
+}


### PR DESCRIPTION
DAFFODIL-1422 is a ticket about restricting the XML we accept so that we do not allow DOCTYPE declarations in it.
This is a security related provision, as use of DOCTYPEs leaves XML loaders subject to a variety of problems such as documents exploding in size as the DOCTYPE declarations are expanded. 
DOCTYPEs are an old obsolete idea, and simply disallowing them entirely is the best option.

There are other jira tickets about disallowing resolvers and loaders from dereferencing URIs treating them as internet URLs. 

The upshot of all this is that "loading" XML is tricky, and needs to be done carefully via a centralized library that provides the various options different loading requires, while not exposing/allowing the security vulnerabilities. 

This change set does not yet include establishing a single central library that all XML loading goes through. 

Right now this is at the point where it is apparent such a library is needed, because there are too many places that are invoking XML loaders for them to just all be "done the right way". Under maintenance this is too likely to drift. 

A key starting point is to survey every place Daffodil does XML loading. These include loading of:

* DFDL schemas and the include/import schema files they reference
** This can include DFDL schemas, but also XSD for annotation languages (e.g., schematron annotations)
** Note that this validating loader is loading a schema, but loading it not as a schema, but as ordinary XML. This should be validated against the schema for DFDL schemas. 
* XML Infosets being unparsed
** (Currently not a validating loader)
* TDML files for testing - this can in turn lead to loading of DFDL schemas
** Test cases can load XML Infoset files. 
** validation here involves validating defineSchema elements which contain DFDL schema. 
* Config files
* daffodil-propgen loads the XSD files for DFDL annotations, tunables, etc.
* Xerces validator loads a schema, and the include/import files it references
* Xerces validator loads XML being validated 

This may not be a comprehensive list. 
