### PR TITLE
Updated test to check for both '.' or ','

### DIFF
--- a/daffodil-lib/src/test/scala/org/apache/daffodil/util/TestLogger.scala
+++ b/daffodil-lib/src/test/scala/org/apache/daffodil/util/TestLogger.scala
@@ -86,7 +86,7 @@ class TestLogger {
     a.setLoggingLevel(LogLevel.Error)
     a.setLogWriter(lw)
     a.logSomething()
-    assertTrue(lw.loggedMsg.contains("Message: int=1 float=3.0"))
+    assertTrue(lw.loggedMsg matches ".*Message: int=1 float=3[.,]0.*")
   }
 
 }


### PR DESCRIPTION
Using the following settings:

export SBT_OPTS="-Xss2M -Xmx5G -Xms5G -Duser.country=DE
-Duser.language=de"

Results in floating point numbers using a ',' instead of a '.' (ie.
'3,0' instead of '3.0'. Updated test to use a regex to check for both
symbols.

DAFFODIL-2492