### PR TITLE
Make some daffodil-runtime2 improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@
   limitations under the License.
 -->
 
+<!-- markdownlint-disable first-line-heading -->
+<!-- markdownlint-disable line-length -->
+<!-- markdownlint-disable no-inline-html -->
 [<img src="https://daffodil.apache.org/assets/themes/apache/img/apache-daffodil-logo.svg" height="85" align="left" alt="Apache Daffodil"/>][Website]
 [<img src="https://img.shields.io/github/workflow/status/apache/daffodil/Daffodil%20CI/master.svg" align="right"/>][GitHub Actions]
 <br clear="right" />
@@ -23,89 +26,114 @@
 [<img src="https://img.shields.io/maven-central/v/org.apache.daffodil/daffodil-core_2.12.svg?color=brightgreen&label=version" align="right"/>][Releases]
 <br clear="both" />
 
-Apache Daffodil is an open-source implementation of the [DFDL specification]
-that uses DFDL data descriptions to parse fixed format data into an infoset.
-This infoset is commonly converted into XML or JSON to enable the use of
-well-established XML or JSON technologies and libraries to consume, inspect,
-and manipulate fixed format data in existing solutions. Daffodil is also
-capable of serializing or "unparsing" data back to the original data format.
-The DFDL infoset can also be converted directly to/from the data structures
-carried by data processing frameworks so as to bypass any XML/JSON overheads.
+Apache Daffodil is an open-source implementation of the [DFDL
+specification] that uses DFDL data descriptions to parse fixed format
+data into an infoset.  This infoset is commonly converted into XML or
+JSON to enable the use of well-established XML or JSON technologies
+and libraries to consume, inspect, and manipulate fixed format data in
+existing solutions.  Daffodil is also capable of serializing or
+"unparsing" data back to the original data format.  The DFDL infoset
+can also be converted directly to/from the data structures carried by
+data processing frameworks so as to bypass any XML/JSON overheads.
 
-For more information about Daffodil, see https://daffodil.apache.org/.
+For more information about Daffodil, see the [Website].
 
 ## Build Requirements
 
 * JDK 8 or higher
 * SBT 0.13.8 or higher
-* C compiler (for daffodil-runtime2 only)
-* Mini-XML Version 3.2 or higher (for daffodil-runtime2 only)
+* C compiler C99 or higher
+* Mini-XML Version 3.2 or higher
+
+Since Daffodil has a DFDL to C backend, you will need a C compiler
+([gcc] or [clang]), the [Mini-XML] library, and possibly the GNU
+[argp] library if your system's C library doesn't include it.  You can
+install gcc and libmxml as system packages on most Unix based
+platforms with distribution-specific packager commands such as (Debian
+and Ubuntu):
+
+    # Just mentioning all other packages you might need too
+    sudo apt install build-essential curl git libmxml-dev
+
+You will need the Java Software Development Kit ([JDK]) and the Scala
+Build Tool ([SBT]) to build Daffodil, run all tests, create packages,
+and more.  [SDK] offers an easy and uniform way to install both java
+and sbt on any Unix based platform:
+
+    curl -s "https://get.sdkman.io" | bash
+    sdk install java
+    sdk install sbt
+
+You can edit the Compile / cCompiler setting in build.sbt if you don't
+want sbt to call your C compiler with "cc" as the driver command.
+
+On Windows, the easiest way to install gcc and libargp is to install
+[MSYS2]'s collection of free tools and libraries although MSYS2 has no
+package for libmxml which you'll need to build from source.  First
+install [MSYS2] following its website's installation instructions,
+then run the following commands in a "MSYS2 MSYS" window:
+
+    pacman -S gcc git libargp-devel make pkgconf
+    git clone https://github.com/michaelrsweet/mxml.git
+    cd mxml
+    ./configure --prefix=/usr --disable-shared --disable-threads
+    make
+    make install
+
+You also need to install [JDK} and [SBT] from their Windows
+installation packages and define an environment variable using
+Windows' control panel for editing environment variables.  Define an
+environment variable with the name `MSYS2_PATH_TYPE` and the value
+`inherit`.  Now when you open a new "MSYS2 MSYS" window from the Start
+Menu, you will be able to type your sbt commands in the MSYS2 window
+and both sbt and daffodil will be able to call the C compiler.
 
 ## Getting Started
-
-You will need the full Java Software Development Kit ([JDK] or [SDK]),
-not the Java Runtime Environment (JRE), to build Daffodil.  You also
-will need [SBT] to build Daffodil, run all tests, create packages, and
-more.
-
-In order to build daffodil-runtime2, you will need a C compiler (for
-example, [gcc]), the [Mini-XML] library, and possibly the [argp]
-library if your system doesn't include it in its C library.
 
 Below are some of the more common commands used for Daffodil development.
 
 ### Compile
 
-```text
-$ sbt compile
-```
+    sbt compile
 
 ### Tests
 
 Run all unit tests:
 
-```text
-$ sbt test 
-```
+    sbt test
 
 Run all command line interface tests:
 
-```text
-$ sbt it:test
-```
+    sbt it:test
 
 ### Command Line Interface
 
-Create Linux and Windows shell scripts in `daffodil-cli/target/universal/stage/bin/`. See
-the [Command Line Interface] documentation for details on its usage:
+Create Linux and Windows shell scripts in
+`daffodil-cli/target/universal/stage/bin/`.  See the [Command Line
+Interface] documentation for details on its usage:
 
-```btext
-$ sbt daffodil-cli/stage
-```
+    sbt daffodil-cli/stage
 
 ### License Check
 
-Generate an [Apache RAT] license check report located in ``target/rat.txt`` and error if
-any unapproved licenses are found:
+Generate an [Apache RAT] license check report located in
+``target/rat.txt`` and error if any unapproved licenses are found:
 
-```text
-$ sbt ratCheck
-```
+    sbt ratCheck
 
 ### Test Coverage Report
 
 Generate an [sbt-scoverage] test coverage report located in
 ``target/scala-ver/scoverage-report/``:
 
-```text
-$ sbt clean coverage test it:test
-$ sbt coverageAggregate
-```
+    sbt clean coverage test it:test
+    sbt coverageAggregate
 
 ## Getting Help
 
 For questions, we can be reached at the dev@daffodil.apache.org or
-users@daffodil.apache.org mailing lists. Bugs can be reported via the [Daffodil JIRA].
+users@daffodil.apache.org mailing lists.  Bugs can be reported via the
+[Daffodil JIRA].
 
 ## License
 
@@ -113,17 +141,19 @@ Apache Daffodil is licensed under the [Apache License, v2.0].
 
 [Apache License, v2.0]: https://www.apache.org/licenses/LICENSE-2.0
 [Apache RAT]: https://creadur.apache.org/rat/
-[CodeCov]: https://codecov.io/gh/apache/daffodil/
+[CodeCov]: https://app.codecov.io/gh/apache/daffodil
 [Command Line Interface]: https://daffodil.apache.org/cli/
-[DFDL specification]: http://www.ogf.org/dfdl
-[Daffodil JIRA]: https://issues.apache.org/jira/projects/DAFFODIL
+[DFDL specification]: https://daffodil.apache.org/docs/dfdl/
+[Daffodil JIRA]: https://issues.apache.org/jira/projects/DAFFODIL/
 [Github Actions]: https://github.com/apache/daffodil/actions?query=branch%3Amaster+
-[JDK]: https://docs.oracle.com/en/java/javase/11/install/overview-jdk-installation.html
+[JDK]: https://adoptopenjdk.net/
 [Mini-XML]: https://www.msweet.org/mxml/
+[MSYS2]: https://www.msys2.org/
 [Releases]: http://daffodil.apache.org/releases/
-[SBT]: http://www.scala-sbt.org
-[SDK]: https://sdkman.io
-[Website]: https://daffodil.apache.org
+[SBT]: https://www.scala-sbt.org/
+[SDK]: https://sdkman.io/
+[Website]: https://daffodil.apache.org/
 [argp]: https://packages.msys2.org/package/libargp-devel
+[clang]: https://clang.llvm.org/get_started.html
 [gcc]: https://linuxize.com/post/how-to-install-gcc-on-ubuntu-20-04/
-[sbt-scoverage]: https://github.com/scoverage/sbt-scoverage
+[sbt-scoverage]: https://github.com/scoverage/sbt-scoverage/

--- a/build.sbt
+++ b/build.sbt
@@ -68,6 +68,8 @@ lazy val runtime2         = Project("daffodil-runtime2", file("daffodil-runtime2
                               .settings(commonSettings)
                               .settings(publishArtifact in (Compile, packageDoc) := false)
                               .settings(
+                                Compile / cCompiler := "cc",
+                                Compile / ccArchiveCommand := "ar",
                                 Compile / ccTargets := ListSet(runtime2CFiles),
                                 Compile / cSources  := Map(
                                   runtime2CFiles -> (

--- a/daffodil-runtime2/src/main/resources/c/libcli/daffodil_argp.c
+++ b/daffodil-runtime2/src/main/resources/c/libcli/daffodil_argp.c
@@ -21,10 +21,6 @@
 #include <stdlib.h>  // for putenv
 #include <string.h>  // for strlen, strcmp
 
-// Initialize our "daffodil" name and version
-
-const char *argp_program_version = "Apache Daffodil (runtime2) 0.1";
-
 // Initialize our "daffodil parse" CLI options
 
 struct daffodil_parse_cli daffodil_parse = {

--- a/daffodil-runtime2/src/main/resources/c/libcli/stack.c
+++ b/daffodil-runtime2/src/main/resources/c/libcli/stack.c
@@ -16,10 +16,9 @@
  */
 
 #include "stack.h"
-#include <error.h>    // for error
 #include <stdbool.h>  // for bool
-#include <stddef.h>   // for ptrdiff_t
-#include <stdlib.h>   // for EXIT_FAILURE
+#include <stddef.h>   // for NULL, ptrdiff_t
+#include "errors.h"   // for continue_or_exit, Error, ERR_STACK_EMPTY, ERR_STACK_OVERFLOW, ERR_STACK_UNDERFLOW
 
 // Initialize stack with preallocated array
 
@@ -55,7 +54,8 @@ stack_pop(stack_t *p_stack)
 {
     if (stack_is_empty(p_stack))
     {
-        error(EXIT_FAILURE, 0, "Stack underflow - program terminated");
+        const Error error = {ERR_STACK_UNDERFLOW, {NULL}};
+        continue_or_exit(&error);
     }
     return *(--p_stack->p_after);
 }
@@ -67,7 +67,8 @@ stack_push(stack_t *p_stack, stack_item_t item)
 {
     if (stack_is_full(p_stack))
     {
-        error(EXIT_FAILURE, 0, "Stack overflow - program terminated");
+        const Error error = {ERR_STACK_OVERFLOW, {NULL}};
+        continue_or_exit(&error);
     }
     *(p_stack->p_after++) = item;
 }
@@ -79,7 +80,8 @@ stack_top(stack_t *p_stack)
 {
     if (stack_is_empty(p_stack))
     {
-        error(EXIT_FAILURE, 0, "Stack empty - program terminated");
+        const Error error = {ERR_STACK_EMPTY, {NULL}};
+        continue_or_exit(&error);
     }
     return *(p_stack->p_after - 1);
 }

--- a/daffodil-runtime2/src/main/resources/c/libcli/xml_reader.h
+++ b/daffodil-runtime2/src/main/resources/c/libcli/xml_reader.h
@@ -18,9 +18,9 @@
 #ifndef XML_READER_H
 #define XML_READER_H
 
-#include "infoset.h"  // for VisitEventHandler, InfosetBase
 #include <mxml.h>     // for mxml_node_t
 #include <stdio.h>    // for FILE
+#include "infoset.h"  // for VisitEventHandler, InfosetBase
 
 // XMLReader - infoset visitor with methods to read XML
 

--- a/daffodil-runtime2/src/main/resources/c/libcli/xml_writer.h
+++ b/daffodil-runtime2/src/main/resources/c/libcli/xml_writer.h
@@ -18,9 +18,9 @@
 #ifndef XML_WRITER_H
 #define XML_WRITER_H
 
+#include <stdio.h>    // for FILE
 #include "infoset.h"  // for VisitEventHandler
 #include "stack.h"    // for stack_t
-#include <stdio.h>    // for FILE
 
 // XMLWriter - infoset visitor with methods to output XML
 

--- a/daffodil-runtime2/src/main/resources/c/libruntime/errors.c
+++ b/daffodil-runtime2/src/main/resources/c/libruntime/errors.c
@@ -1,0 +1,183 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "errors.h"
+#include <error.h>     // for error
+#include <inttypes.h>  // for PRId64
+#include <stdio.h>     // for NULL, feof, ferror, FILE, size_t
+#include <stdlib.h>    // for EXIT_FAILURE
+
+// error_message - return an internationalized error message
+
+static const char *
+error_message(enum ErrorCode code)
+{
+    switch (code)
+    {
+    case ERR_CHOICE_KEY:
+        return "no match between choice dispatch key %" PRId64
+               " and any branch key";
+    case ERR_FILE_CLOSE:
+        return "error closing file";
+    case ERR_FILE_FLUSH:
+        return "error flushing stream to file";
+    case ERR_FILE_OPEN:
+        return "error opening file '%s'";
+    case ERR_FIXED_VALUE:
+        return "value of element '%s' does not match value of its "
+               "'fixed' attribute";
+    case ERR_INFOSET_READ:
+        return "cannot read infoset type '%s'";
+    case ERR_INFOSET_WRITE:
+        return "cannot write infoset type '%s'";
+    case ERR_PARSE_BOOL:
+        return "error parsing binary value %" PRId64 " as either true or false";
+    case ERR_STACK_EMPTY:
+        return "stack empty, stopping program";
+    case ERR_STACK_OVERFLOW:
+        return "stack overflow, stopping program";
+    case ERR_STACK_UNDERFLOW:
+        return "stack underflow, stopping program";
+    case ERR_STREAM_EOF:
+        return "EOF in stream, stopping program";
+    case ERR_STREAM_ERROR:
+        return "error in stream, stopping program";
+    case ERR_STRTOBOOL:
+        return "error converting XML data '%s' to boolean";
+    case ERR_STRTOD_ERRNO:
+        return "error converting XML data '%s' to number";
+    case ERR_STRTOI_ERRNO:
+        return "error converting XML data '%s' to integer";
+    case ERR_STRTONUM_EMPTY:
+        return "found no number in XML data '%s'";
+    case ERR_STRTONUM_NOT:
+        return "found non-number characters in XML data '%s'";
+    case ERR_STRTONUM_RANGE:
+        return "number in XML data '%s' out of range";
+    case ERR_XML_DECL:
+        return "error making new XML declaration";
+    case ERR_XML_ELEMENT:
+        return "error making new XML element '%s'";
+    case ERR_XML_ERD:
+        return "unexpected ERD typeCode %" PRId64 " while reading XML data";
+    case ERR_XML_GONE:
+        return "ran out of XML data";
+    case ERR_XML_INPUT:
+        return "unable to read XML data from input file";
+    case ERR_XML_LEFT:
+        return "did not consume all of the XML data, '%s' left";
+    case ERR_XML_MISMATCH:
+        return "found mismatch between XML data and infoset '%s'";
+    case ERR_XML_WRITE:
+        return "error writing XML document";
+    default:
+        return "unrecognized error code, shouldn't happen";
+    }
+}
+
+// print_maybe_stop - print a message and maybe stop the program
+
+static void
+print_maybe_stop(const Error *err, int status)
+{
+    const int   errnum = 0;
+    const char *format = "%s";
+    const char *msg = error_message(err->code);
+
+    switch (err->code)
+    {
+    case ERR_FILE_OPEN:
+    case ERR_FIXED_VALUE:
+    case ERR_INFOSET_READ:
+    case ERR_INFOSET_WRITE:
+    case ERR_STRTOBOOL:
+    case ERR_STRTOD_ERRNO:
+    case ERR_STRTOI_ERRNO:
+    case ERR_STRTONUM_EMPTY:
+    case ERR_STRTONUM_NOT:
+    case ERR_STRTONUM_RANGE:
+    case ERR_XML_ELEMENT:
+    case ERR_XML_LEFT:
+    case ERR_XML_MISMATCH:
+        error(status, errnum, msg, err->s);
+        break;
+    case ERR_CHOICE_KEY:
+    case ERR_PARSE_BOOL:
+    case ERR_XML_ERD:
+        error(status, errnum, msg, err->d64);
+        break;
+    default:
+        error(status, errnum, format, msg);
+        break;
+    }
+}
+
+// need_diagnostics - return pointer to validation diagnostics
+
+Diagnostics *
+need_diagnostics(void)
+{
+    static Diagnostics validati;
+    return &validati;
+}
+
+// print_diagnostics - print any validation diagnostics
+
+void
+print_diagnostics(const Diagnostics *validati)
+{
+    if (validati)
+    {
+        for (size_t i = 0; i < validati->length; i++)
+        {
+            const Error *error = &validati->array[i];
+            print_maybe_stop(error, 0);
+        }
+    }
+}
+
+// continue_or_exit - print and exit if an error occurred or continue otherwise
+
+void
+continue_or_exit(const Error *error)
+{
+    if (error)
+    {
+        print_maybe_stop(error, EXIT_FAILURE);
+    }
+}
+
+// eof_or_error - return an error if a stream has its eof or error indicator set
+
+const Error *
+eof_or_error(FILE *stream)
+{
+    if (feof(stream))
+    {
+        static Error error = {ERR_STREAM_EOF, {NULL}};
+        return &error;
+    }
+    else if (ferror(stream))
+    {
+        static Error error = {ERR_STREAM_ERROR, {NULL}};
+        return &error;
+    }
+    else
+    {
+        return NULL;
+    }
+}

--- a/daffodil-runtime2/src/main/resources/c/libruntime/errors.h
+++ b/daffodil-runtime2/src/main/resources/c/libruntime/errors.h
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef ERRORS_H
+#define ERRORS_H
+
+#include <stdio.h>    // for FILE, size_t
+#include <stdint.h>   // for int64_t
+
+// ErrorCode - types of errors which could occur
+
+enum ErrorCode
+{
+    ERR_CHOICE_KEY,
+    ERR_FILE_CLOSE,
+    ERR_FILE_FLUSH,
+    ERR_FILE_OPEN,
+    ERR_FIXED_VALUE,
+    ERR_INFOSET_READ,
+    ERR_INFOSET_WRITE,
+    ERR_PARSE_BOOL,
+    ERR_STACK_EMPTY,
+    ERR_STACK_OVERFLOW,
+    ERR_STACK_UNDERFLOW,
+    ERR_STREAM_EOF,
+    ERR_STREAM_ERROR,
+    ERR_STRTOBOOL,
+    ERR_STRTOD_ERRNO,
+    ERR_STRTOI_ERRNO,
+    ERR_STRTONUM_EMPTY,
+    ERR_STRTONUM_NOT,
+    ERR_STRTONUM_RANGE,
+    ERR_XML_DECL,
+    ERR_XML_ELEMENT,
+    ERR_XML_ERD,
+    ERR_XML_GONE,
+    ERR_XML_INPUT,
+    ERR_XML_LEFT,
+    ERR_XML_MISMATCH,
+    ERR_XML_WRITE
+};
+
+// Error - specific error occuring now
+
+typedef struct Error
+{
+    enum ErrorCode code;
+    union
+    {
+        const char *s;   // for %s
+        int64_t     d64; // for %d64
+    };
+} Error;
+
+// Diagnostics - array of validation errors
+
+typedef struct Diagnostics
+{
+    Error  array[100];
+    size_t length;
+} Diagnostics;
+
+// PState - mutable state while parsing data
+
+typedef struct PState
+{
+    FILE *       stream;   // input to read data from
+    size_t       position; // 0-based position in stream
+    Diagnostics *validati; // any validation diagnostics
+    const Error *error;    // any error which stops program
+} PState;
+
+// UState - mutable state while unparsing infoset
+
+typedef struct UState
+{
+    FILE *       stream;   // output to write data to
+    size_t       position; // 0-based position in stream
+    Diagnostics *validati; // any validation diagnostics
+    const Error *error;    // any error which stops program
+} UState;
+
+// need_diagnostics - return pointer to validation diagnostics
+
+extern Diagnostics *need_diagnostics(void);
+
+// print_diagnostics - print any validation diagnostics
+
+extern void print_diagnostics(const Diagnostics *validati);
+
+// continue_or_exit - print and exit if an error occurred or continue otherwise
+
+extern void continue_or_exit(const Error *error);
+
+// eof_or_error - return an error if a stream has its eof or error indicator set
+
+extern const Error *eof_or_error(FILE *stream);
+
+// UNUSED - suppress compiler warning about unused variable
+
+#define UNUSED(x) (void)(x)
+
+#endif // ERRORS_H

--- a/daffodil-runtime2/src/main/resources/c/libruntime/infoset.h
+++ b/daffodil-runtime2/src/main/resources/c/libruntime/infoset.h
@@ -18,32 +18,29 @@
 #ifndef INFOSET_H
 #define INFOSET_H
 
-#include <stdbool.h>  // for bool
-#include <stddef.h>   // for size_t
-#include <stdio.h>    // for FILE
+#include <stddef.h>  // for size_t
+#include "errors.h"  // for Error, PState, UState
 
 // Prototypes needed for compilation
 
 typedef struct ElementRuntimeData ERD;
 typedef struct InfosetBase        InfosetBase;
-typedef struct PState             PState;
-typedef struct UState             UState;
 typedef struct VisitEventHandler  VisitEventHandler;
 
 typedef void (*ERDInitSelf)(InfosetBase *infoNode);
 typedef void (*ERDParseSelf)(InfosetBase *infoNode, PState *pstate);
 typedef void (*ERDUnparseSelf)(const InfosetBase *infoNode, UState *ustate);
-typedef bool (*InitChoiceRD)(const InfosetBase *infoNode,
-                             const InfosetBase *rootElement);
+typedef const Error *(*InitChoiceRD)(const InfosetBase *infoNode,
+                                     const InfosetBase *rootElement);
 
-typedef const char *(*VisitStartDocument)(const VisitEventHandler *handler);
-typedef const char *(*VisitEndDocument)(const VisitEventHandler *handler);
-typedef const char *(*VisitStartComplex)(const VisitEventHandler *handler,
-                                         const InfosetBase *      base);
-typedef const char *(*VisitEndComplex)(const VisitEventHandler *handler,
-                                       const InfosetBase *      base);
-typedef const char *(*VisitNumberElem)(const VisitEventHandler *handler,
-                                       const ERD *erd, const void *number);
+typedef const Error *(*VisitStartDocument)(const VisitEventHandler *handler);
+typedef const Error *(*VisitEndDocument)(const VisitEventHandler *handler);
+typedef const Error *(*VisitStartComplex)(const VisitEventHandler *handler,
+                                          const InfosetBase *      base);
+typedef const Error *(*VisitEndComplex)(const VisitEventHandler *handler,
+                                        const InfosetBase *      base);
+typedef const Error *(*VisitNumberElem)(const VisitEventHandler *handler,
+                                        const ERD *erd, const void *number);
 
 // NamedQName - name of an infoset element
 
@@ -54,7 +51,7 @@ typedef struct NamedQName
     const char *ns;     // namespace URI (optional, may be NULL)
 } NamedQName;
 
-// TypeCode - type of an infoset element
+// TypeCode - types of infoset elements
 
 enum TypeCode
 {
@@ -96,24 +93,6 @@ typedef struct InfosetBase
     const ERD *erd;
 } InfosetBase;
 
-// PState - mutable state while parsing data
-
-typedef struct PState
-{
-    FILE *      stream;    // input to read data from
-    size_t      position;  // 0-based position in stream
-    const char *error_msg; // to stop if an error happens
-} PState;
-
-// UState - mutable state while unparsing infoset
-
-typedef struct UState
-{
-    FILE *      stream;    // output to write data to
-    size_t      position;  // 0-based position in stream
-    const char *error_msg; // to stop if an error happens
-} UState;
-
 // VisitEventHandler - methods to be called when walking an infoset
 
 typedef struct VisitEventHandler
@@ -140,19 +119,7 @@ extern InfosetBase *rootElement(void);
 
 // walkInfoset - walk an infoset and call VisitEventHandler methods
 
-extern const char *walkInfoset(const VisitEventHandler *handler,
-                               const InfosetBase *      infoset);
-
-// eof_or_error_msg - check if a stream has its eof or error indicator set
-
-extern const char *eof_or_error_msg(FILE *stream);
-
-// NO_CHOICE - define value stored in uninitialized _choice field
-
-static const size_t NO_CHOICE = (size_t)-1;
-
-// UNUSED - suppress compiler warning about unused variable
-
-#define UNUSED(x) (void)(x)
+extern const Error *walkInfoset(const VisitEventHandler *handler,
+                                const InfosetBase *      infoset);
 
 #endif // INFOSET_H

--- a/daffodil-runtime2/src/main/resources/c/libruntime/parsers.c
+++ b/daffodil-runtime2/src/main/resources/c/libruntime/parsers.c
@@ -16,14 +16,14 @@
  */
 
 #include "parsers.h"
-#include <endian.h>   // for be32toh, be64toh, le32toh, le64toh, be16toh, le16toh
-#include <stdbool.h>  // for bool
-#include <stdio.h>    // for fread, size_t
+#include <endian.h>   // for be32toh, le32toh, be16toh, be64toh, le16toh, le64toh
+#include <stdbool.h>  // for bool, false, true
+#include <stdio.h>    // for fread
+#include "errors.h"   // for PState, eof_or_error, Error, ERR_PARSE_BOOL, Error::(anonymous), Diagnostics, need_diagnostics, ERR_FIXED_VALUE
 
-// Macros that are not defined by <endian.h>
+// Macros not defined by <endian.h> which we need for uniformity
 
 #define be8toh(var) var
-
 #define le8toh(var) var
 
 // Helper macro to reduce duplication of C code reading stream,
@@ -34,7 +34,8 @@
     pstate->position += count;                                                 \
     if (count < sizeof(buffer))                                                \
     {                                                                          \
-        pstate->error_msg = eof_or_error_msg(pstate->stream);                  \
+        pstate->error = eof_or_error(pstate->stream);                          \
+        if (pstate->error) return;                                             \
     }
 
 // Macros to define parse_<endian>_<type> functions
@@ -43,70 +44,63 @@
     void parse_##endian##_bool##bits(bool *number, int64_t true_rep,           \
                                      uint32_t false_rep, PState *pstate)       \
     {                                                                          \
-        if (!pstate->error_msg)                                                \
+        union                                                                  \
         {                                                                      \
-            union                                                              \
-            {                                                                  \
-                char           c_val[sizeof(uint##bits##_t)];                  \
-                uint##bits##_t i_val;                                          \
-            } buffer;                                                          \
+            char           c_val[sizeof(uint##bits##_t)];                      \
+            uint##bits##_t i_val;                                              \
+        } buffer;                                                              \
                                                                                \
-            read_stream_update_position;                                       \
-            buffer.i_val = endian##bits##toh(buffer.i_val);                    \
-            if (true_rep < 0)                                                  \
-            {                                                                  \
-                *number = (buffer.i_val != false_rep);                         \
-            }                                                                  \
-            else if (buffer.i_val == (uint32_t)true_rep)                       \
-            {                                                                  \
-                *number = true;                                                \
-            }                                                                  \
-            else if (buffer.i_val == false_rep)                                \
-            {                                                                  \
-                *number = false;                                               \
-            }                                                                  \
-            else                                                               \
-            {                                                                  \
-                pstate->error_msg = "Unable to parse boolean";                 \
-            }                                                                  \
+        read_stream_update_position;                                           \
+        buffer.i_val = endian##bits##toh(buffer.i_val);                        \
+        if (true_rep < 0)                                                      \
+        {                                                                      \
+            *number = (buffer.i_val != false_rep);                             \
+        }                                                                      \
+        else if (buffer.i_val == (uint32_t)true_rep)                           \
+        {                                                                      \
+            *number = true;                                                    \
+        }                                                                      \
+        else if (buffer.i_val == false_rep)                                    \
+        {                                                                      \
+            *number = false;                                                   \
+        }                                                                      \
+        else                                                                   \
+        {                                                                      \
+            static Error error = {ERR_PARSE_BOOL, {NULL}};                     \
+            error.d64 = (int64_t)buffer.i_val;                                 \
+            pstate->error = &error;                                            \
         }                                                                      \
     }
 
 #define define_parse_endian_real(endian, type, bits)                           \
     void parse_##endian##_##type(type *number, PState *pstate)                 \
     {                                                                          \
-        if (!pstate->error_msg)                                                \
+        union                                                                  \
         {                                                                      \
-            union                                                              \
-            {                                                                  \
-                char           c_val[sizeof(type)];                            \
-                type           f_val;                                          \
-                uint##bits##_t i_val;                                          \
-            } buffer;                                                          \
+            char           c_val[sizeof(type)];                                \
+            type           f_val;                                              \
+            uint##bits##_t i_val;                                              \
+        } buffer;                                                              \
                                                                                \
-            read_stream_update_position;                                       \
-            buffer.i_val = endian##bits##toh(buffer.i_val);                    \
-            *number = buffer.f_val;                                            \
-        }                                                                      \
+        read_stream_update_position;                                           \
+        buffer.i_val = endian##bits##toh(buffer.i_val);                        \
+        *number = buffer.f_val;                                                \
     }
 
 #define define_parse_endian_integer(endian, type, bits)                        \
     void parse_##endian##_##type##bits(type##bits##_t *number, PState *pstate) \
     {                                                                          \
-        if (!pstate->error_msg)                                                \
+        union                                                                  \
         {                                                                      \
-            union                                                              \
-            {                                                                  \
-                char           c_val[sizeof(type##bits##_t)];                  \
-                type##bits##_t i_val;                                          \
-            } buffer;                                                          \
+            char           c_val[sizeof(type##bits##_t)];                      \
+            type##bits##_t i_val;                                              \
+        } buffer;                                                              \
                                                                                \
-            read_stream_update_position;                                       \
-            *number = endian##bits##toh(buffer.i_val);                         \
-        }                                                                      \
+        read_stream_update_position;                                           \
+        *number = endian##bits##toh(buffer.i_val);                             \
     }
 
-// Define functions to parse binary real numbers and integers
+// Parse binary booleans, real numbers, and integers
 
 define_parse_endian_bool(be, 16);
 define_parse_endian_bool(be, 32);
@@ -142,36 +136,38 @@ define_parse_endian_integer(le, uint, 32)
 define_parse_endian_integer(le, uint, 64)
 define_parse_endian_integer(le, uint, 8)
 
-// Define function to parse fill bytes until end position is reached
+// Parse fill bytes until end position is reached
 
 void
 parse_fill_bytes(size_t end_position, PState *pstate)
 {
-    while (!pstate->error_msg && pstate->position < end_position)
+    union
     {
-        char   buffer;
-        size_t count = fread(&buffer, 1, sizeof(buffer), pstate->stream);
+        char c_val[1];
+    } buffer;
 
-        pstate->position += count;
-        if (count < sizeof(buffer))
-        {
-            pstate->error_msg = eof_or_error_msg(pstate->stream);
-        }
+    while (pstate->position < end_position)
+    {
+        read_stream_update_position;
     }
 }
 
-// Define function to validate number is same as fixed value after parse
+// Validate parsed number is same as fixed value
 
 void
 parse_validate_fixed(bool same, const char *element, PState *pstate)
 {
-    UNUSED(element); // because managing strings hard in embedded C
-    if (!pstate->error_msg && !same)
+    if (!same)
     {
-        // Error message would be easier to assemble and
-        // internationalize if we used an error struct with multiple
-        // fields instead of a const char string.
-        pstate->error_msg = "Parse: Value of element does not match value of "
-                            "its 'fixed' attribute";
+        Diagnostics *validati = need_diagnostics();
+        pstate->validati = validati;
+
+        if (validati->length <
+            sizeof(validati->array) / sizeof(*validati->array))
+        {
+            Error *error = &validati->array[validati->length++];
+            error->code = ERR_FIXED_VALUE;
+            error->s = element;
+        }
     }
 }

--- a/daffodil-runtime2/src/main/resources/c/libruntime/parsers.h
+++ b/daffodil-runtime2/src/main/resources/c/libruntime/parsers.h
@@ -18,11 +18,12 @@
 #ifndef PARSERS_H
 #define PARSERS_H
 
-#include "infoset.h"  // for PState
 #include <stdbool.h>  // for bool
-#include <stdint.h>   // for int16_t, int32_t, int64_t, int8_t, uint16_t, uint32_t, uint64_t, uint8_t
+#include <stddef.h>   // for size_t
+#include <stdint.h>   // for int64_t, uint32_t, int16_t, int32_t, int8_t, uint16_t, uint64_t, uint8_t
+#include "errors.h"   // for PState
 
-// Functions to parse binary booleans, real numbers, and integers
+// Parse binary booleans, real numbers, and integers
 
 extern void parse_be_bool16(bool *number, int64_t true_rep, uint32_t false_rep,
                             PState *pstate);
@@ -64,11 +65,11 @@ extern void parse_le_uint32(uint32_t *number, PState *pstate);
 extern void parse_le_uint64(uint64_t *number, PState *pstate);
 extern void parse_le_uint8(uint8_t *number, PState *pstate);
 
-// Function to parse fill bytes until end position is reached
+// Parse fill bytes until end position is reached
 
 extern void parse_fill_bytes(size_t end_position, PState *pstate);
 
-// Function to validate number is same as fixed value after parse
+// Validate parsed number is same as fixed value
 
 extern void parse_validate_fixed(bool same, const char *element,
                                  PState *pstate);

--- a/daffodil-runtime2/src/main/resources/c/libruntime/unparsers.h
+++ b/daffodil-runtime2/src/main/resources/c/libruntime/unparsers.h
@@ -18,11 +18,12 @@
 #ifndef UNPARSERS_H
 #define UNPARSERS_H
 
-#include "infoset.h"  // for UState
 #include <stdbool.h>  // for bool
-#include <stdint.h>   // for int16_t, int32_t, int64_t, int8_t, uint16_t, uint32_t, uint64_t, uint8_t
+#include <stddef.h>   // for size_t
+#include <stdint.h>   // for uint32_t, int16_t, int32_t, int64_t, int8_t, uint16_t, uint64_t, uint8_t
+#include "errors.h"   // for UState
 
-// Functions to unparse binary booleans, real numbers, and integers
+// Unparse binary booleans, real numbers, and integers
 
 extern void unparse_be_bool16(bool number, uint32_t true_rep,
                               uint32_t false_rep, UState *ustate);
@@ -64,12 +65,12 @@ extern void unparse_le_uint32(uint32_t number, UState *ustate);
 extern void unparse_le_uint64(uint64_t number, UState *ustate);
 extern void unparse_le_uint8(uint8_t number, UState *ustate);
 
-// Function to unparse fill bytes until end position is reached
+// Unparse fill bytes until end position is reached
 
 extern void unparse_fill_bytes(size_t end_position, const char fill_byte,
                                UState *ustate);
 
-// Function to validate number is same as fixed value during unparse
+// Validate unparsed number is same as fixed value
 
 extern void unparse_validate_fixed(bool same, const char *element,
                                    UState *ustate);

--- a/daffodil-runtime2/src/main/resources/examples/NestedUnion.h
+++ b/daffodil-runtime2/src/main/resources/examples/NestedUnion.h
@@ -18,9 +18,10 @@
 #ifndef GENERATED_CODE_H
 #define GENERATED_CODE_H
 
-#include "infoset.h"  // for InfosetBase
 #include <stdbool.h>  // for bool
-#include <stdint.h>   // for int16_t, int32_t, int64_t, int8_t, uint16_t, uint32_t, uint64_t, uint8_t
+#include <stddef.h>   // for size_t
+#include <stdint.h>   // for int16_t, int32_t, int64_t, uint32_t, uint8_t, int8_t, uint16_t, uint64_t
+#include "infoset.h"  // for InfosetBase
 
 // Define infoset structures
 

--- a/daffodil-runtime2/src/main/resources/examples/ex_nums.c
+++ b/daffodil-runtime2/src/main/resources/examples/ex_nums.c
@@ -16,13 +16,18 @@
  */
 
 #include "ex_nums.h"
-#include "parsers.h"    // for parse_be_double, parse_be_float, parse_be_int16, parse_be_int32, parse_be_int64, parse_be_int8, parse_be_uint16, parse_be_uint32, parse_be_uint64, parse_be_uint8, parse_le_double, parse_le_float, parse_le_int16, parse_le_int32, parse_le_int64, parse_le_int8, parse_le_uint16, parse_le_uint32, parse_le_uint64, parse_le_uint8
-#include "unparsers.h"  // for unparse_be_double, unparse_be_float, unparse_be_int16, unparse_be_int32, unparse_be_int64, unparse_be_int8, unparse_be_uint16, unparse_be_uint32, unparse_be_uint64, unparse_be_uint8, unparse_le_double, unparse_le_float, unparse_le_int16, unparse_le_int32, unparse_le_int64, unparse_le_int8, unparse_le_uint16, unparse_le_uint32, unparse_le_uint64, unparse_le_uint8
 #include <math.h>       // for NAN
-#include <stdbool.h>    // for bool, false, true
+#include <stdbool.h>    // for bool, true, false
 #include <stddef.h>     // for NULL, size_t
+#include "errors.h"     // for Error, PState, UState, ERR_CHOICE_KEY, UNUSED
+#include "parsers.h"    // for parse_be_float, parse_be_int16, parse_be_bool32, parse_validate_fixed, parse_be_bool16, parse_be_int32, parse_be_uint32, parse_le_bool32, parse_le_int64, parse_le_uint8, parse_be_bool8, parse_be_double, parse_be_int64, parse_be_int8, parse_be_uint16, parse_be_uint64, parse_be_uint8, parse_le_bool16, parse_le_bool8, parse_le_double, parse_le_float, parse_le_int16, parse_le_int32, parse_le_int8, parse_le_uint16, parse_le_uint32, parse_le_uint64
+#include "unparsers.h"  // for unparse_be_float, unparse_be_int16, unparse_be_bool32, unparse_validate_fixed, unparse_be_bool16, unparse_be_int32, unparse_be_uint32, unparse_le_bool32, unparse_le_int64, unparse_le_uint8, unparse_be_bool8, unparse_be_double, unparse_be_int64, unparse_be_int8, unparse_be_uint16, unparse_be_uint64, unparse_be_uint8, unparse_le_bool16, unparse_le_bool8, unparse_le_double, unparse_le_float, unparse_le_int16, unparse_le_int32, unparse_le_int8, unparse_le_uint16, unparse_le_uint32, unparse_le_uint64
 
-// Prototypes needed for compilation
+// Initialize our program's name and version
+
+const char *argp_program_version = "daffodil-runtime2 3.1.0-SNAPSHOT";
+
+// Declare prototypes for easier compilation
 
 static void array_initSelf(array *instance);
 static void array_parseSelf(array *instance, PState *pstate);
@@ -40,7 +45,7 @@ static void ex_nums_initSelf(ex_nums *instance);
 static void ex_nums_parseSelf(ex_nums *instance, PState *pstate);
 static void ex_nums_unparseSelf(const ex_nums *instance, UState *ustate);
 
-// Metadata singletons
+// Define metadata for the infoset
 
 static const ERD be_bool16_array_ex_nums_ERD = {
     {
@@ -648,7 +653,7 @@ static const ERD ex_nums_ERD = {
     NULL // initChoice
 };
 
-// Return a root element to be used for parsing or unparsing
+// Return a root element for parsing or unparsing the infoset
 
 InfosetBase *
 rootElement(void)
@@ -663,7 +668,7 @@ rootElement(void)
     return &root._base;
 }
 
-// Methods to initialize, parse, and unparse infoset nodes
+// Initialize, parse, and unparse nodes of the infoset
 
 static void
 array_initSelf(array *instance)
@@ -683,26 +688,42 @@ static void
 array_parseSelf(array *instance, PState *pstate)
 {
     parse_be_bool16(&instance->be_bool16[0], -1, 0, pstate);
+    if (pstate->error) return;
     parse_be_bool16(&instance->be_bool16[1], -1, 0, pstate);
+    if (pstate->error) return;
     parse_be_float(&instance->be_float[0], pstate);
+    if (pstate->error) return;
     parse_be_float(&instance->be_float[1], pstate);
+    if (pstate->error) return;
     parse_be_float(&instance->be_float[2], pstate);
+    if (pstate->error) return;
     parse_be_int16(&instance->be_int16[0], pstate);
+    if (pstate->error) return;
     parse_be_int16(&instance->be_int16[1], pstate);
+    if (pstate->error) return;
     parse_be_int16(&instance->be_int16[2], pstate);
+    if (pstate->error) return;
 }
 
 static void
 array_unparseSelf(const array *instance, UState *ustate)
 {
     unparse_be_bool16(instance->be_bool16[0], ~0, 0, ustate);
+    if (ustate->error) return;
     unparse_be_bool16(instance->be_bool16[1], ~0, 0, ustate);
+    if (ustate->error) return;
     unparse_be_float(instance->be_float[0], ustate);
+    if (ustate->error) return;
     unparse_be_float(instance->be_float[1], ustate);
+    if (ustate->error) return;
     unparse_be_float(instance->be_float[2], ustate);
+    if (ustate->error) return;
     unparse_be_int16(instance->be_int16[0], ustate);
+    if (ustate->error) return;
     unparse_be_int16(instance->be_int16[1], ustate);
+    if (ustate->error) return;
     unparse_be_int16(instance->be_int16[2], ustate);
+    if (ustate->error) return;
 }
 
 static void
@@ -731,42 +752,74 @@ static void
 bigEndian_parseSelf(bigEndian *instance, PState *pstate)
 {
     parse_be_bool16(&instance->be_bool16, 1, 0, pstate);
+    if (pstate->error) return;
     parse_be_bool32(&instance->be_bool32, -1, 0, pstate);
+    if (pstate->error) return;
     parse_be_bool8(&instance->be_bool8, -1, 0, pstate);
+    if (pstate->error) return;
     parse_be_bool32(&instance->be_boolean, -1, 0, pstate);
+    if (pstate->error) return;
     parse_be_double(&instance->be_double, pstate);
+    if (pstate->error) return;
     parse_be_float(&instance->be_float, pstate);
+    if (pstate->error) return;
     parse_be_int16(&instance->be_int16, pstate);
+    if (pstate->error) return;
     parse_be_int32(&instance->be_int32, pstate);
+    if (pstate->error) return;
     parse_be_int64(&instance->be_int64, pstate);
+    if (pstate->error) return;
     parse_be_int8(&instance->be_int8, pstate);
+    if (pstate->error) return;
     parse_be_int16(&instance->be_integer16, pstate);
+    if (pstate->error) return;
     parse_be_uint16(&instance->be_uint16, pstate);
+    if (pstate->error) return;
     parse_be_uint32(&instance->be_uint32, pstate);
+    if (pstate->error) return;
     parse_be_uint64(&instance->be_uint64, pstate);
+    if (pstate->error) return;
     parse_be_uint8(&instance->be_uint8, pstate);
+    if (pstate->error) return;
     parse_be_uint32(&instance->be_nonNegativeInteger32, pstate);
+    if (pstate->error) return;
 }
 
 static void
 bigEndian_unparseSelf(const bigEndian *instance, UState *ustate)
 {
     unparse_be_bool16(instance->be_bool16, 1, 0, ustate);
+    if (ustate->error) return;
     unparse_be_bool32(instance->be_bool32, ~0, 0, ustate);
+    if (ustate->error) return;
     unparse_be_bool8(instance->be_bool8, ~0, 0, ustate);
+    if (ustate->error) return;
     unparse_be_bool32(instance->be_boolean, ~0, 0, ustate);
+    if (ustate->error) return;
     unparse_be_double(instance->be_double, ustate);
+    if (ustate->error) return;
     unparse_be_float(instance->be_float, ustate);
+    if (ustate->error) return;
     unparse_be_int16(instance->be_int16, ustate);
+    if (ustate->error) return;
     unparse_be_int32(instance->be_int32, ustate);
+    if (ustate->error) return;
     unparse_be_int64(instance->be_int64, ustate);
+    if (ustate->error) return;
     unparse_be_int8(instance->be_int8, ustate);
+    if (ustate->error) return;
     unparse_be_int16(instance->be_integer16, ustate);
+    if (ustate->error) return;
     unparse_be_uint16(instance->be_uint16, ustate);
+    if (ustate->error) return;
     unparse_be_uint32(instance->be_uint32, ustate);
+    if (ustate->error) return;
     unparse_be_uint64(instance->be_uint64, ustate);
+    if (ustate->error) return;
     unparse_be_uint8(instance->be_uint8, ustate);
+    if (ustate->error) return;
     unparse_be_uint32(instance->be_nonNegativeInteger32, ustate);
+    if (ustate->error) return;
 }
 
 static void
@@ -795,42 +848,74 @@ static void
 littleEndian_parseSelf(littleEndian *instance, PState *pstate)
 {
     parse_le_bool16(&instance->le_bool16, 1, 0, pstate);
+    if (pstate->error) return;
     parse_le_bool32(&instance->le_bool32, -1, 0, pstate);
+    if (pstate->error) return;
     parse_le_bool8(&instance->le_bool8, -1, 0, pstate);
+    if (pstate->error) return;
     parse_le_bool32(&instance->le_boolean, -1, 0, pstate);
+    if (pstate->error) return;
     parse_le_double(&instance->le_double, pstate);
+    if (pstate->error) return;
     parse_le_float(&instance->le_float, pstate);
+    if (pstate->error) return;
     parse_le_int16(&instance->le_int16, pstate);
+    if (pstate->error) return;
     parse_le_int32(&instance->le_int32, pstate);
+    if (pstate->error) return;
     parse_le_int64(&instance->le_int64, pstate);
+    if (pstate->error) return;
     parse_le_int8(&instance->le_int8, pstate);
+    if (pstate->error) return;
     parse_le_int64(&instance->le_integer64, pstate);
+    if (pstate->error) return;
     parse_le_uint16(&instance->le_uint16, pstate);
+    if (pstate->error) return;
     parse_le_uint32(&instance->le_uint32, pstate);
+    if (pstate->error) return;
     parse_le_uint64(&instance->le_uint64, pstate);
+    if (pstate->error) return;
     parse_le_uint8(&instance->le_uint8, pstate);
+    if (pstate->error) return;
     parse_le_uint8(&instance->le_nonNegativeInteger8, pstate);
+    if (pstate->error) return;
 }
 
 static void
 littleEndian_unparseSelf(const littleEndian *instance, UState *ustate)
 {
     unparse_le_bool16(instance->le_bool16, 1, 0, ustate);
+    if (ustate->error) return;
     unparse_le_bool32(instance->le_bool32, ~0, 0, ustate);
+    if (ustate->error) return;
     unparse_le_bool8(instance->le_bool8, ~0, 0, ustate);
+    if (ustate->error) return;
     unparse_le_bool32(instance->le_boolean, ~0, 0, ustate);
+    if (ustate->error) return;
     unparse_le_double(instance->le_double, ustate);
+    if (ustate->error) return;
     unparse_le_float(instance->le_float, ustate);
+    if (ustate->error) return;
     unparse_le_int16(instance->le_int16, ustate);
+    if (ustate->error) return;
     unparse_le_int32(instance->le_int32, ustate);
+    if (ustate->error) return;
     unparse_le_int64(instance->le_int64, ustate);
+    if (ustate->error) return;
     unparse_le_int8(instance->le_int8, ustate);
+    if (ustate->error) return;
     unparse_le_int64(instance->le_integer64, ustate);
+    if (ustate->error) return;
     unparse_le_uint16(instance->le_uint16, ustate);
+    if (ustate->error) return;
     unparse_le_uint32(instance->le_uint32, ustate);
+    if (ustate->error) return;
     unparse_le_uint64(instance->le_uint64, ustate);
+    if (ustate->error) return;
     unparse_le_uint8(instance->le_uint8, ustate);
+    if (ustate->error) return;
     unparse_le_uint8(instance->le_nonNegativeInteger8, ustate);
+    if (ustate->error) return;
 }
 
 static void
@@ -847,26 +932,42 @@ static void
 fixed_parseSelf(fixed *instance, PState *pstate)
 {
     parse_be_bool32(&instance->boolean_false, -1, 0, pstate);
+    if (pstate->error) return;
     parse_validate_fixed(instance->boolean_false == false, "boolean_false", pstate);
+    if (pstate->error) return;
     parse_be_bool32(&instance->boolean_true, -1, 0, pstate);
+    if (pstate->error) return;
     parse_validate_fixed(instance->boolean_true == true, "boolean_true", pstate);
+    if (pstate->error) return;
     parse_be_float(&instance->float_1_5, pstate);
+    if (pstate->error) return;
     parse_validate_fixed(instance->float_1_5 == 1.5, "float_1_5", pstate);
+    if (pstate->error) return;
     parse_be_int32(&instance->int_32, pstate);
+    if (pstate->error) return;
     parse_validate_fixed(instance->int_32 == 32, "int_32", pstate);
+    if (pstate->error) return;
 }
 
 static void
 fixed_unparseSelf(const fixed *instance, UState *ustate)
 {
     unparse_be_bool32(instance->boolean_false, ~0, 0, ustate);
+    if (ustate->error) return;
     unparse_validate_fixed(instance->boolean_false == false, "boolean_false", ustate);
+    if (ustate->error) return;
     unparse_be_bool32(instance->boolean_true, ~0, 0, ustate);
+    if (ustate->error) return;
     unparse_validate_fixed(instance->boolean_true == true, "boolean_true", ustate);
+    if (ustate->error) return;
     unparse_be_float(instance->float_1_5, ustate);
+    if (ustate->error) return;
     unparse_validate_fixed(instance->float_1_5 == 1.5, "float_1_5", ustate);
+    if (ustate->error) return;
     unparse_be_int32(instance->int_32, ustate);
+    if (ustate->error) return;
     unparse_validate_fixed(instance->int_32 == 32, "int_32", ustate);
+    if (ustate->error) return;
 }
 
 static void
@@ -883,17 +984,25 @@ static void
 ex_nums_parseSelf(ex_nums *instance, PState *pstate)
 {
     array_parseSelf(&instance->array, pstate);
+    if (pstate->error) return;
     bigEndian_parseSelf(&instance->bigEndian, pstate);
+    if (pstate->error) return;
     littleEndian_parseSelf(&instance->littleEndian, pstate);
+    if (pstate->error) return;
     fixed_parseSelf(&instance->fixed, pstate);
+    if (pstate->error) return;
 }
 
 static void
 ex_nums_unparseSelf(const ex_nums *instance, UState *ustate)
 {
     array_unparseSelf(&instance->array, ustate);
+    if (ustate->error) return;
     bigEndian_unparseSelf(&instance->bigEndian, ustate);
+    if (ustate->error) return;
     littleEndian_unparseSelf(&instance->littleEndian, ustate);
+    if (ustate->error) return;
     fixed_unparseSelf(&instance->fixed, ustate);
+    if (ustate->error) return;
 }
 

--- a/daffodil-runtime2/src/main/resources/examples/ex_nums.h
+++ b/daffodil-runtime2/src/main/resources/examples/ex_nums.h
@@ -18,9 +18,10 @@
 #ifndef GENERATED_CODE_H
 #define GENERATED_CODE_H
 
-#include "infoset.h"  // for InfosetBase
 #include <stdbool.h>  // for bool
-#include <stdint.h>   // for int16_t, int32_t, int64_t, int8_t, uint16_t, uint32_t, uint64_t, uint8_t
+#include <stddef.h>   // for size_t
+#include <stdint.h>   // for int16_t, int32_t, int64_t, uint32_t, uint8_t, int8_t, uint16_t, uint64_t
+#include "infoset.h"  // for InfosetBase
 
 // Define infoset structures
 

--- a/daffodil-runtime2/src/main/scala/org/apache/daffodil/runtime2/generators/BinaryAbstractCodeGenerator.scala
+++ b/daffodil-runtime2/src/main/scala/org/apache/daffodil/runtime2/generators/BinaryAbstractCodeGenerator.scala
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.daffodil.runtime2.generators
+
+import org.apache.daffodil.dsom.ElementBase
+import org.apache.daffodil.schema.annotation.props.gen.BitOrder
+import org.apache.daffodil.schema.annotation.props.gen.ByteOrder
+import org.apache.daffodil.schema.annotation.props.gen.OccursCountKind
+
+trait BinaryAbstractCodeGenerator {
+
+  def binaryAbstractGenerateCode(e: ElementBase, initialValue: String, prim: String,
+    parseArgs: String, unparseArgs: String, cgState: CodeGeneratorState): Unit = {
+
+    // For the time being this is a very limited back end.
+    // So there are some restrictions to enforce.
+    e.schemaDefinitionUnless(e.bitOrder eq BitOrder.MostSignificantBitFirst, "Only dfdl:bitOrder 'mostSignificantBitFirst' is supported.")
+    e.schemaDefinitionUnless(e.byteOrderEv.isConstant, "Runtime dfdl:byteOrder expressions not supported.")
+    e.schemaDefinitionUnless(e.elementLengthInBitsEv.isConstant, "Runtime dfdl:length expressions not supported.")
+
+    val fieldName = e.namedQName.local
+    val byteOrder = e.byteOrderEv.constValue
+    val conv = if (byteOrder eq ByteOrder.BigEndian) "be" else "le"
+    val arraySize = if (e.occursCountKind == OccursCountKind.Fixed) e.maxOccurs else 0
+    val fixed = e.xml.attribute("fixed")
+    val fixedValue = if (fixed.isDefined) fixed.get.text else ""
+
+    def addStatements(deref: String): Unit = {
+      val initStatement = s"    instance->$fieldName$deref = $initialValue;"
+      val parseStatement =
+        s"""    parse_${conv}_$prim(&instance->$fieldName$deref, $parseArgs);
+           |    if (pstate->error) return;""".stripMargin
+      val unparseStatement =
+        s"""    unparse_${conv}_$prim(instance->$fieldName$deref, $unparseArgs);
+           |    if (ustate->error) return;""".stripMargin
+      cgState.addSimpleTypeStatements(initStatement, parseStatement, unparseStatement)
+
+      if (fixedValue.nonEmpty) {
+        val init2 = ""
+        val parse2 =
+          s"""    parse_validate_fixed(instance->$fieldName$deref == $fixedValue, "$fieldName", pstate);
+             |    if (pstate->error) return;""".stripMargin
+        val unparse2 =
+          s"""    unparse_validate_fixed(instance->$fieldName$deref == $fixedValue, "$fieldName", ustate);
+             |    if (ustate->error) return;""".stripMargin
+        cgState.addSimpleTypeStatements(init2, parse2, unparse2)
+      }
+    }
+    if (arraySize > 0)
+      for (i <- 0 until arraySize)
+        addStatements(s"[$i]")
+    else
+      addStatements("")
+  }
+}

--- a/daffodil-runtime2/src/main/scala/org/apache/daffodil/runtime2/generators/BinaryBooleanCodeGenerator.scala
+++ b/daffodil-runtime2/src/main/scala/org/apache/daffodil/runtime2/generators/BinaryBooleanCodeGenerator.scala
@@ -19,60 +19,27 @@ package org.apache.daffodil.runtime2.generators
 
 import org.apache.daffodil.dsom.ElementBase
 import org.apache.daffodil.exceptions.Assert
-import org.apache.daffodil.schema.annotation.props.gen.BitOrder
-import org.apache.daffodil.schema.annotation.props.gen.ByteOrder
-import org.apache.daffodil.schema.annotation.props.gen.OccursCountKind
 import passera.unsigned.ULong
 
-trait BinaryBooleanCodeGenerator {
+trait BinaryBooleanCodeGenerator extends BinaryAbstractCodeGenerator {
 
   def binaryBooleanGenerateCode(e: ElementBase, cgState: CodeGeneratorState): Unit = {
-    // For the time being this is a very limited back end.
-    // So there are some restrictions to enforce.
-    e.schemaDefinitionUnless(e.bitOrder eq BitOrder.MostSignificantBitFirst, "Only dfdl:bitOrder 'mostSignificantBitFirst' is supported.")
-    val byteOrder: ByteOrder = {
-      e.schemaDefinitionUnless(e.byteOrderEv.isConstant, "Runtime dfdl:byteOrder expressions not supported.")
-      e.byteOrderEv.constValue
-    }
-    val lengthInBits: Long = {
-      e.schemaDefinitionUnless(e.elementLengthInBitsEv.isConstant, "Runtime dfdl:length expressions not supported.")
-      val len = e.elementLengthInBitsEv.constValue.get
-      len match {
-        case 8 | 16 | 32 => len
-        case _ => e.SDE("Boolean lengths other than 8, 16, or 32 bits are not supported.")
-      }
-    }
     Assert.invariant(e.binaryBooleanTrueRep.isEmpty || e.binaryBooleanTrueRep.getULong >= ULong(0))
     Assert.invariant(e.binaryBooleanFalseRep >= ULong(0))
+    Assert.invariant(e.elementLengthInBitsEv.isConstant)
 
-    val initialValue = "true"
-    val fieldName = e.namedQName.local
-    val conv = if (byteOrder eq ByteOrder.BigEndian) "be" else "le"
+    val lengthInBits = e.elementLengthInBitsEv.constValue.get
+    val initialValue = lengthInBits match {
+      case 8 | 16 | 32 => "true"
+      case _ => e.SDE("Boolean lengths other than 8, 16, or 32 bits are not supported.")
+    }
     val prim = s"bool$lengthInBits"
     val trueRep = if (e.binaryBooleanTrueRep.isDefined) e.binaryBooleanTrueRep.getULong else -1
     val falseRep = e.binaryBooleanFalseRep
+    val parseArgs = s"$trueRep, $falseRep, pstate"
     val unparseTrueRep = if (e.binaryBooleanTrueRep.isDefined) s"$trueRep" else s"~$falseRep"
-    val arraySize = if (e.occursCountKind == OccursCountKind.Fixed) e.maxOccurs else 0
-    val fixed = e.xml.attribute("fixed")
-    val fixedValue = if (fixed.isDefined) fixed.get.text else ""
+    val unparseArgs = s"$unparseTrueRep, $falseRep, ustate"
 
-    def addStatements(deref: String): Unit = {
-      val initStatement = s"    instance->$fieldName$deref = $initialValue;"
-      val parseStatement = s"    parse_${conv}_$prim(&instance->$fieldName$deref, $trueRep, $falseRep, pstate);"
-      val unparseStatement = s"    unparse_${conv}_$prim(instance->$fieldName$deref, $unparseTrueRep, $falseRep, ustate);"
-      cgState.addSimpleTypeStatements(initStatement, parseStatement, unparseStatement)
-
-      if (fixedValue.nonEmpty) {
-        val init2 = ""
-        val parse2 = s"""    parse_validate_fixed(instance->$fieldName$deref == $fixedValue, "$fieldName", pstate);"""
-        val unparse2 = s"""    unparse_validate_fixed(instance->$fieldName$deref == $fixedValue, "$fieldName", ustate);"""
-        cgState.addSimpleTypeStatements(init2, parse2, unparse2)
-      }
-    }
-    if (arraySize > 0)
-      for (i <- 0 until arraySize)
-        addStatements(s"[$i]")
-    else
-      addStatements("")
+    binaryAbstractGenerateCode(e, initialValue, prim, parseArgs, unparseArgs, cgState)
   }
 }

--- a/daffodil-runtime2/src/main/scala/org/apache/daffodil/runtime2/generators/BinaryFloatCodeGenerator.scala
+++ b/daffodil-runtime2/src/main/scala/org/apache/daffodil/runtime2/generators/BinaryFloatCodeGenerator.scala
@@ -18,48 +18,21 @@
 package org.apache.daffodil.runtime2.generators
 
 import org.apache.daffodil.dsom.ElementBase
-import org.apache.daffodil.schema.annotation.props.gen.ByteOrder
-import org.apache.daffodil.schema.annotation.props.gen.OccursCountKind
 
-trait BinaryFloatCodeGenerator {
+trait BinaryFloatCodeGenerator extends BinaryAbstractCodeGenerator {
 
   def binaryFloatGenerateCode(e: ElementBase, lengthInBits: Int, cgState: CodeGeneratorState): Unit = {
-    // For the time being this is a very limited back end.
-    // So there are some restrictions to enforce.
-    assert(lengthInBits == 32 || lengthInBits == 64)
-    val byteOrder: ByteOrder = {
-      e.schemaDefinitionUnless(e.byteOrderEv.isConstant, "Runtime dfdl:byteOrder expressions not supported.")
-      val bo = e.byteOrderEv.constValue
-      bo
-    }
 
     // Use a NAN to mark our field as uninitialized in case parsing or unparsing
     // fails to set the field.
-    val initialValue = "NAN"
-    val fieldName = e.namedQName.local
-    val conv = if (byteOrder eq ByteOrder.BigEndian) "be" else "le"
-    val prim = if (lengthInBits == 32) "float" else "double"
-    val arraySize = if (e.occursCountKind == OccursCountKind.Fixed) e.maxOccurs else 0
-    val fixed = e.xml.attribute("fixed")
-    val fixedValue = if (fixed.isDefined) fixed.get.text else ""
-
-    def addStatements(deref: String): Unit = {
-      val initStatement = s"    instance->$fieldName$deref = $initialValue;"
-      val parseStatement = s"    parse_${conv}_$prim(&instance->$fieldName$deref, pstate);"
-      val unparseStatement = s"    unparse_${conv}_$prim(instance->$fieldName$deref, ustate);"
-      cgState.addSimpleTypeStatements(initStatement, parseStatement, unparseStatement)
-
-      if (fixedValue.nonEmpty) {
-        val init2 = ""
-        val parse2 = s"""    parse_validate_fixed(instance->$fieldName$deref == $fixedValue, "$fieldName", pstate);"""
-        val unparse2 = s"""    unparse_validate_fixed(instance->$fieldName$deref == $fixedValue, "$fieldName", ustate);"""
-        cgState.addSimpleTypeStatements(init2, parse2, unparse2)
-      }
+    val initialValue = lengthInBits match {
+      case 32 | 64 => "NAN"
+      case _ => e.SDE("Floating point lengths other than 32 or 64 bits are not supported.")
     }
-    if (arraySize > 0)
-      for (i <- 0 until arraySize)
-        addStatements(s"[$i]")
-    else
-      addStatements("")
+    val prim = if (lengthInBits == 32) "float" else "double"
+    val parseArgs = "pstate"
+    val unparseArgs = "ustate"
+
+    binaryAbstractGenerateCode(e, initialValue, prim, parseArgs, unparseArgs, cgState)
   }
 }

--- a/daffodil-runtime2/src/main/scala/org/apache/daffodil/runtime2/generators/BinaryIntegerKnownLengthCodeGenerator.scala
+++ b/daffodil-runtime2/src/main/scala/org/apache/daffodil/runtime2/generators/BinaryIntegerKnownLengthCodeGenerator.scala
@@ -18,60 +18,25 @@
 package org.apache.daffodil.runtime2.generators
 
 import org.apache.daffodil.grammar.primitives.BinaryIntegerKnownLength
-import org.apache.daffodil.schema.annotation.props.gen.OccursCountKind
-import org.apache.daffodil.schema.annotation.props.gen.{ BitOrder, ByteOrder }
 
-trait BinaryIntegerKnownLengthCodeGenerator {
+trait BinaryIntegerKnownLengthCodeGenerator extends BinaryAbstractCodeGenerator {
 
   def binaryIntegerKnownLengthGenerateCode(g: BinaryIntegerKnownLength, cgState: CodeGeneratorState): Unit = {
-    // For the time being this is a very limited back end.
-    // So there are some restrictions to enforce.
-    val e = g.e
-    val lengthInBits: Long = {
-      e.schemaDefinitionUnless(e.elementLengthInBitsEv.isConstant, "Runtime dfdl:length expressions not supported.")
-      val len = e.elementLengthInBitsEv.constValue.get
-      len
-    }
-    e.schemaDefinitionUnless(e.bitOrder eq BitOrder.MostSignificantBitFirst, "Only dfdl:bitOrder 'mostSignificantBitFirst' is supported.")
-    val byteOrder: ByteOrder = {
-      e.schemaDefinitionUnless(e.byteOrderEv.isConstant, "Runtime dfdl:byteOrder expressions not supported.")
-      val bo = e.byteOrderEv.constValue
-      bo
-    }
 
     // Use an unusual memory bit pattern (magic debug value) to mark our field
     // as uninitialized in case parsing or unparsing fails to set the field.
-    val initialValue = lengthInBits match {
+    val e = g.e
+    val initialValue = g.lengthInBits match {
       case 8 => "0xCC"
       case 16 => "0xCCCC"
       case 32 => "0xCCCCCCCC"
       case 64 => "0xCCCCCCCCCCCCCCCC"
       case _ => e.SDE("Integer lengths other than 8, 16, 32, or 64 bits are not supported.")
     }
-    val fieldName = e.namedQName.local
-    val conv = if (byteOrder eq ByteOrder.BigEndian) "be" else "le"
-    val prim = if (g.signed) s"int${lengthInBits}" else s"uint${lengthInBits}"
-    val arraySize = if (e.occursCountKind == OccursCountKind.Fixed) e.maxOccurs else 0
-    val fixed = e.xml.attribute("fixed")
-    val fixedValue = if (fixed.isDefined) fixed.get.text else ""
+    val prim = if (g.signed) s"int${g.lengthInBits}" else s"uint${g.lengthInBits}"
+    val parseArgs = "pstate"
+    val unparseArgs = "ustate"
 
-    def addStatements(deref: String): Unit = {
-      val initStatement = s"    instance->$fieldName$deref = $initialValue;"
-      val parseStatement = s"    parse_${conv}_$prim(&instance->$fieldName$deref, pstate);"
-      val unparseStatement = s"    unparse_${conv}_$prim(instance->$fieldName$deref, ustate);"
-      cgState.addSimpleTypeStatements(initStatement, parseStatement, unparseStatement)
-
-      if (fixedValue.nonEmpty) {
-        val init2 = ""
-        val parse2 = s"""    parse_validate_fixed(instance->$fieldName$deref == $fixedValue, "$fieldName", pstate);"""
-        val unparse2 = s"""    unparse_validate_fixed(instance->$fieldName$deref == $fixedValue, "$fieldName", ustate);"""
-        cgState.addSimpleTypeStatements(init2, parse2, unparse2)
-      }
-    }
-    if (arraySize > 0)
-      for (i <- 0 until arraySize)
-        addStatements(s"[$i]")
-    else
-      addStatements("")
+    binaryAbstractGenerateCode(e, initialValue, prim, parseArgs, unparseArgs, cgState)
   }
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -15,4 +15,4 @@
  * limitations under the License.
  */
 
-sbt.version=1.4.1
+sbt.version=1.4.9


### PR DESCRIPTION
Refactor duplicate code in Binary*CodeGenerator.scala files.

Change PState/UState member field from a string error message to a
struct error object.  Make parse/unparse functions initialize that
member field if any error happens.  Move checks for errors from
parse/unparse functions to their callers, e.g., "if (ustate->error)
return;".

Collect validation errors without stopping parsing or unparsing by
initializing another PState/UState member field pointing to a
validation struct with some fields.  As last step, update all C files
using include-what-you-use to document what's used from each include.

Add instructions to README.md how to setup required C tool-chain
elements on Linux and Windows.

Generate daffodil-runtime2's name and version into generated_code.c
automatically so we won't need to keep it up to date.

Changelog:

In README.md, fix or disable markdownlint warnings.  Expand Build
Requirements with instructions how to install C compiler, Mini-XML
library, java, and sbt on Linux and Windows.  Verify/update old
hyperlinks and add new MSYS2 and clang hyperlinks.

In build.sbt, add Compile / cCompiler and ccArchiveCommand settings as
a guide to show developers how to override these default settings if
they want sbt to call the C compiler with a different name than "cc".
The sbt-cc plugin doesn't iterate through a list (${CC}, cc, gcc,
clang, zig cc) to find a C compiler like our runtime2 code does.

In daffodil_argp.c, remove argp_program_version's definition since we
now generate it automatically within generated_code.c.

In daffodil_main.c, add fflush_or_exit and change fopen_or_exit /
fclose_or_open to call continue_or_exit with error message instead of
calling exit directly.  Make main print any validation diagnostics
before printing any errors since they've been split into separate
PState/UState member fields.  Also make main call continue_or_exit
instead of calling error directly and pass Error structs, not strings,
to all continue_or_exit calls.

In stack.c, make stack functions call continue_or_exit instead of
calling error directly and pass Error structs, not strings, to all
continue_or_exit calls.

In xml_reader.c, make conversion functions return Error structs, not
strings, to indicate errors converting strings to primitive datums.
Make reader functions return Error structs, not strings, to indicate
errors reading XML data.

In xml_writer.c, make writer functions return Error structs, not
strings, to indicate errors writing XML data.  Remove redundant stack
checking code already performed within stack fuctions.

In errors.c (new file), use switch statement inside error_message
function to centralize all error messages in one place for easier
future internationalization.  Use switch statement inside
print_mybe_stop function to allow error messages to interpolate an
extra detail (string or integer) if needed.  Define a single static
array that can be used to store validation diagnostics and define a
function to print validation diagnostics.  Implement continue_or_exit
and eof_or_error functions here as well.

In errors.h (new file), define enumerations for each type of error
which could occur in C code.  Define an Error struct to store an
enumeration and optionally an extra detail (string or integer).  Also
define a Diagnostics struct to store an array of data validation
errors which should be reported separately from parse errors.  Move
PState and UState structs here from infoset.h and give them member
fields pointing to data validation and parse errors.  Also declare
need_diagnostics, print_diagnostics, continue_or_exit, eof_or_error
prototypes and UNUSED macro in errors.h.

In infoset.c, make walkInfosetNode and walkInfoset functions return
Error struct, not string.  Remove eof_or_error_msg function (now moved
to errors.c with shorter name).

In infoset.h, change InitChoiceRD and Visit* prototypes to return
Error structs, not strings.  Remove PState & UState structs,
eof_or_error_msg prototype, and UNUSED macro (all moved to errors.h).

In parsers.c, make parse_<endian>_<type> functions stop enclosing
their code in "if (!pstate->error_msg)" statements and use Error
structs, not strings.  Callers are now expected to check for errors
after each call immediately.  Make parse_fill_bytes use
read_stream_update_position helper macro too.  Make
parse_validate_fixed report errors in separate pstate->validati field,
not pstate->error field.

In unparsers.c, make unparse_<endian>_<type> functions stop enclosing
their code in "if (!ustate->error_msg)" statements and use Error
structs, not strings.  Callers are now expected to check for errors
after each call immediately.  Make unparse_fill_bytes use
write_stream_update_position helper macro too.  Make
unparse_validate_fixed report errors in separate ustate->validati
field, not ustate->error field.

In NestedUnion.c and ex_nums.c examples, update with freshly generated
code to illustrate code generator changes (in particular, defining
argp_program_version, adding an if statement after each parse/unparse
call to check for an error and skip rest of calls immediately, and
returning errors directly from initChoice functions with choice key
that failed to match any branch key).

In BinaryAbstractCodeGenerator.scala (new file), refactor common code
that used to be duplicated in BinaryBooleanCodeGenerator.scala,
BinaryFloatCodeGenerator.scala, and
BinaryIntegerKnownLengthCodeGenerator.scala; now they pass parameters
to binaryAbstractGenerateCode instead.

In CodeGeneratorState.scala, make all necessary changes to report
errors using structs instead of strings in generated code including
initChoice functions, add if statements after each parse/unparse call,
and generate the program name and version automatically.

In build.properties, change sbt.version from 1.4.1 to 1.4.9 to ensure
successful sbt build from scratch in a new Ubuntu or Windows VM (sbt
was getting java.lang.NoClassDefFound: scala/Serializer).