### PR TITLE
Preserve raw validation output

### DIFF
--- a/daffodil-cli/src/it/scala/org/apache/daffodil/schematron/TestSvrlOutput.scala
+++ b/daffodil-cli/src/it/scala/org/apache/daffodil/schematron/TestSvrlOutput.scala
@@ -1,0 +1,153 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.daffodil.schematron
+
+import net.sf.expectit.matcher.Matchers.sequence
+import org.apache.daffodil.CLI.Util
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Test
+
+import java.nio.file.Path
+import java.nio.file.Paths
+import scala.xml.XML
+
+class TestSvrlOutput {
+  import TestValidating._
+
+  @Test def validationSuccess(): Unit = {
+    val svrlPath = makeTempFilePath()
+    val confFile = mkTmpConf(never, svrlPath)
+    withShell(stderr=true) {
+      s"parse --validate schematron=$confFile -s {{$uuid}} {$data}" -> alwaysResult
+    }
+
+    val svrlFile = svrlPath.toFile
+    assertTrue(svrlFile.exists())
+
+    try {
+      XML.loadFile(svrlFile) match {
+        case <svrl:schematron-output>{rules @ _*}</svrl:schematron-output> =>
+          val res = rules.find {
+            case <svrl:failed-assert>{  _* }</svrl:failed-assert> => true
+            case _ => false
+          }
+          // we should not have found failures
+          assertFalse(res.isDefined)
+        case _ =>
+          fail("schematron pattern didnt match")
+      }
+    } finally {
+      svrlFile.delete()
+    }
+  }
+
+  // should get validation output file on a validation failure
+  @Test def validationFailure(): Unit = {
+    val svrlPath = makeTempFilePath()
+    val confFile = mkTmpConf(always, svrlPath)
+    withShell(FailureErrorCode) {
+      s"parse --validate schematron=$confFile -s {{$uuid}} {$data}" -> alwaysResult
+    }
+
+    val svrlFile = svrlPath.toFile
+    assertTrue(svrlFile.exists())
+
+    try {
+      XML.loadFile(svrlFile) match {
+        case <svrl:schematron-output>{rules @ _*}</svrl:schematron-output> =>
+          val res = rules.find {
+            case <svrl:failed-assert>{  _* }</svrl:failed-assert> => true
+            case _ => false
+          }
+          // we should have found some failures
+          assertTrue(res.isDefined)
+        case _ =>
+          fail("schematron pattern didnt match")
+      }
+    } finally {
+      svrlFile.delete()
+    }
+  }
+
+  // shouldnt get a validation output file on parse failure
+  // based on negative test test_996_CLI_Parsing_negativeTest04
+  @Test def parseFailure(): Unit = {
+    val svrlPath = makeTempFilePath()
+    val confFile = mkTmpConf(never, svrlPath)
+    val data = mktmp("12")
+    withShell(FailureErrorCode, stderr = true) {
+      val schemaFile = Util.daffodilPath(
+        "daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/charClassEntities.dfdl.xsd")
+      val schema = if (Util.isWindows) Util.cmdConvert(schemaFile) else schemaFile
+      s"parse --validate schematron=$confFile -s $schema -r unknown $data" ->
+        lineEndsWith("No root element found for unknown in any available namespace")
+    }
+
+    val svrlFile = svrlPath.toFile
+    if (svrlFile.exists()) {
+      svrlFile.delete()
+      fail("svrl file should not exist on failed parse")
+    }
+  }
+
+  // parse should fail with validation diagnostic when unable to write to the specified location
+  @Test def outputPathFailure(): Unit = {
+    val badSvrlPath = Paths.get("thisisnotavalidlocation/schematron.svrl")
+    val confFile = mkTmpConf(never, badSvrlPath)
+    withShell(FailureErrorCode, JoinStdError) {
+      s"""parse --validate schematron="$confFile" -s {{$uuid}} {$data}""" -> sequence(
+        lineEndsWithRegex(s"\\[error] Validation Error: .+"),
+        anyLines(2))
+    }
+
+    val svrlFile = badSvrlPath.toFile
+    assertFalse(svrlFile.exists())
+  }
+
+  // validator output should overwrite existing file
+  @Test def overwriteExistingFile(): Unit = {
+    val svrlPath = mktmp("=== this content will be overwritten ===")
+    val confFile = mkTmpConf(never, svrlPath)
+    withShell() {
+      s"parse --validate schematron=$confFile -s {{$uuid}} {$data}" -> alwaysResult
+    }
+
+    val svrlFile = svrlPath.toFile
+    assertTrue(svrlFile.exists())
+
+    try {
+      XML.loadFile(svrlFile) match {
+        case <svrl:schematron-output>{rules @ _*}</svrl:schematron-output> =>
+          val res = rules.find {
+            case <svrl:failed-assert>{  _* }</svrl:failed-assert> => true
+            case _ => false
+          }
+          // we should not have found failures
+          assertFalse(res.isDefined)
+        case _ =>
+          fail("schematron pattern didnt match")
+      }
+    } finally {
+      svrlFile.delete()
+    }
+  }
+
+  private def makeTempFilePath(): Path = Paths.get(System.getProperty("java.io.tmpdir"), "schTestRaw.svrl")
+}

--- a/daffodil-cli/src/it/scala/org/apache/daffodil/schematron/TestValidating.scala
+++ b/daffodil-cli/src/it/scala/org/apache/daffodil/schematron/TestValidating.scala
@@ -19,13 +19,16 @@ package org.apache.daffodil.schematron
 
 import org.junit.Test
 
-class TestValidating {
+object TestValidating {
   val data = "input/uuid.txt"
   val uuid = "xsd/string.dfdl.xsd"
   val never = "sch/never-fails.sch"
   val always = "sch/always-fails.sch"
 
   val alwaysResult = regexLine("<.+-fails>2f6481e6-542c-11eb-ae93-0242ac130002</.+-fails>")
+}
+class TestValidating {
+  import TestValidating._
 
   // always fails sch, but no validate flag so it should pass
   @Test def nonShouldPass(): Unit = withShell() {

--- a/daffodil-cli/src/main/scala/org/apache/daffodil/Main.scala
+++ b/daffodil-cli/src/main/scala/org/apache/daffodil/Main.scala
@@ -230,7 +230,7 @@ class CLIConf(arguments: Array[String]) extends scallop.ScallopConf(arguments)
       case "limited" => ValidationMode.Limited
       case "off" => ValidationMode.Off
       case DefaultArgPattern(name, arg) if Validators.isRegistered(name) =>
-        val config = if(arg.endsWith(".conf")) ConfigFactory.load(arg) else ConfigFactory.parseString(s"$name=$arg")
+        val config = if(arg.endsWith(".conf")) ConfigFactory.parseFile(new File(arg)) else ConfigFactory.parseString(s"$name=$arg")
         ValidationMode.Custom(Validators.get(name).make(config))
       case NoArgsPattern(name) if Validators.isRegistered(name) =>
         ValidationMode.Custom(Validators.get(name).make(ConfigFactory.empty))

--- a/daffodil-japi/src/test/java/org/apache/daffodil/example/validation/FailingValidator.java
+++ b/daffodil-japi/src/test/java/org/apache/daffodil/example/validation/FailingValidator.java
@@ -17,10 +17,13 @@
 
 package org.apache.daffodil.example.validation;
 
+import org.apache.daffodil.api.ValidationFailure;
 import org.apache.daffodil.api.ValidationResult;
+import org.apache.daffodil.api.ValidationWarning;
 import org.apache.daffodil.api.Validator;
 
 import java.io.InputStream;
+import java.util.Collection;
 import java.util.Collections;
 
 public class FailingValidator implements Validator {
@@ -28,6 +31,16 @@ public class FailingValidator implements Validator {
 
     @Override
     public ValidationResult validateXML(InputStream document) {
-        return new ValidationResult(Collections.emptyList(), Collections.singletonList(() -> "boom"));
+        return new ValidationResult() {
+            @Override
+            public Collection<ValidationWarning> warnings() {
+                return Collections.emptyList();
+            }
+
+            @Override
+            public Collection<ValidationFailure> errors() {
+                return Collections.singletonList(() -> "boom");
+            }
+        };
     }
 }

--- a/daffodil-japi/src/test/java/org/apache/daffodil/example/validation/PassingValidator.java
+++ b/daffodil-japi/src/test/java/org/apache/daffodil/example/validation/PassingValidator.java
@@ -17,10 +17,13 @@
 
 package org.apache.daffodil.example.validation;
 
+import org.apache.daffodil.api.ValidationFailure;
 import org.apache.daffodil.api.ValidationResult;
+import org.apache.daffodil.api.ValidationWarning;
 import org.apache.daffodil.api.Validator;
 
 import java.io.InputStream;
+import java.util.Collection;
 import java.util.Collections;
 
 public class PassingValidator implements Validator {
@@ -28,6 +31,22 @@ public class PassingValidator implements Validator {
 
     @Override
     public ValidationResult validateXML(InputStream document) {
-        return new ValidationResult(Collections.emptyList(), Collections.emptyList());
+        return new Result();
+    }
+
+    public static class Result implements ValidationResult {
+        public int magicNumberIs() {
+            return 42;
+        }
+
+        @Override
+        public Collection<ValidationWarning> warnings() {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public Collection<ValidationFailure> errors() {
+            return Collections.emptyList();
+        }
     }
 }

--- a/daffodil-lib/src/main/scala/org/apache/daffodil/api/Validator.scala
+++ b/daffodil-lib/src/main/scala/org/apache/daffodil/api/Validator.scala
@@ -54,10 +54,11 @@ trait ValidatorFactory {
 
 /**
  * Results of a validation execution
- * @param warnings [[org.apache.daffodil.api.ValidationWarning]] objects
- * @param errors [[org.apache.daffodil.api.ValidationFailure]] objects
  */
-final case class ValidationResult(warnings: java.util.Collection[ValidationWarning], errors: java.util.Collection[ValidationFailure])
+trait ValidationResult {
+  def warnings(): java.util.Collection[ValidationWarning]
+  def errors(): java.util.Collection[ValidationFailure]
+}
 
 object ValidationResult {
   /**
@@ -65,9 +66,12 @@ object ValidationResult {
    */
   val empty: ValidationResult = ValidationResult(Seq.empty, Seq.empty)
 
-  def apply(warnings: Seq[ValidationWarning], errors: Seq[ValidationFailure]): ValidationResult = {
+  def apply(w: Seq[ValidationWarning], e: Seq[ValidationFailure]): ValidationResult = {
     import scala.collection.JavaConverters.asJavaCollectionConverter
-    ValidationResult(warnings.asJavaCollection, errors.asJavaCollection)
+    new ValidationResult{
+      val warnings: java.util.Collection[ValidationWarning] = w.asJavaCollection
+      val errors: java.util.Collection[ValidationFailure] = e.asJavaCollection
+    }
   }
 }
 
@@ -86,9 +90,9 @@ trait ValidationFailure {
 }
 
 /**
- * Represents a fatal validation notification backed by a Throwable
+ * Represents a ValidationFailure that is backed by a Throwable
  */
-trait ValidationException {
+trait ValidationException extends ValidationFailure {
   def getCause: Throwable
 }
 

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/api/DFDLParserUnparser.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/api/DFDLParserUnparser.scala
@@ -293,6 +293,7 @@ object DFDL {
 
   trait ParseResult extends Result with WithDiagnostics {
     def resultState: State
+    def validationResult(): Option[ValidationResult]
   }
 
   trait UnparseResult extends Result with WithDiagnostics {

--- a/daffodil-schematron/src/main/scala/org/apache/daffodil/validation/schematron/SchematronResult.scala
+++ b/daffodil-schematron/src/main/scala/org/apache/daffodil/validation/schematron/SchematronResult.scala
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.daffodil.validation.schematron
+
+import org.apache.daffodil.api.ValidationFailure
+import org.apache.daffodil.api.ValidationResult
+import org.apache.daffodil.api.ValidationWarning
+
+import java.util
+import scala.collection.JavaConverters.asJavaCollectionConverter
+
+/**
+ * Captures the output of Schematron validation as a Daffodil ValidationResult
+ *
+ * @param warnings Schematron warnings parsed into ValidationWarning objects
+ * @param errors   Schematron errors parsed into ValidationFailure objects
+ * @param svrl     Full SVRL output
+ */
+case class SchematronResult(warnings: util.Collection[ValidationWarning],
+                            errors: util.Collection[ValidationFailure],
+                            svrl: String) extends ValidationResult
+
+object SchematronResult {
+  def apply(w: Seq[ValidationWarning], e: Seq[ValidationFailure], svrl: String): SchematronResult =
+    SchematronResult(w.asJavaCollection, e.asJavaCollection, svrl)
+}


### PR DESCRIPTION
The Validator API provides structured results in a form fitting translation to Daffodil diagnostics, but discards the original data in the native validator format.  For some applications data in this native format is a requirement and needs preserved by writing to disk in a predictable way.  One example of this is the Schematron SVRL output which is resolved in this PR.

- changes `ValidationResult` to trait to allow subtyping
- refactors the `ValidationResult` to an immutable member of `ParseResult`
- optionally write SVRL from schematron validator based on configuration

DAFFODIL- 2482
