### PR TITLE
WIP: Added -Y warning check options

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -192,7 +192,12 @@ def buildScalacOptions(scalaVersion: String) = {
     "-unchecked",
     "-Xfatal-warnings",
     "-Xxml:-coalescing",
-    "-Xfuture"
+    "-Xfuture",
+    "-Ywarn-infer-any",
+    "-Ywarn-inaccessible",
+    // "-Ywarn-nullary-unit", // we cannot use this. It interferes with the Uniform Access Principle.
+    // See https://stackoverflow.com/questions/7600910/difference-between-function-with-parentheses-and-without.
+    "-Ywarn-unused-import"
   )
 
   val scalaVersionSpecificOptions = CrossVersion.partialVersion(scalaVersion) match {
@@ -211,6 +216,8 @@ def buildScalacOptions(scalaVersion: String) = {
     commonOptions ++ scalaVersionSpecificOptions ++ javaVersionSpecificOptions
 }
 
+// Workaround issue that some options are valid for javac, not javadoc.
+// These javacOptions are for code compilation only. (Issue sbt/sbt#355)
 def buildJavacOptions() = {
   val commonOptions = Seq(
     "-Werror",

--- a/daffodil-core/src/test/scala/org/apache/daffodil/dsom/TestBinaryInput_01.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/dsom/TestBinaryInput_01.scala
@@ -51,7 +51,7 @@ class TestBinaryInput_01 {
     (dis, finfo)
   }
 
-  @After def shutDown: Unit = {
+  @After def shutDown(): Unit = {
     dis.discard(startOver)
   }
 

--- a/daffodil-core/src/test/scala/org/apache/daffodil/dsom/TestDsomCompiler.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/dsom/TestDsomCompiler.scala
@@ -215,7 +215,7 @@ class TestDsomCompiler {
     assertTrue(elem.isInstanceOf[LocalElementDecl])
   }
 
-  @Test def test3: Unit = {
+  @Test def test3(): Unit = {
     val testSchema = XML.load(Misc.getRequiredResource("/test/example-of-most-dfdl-constructs.dfdl.xml").toURL)
 
     val sset = SchemaSet(testSchema)
@@ -297,7 +297,7 @@ class TestDsomCompiler {
     assertEquals("ex:a", e1r.ref)
   }
 
-  @Test def test4: Unit = {
+  @Test def test4(): Unit = {
     val testSchema = XML.load(Misc.getRequiredResource("/test/example-of-most-dfdl-constructs.dfdl.xml").toURL)
 
     val sset = SchemaSet(testSchema)
@@ -324,7 +324,7 @@ class TestDsomCompiler {
     assertEquals("{ $myVar1 eq xs:int(xs:string(fn:round-half-to-even(8.5))) }", asrt1.testTxt)
   }
 
-  @Test def test_named_format_chaining: Unit = {
+  @Test def test_named_format_chaining(): Unit = {
     val testSchema =
       XML.load(
         Misc.getRequiredResource(
@@ -342,7 +342,7 @@ class TestDsomCompiler {
     assertEquals(true, a1.verifyPropValue("binaryNumberRep", "packed"))
   }
 
-  @Test def test_simple_types_access_works: Unit = {
+  @Test def test_simple_types_access_works(): Unit = {
     val testSchema =
       XML.load(
         Misc.getRequiredResource(
@@ -357,7 +357,7 @@ class TestDsomCompiler {
     assertEquals(AlignmentUnits.Bytes, x.alignmentUnits)
   }
 
-  @Test def test_simple_types_property_combining: Unit = {
+  @Test def test_simple_types_property_combining(): Unit = {
     val testSchema =
       XML.load(
         Misc.getRequiredResource(
@@ -389,7 +389,7 @@ class TestDsomCompiler {
     assertEquals(BinaryNumberRep.Packed, ge6.binaryNumberRep)
   }
 
-  @Test def test_simpleType_base_combining: Unit = {
+  @Test def test_simpleType_base_combining(): Unit = {
     val testSchema = XML.load(Misc.getRequiredResource("/test/example-of-most-dfdl-constructs.dfdl.xml").toURL)
 
     val sset = SchemaSet(testSchema)
@@ -436,7 +436,7 @@ class TestDsomCompiler {
     assertTrue(msgs.contains("initiator".toLowerCase))
   }
 
-  @Test def test_group_references: Unit = {
+  @Test def test_group_references(): Unit = {
     val testSchema = XML.load(Misc.getRequiredResource("/test/example-of-most-dfdl-constructs.dfdl.xml").toURL)
 
     val sset = SchemaSet(testSchema)
@@ -489,7 +489,7 @@ class TestDsomCompiler {
 
   }
 
-  @Test def test_ibm_7132: Unit = {
+  @Test def test_ibm_7132(): Unit = {
     val ibm7132Schema = XML.load(Misc.getRequiredResource("/test/TestRefChainingIBM7132.dfdl.xml").toURL)
     // val ibm7132Schema = "test/TestRefChainingIBM7132.dfdl.xml"
     val sset = SchemaSet(ibm7132Schema)
@@ -533,7 +533,7 @@ class TestDsomCompiler {
 
   }
 
-  @Test def testGetQName = {
+  @Test def testGetQName() = {
     val testSchema = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:defineFormat name="ref1">
@@ -565,7 +565,7 @@ class TestDsomCompiler {
     scala.xml.Elem("dfdl", "element", scala.xml.Null, scope, true)
   }
 
-  @Test def test_escapeSchemeOverride = {
+  @Test def test_escapeSchemeOverride() = {
     val testSchema = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format ref="tns:GeneralFormat" separator="" initiator="" terminator="" emptyValueDelimiterPolicy="none" textNumberRep="standard" representation="text" occursStopValue="-1" occursCountKind="expression" escapeSchemeRef="pound"/>
@@ -608,7 +608,7 @@ class TestDsomCompiler {
     assertEquals("cStyleComment", e2f_esref)
   }
 
-  @Test def test_element_references: Unit = {
+  @Test def test_element_references(): Unit = {
     val testSchema = XML.load(Misc.getRequiredResource("/test/example-of-most-dfdl-constructs.dfdl.xml").toURL)
 
     val sset = SchemaSet(testSchema)

--- a/daffodil-core/src/test/scala/org/apache/daffodil/dsom/TestMiddleEndAttributes.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/dsom/TestMiddleEndAttributes.scala
@@ -28,7 +28,7 @@ class TestMiddleEndAttributes {
   val xsi = XMLUtils.XSI_NAMESPACE
   val example = XMLUtils.EXAMPLE_NAMESPACE
 
-  @Test def test_hasStaticallyRequiredOccurrencesInDataRepresentation_1: Unit = {
+  @Test def test_hasStaticallyRequiredOccurrencesInDataRepresentation_1(): Unit = {
     val testSchema = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format representation="text" lengthUnits="bytes" encoding="US-ASCII" initiator="" terminator="" separator="" ignoreCase="no"/>,
@@ -54,7 +54,7 @@ class TestMiddleEndAttributes {
     assertTrue(s2.hasStaticallyRequiredOccurrencesInDataRepresentation)
   }
 
-  @Test def test_hasStaticallyRequiredOccurrencesInDataRepresentation_2: Unit = {
+  @Test def test_hasStaticallyRequiredOccurrencesInDataRepresentation_2(): Unit = {
     val testSchema = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format representation="text" occursCountKind="parsed" lengthUnits="bytes" encoding="US-ASCII" initiator="" terminator="" separator="" ignoreCase="no"/>,
@@ -80,7 +80,7 @@ class TestMiddleEndAttributes {
     assertFalse(s2.hasStaticallyRequiredOccurrencesInDataRepresentation)
   }
 
-  @Test def testRequiredSiblings: Unit = {
+  @Test def testRequiredSiblings(): Unit = {
     val testSchema = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format representation="text" occursCountKind="parsed" lengthUnits="bytes" encoding="US-ASCII" initiator="" terminator="" separator="" ignoreCase="no"/>,
@@ -112,7 +112,7 @@ class TestMiddleEndAttributes {
     assertFalse(s5.hasStaticallyRequiredOccurrencesInDataRepresentation)
   }
 
-  @Test def testStaticallyFirstWithChoice: Unit = {
+  @Test def testStaticallyFirstWithChoice(): Unit = {
     val testSchema = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format representation="text" occursCountKind="parsed" lengthUnits="bytes" encoding="US-ASCII" initiator="" terminator="" separator="" ignoreCase="no"

--- a/daffodil-core/src/test/scala/org/apache/daffodil/dsom/TestSimpleTypeUnions.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/dsom/TestSimpleTypeUnions.scala
@@ -64,7 +64,7 @@ class TestSimpleTypeUnions {
       </xs:annotation>
     </xs:element>)
 
-  @Test def testUnion01: Unit = {
+  @Test def testUnion01(): Unit = {
 
     val sset = SchemaSet(testSchema1)
     val Seq(sch) = sset.schemas
@@ -95,7 +95,7 @@ class TestSimpleTypeUnions {
     assertEquals("int2Type", st2rd.diagnosticDebugName)
   }
 
-  @Test def testUnionFirstUnionMemberOk: Unit = {
+  @Test def testUnionFirstUnionMemberOk(): Unit = {
     val (result, actual) = TestUtils.testString(testSchema1, "1")
     val i = result.resultState.asInstanceOf[PState].infoset.asInstanceOf[DIDocument].contents(0).asInstanceOf[DISimple]
     val umstrd = i.unionMemberRuntimeData.get
@@ -105,7 +105,7 @@ class TestSimpleTypeUnions {
     TestUtils.assertEqualsXMLElements(expected, actual)
   }
 
-  @Test def testUnionSecondUnionMemberOk: Unit = {
+  @Test def testUnionSecondUnionMemberOk(): Unit = {
     val (result, actual) = TestUtils.testString(testSchema1, "2")
     val i = result.resultState.asInstanceOf[PState].infoset.asInstanceOf[DIDocument].contents(0).asInstanceOf[DISimple]
     val umstrd = i.unionMemberRuntimeData.get
@@ -115,7 +115,7 @@ class TestSimpleTypeUnions {
     TestUtils.assertEqualsXMLElements(expected, actual)
   }
 
-  @Test def testUnionNoUnionMemberOK: Unit = {
+  @Test def testUnionNoUnionMemberOK(): Unit = {
     val (result, _) = TestUtils.testString(testSchema1, "3")
     val i = result.resultState.asInstanceOf[PState].infoset.asInstanceOf[DIDocument].contents(0).asInstanceOf[DISimple]
     val Some(dv: java.lang.Integer) = Some(i.dataValue.getInt)
@@ -127,17 +127,17 @@ class TestSimpleTypeUnions {
     val d = ds.head
     assertTrue(d.isInstanceOf[ValidationError])
     val msg = d.getMessage()
-    def die = { println(msg); fail() }
+    def die() = { println(msg); fail() }
     if (!msg.contains("e1"))
-      die
+      die()
     if (!msg.contains("union members"))
-      die
+      die()
     if (!msg.contains("int1Type"))
-      die
+      die()
     if (!msg.contains("int2Type"))
-      die
+      die()
     if (!msg.contains("failed facet checks"))
-      die
+      die()
   }
 
   val testSchema2 = SchemaUtils.dfdlTestSchema(
@@ -203,7 +203,7 @@ class TestSimpleTypeUnions {
       </xs:annotation>
     </xs:element>)
 
-  @Test def testUnionNot3: Unit = {
+  @Test def testUnionNot3(): Unit = {
     val (result, _) = TestUtils.testString(testSchema2, "3")
     val i = result.resultState.asInstanceOf[PState].infoset.asInstanceOf[DIDocument].contents(0).asInstanceOf[DISimple]
     val Some(dv: java.lang.Integer) = Some(i.dataValue.getInt)
@@ -215,20 +215,20 @@ class TestSimpleTypeUnions {
     val d = ds.head
     assertTrue(d.isInstanceOf[ValidationError])
     val msg = d.getMessage()
-    def die = { println(msg); fail() }
+    def die() = { println(msg); fail() }
     if (!msg.contains("e1"))
-      die
+      die()
     if (!msg.contains("union members"))
-      die
+      die()
     if (!msg.contains("int12or47Type"))
-      die
+      die()
     if (!msg.contains("negIntType"))
-      die
+      die()
     if (!msg.contains("failed facet checks"))
-      die
+      die()
   }
 
-  @Test def testUnionNot3_01: Unit = {
+  @Test def testUnionNot3_01(): Unit = {
     val (result, actual) = TestUtils.testString(testSchema2, "1")
     val i = result.resultState.asInstanceOf[PState].infoset.asInstanceOf[DIDocument].contents(0).asInstanceOf[DISimple]
     val umstrd = i.unionMemberRuntimeData.get
@@ -238,7 +238,7 @@ class TestSimpleTypeUnions {
     TestUtils.assertEqualsXMLElements(expected, actual)
   }
 
-  @Test def testUnionNot3_02: Unit = {
+  @Test def testUnionNot3_02(): Unit = {
     val (result, actual) = TestUtils.testString(testSchema2, "2")
     val i = result.resultState.asInstanceOf[PState].infoset.asInstanceOf[DIDocument].contents(0).asInstanceOf[DISimple]
     val umstrd = i.unionMemberRuntimeData.get
@@ -248,7 +248,7 @@ class TestSimpleTypeUnions {
     TestUtils.assertEqualsXMLElements(expected, actual)
   }
 
-  @Test def testUnionNot3_03: Unit = {
+  @Test def testUnionNot3_03(): Unit = {
     val (result, actual) = TestUtils.testString(testSchema2, "-1")
     val i = result.resultState.asInstanceOf[PState].infoset.asInstanceOf[DIDocument].contents(0).asInstanceOf[DISimple]
     val umstrd = i.unionMemberRuntimeData.get
@@ -305,7 +305,7 @@ class TestSimpleTypeUnions {
       </xs:annotation>
     </xs:element>)
 
-  @Test def testRestrictionOnUnion_01: Unit = {
+  @Test def testRestrictionOnUnion_01(): Unit = {
     val (result, actual) = TestUtils.testString(testSchema3, "foo3bar")
     val i = result.resultState.asInstanceOf[PState].infoset.asInstanceOf[DIDocument].contents(0).asInstanceOf[DISimple]
     val umstrd = i.unionMemberRuntimeData.get
@@ -315,7 +315,7 @@ class TestSimpleTypeUnions {
     TestUtils.assertEqualsXMLElements(expected, actual)
   }
 
-  @Test def testRestrictionOnUnion_02: Unit = {
+  @Test def testRestrictionOnUnion_02(): Unit = {
     val (result, actual) = TestUtils.testString(testSchema3, "foo1bar")
     val i = result.resultState.asInstanceOf[PState].infoset.asInstanceOf[DIDocument].contents(0).asInstanceOf[DISimple]
     val umstrd = i.unionMemberRuntimeData.get
@@ -325,7 +325,7 @@ class TestSimpleTypeUnions {
     TestUtils.assertEqualsXMLElements(expected, actual)
   }
 
-  @Test def testRestrictionOnUnion_03: Unit = {
+  @Test def testRestrictionOnUnion_03(): Unit = {
     val (result, actual) = TestUtils.testString(testSchema3, "foo2bar")
     val i = result.resultState.asInstanceOf[PState].infoset.asInstanceOf[DIDocument].contents(0).asInstanceOf[DISimple]
     val umstrd = i.unionMemberRuntimeData.get
@@ -335,7 +335,7 @@ class TestSimpleTypeUnions {
     TestUtils.assertEqualsXMLElements(expected, actual)
   }
 
-  @Test def testRestrictionOnUnionFail_01: Unit = {
+  @Test def testRestrictionOnUnionFail_01(): Unit = {
     val (result, _) = TestUtils.testString(testSchema3, "foo4bar")
     val i = result.resultState.asInstanceOf[PState].infoset.asInstanceOf[DIDocument].contents(0).asInstanceOf[DISimple]
     val Some(dv: String) = Some(i.dataValue.getString)
@@ -347,24 +347,24 @@ class TestSimpleTypeUnions {
     val d = ds.head
     assertTrue(d.isInstanceOf[ValidationError])
     val msg = d.getMessage()
-    def die = { println(msg); fail() }
+    def die() = { println(msg); fail() }
     if (!msg.contains("e1"))
-      die
+      die()
     if (!msg.contains("union members"))
-      die
+      die()
     if (!msg.contains("foo1or2bar"))
-      die
+      die()
     if (!msg.contains("foo3or4bar"))
-      die
+      die()
     if (!msg.contains("failed facet checks"))
-      die
+      die()
   }
 
   /**
    * This test shows that the union isn't even attempted if the
    * restriction on the union fails.
    */
-  @Test def testRestrictionOnUnionFail_02: Unit = {
+  @Test def testRestrictionOnUnionFail_02(): Unit = {
     val (result, _) = TestUtils.testString(testSchema3, "notfoo1bar")
     val i = result.resultState.asInstanceOf[PState].infoset.asInstanceOf[DIDocument].contents(0).asInstanceOf[DISimple]
     val Some(dv: String) = Some(i.dataValue.getString)
@@ -376,14 +376,14 @@ class TestSimpleTypeUnions {
     val d = ds.head
     assertTrue(d.isInstanceOf[ValidationError])
     val msg = d.getMessage()
-    def die = { println(msg); fail() }
+    def die() = { println(msg); fail() }
     if (!msg.contains("e1"))
-      die
+      die()
     if (!msg.contains("facet pattern"))
-      die
+      die()
     if (!msg.contains("foo[1234]bar"))
-      die
+      die()
     if (!msg.contains("failed facet checks"))
-      die
+      die()
   }
 }

--- a/daffodil-core/src/test/scala/org/apache/daffodil/general/TestPrimitives.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/general/TestPrimitives.scala
@@ -26,7 +26,7 @@ import org.apache.daffodil.util.SchemaUtils
 
 class TestPrimitives {
 
-  @Test def testInitiator: Unit = {
+  @Test def testInitiator(): Unit = {
     val sch = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format ref="tns:GeneralFormat" representation="text" lengthUnits="bytes" encoding="US-ASCII" terminator="" separator="" ignoreCase="no"/>,
@@ -39,7 +39,7 @@ class TestPrimitives {
     TestUtils.assertEqualsXMLElements(expected, actual)
   }
 
-  @Test def testTerminator: Unit = {
+  @Test def testTerminator(): Unit = {
     val sch = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:format ref="tns:GeneralFormat" representation="text" lengthUnits="bytes" encoding="US-ASCII" initiator="" separator="" ignoreCase="no"/>,
@@ -71,7 +71,7 @@ class TestPrimitives {
     TestUtils.assertEqualsXMLElements(expected, actual)
   }
 
-  @Test def testLengthKindDelimited: Unit = {
+  @Test def testLengthKindDelimited(): Unit = {
     val sch = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
 
@@ -91,7 +91,7 @@ class TestPrimitives {
     TestUtils.assertEqualsXMLElements(expected, actual)
   }
 
-  @Test def testLengthKindDelimited2: Unit = {
+  @Test def testLengthKindDelimited2(): Unit = {
     val sch = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
 
@@ -110,7 +110,7 @@ class TestPrimitives {
     TestUtils.assertEqualsXMLElements(expected, actual)
   }
 
-  @Test def testLengthKindDelimited3: Unit = {
+  @Test def testLengthKindDelimited3(): Unit = {
     val sch = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
 
@@ -137,7 +137,7 @@ class TestPrimitives {
     TestUtils.assertEqualsXMLElements(expected, actual)
   }
 
-  @Test def testDelimiterInheritance: Unit = {
+  @Test def testDelimiterInheritance(): Unit = {
     val sch = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
       <dfdl:defineFormat name="config">
@@ -177,7 +177,7 @@ class TestPrimitives {
     TestUtils.assertEqualsXMLElements(expected, actual)
   }
 
-  @Test def testEntityReplacementSeparator: Unit = {
+  @Test def testEntityReplacementSeparator(): Unit = {
     val sch = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
 
@@ -197,7 +197,7 @@ class TestPrimitives {
     TestUtils.assertEqualsXMLElements(expected, actual)
   }
 
-  @Test def testEntityReplacementInitiator: Unit = {
+  @Test def testEntityReplacementInitiator(): Unit = {
     val sch = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
 
@@ -210,7 +210,7 @@ class TestPrimitives {
     TestUtils.assertEqualsXMLElements(expected, actual)
   }
 
-  @Test def testEntityReplacementTerminator: Unit = {
+  @Test def testEntityReplacementTerminator(): Unit = {
     val sch = SchemaUtils.dfdlTestSchema(
       <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
 

--- a/daffodil-io/src/main/scala/org/apache/daffodil/io/DataOutputStreamImplMixin.scala
+++ b/daffodil-io/src/main/scala/org/apache/daffodil/io/DataOutputStreamImplMixin.scala
@@ -19,18 +19,14 @@ package org.apache.daffodil.io
 
 import java.io.ByteArrayOutputStream
 import java.math.{BigInteger => JBigInt}
-import java.math.{BigInteger => JBigInt}
 import java.nio.ByteBuffer
 import java.nio.channels.Channels
 import java.nio.charset.CoderResult
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.StandardOpenOption
-
 import passera.unsigned.ULong
-
 import org.apache.commons.io.output.TeeOutputStream
-
 import org.apache.daffodil.equality._
 import org.apache.daffodil.exceptions.Assert
 import org.apache.daffodil.processors.charset.BitsCharsetNonByteSizeEncoder
@@ -41,7 +37,6 @@ import org.apache.daffodil.util.Maybe
 import org.apache.daffodil.util.Maybe.Nope
 import org.apache.daffodil.util.Maybe.One
 import org.apache.daffodil.util.MaybeULong
-
 
 sealed trait DOSState
 private[io] case object Active extends DOSState
@@ -1079,10 +1074,6 @@ trait DataOutputStreamImplMixin extends DataStreamCommonState
   override final def resetMaybeRelBitLimit0b(savedBitLimit0b: MaybeULong): Unit = {
     Assert.usage(isWritable)
     setMaybeRelBitLimit0b(savedBitLimit0b, true)
-  }
-
-  final override def validateFinalStreamState: Unit = {
-    // nothing to validate
   }
 
   final override def isAligned(bitAlignment1b: Int): Boolean = {

--- a/daffodil-io/src/main/scala/org/apache/daffodil/io/DataStreamCommon.scala
+++ b/daffodil-io/src/main/scala/org/apache/daffodil/io/DataStreamCommon.scala
@@ -98,14 +98,4 @@ trait DataStreamCommon {
    */
   def pastData(nBytesRequested: Int): ByteBuffer
   def futureData(nBytesRequested: Int): ByteBuffer
-
-  /**
-   * Called once after each parse operation to verify final invariants for
-   * the implementation.
-   *
-   * Use to perform checks such as that data structures held in pools are
-   * all returned before end of parse.
-   */
-  def validateFinalStreamState: Unit
-
 }

--- a/daffodil-io/src/main/scala/org/apache/daffodil/io/DataStreamCommonImplMixin.scala
+++ b/daffodil-io/src/main/scala/org/apache/daffodil/io/DataStreamCommonImplMixin.scala
@@ -54,7 +54,7 @@ trait DataStreamCommonState {
   var maybeTrailingSurrogateForUTF8: MaybeChar = MaybeChar.Nope
   var priorBitPos: Long = 0L
 
-  def resetUTF8SurrogatePairCapture: Unit = {
+  def resetUTF8SurrogatePairCapture(): Unit = {
     this.priorBitPos = -1
   }
 

--- a/daffodil-io/src/main/scala/org/apache/daffodil/io/InputSource.scala
+++ b/daffodil-io/src/main/scala/org/apache/daffodil/io/InputSource.scala
@@ -191,7 +191,7 @@ abstract class InputSource {
   final def areDebugging: Boolean = _debugging
   final def isValid: Boolean = _isValid
 
-  final def setInvalid: Unit = { _isValid = false }
+  final def setInvalid(): Unit = { _isValid = false }
   final def setDebugging(setting: Boolean): Unit = _debugging = setting
 }
 

--- a/daffodil-io/src/main/scala/org/apache/daffodil/io/InputSourceDataInputStream.scala
+++ b/daffodil-io/src/main/scala/org/apache/daffodil/io/InputSourceDataInputStream.scala
@@ -609,7 +609,7 @@ final class InputSourceDataInputStream private(val inputSource: InputSource)
     setBitPos0b(m)
   }
 
-  def validateFinalStreamState: Unit = {
+  def validateFinalStreamState(): Unit = {
     // threadCheck()
     markPool.finalCheck
   }

--- a/daffodil-io/src/main/scala/org/apache/daffodil/io/StringDataInputStreamForUnparse.scala
+++ b/daffodil-io/src/main/scala/org/apache/daffodil/io/StringDataInputStreamForUnparse.scala
@@ -83,6 +83,4 @@ final class StringDataInputStreamForUnparse
   override def hasData: Boolean = doNotUse
   override def skip(nBits: Long, finfo: FormatInfo): Boolean = doNotUse
   override def resetBitLimit0b(savedBitLimit0b: MaybeULong): Unit = doNotUse
-  // $COVERAGE-ON$
-  override def validateFinalStreamState: Unit = {} // does nothing
 }

--- a/daffodil-io/src/test/scala/org/apache/daffodil/io/TestDaffodilDataInputSource.scala
+++ b/daffodil-io/src/test/scala/org/apache/daffodil/io/TestDaffodilDataInputSource.scala
@@ -79,7 +79,7 @@ class TestInputStream extends java.io.InputStream {
 // expected
 class TestTestInputStream {
 
-  @Test def testTestInputStream1: Unit = {
+  @Test def testTestInputStream1(): Unit = {
     val is = new TestInputStream
     var i = 0
     while (i < 100) {
@@ -88,7 +88,7 @@ class TestTestInputStream {
     }
   }
   
-  @Test def testTestInputStream2: Unit = {
+  @Test def testTestInputStream2(): Unit = {
     val is = new TestInputStream
     val b = new Array[Byte](10)
     is.read(b)
@@ -99,7 +99,7 @@ class TestTestInputStream {
     }
   }
   
-  @Test def testTestInputStream3: Unit = {
+  @Test def testTestInputStream3(): Unit = {
     val is = new TestInputStream
     val b = new Array[Byte](10)
     is.read(b, 3, 3)
@@ -110,7 +110,7 @@ class TestTestInputStream {
     }
   }
 
-  @Test def testTestInputStream4: Unit = {
+  @Test def testTestInputStream4(): Unit = {
     val is = new TestInputStream
     is.setEOF(4)
     assertEquals(0, is.read)
@@ -120,7 +120,7 @@ class TestTestInputStream {
     assertEquals(-1, is.read)
   }
   
-  @Test def testTestInputStream5: Unit = {
+  @Test def testTestInputStream5(): Unit = {
     val is = new TestInputStream
     val b = new Array[Byte](10)
     is.setEOF(4)
@@ -131,7 +131,7 @@ class TestTestInputStream {
 
 class TestBucketingInputSource {
 
-  @Test def testBucketingInputSource1: Unit = {
+  @Test def testBucketingInputSource1(): Unit = {
     val tis = new TestInputStream
     val bis = new BucketingInputSource(tis, 17)
     var i = 0
@@ -143,7 +143,7 @@ class TestBucketingInputSource {
     }
   }
 
-  @Test def testBucketingInputSource2: Unit = {
+  @Test def testBucketingInputSource2(): Unit = {
     val tis = new TestInputStream
     val bis = new BucketingInputSource(tis, 7)
     val b = new Array[Byte](10)
@@ -162,7 +162,7 @@ class TestBucketingInputSource {
     assertEquals(20, bis.position())
   }
  
-  @Test def testBucketingInputSource3: Unit = {
+  @Test def testBucketingInputSource3(): Unit = {
     val tis = new TestInputStream
     val bis = new BucketingInputSource(tis, 7)
     val b = new Array[Byte](10)
@@ -179,7 +179,7 @@ class TestBucketingInputSource {
     }
   }
 
-  @Test def testBucketingInputSource4: Unit = {
+  @Test def testBucketingInputSource4(): Unit = {
     val tis = new TestInputStream
     val bis = new BucketingInputSource(tis, 7)
     tis.setEOF(4)
@@ -190,7 +190,7 @@ class TestBucketingInputSource {
     assertEquals(-1, bis.get)
   }
  
-  @Test def testBucketingInputSource5: Unit = {
+  @Test def testBucketingInputSource5(): Unit = {
     val tis = new TestInputStream
     val bis = new BucketingInputSource(tis, 7)
     val b = new Array[Byte](10)
@@ -205,7 +205,7 @@ class TestBucketingInputSource {
     assertEquals(-1, bis.get)
   }
 
-  @Test def testBucketingInputSource6: Unit = {
+  @Test def testBucketingInputSource6(): Unit = {
     val tis = new TestInputStream
     val bis = new BucketingInputSource(tis, 7)
     tis.setEOF(17)
@@ -224,7 +224,7 @@ class TestBucketingInputSource {
     assertEquals(-1, bis.get) 
   }
 
-  @Test def testBucketingInputSource7: Unit = {
+  @Test def testBucketingInputSource7(): Unit = {
     val tis = new TestInputStream
     val bis = new BucketingInputSource(tis, 7)
     tis.setEOF(17)
@@ -265,7 +265,7 @@ class TestByteBufferInputSource {
                          0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
                          0, 1, 2, 3, 4, 5, 6, 7, 8, 9)
 
-  @Test def testByteBufferInputSource1: Unit = {
+  @Test def testByteBufferInputSource1(): Unit = {
     val bb = ByteBuffer.wrap(data)
     val bis = new ByteBufferInputSource(bb)
     var i = 0
@@ -278,7 +278,7 @@ class TestByteBufferInputSource {
     assertEquals(-1, bis.get)
   }
 
-  @Test def testByteBufferInputSource2: Unit = {
+  @Test def testByteBufferInputSource2(): Unit = {
     val bb = ByteBuffer.wrap(data)
     val bis = new ByteBufferInputSource(bb)
     val b = new Array[Byte](10)
@@ -297,7 +297,7 @@ class TestByteBufferInputSource {
     assertEquals(20, bis.position())
   }
 
-  @Test def testByteBufferInputSource3: Unit = {
+  @Test def testByteBufferInputSource3(): Unit = {
     val bb = ByteBuffer.wrap(data)
     val bis = new ByteBufferInputSource(bb)
     val b = new Array[Byte](10)
@@ -314,7 +314,7 @@ class TestByteBufferInputSource {
     }
   }
 
-  @Test def testByteBufferInputSource4: Unit = {
+  @Test def testByteBufferInputSource4(): Unit = {
     val bb = ByteBuffer.wrap(data, 0, 4)
     val bis = new ByteBufferInputSource(bb)
     assertEquals(0, bis.get)
@@ -324,7 +324,7 @@ class TestByteBufferInputSource {
     assertEquals(-1, bis.get)
   }
  
-  @Test def testByteBufferInputSource5: Unit = {
+  @Test def testByteBufferInputSource5(): Unit = {
     val bb = ByteBuffer.wrap(data, 0, 4)
     val bis = new ByteBufferInputSource(bb)
     val b = new Array[Byte](10)
@@ -338,7 +338,7 @@ class TestByteBufferInputSource {
     assertEquals(-1, bis.get)
   }
 
-  @Test def testByteBufferInputSource6: Unit = {
+  @Test def testByteBufferInputSource6(): Unit = {
     val bb = ByteBuffer.wrap(data, 0, 17)
     val bis = new ByteBufferInputSource(bb)
     var i = 0
@@ -356,7 +356,7 @@ class TestByteBufferInputSource {
     assertEquals(-1, bis.get) 
   }
 
-  @Test def testByteBufferInputSource7: Unit = {
+  @Test def testByteBufferInputSource7(): Unit = {
     val bb = ByteBuffer.wrap(data, 0, 17)
     val bis = new ByteBufferInputSource(bb)
     var i = 0

--- a/daffodil-io/src/test/scala/org/apache/daffodil/io/TestDataOutputStream.scala
+++ b/daffodil-io/src/test/scala/org/apache/daffodil/io/TestDataOutputStream.scala
@@ -34,7 +34,7 @@ class TestDataOutputStream {
     os
   }
 
-  @Test def testPutLongDirect1_BE_MSBF: Unit = {
+  @Test def testPutLongDirect1_BE_MSBF(): Unit = {
 
     val baos = new ByteArrayOrFileOutputStream(2000 * (1 << 20), new File("."), Maybe.Nope)
     val out = newDirectOrBufferedDataOutputStream(baos, null)
@@ -52,7 +52,7 @@ class TestDataOutputStream {
 
   }
 
-  @Test def testPutLongDirect1Bit_BE_MSBF: Unit = {
+  @Test def testPutLongDirect1Bit_BE_MSBF(): Unit = {
 
     val baos = new ByteArrayOrFileOutputStream(2000 * (1 << 20), new File("."), Maybe.Nope)
     val out = newDirectOrBufferedDataOutputStream(baos, null)
@@ -69,7 +69,7 @@ class TestDataOutputStream {
 
   }
 
-  @Test def testPutLongDirect2Bit_BE_MSBF: Unit = {
+  @Test def testPutLongDirect2Bit_BE_MSBF(): Unit = {
     val baos = new ByteArrayOrFileOutputStream(2000 * (1 << 20), new File("."), Maybe.Nope)
     val out = newDirectOrBufferedDataOutputStream(baos, null)
 
@@ -85,7 +85,7 @@ class TestDataOutputStream {
 
   }
 
-  @Test def testPutLongDirect7Bit_BE_MSBF: Unit = {
+  @Test def testPutLongDirect7Bit_BE_MSBF(): Unit = {
     val baos = new ByteArrayOrFileOutputStream(2000 * (1 << 20), new File("."), Maybe.Nope)
     val out = newDirectOrBufferedDataOutputStream(baos, null)
 
@@ -101,7 +101,7 @@ class TestDataOutputStream {
 
   }
 
-  @Test def testPutLongDirect8Bit_BE_MSBF: Unit = {
+  @Test def testPutLongDirect8Bit_BE_MSBF(): Unit = {
     val baos = new ByteArrayOrFileOutputStream(2000 * (1 << 20), new File("."), Maybe.Nope)
     val out = newDirectOrBufferedDataOutputStream(baos, null)
 
@@ -117,7 +117,7 @@ class TestDataOutputStream {
 
   }
 
-  @Test def testPutLongDirect9Bit_BE_MSBF: Unit = {
+  @Test def testPutLongDirect9Bit_BE_MSBF(): Unit = {
     val baos = new ByteArrayOrFileOutputStream(2000 * (1 << 20), new File("."), Maybe.Nope)
     val out = newDirectOrBufferedDataOutputStream(baos, null)
 
@@ -134,7 +134,7 @@ class TestDataOutputStream {
 
   }
 
-  @Test def testPutLongDirect63Bit_BE_MSBF: Unit = {
+  @Test def testPutLongDirect63Bit_BE_MSBF(): Unit = {
     val baos = new ByteArrayOrFileOutputStream(2000 * (1 << 20), new File("."), Maybe.Nope)
     val out = newDirectOrBufferedDataOutputStream(baos, null)
 
@@ -157,7 +157,7 @@ class TestDataOutputStream {
 
   }
 
-  @Test def testPutLongDirect64Bit_BE_MSBF: Unit = {
+  @Test def testPutLongDirect64Bit_BE_MSBF(): Unit = {
     val baos = new ByteArrayOrFileOutputStream(2000 * (1 << 20), new File("."), Maybe.Nope)
     val out = newDirectOrBufferedDataOutputStream(baos, null)
 
@@ -184,7 +184,7 @@ class TestDataOutputStream {
   // Tests of Buffered and putLong
   /////////////////////////////////////////////////////
 
-  @Test def testPutLongBuffered1_BE_MSBF: Unit = {
+  @Test def testPutLongBuffered1_BE_MSBF(): Unit = {
 
     val baos = new ByteArrayOrFileOutputStream(2000 * (1 << 20), new File("."), Maybe.Nope)
     val direct = newDirectOrBufferedDataOutputStream(baos, null)
@@ -207,7 +207,7 @@ class TestDataOutputStream {
 
   }
 
-  @Test def testPutLongBuffered1Bit_BE_MSBF: Unit = {
+  @Test def testPutLongBuffered1Bit_BE_MSBF(): Unit = {
 
     val baos = new ByteArrayOrFileOutputStream(2000 * (1 << 20), new File("."), Maybe.Nope)
     val direct = newDirectOrBufferedDataOutputStream(baos, null)
@@ -227,7 +227,7 @@ class TestDataOutputStream {
 
   }
 
-  @Test def testPutLongBuffered2Bit_BE_MSBF: Unit = {
+  @Test def testPutLongBuffered2Bit_BE_MSBF(): Unit = {
     val baos = new ByteArrayOrFileOutputStream(2000 * (1 << 20), new File("."), Maybe.Nope)
     val direct = newDirectOrBufferedDataOutputStream(baos, null)
 
@@ -246,7 +246,7 @@ class TestDataOutputStream {
 
   }
 
-  @Test def testPutLongBuffered7Bit_BE_MSBF: Unit = {
+  @Test def testPutLongBuffered7Bit_BE_MSBF(): Unit = {
     val baos = new ByteArrayOrFileOutputStream(2000 * (1 << 20), new File("."), Maybe.Nope)
     val direct = newDirectOrBufferedDataOutputStream(baos, null)
 
@@ -265,7 +265,7 @@ class TestDataOutputStream {
 
   }
 
-  @Test def testPutLongBuffered8Bit_BE_MSBF: Unit = {
+  @Test def testPutLongBuffered8Bit_BE_MSBF(): Unit = {
     val baos = new ByteArrayOrFileOutputStream(2000 * (1 << 20), new File("."), Maybe.Nope)
     val direct = newDirectOrBufferedDataOutputStream(baos, null)
     direct.setPriorBitOrder(BitOrder.MostSignificantBitFirst)
@@ -285,7 +285,7 @@ class TestDataOutputStream {
 
   }
 
-  @Test def testPutLongBuffered9Bit_BE_MSBF: Unit = {
+  @Test def testPutLongBuffered9Bit_BE_MSBF(): Unit = {
     val baos = new ByteArrayOrFileOutputStream(2000 * (1 << 20), new File("."), Maybe.Nope)
     val direct = newDirectOrBufferedDataOutputStream(baos, null)
 
@@ -305,7 +305,7 @@ class TestDataOutputStream {
 
   }
 
-  @Test def testPutLongBuffered63Bit_BE_MSBF: Unit = {
+  @Test def testPutLongBuffered63Bit_BE_MSBF(): Unit = {
     val baos = new ByteArrayOrFileOutputStream(2000 * (1 << 20), new File("."), Maybe.Nope)
     val direct = newDirectOrBufferedDataOutputStream(baos, null)
 
@@ -331,7 +331,7 @@ class TestDataOutputStream {
 
   }
 
-  @Test def testPutLongBuffered64Bit_BE_MSBF: Unit = {
+  @Test def testPutLongBuffered64Bit_BE_MSBF(): Unit = {
     val baos = new ByteArrayOrFileOutputStream(2000 * (1 << 20), new File("."), Maybe.Nope)
     val direct = newDirectOrBufferedDataOutputStream(baos, null)
 
@@ -361,7 +361,7 @@ class TestDataOutputStream {
   // Tests of Direct + Buffered and putLong
   /////////////////////////////////////////////////////
 
-  @Test def testPutLongDirectAndBuffered1_BE_MSBF: Unit = {
+  @Test def testPutLongDirectAndBuffered1_BE_MSBF(): Unit = {
 
     val baos = new ByteArrayOrFileOutputStream(2000 * (1 << 20), new File("."), Maybe.Nope)
     val direct = newDirectOrBufferedDataOutputStream(baos, null)
@@ -389,7 +389,7 @@ class TestDataOutputStream {
 
   }
 
-  @Test def testPutLongDirectAndBuffered1Bit_BE_MSBF: Unit = {
+  @Test def testPutLongDirectAndBuffered1Bit_BE_MSBF(): Unit = {
 
     val baos = new ByteArrayOrFileOutputStream(2000 * (1 << 20), new File("."), Maybe.Nope)
     val direct = newDirectOrBufferedDataOutputStream(baos, null)
@@ -410,7 +410,7 @@ class TestDataOutputStream {
 
   }
 
-  @Test def testPutLongDirectAndBuffered2Bit_BE_MSBF: Unit = {
+  @Test def testPutLongDirectAndBuffered2Bit_BE_MSBF(): Unit = {
     val baos = new ByteArrayOrFileOutputStream(2000 * (1 << 20), new File("."), Maybe.Nope)
     val direct = newDirectOrBufferedDataOutputStream(baos, null)
 
@@ -430,7 +430,7 @@ class TestDataOutputStream {
 
   }
 
-  @Test def testPutLongDirectAndBuffered7Bit_BE_MSBF: Unit = {
+  @Test def testPutLongDirectAndBuffered7Bit_BE_MSBF(): Unit = {
     val baos = new ByteArrayOrFileOutputStream(2000 * (1 << 20), new File("."), Maybe.Nope)
     val direct = newDirectOrBufferedDataOutputStream(baos, null)
 
@@ -451,7 +451,7 @@ class TestDataOutputStream {
 
   }
 
-  @Test def testPutLongDirectAndBuffered8Bit_BE_MSBF: Unit = {
+  @Test def testPutLongDirectAndBuffered8Bit_BE_MSBF(): Unit = {
     val baos = new ByteArrayOrFileOutputStream(2000 * (1 << 20), new File("."), Maybe.Nope)
     val direct = newDirectOrBufferedDataOutputStream(baos, null)
 
@@ -472,7 +472,7 @@ class TestDataOutputStream {
 
   }
 
-  @Test def testPutLongDirectAndBuffered9Bit_BE_MSBF: Unit = {
+  @Test def testPutLongDirectAndBuffered9Bit_BE_MSBF(): Unit = {
     val baos = new ByteArrayOrFileOutputStream(2000 * (1 << 20), new File("."), Maybe.Nope)
     val direct = newDirectOrBufferedDataOutputStream(baos, null)
 
@@ -494,7 +494,7 @@ class TestDataOutputStream {
 
   }
 
-  @Test def testPutLongDirectAndBuffered63BitPlus1Bit_BE_MSBF: Unit = {
+  @Test def testPutLongDirectAndBuffered63BitPlus1Bit_BE_MSBF(): Unit = {
     val baos = new ByteArrayOrFileOutputStream(2000 * (1 << 20), new File("."), Maybe.Nope)
     val direct = newDirectOrBufferedDataOutputStream(baos, null)
 
@@ -521,7 +521,7 @@ class TestDataOutputStream {
 
   }
 
-  @Test def testPutLongDirectAndBuffered63BitPlus63Bit_BE_MSBF: Unit = {
+  @Test def testPutLongDirectAndBuffered63BitPlus63Bit_BE_MSBF(): Unit = {
     val baos = new ByteArrayOrFileOutputStream(2000 * (1 << 20), new File("."), Maybe.Nope)
     val direct = newDirectOrBufferedDataOutputStream(baos, null)
 
@@ -557,7 +557,7 @@ class TestDataOutputStream {
 
   }
 
-  @Test def testPutLongDirectAndBuffered64BitPlus64Bit_BE_MSBF: Unit = {
+  @Test def testPutLongDirectAndBuffered64BitPlus64Bit_BE_MSBF(): Unit = {
     val baos = new ByteArrayOrFileOutputStream(2000 * (1 << 20), new File("."), Maybe.Nope)
     val direct = newDirectOrBufferedDataOutputStream(baos, null)
 
@@ -593,7 +593,7 @@ class TestDataOutputStream {
 
   }
 
-  @Test def testPutLong5_4Bits_BE_MSBF: Unit = {
+  @Test def testPutLong5_4Bits_BE_MSBF(): Unit = {
 
     val baos = new ByteArrayOrFileOutputStream(2000 * (1 << 20), new File("."), Maybe.Nope)
     val out = newDirectOrBufferedDataOutputStream(baos, null)

--- a/daffodil-io/src/test/scala/org/apache/daffodil/io/TestDataOutputStream2.scala
+++ b/daffodil-io/src/test/scala/org/apache/daffodil/io/TestDataOutputStream2.scala
@@ -31,7 +31,7 @@ class TestDataOutputStream2 {
    * BitBuffer tests
    */
 
-  @Test def testPutBitBufferDirect0_BE_MSBF: Unit = {
+  @Test def testPutBitBufferDirect0_BE_MSBF(): Unit = {
 
     val baos = new ByteArrayOrFileOutputStream(2000 * (1 << 20), new File("."), Maybe.Nope)
     val out = DirectOrBufferedDataOutputStream(baos, null, false, 4096, 2000 * (1 << 20), new File("."), Maybe.Nope)
@@ -51,7 +51,7 @@ class TestDataOutputStream2 {
 
   }
 
-  @Test def testPutBitBufferDirect1_BE_MSBF: Unit = {
+  @Test def testPutBitBufferDirect1_BE_MSBF(): Unit = {
 
     val baos = new ByteArrayOrFileOutputStream(2000 * (1 << 20), new File("."), Maybe.Nope)
     val out = DirectOrBufferedDataOutputStream(baos, null, false, 4096, 2000 * (1 << 20), new File("."), Maybe.Nope)
@@ -71,7 +71,7 @@ class TestDataOutputStream2 {
 
   }
 
-  @Test def testPutBitBufferDirect7_BE_MSBF: Unit = {
+  @Test def testPutBitBufferDirect7_BE_MSBF(): Unit = {
 
     val baos = new ByteArrayOrFileOutputStream(2000 * (1 << 20), new File("."), Maybe.Nope)
     val out = DirectOrBufferedDataOutputStream(baos, null, false, 4096, 2000 * (1 << 20), new File("."), Maybe.Nope)

--- a/daffodil-io/src/test/scala/org/apache/daffodil/io/TestDataOutputStream3.scala
+++ b/daffodil-io/src/test/scala/org/apache/daffodil/io/TestDataOutputStream3.scala
@@ -37,7 +37,7 @@ class TestDataOutputStream3 {
     os
   }
 
-  @Test def testPutLongDirect1_LE_LSBF: Unit = {
+  @Test def testPutLongDirect1_LE_LSBF(): Unit = {
 
     val baos = new ByteArrayOrFileOutputStream(2000 * (1 << 20), new File("."), Maybe.Nope)
     val out = newDirectOrBufferedDataOutputStream(baos, null)
@@ -55,7 +55,7 @@ class TestDataOutputStream3 {
 
   }
 
-  @Test def testPutLongDirect1Bit_LE_LSBF: Unit = {
+  @Test def testPutLongDirect1Bit_LE_LSBF(): Unit = {
 
     val baos = new ByteArrayOrFileOutputStream(2000 * (1 << 20), new File("."), Maybe.Nope)
     val out = newDirectOrBufferedDataOutputStream(baos, null)
@@ -72,7 +72,7 @@ class TestDataOutputStream3 {
 
   }
 
-  @Test def testPutLongDirect2Bit_LE_LSBF: Unit = {
+  @Test def testPutLongDirect2Bit_LE_LSBF(): Unit = {
     val baos = new ByteArrayOrFileOutputStream(2000 * (1 << 20), new File("."), Maybe.Nope)
     val out = newDirectOrBufferedDataOutputStream(baos, null)
 
@@ -88,7 +88,7 @@ class TestDataOutputStream3 {
 
   }
 
-  @Test def testPutLongDirect7Bit_LE_LSBF: Unit = {
+  @Test def testPutLongDirect7Bit_LE_LSBF(): Unit = {
     val baos = new ByteArrayOrFileOutputStream(2000 * (1 << 20), new File("."), Maybe.Nope)
     val out = newDirectOrBufferedDataOutputStream(baos, null)
 
@@ -104,7 +104,7 @@ class TestDataOutputStream3 {
 
   }
 
-  @Test def testPutLongDirect8Bit_LE_LSBF: Unit = {
+  @Test def testPutLongDirect8Bit_LE_LSBF(): Unit = {
     val baos = new ByteArrayOrFileOutputStream(2000 * (1 << 20), new File("."), Maybe.Nope)
     val out = newDirectOrBufferedDataOutputStream(baos, null)
 
@@ -120,7 +120,7 @@ class TestDataOutputStream3 {
 
   }
 
-  @Test def testPutLongDirect9Bit_LE_LSBF: Unit = {
+  @Test def testPutLongDirect9Bit_LE_LSBF(): Unit = {
     val baos = new ByteArrayOrFileOutputStream(2000 * (1 << 20), new File("."), Maybe.Nope)
     val out = newDirectOrBufferedDataOutputStream(baos, null)
 
@@ -137,7 +137,7 @@ class TestDataOutputStream3 {
 
   }
 
-  @Test def testPutLongDirect63Bit_LE_LSBF: Unit = {
+  @Test def testPutLongDirect63Bit_LE_LSBF(): Unit = {
     val baos = new ByteArrayOrFileOutputStream(2000 * (1 << 20), new File("."), Maybe.Nope)
     val out = newDirectOrBufferedDataOutputStream(baos, null)
 
@@ -160,7 +160,7 @@ class TestDataOutputStream3 {
 
   }
 
-  @Test def testPutLongDirect64Bit_LE_LSBF: Unit = {
+  @Test def testPutLongDirect64Bit_LE_LSBF(): Unit = {
     val baos = new ByteArrayOrFileOutputStream(2000 * (1 << 20), new File("."), Maybe.Nope)
     val out = newDirectOrBufferedDataOutputStream(baos, null)
 
@@ -187,7 +187,7 @@ class TestDataOutputStream3 {
   // Tests of Buffered and putLong
   /////////////////////////////////////////////////////
 
-  @Test def testPutLongBuffered1_LE_LSBF: Unit = {
+  @Test def testPutLongBuffered1_LE_LSBF(): Unit = {
 
     val baos = new ByteArrayOrFileOutputStream(2000 * (1 << 20), new File("."), Maybe.Nope)
     val direct = newDirectOrBufferedDataOutputStream(baos, null)
@@ -209,7 +209,7 @@ class TestDataOutputStream3 {
 
   }
 
-  @Test def testPutLongBuffered1Bit_LE_LSBF: Unit = {
+  @Test def testPutLongBuffered1Bit_LE_LSBF(): Unit = {
 
     val baos = new ByteArrayOrFileOutputStream(2000 * (1 << 20), new File("."), Maybe.Nope)
     val direct = newDirectOrBufferedDataOutputStream(baos, null)
@@ -228,7 +228,7 @@ class TestDataOutputStream3 {
 
   }
 
-  @Test def testPutLongBuffered2Bit_LE_LSBF: Unit = {
+  @Test def testPutLongBuffered2Bit_LE_LSBF(): Unit = {
     val baos = new ByteArrayOrFileOutputStream(2000 * (1 << 20), new File("."), Maybe.Nope)
     val direct = newDirectOrBufferedDataOutputStream(baos, null)
     val out = direct.addBuffered
@@ -246,7 +246,7 @@ class TestDataOutputStream3 {
 
   }
 
-  @Test def testPutLongBuffered7Bit_LE_LSBF: Unit = {
+  @Test def testPutLongBuffered7Bit_LE_LSBF(): Unit = {
     val baos = new ByteArrayOrFileOutputStream(2000 * (1 << 20), new File("."), Maybe.Nope)
     val direct = newDirectOrBufferedDataOutputStream(baos, null)
     val out = direct.addBuffered
@@ -264,7 +264,7 @@ class TestDataOutputStream3 {
 
   }
 
-  @Test def testPutLongBuffered8Bit_LE_LSBF: Unit = {
+  @Test def testPutLongBuffered8Bit_LE_LSBF(): Unit = {
     val baos = new ByteArrayOrFileOutputStream(2000 * (1 << 20), new File("."), Maybe.Nope)
     val direct = newDirectOrBufferedDataOutputStream(baos, null)
     val out = direct.addBuffered
@@ -282,7 +282,7 @@ class TestDataOutputStream3 {
 
   }
 
-  @Test def testPutLongBuffered9Bit_LE_LSBF: Unit = {
+  @Test def testPutLongBuffered9Bit_LE_LSBF(): Unit = {
     val baos = new ByteArrayOrFileOutputStream(2000 * (1 << 20), new File("."), Maybe.Nope)
     val direct = newDirectOrBufferedDataOutputStream(baos, null)
     val out = direct.addBuffered
@@ -301,7 +301,7 @@ class TestDataOutputStream3 {
 
   }
 
-  @Test def testPutLongBuffered63Bit_LE_LSBF: Unit = {
+  @Test def testPutLongBuffered63Bit_LE_LSBF(): Unit = {
     val baos = new ByteArrayOrFileOutputStream(2000 * (1 << 20), new File("."), Maybe.Nope)
     val direct = newDirectOrBufferedDataOutputStream(baos, null)
     val out = direct.addBuffered
@@ -326,7 +326,7 @@ class TestDataOutputStream3 {
 
   }
 
-  @Test def testPutLongBuffered64Bit_LE_LSBF: Unit = {
+  @Test def testPutLongBuffered64Bit_LE_LSBF(): Unit = {
     val baos = new ByteArrayOrFileOutputStream(2000 * (1 << 20), new File("."), Maybe.Nope)
     val direct = newDirectOrBufferedDataOutputStream(baos, null)
     val out = direct.addBuffered
@@ -355,7 +355,7 @@ class TestDataOutputStream3 {
   // Tests of Direct + Buffered and putLong
   /////////////////////////////////////////////////////
 
-  @Test def testPutLongDirectAndBuffered1_LE_LSBF: Unit = {
+  @Test def testPutLongDirectAndBuffered1_LE_LSBF(): Unit = {
 
     val baos = new ByteArrayOrFileOutputStream(2000 * (1 << 20), new File("."), Maybe.Nope)
     val direct = newDirectOrBufferedDataOutputStream(baos, null)
@@ -382,7 +382,7 @@ class TestDataOutputStream3 {
 
   }
 
-  @Test def testPutLongDirectAndBuffered1Bit_LE_LSBF: Unit = {
+  @Test def testPutLongDirectAndBuffered1Bit_LE_LSBF(): Unit = {
 
     val baos = new ByteArrayOrFileOutputStream(2000 * (1 << 20), new File("."), Maybe.Nope)
     val direct = newDirectOrBufferedDataOutputStream(baos, null, BitOrder.LeastSignificantBitFirst)
@@ -402,7 +402,7 @@ class TestDataOutputStream3 {
 
   }
 
-  @Test def testPutLongDirectAndBuffered2Bit_LE_LSBF: Unit = {
+  @Test def testPutLongDirectAndBuffered2Bit_LE_LSBF(): Unit = {
     val baos = new ByteArrayOrFileOutputStream(2000 * (1 << 20), new File("."), Maybe.Nope)
     val direct = newDirectOrBufferedDataOutputStream(baos, null, BitOrder.LeastSignificantBitFirst)
     val out = direct.addBuffered
@@ -421,7 +421,7 @@ class TestDataOutputStream3 {
 
   }
 
-  @Test def testPutLongDirectAndBuffered7Bit_LE_LSBF: Unit = {
+  @Test def testPutLongDirectAndBuffered7Bit_LE_LSBF(): Unit = {
     val baos = new ByteArrayOrFileOutputStream(2000 * (1 << 20), new File("."), Maybe.Nope)
     val direct = newDirectOrBufferedDataOutputStream(baos, null)
     direct.setPriorBitOrder(BitOrder.LeastSignificantBitFirst)
@@ -442,7 +442,7 @@ class TestDataOutputStream3 {
 
   }
 
-  @Test def testPutLongDirectAndBuffered8Bit_LE_LSBF: Unit = {
+  @Test def testPutLongDirectAndBuffered8Bit_LE_LSBF(): Unit = {
     val baos = new ByteArrayOrFileOutputStream(2000 * (1 << 20), new File("."), Maybe.Nope)
     val direct = newDirectOrBufferedDataOutputStream(baos, null)
     val out = direct.addBuffered
@@ -462,7 +462,7 @@ class TestDataOutputStream3 {
 
   }
 
-  @Test def testPutLongDirectAndBuffered9Bit_LE_LSBF: Unit = {
+  @Test def testPutLongDirectAndBuffered9Bit_LE_LSBF(): Unit = {
     val baos = new ByteArrayOrFileOutputStream(2000 * (1 << 20), new File("."), Maybe.Nope)
     val direct = newDirectOrBufferedDataOutputStream(baos, null, BitOrder.LeastSignificantBitFirst)
     val out = direct.addBuffered
@@ -483,7 +483,7 @@ class TestDataOutputStream3 {
 
   }
 
-  @Test def testPutLongDirectAndBuffered63BitPlus1Bit_LE_LSBF: Unit = {
+  @Test def testPutLongDirectAndBuffered63BitPlus1Bit_LE_LSBF(): Unit = {
     val baos = new ByteArrayOrFileOutputStream(2000 * (1 << 20), new File("."), Maybe.Nope)
     val direct = newDirectOrBufferedDataOutputStream(baos, null, BitOrder.LeastSignificantBitFirst)
     val out = direct.addBuffered
@@ -509,7 +509,7 @@ class TestDataOutputStream3 {
 
   }
 
-  @Test def testPutLongDirectAndBuffered63BitPlus63Bit_LE_LSBF: Unit = {
+  @Test def testPutLongDirectAndBuffered63BitPlus63Bit_LE_LSBF(): Unit = {
     val baos = new ByteArrayOrFileOutputStream(2000 * (1 << 20), new File("."), Maybe.Nope)
     val direct = newDirectOrBufferedDataOutputStream(baos, null, BitOrder.LeastSignificantBitFirst)
     val out = direct.addBuffered
@@ -544,7 +544,7 @@ class TestDataOutputStream3 {
 
   }
 
-  @Test def testPutLongDirectAndBuffered64BitPlus64Bit_LE_LSBF: Unit = {
+  @Test def testPutLongDirectAndBuffered64BitPlus64Bit_LE_LSBF(): Unit = {
     val baos = new ByteArrayOrFileOutputStream(2000 * (1 << 20), new File("."), Maybe.Nope)
     val direct = newDirectOrBufferedDataOutputStream(baos, null)
     val out = direct.addBuffered
@@ -579,7 +579,7 @@ class TestDataOutputStream3 {
 
   }
 
-  @Test def testPutLong5_4Bits_LE_LSBF: Unit = {
+  @Test def testPutLong5_4Bits_LE_LSBF(): Unit = {
 
     val baos = new ByteArrayOrFileOutputStream(2000 * (1 << 20), new File("."), Maybe.Nope)
     val out = newDirectOrBufferedDataOutputStream(baos, null)

--- a/daffodil-io/src/test/scala/org/apache/daffodil/io/TestDataOutputStream4.scala
+++ b/daffodil-io/src/test/scala/org/apache/daffodil/io/TestDataOutputStream4.scala
@@ -76,7 +76,7 @@ class TestDataOutputStream4 {
     assertEquals(0x80.toByte, buf(7))
   }
 
-  @Test def testPutLong19FinishInOrderAbs: Unit = {
+  @Test def testPutLong19FinishInOrderAbs(): Unit = {
     val (baos, direct, out, out2) = setup()
 
     direct.setFinished(finfo)
@@ -87,7 +87,7 @@ class TestDataOutputStream4 {
 
   }
 
-  @Test def testPutLong19FinishOutOfOrder1Abs: Unit = {
+  @Test def testPutLong19FinishOutOfOrder1Abs(): Unit = {
     val (baos, direct, out, out2) = setup()
 
     out.setFinished(finfo)
@@ -98,7 +98,7 @@ class TestDataOutputStream4 {
 
   }
 
-  @Test def testPutLong19FinishOutOfOrder2Abs: Unit = {
+  @Test def testPutLong19FinishOutOfOrder2Abs(): Unit = {
     val (baos, direct, out, out2) = setup()
 
     out2.setFinished(finfo)
@@ -109,7 +109,7 @@ class TestDataOutputStream4 {
 
   }
 
-  @Test def testPutLong19FinishOutOfOrder3Abs: Unit = {
+  @Test def testPutLong19FinishOutOfOrder3Abs(): Unit = {
     val (baos, direct, out, out2) = setup()
 
     out2.setFinished(finfo)
@@ -120,7 +120,7 @@ class TestDataOutputStream4 {
 
   }
 
-  @Test def testPutLong19FinishInOrder: Unit = {
+  @Test def testPutLong19FinishInOrder(): Unit = {
     val (baos, direct, out, out2) = setup(false)
 
     direct.setFinished(finfo)
@@ -131,7 +131,7 @@ class TestDataOutputStream4 {
 
   }
 
-  @Test def testPutLong19FinishOutOfOrder1: Unit = {
+  @Test def testPutLong19FinishOutOfOrder1(): Unit = {
     val (baos, direct, out, out2) = setup(false)
 
     out.setFinished(finfo)
@@ -142,7 +142,7 @@ class TestDataOutputStream4 {
 
   }
 
-  @Test def testPutLong19FinishOutOfOrder2: Unit = {
+  @Test def testPutLong19FinishOutOfOrder2(): Unit = {
     val (baos, direct, out, out2) = setup(false)
 
     out2.setFinished(finfo)
@@ -153,7 +153,7 @@ class TestDataOutputStream4 {
 
   }
 
-  @Test def testPutLong19FinishOutOfOrder3: Unit = {
+  @Test def testPutLong19FinishOutOfOrder3(): Unit = {
     val (baos, direct, out, out2) = setup(false)
 
     out2.setFinished(finfo)

--- a/daffodil-io/src/test/scala/org/apache/daffodil/io/TestDecoder.scala
+++ b/daffodil-io/src/test/scala/org/apache/daffodil/io/TestDecoder.scala
@@ -65,7 +65,7 @@ class TestDecoder {
    * It seems they don't check for the decode error until after they've
    * checked for enough room for a surrogate pair.
    */
-  @Test def testDecoder1: Unit = {
+  @Test def testDecoder1(): Unit = {
     val originalDecoder = StandardCharsets.UTF_8.newDecoder()
     originalDecoder.onMalformedInput(CodingErrorAction.REPORT)
     originalDecoder.onUnmappableCharacter(CodingErrorAction.REPORT)
@@ -132,7 +132,7 @@ class TestDecoder {
     assertEquals(0, bb.position())
   }
 
-  @Test def testDecoderWorkaround1: Unit = {
+  @Test def testDecoderWorkaround1(): Unit = {
     val originalDecoder = StandardCharsets.UTF_8.newDecoder()
     originalDecoder.onMalformedInput(CodingErrorAction.REPORT)
     originalDecoder.onUnmappableCharacter(CodingErrorAction.REPORT)

--- a/daffodil-io/src/test/scala/org/apache/daffodil/io/TestDirectOrBufferedDataOutputStream.scala
+++ b/daffodil-io/src/test/scala/org/apache/daffodil/io/TestDirectOrBufferedDataOutputStream.scala
@@ -47,7 +47,7 @@ class TestDirectOrBufferedDataOutputStream {
    * Tests that the toString method doesn't throw. Can't even use a debugger
    * if that happens.
    */
-  @Test def testToStringDoesNotThrow: Unit = {
+  @Test def testToStringDoesNotThrow(): Unit = {
     val baos = new ByteArrayOrFileOutputStream(2000 * (1 << 20), new File("."), Maybe.Nope)
     val layered = newDirectOrBufferedDataOutputStream(baos, null)
     assertFalse(layered.toString().isEmpty())
@@ -55,7 +55,7 @@ class TestDirectOrBufferedDataOutputStream {
 
   val finfo = FormatInfoForUnitTest()
 
-  @Test def testCollapsingBufferIntoDirect1: Unit = {
+  @Test def testCollapsingBufferIntoDirect1(): Unit = {
 
     val baos = new ByteArrayOrFileOutputStream(2000 * (1 << 20), new File("."), Maybe.Nope)
     val layered = newDirectOrBufferedDataOutputStream(baos, null)
@@ -82,7 +82,7 @@ class TestDirectOrBufferedDataOutputStream {
 
   }
 
-  @Test def testCollapsingFinishedBufferIntoLayered: Unit = {
+  @Test def testCollapsingFinishedBufferIntoLayered(): Unit = {
 
     val baos = new ByteArrayOrFileOutputStream(2000 * (1 << 20), new File("."), Maybe.Nope)
     val layered = newDirectOrBufferedDataOutputStream(baos, null)
@@ -111,7 +111,7 @@ class TestDirectOrBufferedDataOutputStream {
 
   }
 
-  @Test def testCollapsingTwoBuffersIntoDirect: Unit = {
+  @Test def testCollapsingTwoBuffersIntoDirect(): Unit = {
 
     val baos = new ByteArrayOrFileOutputStream(2000 * (1 << 20), new File("."), Maybe.Nope)
     val layered = newDirectOrBufferedDataOutputStream(baos, null)

--- a/daffodil-io/src/test/scala/org/apache/daffodil/io/TestInputSourceDataInputStream.scala
+++ b/daffodil-io/src/test/scala/org/apache/daffodil/io/TestInputSourceDataInputStream.scala
@@ -68,7 +68,7 @@ class TestInputSourceDataInputStream {
     assertTrue(dis.hasReachedEndOfData)
   }
 
-  @Test def testBitAndBytePos0: Unit = {
+  @Test def testBitAndBytePos0(): Unit = {
     val dis = InputSourceDataInputStream(ten)
     0L assertEqualsTyped (dis.bitPos0b)
     false assertEqualsTyped (dis.bitLimit0b.isDefined)
@@ -77,7 +77,7 @@ class TestInputSourceDataInputStream {
     0L assertEqualsTyped (dis.bytePos0b)
   }
 
-  @Test def testBitAndBytePos1: Unit = {
+  @Test def testBitAndBytePos1(): Unit = {
     val dis = InputSourceDataInputStream(ten)
     val arr = dis.getByteArray(8, finfo)
     assertEqualsTyped[Long](1, arr.size)
@@ -89,7 +89,7 @@ class TestInputSourceDataInputStream {
     assertEqualsTyped[Long](1, dis.bytePos0b)
   }
 
-  @Test def testBitAndBytePos10: Unit = {
+  @Test def testBitAndBytePos10(): Unit = {
     val dis = InputSourceDataInputStream(ten)
     val arr = dis.getByteArray(80, finfo)
     assertEqualsTyped[Long](10, arr.size)
@@ -101,7 +101,7 @@ class TestInputSourceDataInputStream {
     assertEqualsTyped[Long](10, dis.bytePos0b)
   }
 
-  @Test def testBitAndBytePosNotEnoughData1: Unit = {
+  @Test def testBitAndBytePosNotEnoughData1(): Unit = {
     val dis = InputSourceDataInputStream(ten)
     intercept[DataInputStream.NotEnoughDataException] {
       dis.getByteArray(81, finfo)
@@ -110,7 +110,7 @@ class TestInputSourceDataInputStream {
     assertEqualsTyped[Boolean](false, dis.bitLimit0b.isDefined)
   }
 
-  @Test def testBitAndBytePosMoreThanEnoughData1: Unit = {
+  @Test def testBitAndBytePosMoreThanEnoughData1(): Unit = {
     val dis = InputSourceDataInputStream(twenty)
     val arr = dis.getByteArray(80, finfo)
     assertEqualsTyped[Long](10, arr.size)
@@ -120,7 +120,7 @@ class TestInputSourceDataInputStream {
     assertEqualsTyped[Long](10, dis.bytePos0b)
   }
 
-  @Test def testBitLengthLimit1: Unit = {
+  @Test def testBitLengthLimit1(): Unit = {
     val dis = InputSourceDataInputStream(twenty)
     assertEqualsTyped[Boolean](false, dis.bitLimit0b.isDefined)
     val isLimitOk = dis.withBitLengthLimit(80) {
@@ -136,7 +136,7 @@ class TestInputSourceDataInputStream {
     assertEqualsTyped[Long](10, dis.bytePos0b)
   }
 
-  @Test def testBinaryDouble1: Unit = {
+  @Test def testBinaryDouble1(): Unit = {
     val dis = InputSourceDataInputStream("123".getBytes("utf-8"))
     intercept[DataInputStream.NotEnoughDataException] {
       dis.getBinaryDouble(finfo)
@@ -144,14 +144,14 @@ class TestInputSourceDataInputStream {
     assertEqualsTyped[Long](0, dis.bitPos0b)
   }
 
-  @Test def testBinaryDouble2: Unit = {
+  @Test def testBinaryDouble2(): Unit = {
     val dis = InputSourceDataInputStream(twenty)
     val expected = ByteBuffer.wrap(twenty).asDoubleBuffer().get()
     val d = dis.getBinaryDouble(finfo)
     assertEqualsTyped(expected, d, 0.0)
   }
 
-  @Test def testBinaryDouble3: Unit = {
+  @Test def testBinaryDouble3(): Unit = {
     val dis = InputSourceDataInputStream(twenty)
     dis.setBitLimit1b(MaybeULong(63)) // not enough bits
     intercept[DataInputStream.NotEnoughDataException] {
@@ -159,7 +159,7 @@ class TestInputSourceDataInputStream {
     }
   }
 
-  @Test def testBinaryDouble4: Unit = {
+  @Test def testBinaryDouble4(): Unit = {
     val dis = InputSourceDataInputStream(twenty)
     dis.getByteArray(8, finfo)
     dis.setBitLimit1b(MaybeULong(71)) // not enough bits
@@ -168,7 +168,7 @@ class TestInputSourceDataInputStream {
     }
   }
 
-  @Test def testBinaryFloat1: Unit = {
+  @Test def testBinaryFloat1(): Unit = {
     val dis = InputSourceDataInputStream("123".getBytes("utf-8"))
     intercept[DataInputStream.NotEnoughDataException] {
       dis.getBinaryFloat(finfo)
@@ -176,14 +176,14 @@ class TestInputSourceDataInputStream {
     assertEqualsTyped[Long](0, dis.bitPos0b)
   }
 
-  @Test def testBinaryFloat2: Unit = {
+  @Test def testBinaryFloat2(): Unit = {
     val dis = InputSourceDataInputStream(twenty)
     val expected = ByteBuffer.wrap(twenty).asFloatBuffer().get()
     val d = dis.getBinaryFloat(finfo)
     assertEqualsTyped(expected, d, 0.0)
   }
 
-  @Test def testBinaryFloat3: Unit = {
+  @Test def testBinaryFloat3(): Unit = {
     val dis = InputSourceDataInputStream(twenty)
     dis.setBitLimit1b(MaybeULong(31)) // not enough bits
     assertFalse(dis.isDefinedForLength(32))
@@ -192,7 +192,7 @@ class TestInputSourceDataInputStream {
     }
   }
 
-  @Test def testBinaryFloat4: Unit = {
+  @Test def testBinaryFloat4(): Unit = {
     val dis = InputSourceDataInputStream(twenty)
     dis.getByteArray(8, finfo)
     dis.setBitLimit1b(MaybeULong(39)) // not enough bits
@@ -202,7 +202,7 @@ class TestInputSourceDataInputStream {
     }
   }
 
-  @Test def testSignedLong1: Unit = {
+  @Test def testSignedLong1(): Unit = {
     val dis = InputSourceDataInputStream(twenty)
     dis.setBitLimit1b(MaybeULong(1)) // 1b so 1 means no data
     intercept[DataInputStream.NotEnoughDataException] {
@@ -210,7 +210,7 @@ class TestInputSourceDataInputStream {
     }
   }
 
-  @Test def testSignedLong2: Unit = {
+  @Test def testSignedLong2(): Unit = {
     val dis = InputSourceDataInputStream(twenty)
     dis.setBitLimit1b(MaybeULong(63))
     intercept[DataInputStream.NotEnoughDataException] {
@@ -218,7 +218,7 @@ class TestInputSourceDataInputStream {
     }
   }
 
-  @Test def testSignedLong3: Unit = {
+  @Test def testSignedLong3(): Unit = {
     val dis = InputSourceDataInputStream(twenty)
     // buffer has 0x3132 in first 16 bits
     // binary that is 00110001 00110010
@@ -231,7 +231,7 @@ class TestInputSourceDataInputStream {
     assertEqualsTyped[Long](10, dis.bitPos0b)
   }
 
-  @Test def testSignedLong4: Unit = {
+  @Test def testSignedLong4(): Unit = {
     val dis = InputSourceDataInputStream(twenty)
     var ml = dis.getSignedLong(1, finfo)
     assertEqualsTyped[Long](1, dis.bitPos0b)
@@ -240,7 +240,7 @@ class TestInputSourceDataInputStream {
     assertEqualsTyped[Long](0x3132333435363738L << 1, ml)
   }
 
-  @Test def testSignedLong5: Unit = {
+  @Test def testSignedLong5(): Unit = {
     val dis = InputSourceDataInputStream(List(0xC1, 0xC2, 0xC3, 0xC4, 0xC5, 0xC6, 0xC7, 0xC8, 0xC9, 0xC0).map { _.toByte }.toArray)
     var ml = dis.getSignedLong(1, finfo)
     assertEqualsTyped[Long](1, dis.bitPos0b)
@@ -250,7 +250,7 @@ class TestInputSourceDataInputStream {
     assertEqualsTyped[Long]((0xC1C2C3C4C5C6C7C8L << 1) + (0xC9 >>> 7), ml)
   }
 
-  @Test def testSignedLong6: Unit = {
+  @Test def testSignedLong6(): Unit = {
     val dis = InputSourceDataInputStream(List(0xC1, 0xC2, 0xC3, 0xC4, 0xC5, 0xC6, 0xC7, 0xC8, 0xC9, 0xC0).map { _.toByte }.toArray)
     var ml = dis.getSignedLong(1, finfo)
     assertEqualsTyped[Long](1, dis.bitPos0b)
@@ -261,7 +261,7 @@ class TestInputSourceDataInputStream {
     assertEqualsTyped[Long](expected, ml)
   }
 
-  @Test def testSignedLong7: Unit = {
+  @Test def testSignedLong7(): Unit = {
     val dis = InputSourceDataInputStream(List(0xC1, 0xC2, 0xC3, 0xC4, 0xC5).map { _.toByte }.toArray)
     var ml = dis.getSignedLong(2, finfo)
     assertEqualsTyped[Long](2, dis.bitPos0b)
@@ -272,7 +272,7 @@ class TestInputSourceDataInputStream {
     assertEqualsTyped[Long](expected, ml)
   }
 
-  @Test def testUnsignedLong1: Unit = {
+  @Test def testUnsignedLong1(): Unit = {
     val dis = InputSourceDataInputStream(List(0xC1, 0xC2, 0xC3, 0xC4, 0xC5).map { _.toByte }.toArray)
     val ml = dis.getUnsignedLong(32, finfo)
     assertEqualsTyped[Long](32, dis.bitPos0b)
@@ -280,7 +280,7 @@ class TestInputSourceDataInputStream {
     assertEqualsTyped[ULong](expected, ml)
   }
 
-  @Test def testUnsignedLong2: Unit = {
+  @Test def testUnsignedLong2(): Unit = {
     val dis = InputSourceDataInputStream(List(0xA5, 0xA5, 0xA5, 0xA5, 0xA5).map { _.toByte }.toArray)
     dis.getSignedLong(1, finfo)
     assertEqualsTyped[Long](1, dis.bitPos0b)
@@ -290,7 +290,7 @@ class TestInputSourceDataInputStream {
     assertEqualsTyped[ULong](expected, ml)
   }
 
-  @Test def testUnsignedLong3: Unit = {
+  @Test def testUnsignedLong3(): Unit = {
     val dis = InputSourceDataInputStream(List(0xFF).map { _.toByte }.toArray)
     val ml = dis.getUnsignedLong(1, finfo)
     assertEqualsTyped[Long](1, dis.bitPos0b)
@@ -298,7 +298,7 @@ class TestInputSourceDataInputStream {
     assertEqualsTyped[ULong](expected, ml)
   }
 
-  @Test def testSignedBigInt1: Unit = {
+  @Test def testSignedBigInt1(): Unit = {
     val dis = InputSourceDataInputStream(List(0xFF).map { _.toByte }.toArray)
     val ml = dis.getSignedBigInt(1, finfo)
     assertEqualsTyped[Long](1, dis.bitPos0b)
@@ -306,7 +306,7 @@ class TestInputSourceDataInputStream {
     assertTrue(expected =:= ml)
   }
 
-  @Test def testSignedBigInt2: Unit = {
+  @Test def testSignedBigInt2(): Unit = {
     val dis = InputSourceDataInputStream(List(0xC1, 0xC2, 0xC3, 0xC4, 0xC5).map { _.toByte }.toArray)
     val ml = dis.getSignedBigInt(40, finfo)
     assertEqualsTyped[Long](40, dis.bitPos0b)
@@ -314,7 +314,7 @@ class TestInputSourceDataInputStream {
     assertEqualsTyped[JBigInt](expected, ml)
   }
 
-  @Test def testUnsignedBigInt1: Unit = {
+  @Test def testUnsignedBigInt1(): Unit = {
     val dis = InputSourceDataInputStream(List(0xFF).map { _.toByte }.toArray)
     val ml = dis.getUnsignedBigInt(2, finfo)
     assertEqualsTyped(2, dis.bitPos0b)
@@ -322,7 +322,7 @@ class TestInputSourceDataInputStream {
     assertEqualsTyped[JBigInt](expected, ml)
   }
 
-  @Test def testUnsignedBigInt2: Unit = {
+  @Test def testUnsignedBigInt2(): Unit = {
     val dis = InputSourceDataInputStream(List(0xC1, 0xC2, 0xC3, 0xC4, 0xC5).map { _.toByte }.toArray)
     val ml = dis.getUnsignedBigInt(40, finfo)
     assertEqualsTyped(40, dis.bitPos0b)
@@ -330,7 +330,7 @@ class TestInputSourceDataInputStream {
     assertEqualsTyped[JBigInt](expected, ml)
   }
 
-  @Test def testUnsignedBigInt3: Unit = {
+  @Test def testUnsignedBigInt3(): Unit = {
     val dat = "7766554433221100ffeeddccbbaa99887766554433221100ffeeddccbbaa99887766554433221100ffeeddccbbaa99887766554433221100ffeeddccbbaa99887766554433221100ffeeddccbbaa99887766554433221100ffeeddccbbaa99887766554433221100ffeeddccbbaa99887766554433221100ffeeddccbbaa99887766554433221100ffeeddccbbaa99887766554433221100ffeeddccbbaa99887766554433221100ffeeddccbbaa99887766554433221100ffeeddccbbaa99887766554433221100ffeeddccbbaa99887766554433221100ffeeddccbbaa99887766554433221100ffeeddccbbaa99887766554433221100ffeeddccbbaa99887766554433221100ffeeddccbbaa99887766554433221100ffeeddccbbaa99887766554433221100ffeeddccbbaa99887766554433221100ffeeddccbbaa99887766554433221100ffeeddccbbaa99887766554433221100ffeeddccbbaa99887766554433221100"
     val dats = dat.sliding(2, 2).toList.flatMap { Misc.hex2Bytes(_) }.toArray
     val dis = InputSourceDataInputStream(dats)
@@ -344,7 +344,7 @@ class TestInputSourceDataInputStream {
     assertEqualsTyped[String](expectedHex, actualHex)
   }
 
-  @Test def testUnsignedBigInt4: Unit = {
+  @Test def testUnsignedBigInt4(): Unit = {
     val expectedHex = "00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff0011223344556677"
     assertEqualsTyped(720, expectedHex.length)
     val expected = new JBigInt(expectedHex, 16)
@@ -370,7 +370,7 @@ class TestInputSourceDataInputStream {
     assertEqualsTyped[String](expectedHexNoLeadingZeros, actualHex)
   }
 
-  @Test def testAlignAndSkip1: Unit = {
+  @Test def testAlignAndSkip1(): Unit = {
     val dis = InputSourceDataInputStream(List(0xC1, 0xC2, 0xC3, 0xC4, 0xC5).map { _.toByte }.toArray)
     assertTrue(dis.isAligned(1))
     assertTrue(dis.isAligned(43))
@@ -383,7 +383,7 @@ class TestInputSourceDataInputStream {
     assertEqualsTyped[Long](7, dis.bitPos0b)
   }
 
-  @Test def testGetSomeString1: Unit = {
+  @Test def testGetSomeString1(): Unit = {
     val dis = InputSourceDataInputStream("1".getBytes())
     val ms = dis.getSomeString(1, finfo)
     assertTrue(ms.isDefined)
@@ -393,7 +393,7 @@ class TestInputSourceDataInputStream {
     assertEqualsTyped[Char]('1', s(0))
   }
 
-  @Test def testGetSomeString2: Unit = {
+  @Test def testGetSomeString2(): Unit = {
     val dis = InputSourceDataInputStream("年月日".getBytes("utf-8"))
     val ms = dis.getSomeString(3, finfo)
     assertTrue(ms.isDefined)
@@ -405,7 +405,7 @@ class TestInputSourceDataInputStream {
     assertEqualsTyped[Long](72, dis.bitPos0b)
   }
 
-  @Test def testgetSomeString3: Unit = {
+  @Test def testgetSomeString3(): Unit = {
     val dis = InputSourceDataInputStream("年月日".getBytes("utf-8"))
     dis.setBitLimit0b(MaybeULong(8 * 6))
     val ms = dis.getSomeString(3, finfo)
@@ -419,7 +419,7 @@ class TestInputSourceDataInputStream {
 
   def unicodeReplacementCharacter = '\uFFFD'
 
-  @Test def testGetSomeStringErrors1: Unit = {
+  @Test def testGetSomeStringErrors1(): Unit = {
     val data = List(0xFF.toByte).toArray ++ "年月日".getBytes("utf-8")
     assertEqualsTyped(10, data.length)
     val dis = InputSourceDataInputStream(data)
@@ -436,7 +436,7 @@ class TestInputSourceDataInputStream {
     assertEqualsTyped[Long](80, dis.bitPos0b)
   }
 
-  @Test def testGetSomeStringErrors2: Unit = {
+  @Test def testGetSomeStringErrors2(): Unit = {
     val badByte = List(0xFF.toByte).toArray
     val data = "abc".getBytes("utf-8") ++ badByte ++ "123".getBytes("utf-8") ++ badByte ++ badByte ++ "drm".getBytes("utf-8")
     val dis = InputSourceDataInputStream(data)
@@ -466,7 +466,7 @@ class TestInputSourceDataInputStream {
   }
   */
 
-  @Test def testCharIterator1: Unit = {
+  @Test def testCharIterator1(): Unit = {
     val dis = InputSourceDataInputStream("年月日".getBytes("utf-8"))
     val iter = dis.asIteratorChar
     iter.setFormatInfo(finfo)
@@ -508,7 +508,7 @@ class TestInputSourceDataInputStream {
   }
   */
 
-  @Test def testLookingAt1: Unit = {
+  @Test def testLookingAt1(): Unit = {
     val data = "abc".getBytes("utf-8")
     val dis = InputSourceDataInputStream(data)
     val pattern = Pattern.compile("a")
@@ -525,7 +525,7 @@ class TestInputSourceDataInputStream {
    * Illustrates that you cannot restart a match that is
    * partway through the regex.
    */
-  @Test def testCharacterizeMatcherAfterHitEndRequireEnd1: Unit = {
+  @Test def testCharacterizeMatcherAfterHitEndRequireEnd1(): Unit = {
     val pat = Pattern.compile("a*")
     val m = pat.matcher("")
     val cb = CharBuffer.wrap("aaaaa")
@@ -554,7 +554,7 @@ class TestInputSourceDataInputStream {
     assertEqualsTyped[Long](1, end)
   }
 
-  @Test def testCharacterizeMatcherAfterHitEndRequireEnd2: Unit = {
+  @Test def testCharacterizeMatcherAfterHitEndRequireEnd2(): Unit = {
     val pat = Pattern.compile("a*b")
     val m = pat.matcher("")
     val cb = CharBuffer.wrap("aaab")
@@ -592,7 +592,7 @@ class TestInputSourceDataInputStream {
    * the nBytesConsumed by the fillCharBuffer gives the right
    * length.
    */
-  @Test def testCharacterizeMatcherAfterHitEndRequireEnd2a: Unit = {
+  @Test def testCharacterizeMatcherAfterHitEndRequireEnd2a(): Unit = {
     val pat = Pattern.compile("aaa*b")
     val m = pat.matcher("")
     val cb = CharBuffer.wrap("aaab")
@@ -615,7 +615,7 @@ class TestInputSourceDataInputStream {
     assertTrue(!hitEnd)
   }
 
-  @Test def testLookingAt2: Unit = {
+  @Test def testLookingAt2(): Unit = {
     val data = "abc".getBytes("utf-8")
     val dis = InputSourceDataInputStream(data)
     val pattern = Pattern.compile("a*b+c")
@@ -628,7 +628,7 @@ class TestInputSourceDataInputStream {
     assertEqualsTyped[Long](24, dis.bitPos0b)
   }
 
-  @Test def testLookingAtManyMultibyteCharsAndDecodeError1: Unit = {
+  @Test def testLookingAtManyMultibyteCharsAndDecodeError1(): Unit = {
     val dataString1 = "abc年de月fg日"
     val data1 = dataString1.getBytes("utf-8")
     val badByte = List(0xFF.toByte).toArray
@@ -647,7 +647,7 @@ class TestInputSourceDataInputStream {
     assertEqualsTyped[Long](data.length * 8, dis.bitPos0b)
   }
 
-  @Test def testLookingAtManyMultibyteCharsAndDecodeError2: Unit = {
+  @Test def testLookingAtManyMultibyteCharsAndDecodeError2(): Unit = {
     val dataString1 = "abc年de月fg日"
     val data1 = dataString1.getBytes("utf-8")
     val badByte = List(0xFF.toByte).toArray
@@ -667,7 +667,7 @@ class TestInputSourceDataInputStream {
     assertEqualsTyped[Long](expectedByteLength * 8, dis.bitPos0b)
   }
 
-  @Test def testLookingAtManyMultibyteCharsAndDecodeError3: Unit = {
+  @Test def testLookingAtManyMultibyteCharsAndDecodeError3(): Unit = {
     val enc = "utf-16BE"
     val dataString1 = "abc年de月fg日"
     val data1 = dataString1.getBytes(enc)
@@ -690,7 +690,7 @@ class TestInputSourceDataInputStream {
     assertEqualsTyped[Long](expectedByteLength * 8, dis.bitPos0b)
   }
 
-  @Test def testDotMatchesNewline1: Unit = {
+  @Test def testDotMatchesNewline1(): Unit = {
     // val enc = "iso-8859-1"
     val dataURI = Misc.getRequiredResource("iso8859.doc.dat")
     val dataInput = dataURI.toURL.openStream()

--- a/daffodil-io/src/test/scala/org/apache/daffodil/io/TestInputSourceDataInputStream2.scala
+++ b/daffodil-io/src/test/scala/org/apache/daffodil/io/TestInputSourceDataInputStream2.scala
@@ -30,7 +30,7 @@ class TestInputSourceDataInputStream2 {
   val twenty = twentyDigits.getBytes("utf-8")
   val finfo = FormatInfoForUnitTest()
 
-  @Test def testMark1: Unit = {
+  @Test def testMark1(): Unit = {
     val dis = InputSourceDataInputStream(ten)
     val m1 = dis.mark("testMark1")
     var arr = dis.getByteArray(80, finfo)
@@ -52,7 +52,7 @@ class TestInputSourceDataInputStream2 {
     assertEquals(10, dis.bytePos0b)
   }
 
-  @Test def testMark2: Unit = {
+  @Test def testMark2(): Unit = {
     val dis = InputSourceDataInputStream(twenty)
     var m1: DataInputStream.Mark = null
     dis.withBitLengthLimit(5 * 8) {
@@ -86,7 +86,7 @@ class TestInputSourceDataInputStream2 {
     assertEquals(10, dis.bytePos0b)
   }
 
-  @Test def testMark3: Unit = {
+  @Test def testMark3(): Unit = {
     val dis = InputSourceDataInputStream(twenty).asInstanceOf[InputSourceDataInputStream]
     dis.setBitLimit0b(MaybeULong(5 * 8))
     var arr = dis.getByteArray(5 * 8, finfo)

--- a/daffodil-io/src/test/scala/org/apache/daffodil/io/TestInputSourceDataInputStream3.scala
+++ b/daffodil-io/src/test/scala/org/apache/daffodil/io/TestInputSourceDataInputStream3.scala
@@ -24,7 +24,7 @@ class TestInputSourceDataInputStream3 {
 
   val Dump = new DataDumper
 
-  @Test def dumpVisible1: Unit = {
+  @Test def dumpVisible1(): Unit = {
     val bytes = "Date 年月日=2003年08月27日".getBytes("utf-8")
     val lengthInBits = bytes.length * 8
     val dis = InputSourceDataInputStream(bytes)
@@ -42,7 +42,7 @@ class TestInputSourceDataInputStream3 {
     assertEquals(expected, "\n" + dumpString + "\n")
   }
 
-  @Test def dumpVisible2: Unit = {
+  @Test def dumpVisible2(): Unit = {
     val bytes = "Date 年月日=2003年08月27日".getBytes("utf-8")
     val lengthInBits = bytes.length * 8
     val dis = InputSourceDataInputStream(bytes)
@@ -61,7 +61,7 @@ class TestInputSourceDataInputStream3 {
     assertEquals(expected, "\n" + dumpString + "\n")
   }
 
-  @Test def dumpVisible3: Unit = {
+  @Test def dumpVisible3(): Unit = {
     val bytes = "Date 年月日=2003年08月27日".getBytes("utf-8")
     val lengthInBits = bytes.length * 8
     val dis = InputSourceDataInputStream(bytes)

--- a/daffodil-io/src/test/scala/org/apache/daffodil/io/TestInputSourceDataInputStream3Bit.scala
+++ b/daffodil-io/src/test/scala/org/apache/daffodil/io/TestInputSourceDataInputStream3Bit.scala
@@ -82,7 +82,7 @@ class TestInputSourceDataInputStream3Bit {
   }
 
   /** Test the test rig */
-  @Test def testBitsBitteBits = {
+  @Test def testBitsBitteBits() = {
 
     val a = BitsBitte.encode3("5")
     assertEquals(Seq("101"), a)
@@ -111,7 +111,7 @@ class TestInputSourceDataInputStream3Bit {
   /*
    * Tests of unaligned char buffers (ie., 3-bit characters)
    */
-  @Test def testGetSomeStringOne3BitChar: Unit = {
+  @Test def testGetSomeStringOne3BitChar(): Unit = {
     val dis = InputSourceDataInputStream(BitsBitte.enc("01234567"))
     val cs = BitsCharsetOctalLSBF
     val finfo = FormatInfoForUnitTest()
@@ -125,7 +125,7 @@ class TestInputSourceDataInputStream3Bit {
     assertEquals('0', s(0))
   }
 
-  @Test def testGetSomeString3BitString: Unit = {
+  @Test def testGetSomeString3BitString(): Unit = {
     val dat = "01234567"
     val cs = BitsCharsetOctalLSBF
     val dis = InputSourceDataInputStream(BitsBitte.enc(dat))
@@ -140,7 +140,7 @@ class TestInputSourceDataInputStream3Bit {
     assertEquals(dat, s)
   }
 
-  @Test def testGetSomeString3BitStringOffBy2: Unit = {
+  @Test def testGetSomeString3BitStringOffBy2(): Unit = {
     val dat = "01234567"
     val cs = BitsCharsetOctalLSBF
     val bytes = BitsBitte.toBytes(BitsBitte.rtl(BitsBitte.rtl("11"), BitsBitte.encode3(dat)))
@@ -157,7 +157,7 @@ class TestInputSourceDataInputStream3Bit {
     assertEquals(2 + (cs.bitWidthOfACodeUnit * 8), dis.bitPos0b)
   }
 
-  @Test def testGetSomeStringDataEndsMidByte: Unit = {
+  @Test def testGetSomeStringDataEndsMidByte(): Unit = {
     val dat = "01234567"
     val cs = BitsCharsetOctalLSBF
     val bytes = BitsBitte.toBytes(BitsBitte.rtl(BitsBitte.rtl("11"), BitsBitte.encode3(dat)))
@@ -184,7 +184,7 @@ class TestInputSourceDataInputStream3Bit {
    * able to fetch another byte of source data (aka an "underflow"), yet there actually
    * are sufficient bits without that byte to decode a character.
    */
-  @Test def testGetSomeStringDataEndsMidByte2: Unit = {
+  @Test def testGetSomeStringDataEndsMidByte2(): Unit = {
     val dat = "01234567"
     val cs = BitsCharsetOctalLSBF
     val bytes = BitsBitte.toBytes(BitsBitte.rtl(BitsBitte.rtl("1"), BitsBitte.encode3(dat)))
@@ -207,7 +207,7 @@ class TestInputSourceDataInputStream3Bit {
    * enough bits to finish a character.
    */
 
-  @Test def testGetSomeStringrDataEndsMidByte3: Unit = {
+  @Test def testGetSomeStringrDataEndsMidByte3(): Unit = {
     val dat = "56701234"
     val cs = BitsCharsetOctalLSBF
     val bytes = BitsBitte.toBytes(BitsBitte.rtl(BitsBitte.encode3(dat)))
@@ -224,7 +224,7 @@ class TestInputSourceDataInputStream3Bit {
     assertEquals(3, dis.bitPos0b)
   }
 
-  @Test def testGetSomeStringDataEndsMidByte3a: Unit = {
+  @Test def testGetSomeStringDataEndsMidByte3a(): Unit = {
     val dat = "77756701234"
     val cs = BitsCharsetOctalLSBF
     val bytes = BitsBitte.toBytes(BitsBitte.rtl(BitsBitte.encode3(dat)))
@@ -241,7 +241,7 @@ class TestInputSourceDataInputStream3Bit {
     assertEquals(12, dis.bitPos0b)
   }
 
-  @Test def testGetSomeStringDataEndsMidByte3b: Unit = {
+  @Test def testGetSomeStringDataEndsMidByte3b(): Unit = {
     val dat = "56701234"
     val cs = BitsCharsetOctalLSBF
     val bytes = BitsBitte.toBytes(BitsBitte.rtl(BitsBitte.rtl("1"), BitsBitte.encode3(dat)))
@@ -270,7 +270,7 @@ class TestInputSourceDataInputStream3Bit {
    *
    * Also shows that hasNext() doesn't ever move the bitPos.
    */
-  @Test def testCharIteratorWithInterruptingBitSkips1: Unit = {
+  @Test def testCharIteratorWithInterruptingBitSkips1(): Unit = {
     val dis = InputSourceDataInputStream(BitsBitte.enc("01234567"))
     val cs = BitsCharsetOctalLSBF
     val finfo = FormatInfoForUnitTest()
@@ -299,7 +299,7 @@ class TestInputSourceDataInputStream3Bit {
     assertFalse(iter.hasNext)
   }
 
-  @Test def test3BitEncoderOverflowError: Unit = {
+  @Test def test3BitEncoderOverflowError(): Unit = {
     val encoder = BitsCharsetOctalLSBF.newEncoder
     val bb = ByteBuffer.allocate(1) // only big enough for a single byte
     val cb = CharBuffer.wrap("123") // 3 octal digits will cause overflow
@@ -307,7 +307,7 @@ class TestInputSourceDataInputStream3Bit {
     assertTrue(coderResult == CoderResult.OVERFLOW)
   }
 
-  @Test def test3BitEncoderMalformedError: Unit = {
+  @Test def test3BitEncoderMalformedError(): Unit = {
     val encoder = BitsCharsetOctalLSBF.newEncoder
     val bb = ByteBuffer.allocate(3)
     val cb = CharBuffer.wrap("12?") // ? is not encodable in octal

--- a/daffodil-io/src/test/scala/org/apache/daffodil/io/TestInputSourceDataInputStream6.scala
+++ b/daffodil-io/src/test/scala/org/apache/daffodil/io/TestInputSourceDataInputStream6.scala
@@ -112,7 +112,7 @@ class TestInputSourceDataInputStream6 {
    * These just ensure that we move over to the mandatory alignment before decoding
    * any characters.
    */
-  @Test def testGetSomeString1: Unit = {
+  @Test def testGetSomeString1(): Unit = {
     val dis = InputSourceDataInputStream("01".getBytes())
     dis.getSignedLong(1, beFinfo)
     val ms = dis.getSomeString(1, beFinfo)
@@ -123,7 +123,7 @@ class TestInputSourceDataInputStream6 {
     assertEquals('1', s(0))
   }
 
-  @Test def testgetSomeString2: Unit = {
+  @Test def testgetSomeString2(): Unit = {
     val dis = InputSourceDataInputStream("0年月日".getBytes("utf-8"))
     dis.getSignedLong(4, beFinfo)
     val ms = dis.getSomeString(3, beFinfo)
@@ -136,7 +136,7 @@ class TestInputSourceDataInputStream6 {
     assertEquals(80, dis.bitPos0b)
   }
 
-  @Test def testGetSomeStringDataEndsMidByte: Unit = {
+  @Test def testGetSomeStringDataEndsMidByte(): Unit = {
     val dis = InputSourceDataInputStream("年月日".getBytes("utf-8"))
     dis.setBitLimit0b(MaybeULong((8 * 6) + 2)) // 2 extra bits after first 2 chars
     val ms = dis.getSomeString(3, beFinfo)
@@ -148,7 +148,7 @@ class TestInputSourceDataInputStream6 {
     assertEquals(8 * 6, dis.bitPos0b)
   }
 
-  @Test def testGetSomeStringDataEndsMidByte2: Unit = {
+  @Test def testGetSomeStringDataEndsMidByte2(): Unit = {
     val dis = InputSourceDataInputStream("年月日".getBytes("utf-8"))
     dis.setBitLimit0b(MaybeULong((8 * 6) + 2)) // 2 extra bits after first 2 chars
     val ms = dis.getSomeString(3, beFinfo)
@@ -162,7 +162,7 @@ class TestInputSourceDataInputStream6 {
     assertEquals(Maybe.Nope, ms2)
   }
 
-  @Test def testGetSomeStringDataEndsMidByte3: Unit = {
+  @Test def testGetSomeStringDataEndsMidByte3(): Unit = {
     val dis = InputSourceDataInputStream("年月日".getBytes("utf-8"))
     dis.setBitLimit0b(MaybeULong((8 * 6) + 10)) // 1 more byte plus 2 extra bits after first 2 chars
     val ms = dis.getSomeString(3, beFinfo)
@@ -185,7 +185,7 @@ class TestInputSourceDataInputStream6 {
    * any characters.
    */
 
-  @Test def testCharIteratorWithInterruptingBitSkips1: Unit = {
+  @Test def testCharIteratorWithInterruptingBitSkips1(): Unit = {
     val dis = InputSourceDataInputStream("0年1月2日".getBytes("utf-8"))
     val iter = dis.asIteratorChar
     iter.setFormatInfo(beFinfo)
@@ -215,7 +215,7 @@ class TestInputSourceDataInputStream6 {
    * Also shows that hasNext() doesn't ever move the bitPos even
    * if it has to align to a mandatory character alignment boundary.
    */
-  @Test def testCharIteratorWithInterruptingBitSkipsBetweenHasNextAndNext: Unit = {
+  @Test def testCharIteratorWithInterruptingBitSkipsBetweenHasNextAndNext(): Unit = {
     val dis = InputSourceDataInputStream("0年1月2日".getBytes("utf-8"))
     val iter = dis.asIteratorChar
     iter.setFormatInfo(beFinfo)

--- a/daffodil-io/src/test/scala/org/apache/daffodil/io/TestInputSourceDataInputStream7.scala
+++ b/daffodil-io/src/test/scala/org/apache/daffodil/io/TestInputSourceDataInputStream7.scala
@@ -84,7 +84,7 @@ class TestInputSourceDataInputStream7 {
   finfo.bitOrder = BitOrder.LeastSignificantBitFirst
 
   /** Test the test rig */
-  @Test def testBitteBits = {
+  @Test def testBitteBits() = {
 
     val a = Bitte.encode7("a")
     assertEquals(Seq("1100001"), a)
@@ -119,7 +119,7 @@ class TestInputSourceDataInputStream7 {
    *
    * The `getByteArray` call returns 3 bytes, but one is a fragment byte
    */
-  @Test def testGetByteArrayLengthLimit1: Unit = {
+  @Test def testGetByteArrayLengthLimit1(): Unit = {
     val dis = InputSourceDataInputStream(Bitte.enc("abc"))
     dis.setBitLimit0b(MaybeULong(21))
     val finfo = FormatInfoForUnitTest()
@@ -136,7 +136,7 @@ class TestInputSourceDataInputStream7 {
   /*
    * Tests of unaligned char buffers (ie., 7-bit characters)
    */
-  @Test def testGetSomeStringOne7BitChar: Unit = {
+  @Test def testGetSomeStringOne7BitChar(): Unit = {
     val dis = InputSourceDataInputStream(Bitte.enc("abcdefgh"))
     val ms = dis.getSomeString(1, finfo)
     assertTrue(ms.isDefined)
@@ -146,7 +146,7 @@ class TestInputSourceDataInputStream7 {
     assertEquals('a', s(0))
   }
 
-  @Test def testGetSomeString7BitString: Unit = {
+  @Test def testGetSomeString7BitString(): Unit = {
     val dis = InputSourceDataInputStream(Bitte.enc("abcdefgh"))
     val ms = dis.getSomeString(8, finfo)
     assertTrue(ms.isDefined)
@@ -155,7 +155,7 @@ class TestInputSourceDataInputStream7 {
     assertEquals(56, dis.bitPos0b)
     assertEquals("abcdefgh", s)
   }
-  @Test def testGetSomeString7BitStringOffBy3: Unit = {
+  @Test def testGetSomeString7BitStringOffBy3(): Unit = {
     val bytes = Bitte.toBytes(Bitte.rtl(Bitte.rtl("101"), Bitte.encode7("abcdefgh")))
     val dis = InputSourceDataInputStream(bytes)
     dis.skip(3, finfo)
@@ -167,7 +167,7 @@ class TestInputSourceDataInputStream7 {
     assertEquals(59, dis.bitPos0b)
   }
 
-  @Test def testGetSomeStringDataEndsMidByte: Unit = {
+  @Test def testGetSomeStringDataEndsMidByte(): Unit = {
     val bytes = Bitte.toBytes(Bitte.rtl(Bitte.rtl("101"), Bitte.encode7("abcdefgh")))
     val dis = InputSourceDataInputStream(bytes)
     dis.setBitLimit0b(MaybeULong(25))
@@ -189,7 +189,7 @@ class TestInputSourceDataInputStream7 {
    * able to fetch another byte of source data (aka an "underflow"), yet there actually
    * are sufficient bits without that byte to decode a character.
    */
-  @Test def testGetSomeStringDataEndsMidByte2: Unit = {
+  @Test def testGetSomeStringDataEndsMidByte2(): Unit = {
     val bytes = Bitte.toBytes(Bitte.rtl(Bitte.rtl("101"), Bitte.encode7("abcdefgh")))
     val dis = InputSourceDataInputStream(bytes)
     dis.setBitLimit0b(MaybeULong(20))
@@ -206,7 +206,7 @@ class TestInputSourceDataInputStream7 {
    * Similar to above test, except the remaining partial byte does not provide
    * enough bits to finish a character.
    */
-  @Test def testGetSomeStringDataEndsMidByte3: Unit = {
+  @Test def testGetSomeStringDataEndsMidByte3(): Unit = {
     val bytes = Bitte.toBytes(Bitte.rtl(Bitte.rtl("101"), Bitte.encode7("abcdefgh")))
     val dis = InputSourceDataInputStream(bytes)
     dis.setBitLimit0b(MaybeULong(16))
@@ -227,7 +227,7 @@ class TestInputSourceDataInputStream7 {
    * any characters.
    */
 
-  @Test def testCharIteratorWithInterruptingBitSkips1: Unit = {
+  @Test def testCharIteratorWithInterruptingBitSkips1(): Unit = {
     val dis = InputSourceDataInputStream(Bitte.enc("0a1b2c"))
     dis.setBitLimit0b(MaybeULong(42))
     val iter = dis.asIteratorChar
@@ -267,7 +267,7 @@ class TestInputSourceDataInputStream7 {
    * Also shows that hasNext() doesn't ever move the bitPos even
    * if it has to align to a mandatory character alignment boundary.
    */
-  @Test def testCharIteratorWithInterruptingBitSkipsBetweenHasNextAndNext: Unit = {
+  @Test def testCharIteratorWithInterruptingBitSkipsBetweenHasNextAndNext(): Unit = {
     val dis = InputSourceDataInputStream(Bitte.enc("0a1b2c"))
     dis.setBitLimit0b(MaybeULong(42))
     val iter = dis.asIteratorChar
@@ -290,7 +290,7 @@ class TestInputSourceDataInputStream7 {
 
   }
 
-  @Test def testUSASCII7BitEncoderOverflowError: Unit = {
+  @Test def testUSASCII7BitEncoderOverflowError(): Unit = {
     val encoder = BitsCharsetUSASCII7BitPacked.newEncoder
     val bb = ByteBuffer.allocate(1) // only big enough for a single byte
     val cb = CharBuffer.wrap("ab") // two characters will cause overflow
@@ -298,7 +298,7 @@ class TestInputSourceDataInputStream7 {
     assertTrue(coderResult == CoderResult.OVERFLOW)
   }
 
-  @Test def testUSASCII7BitEncoderMalformedError: Unit = {
+  @Test def testUSASCII7BitEncoderMalformedError(): Unit = {
     val encoder = BitsCharsetUSASCII7BitPacked.newEncoder
     val bb = ByteBuffer.allocate(3)
     val cb = CharBuffer.wrap("ab" + 128.toChar) // 128 is not encodable in 7 bits

--- a/daffodil-lib/src/main/scala/org/apache/daffodil/api/Diagnostic.scala
+++ b/daffodil-lib/src/main/scala/org/apache/daffodil/api/Diagnostic.scala
@@ -155,7 +155,7 @@ abstract class Diagnostic protected (
   final def getSomeCause: Some[Throwable] = Misc.getSomeCause(this)
   final def getSomeMessage: Some[String] = Misc.getSomeMessage(this)
 
-  private def init: Unit = {
+  private def init(): Unit = {
     Assert.invariant(maybeCause.isDefined ^ maybeFormatString.isDefined)
     Assert.invariant(maybeCause.isEmpty || args.length == 0) // if there is a cause, there can't be args.
   }

--- a/daffodil-lib/src/main/scala/org/apache/daffodil/oolag/OOLAG.scala
+++ b/daffodil-lib/src/main/scala/org/apache/daffodil/oolag/OOLAG.scala
@@ -299,7 +299,7 @@ object OOLAG {
      * Unconditionally, evaluate the LV arg in order to insure all checks for this
      * object are performed.
      */
-    private def requiredEvaluationsAlways(lv: OOLAGValueBase) : Unit = {
+    private def requiredEvaluationsAlways(lv: OOLAGValueBase): Unit = {
       val accumPoint =
         if (this.hasOOLAGRootSetup)
           oolagRoot
@@ -372,7 +372,7 @@ object OOLAG {
      * Saves the arg LV, and insures it is evaluated later only if
      * setRequiredEvaluationActive() is called for this object.
      */
-    private def requiredEvaluationsIfActivated(lv: OOLAGValueBase) : Unit = {
+    private def requiredEvaluationsIfActivated(lv: OOLAGValueBase): Unit = {
       if (requiredEvalStatus eq Active)
         if (hasOOLAGRootSetup)
           oolagRoot.requiredEvalFunctions +:= lv // active. Rooted. Accumulate centrally.
@@ -391,7 +391,7 @@ object OOLAG {
      * expression/LV, and if so, all the conditional evaluations will be captured and
      * evaluated as part of the ongoing evaluation of requiredEvaluations expressions.
      */
-    final def setRequiredEvaluationsActive() : Unit = setRequiredEvaluationsActiveOnceOnly
+    final def setRequiredEvaluationsActive(): Unit = setRequiredEvaluationsActiveOnceOnly
     private lazy val setRequiredEvaluationsActiveOnceOnly = {
       requiredEvalStatus = Active
       centralizeEvalFunctionsWhenReady()
@@ -410,7 +410,7 @@ object OOLAG {
      * onto the root, which happens automatically via the calls to
      * centralizeEvalFunctionsWhenReady().
      */
-    private def checkErrors: Unit = {
+    final def checkErrors(): Unit = {
       Assert.usage(this.isOOLAGRoot || requiredEvalFunctions == Nil)
       while (oolagRoot.requiredEvalFunctions != Nil) { // while there is an accumulated crop of eval functions
         // grab the current crop of eval functions
@@ -639,7 +639,7 @@ object OOLAG {
       value_ = Maybe(res)
     }
 
-    protected final def oolagFinalize = {
+    protected final def oolagFinalize() = {
       setIndent(indent - 2)
       Logger.log.trace(" " * indent + s"pop: ${thisThing}")
       if (oolagContext.currentOVList.nonEmpty)

--- a/daffodil-lib/src/main/scala/org/apache/daffodil/util/Cursor.scala
+++ b/daffodil-lib/src/main/scala/org/apache/daffodil/util/Cursor.scala
@@ -116,7 +116,7 @@ trait Cursor[AccessorType <: Accessor[AccessorType]] {
    * Cause this cursor to finish and cleanup anything that may be necessary,
    * regardless of if it is complete or not
    */
-  def fini: Unit
+  def fini(): Unit
 }
 
 trait CursorImplMixin[AccessorType <: Accessor[AccessorType]]

--- a/daffodil-lib/src/main/scala/org/apache/daffodil/util/MStack.scala
+++ b/daffodil-lib/src/main/scala/org/apache/daffodil/util/MStack.scala
@@ -187,7 +187,7 @@ protected abstract class MStack[@specialized T] private[util] (
   private var index = 0
   private var table: Array[T] = null
 
-  def init: Unit = {
+  def init(): Unit = {
     index = 0
     table = arrayAllocator(32)
   }

--- a/daffodil-lib/src/main/scala/org/apache/daffodil/util/Pool.scala
+++ b/daffodil-lib/src/main/scala/org/apache/daffodil/util/Pool.scala
@@ -96,7 +96,7 @@ trait Pool[T <: Poolable] {
    * This is to help find resource leaks where items are taken from
    * the pool, but then dropped.
    */
-  final def finalCheck: Unit = {
+  final def finalCheck(): Unit = {
     if (!(numOutstanding =#= 0)) {
       val msg = "Pool " + Misc.getNameFromClass(this) + " leaked " + numOutstanding + " instance(s)." +
         "\n" + inUse.map { item => "poolDebugLabel = " + item.poolDebugLabel }.mkString("\n")

--- a/daffodil-lib/src/main/scala/org/apache/daffodil/xml/XMLUtils.scala
+++ b/daffodil-lib/src/main/scala/org/apache/daffodil/xml/XMLUtils.scala
@@ -340,7 +340,7 @@ object XMLUtils {
     //
     var tn: Node = null
     var sb: StringBuilder = null
-    def processText = {
+    def processText() = {
       if (tn == null) {
         if (sb != null && sb.length > 0) {
           // we have accumulated text

--- a/daffodil-lib/src/test/scala/org/apache/daffodil/TestBitOrderByteOrder.scala
+++ b/daffodil-lib/src/test/scala/org/apache/daffodil/TestBitOrderByteOrder.scala
@@ -18,13 +18,12 @@
 package org.apache.daffodil
 
 import org.junit.Assert.assertEquals
-import org.apache.daffodil.util._
 import org.junit.Test
 import org.apache.daffodil.util._
 
 class TestByteOrder {
 
-  @Test def testLittleEndianBitValue = {
+  @Test def testLittleEndianBitValue() = {
     var bsl = 13
     assertEquals(0x80, Bits.littleEndianBitValue(1, bsl))
     assertEquals(0x40, Bits.littleEndianBitValue(2, bsl))
@@ -49,7 +48,7 @@ class TestByteOrder {
 
 class TestBitOrder {
 
-  @Test def testAsLSBitFirst = {
+  @Test def testAsLSBitFirst() = {
     assertEquals(0x20, Bits.asLSBitFirst(0x04))
     assertEquals(0x80, Bits.asLSBitFirst(1))
     assertEquals(0xA5, Bits.asLSBitFirst(0xA5))

--- a/daffodil-lib/src/test/scala/org/apache/daffodil/util/TestListMap.scala
+++ b/daffodil-lib/src/test/scala/org/apache/daffodil/util/TestListMap.scala
@@ -32,7 +32,7 @@ class TestListMap {
    * practice, it is implemented as a linked list that does maintain order.
    * This test ensures that this behavior does not change.
    */
-  @Test def test_listMap = {
+  @Test def test_listMap() = {
     val orig = Random.shuffle((0 until 1000).toList)
     val mt: ListMap[Int, String] = ListMap.empty
     val listMap: ListMap[Int, String] = orig.foldLeft(mt) {

--- a/daffodil-lib/src/test/scala/org/apache/daffodil/util/TestListUtils.scala
+++ b/daffodil-lib/src/test/scala/org/apache/daffodil/util/TestListUtils.scala
@@ -22,55 +22,55 @@ import org.junit.Test
 
 class TestListUtils {
 
-  @Test def testTailAfter1 = {
+  @Test def testTailAfter1() = {
     val actual = ListUtils.tailAfter(List(1, 2, 3, 4, 5), 3)
     val expected = List(4, 5)
     assertEquals(expected, actual)
   }
 
-  @Test def testTailAfter2 = {
+  @Test def testTailAfter2() = {
     val actual = ListUtils.tailAfter(Nil, 3)
     val expected = Nil
     assertEquals(expected, actual)
   }
 
-  @Test def testTailAfter3 = {
+  @Test def testTailAfter3() = {
     val actual = ListUtils.tailAfter(List(1, 2, 3, 4, 5), 5)
     val expected = Nil
     assertEquals(expected, actual)
   }
 
-  @Test def testTailAfter4 = {
+  @Test def testTailAfter4() = {
     val actual = ListUtils.tailAfter(List(1, 2, 3, 4, 5), 0)
     val expected = Nil // The answer if not found at all is Nil
     assertEquals(expected, actual)
   }
 
-  @Test def testPreceding1 = {
+  @Test def testPreceding1() = {
     val actual = ListUtils.preceding(List(1, 2, 3, 4, 5), 3)
     val expected = List(1, 2)
     assertEquals(expected, actual)
   }
 
-  @Test def testPreceding2 = {
+  @Test def testPreceding2() = {
     val actual = ListUtils.preceding(Nil, 3)
     val expected = Nil
     assertEquals(expected, actual)
   }
 
-  @Test def testPreceding3 = {
+  @Test def testPreceding3() = {
     val actual = ListUtils.preceding(List(1, 2, 3, 4, 5), 1)
     val expected = Nil
     assertEquals(expected, actual)
   }
 
-  @Test def testPreceding4 = {
+  @Test def testPreceding4() = {
     val actual = ListUtils.preceding(List(1, 2, 3, 4, 5), 0)
     val expected = Nil // The answer if not found at all is Nil
     assertEquals(expected, actual)
   }
 
-  @Test def testPreceding5 = {
+  @Test def testPreceding5() = {
     val actual = ListUtils.preceding(List(1, 2, 3, 4, 5), 5)
     val expected = List(1, 2, 3, 4)
     assertEquals(expected, actual)

--- a/daffodil-lib/src/test/scala/org/apache/daffodil/util/TestMaybeInlineForeach.scala
+++ b/daffodil-lib/src/test/scala/org/apache/daffodil/util/TestMaybeInlineForeach.scala
@@ -65,7 +65,7 @@ final class TestMaybeInlineForeach {
    */
   @inline private def limit = 1000000000L // 50000000000L runs for about a minute
 
-  def testForeach: Unit = {
+  def testForeach(): Unit = {
     var i: Long = 0
     while (i < limit) {
       i += 1
@@ -73,7 +73,7 @@ final class TestMaybeInlineForeach {
     }
   }
 
-  def testIfDefined: Unit = {
+  def testIfDefined(): Unit = {
     var i: Long = 0
     i = 0
     while (i < limit) {
@@ -82,7 +82,7 @@ final class TestMaybeInlineForeach {
     }
   }
 
-  def testIfNull: Unit = {
+  def testIfNull(): Unit = {
     var i: Long = 0
     i = 0
     while (i < limit) {
@@ -97,7 +97,7 @@ final class TestMaybeInlineForeach {
    * but there's no point waiting 2 seconds for this test to run all the time.
    */
   // @Test
-  def testForeachVersusIfDefined: Unit = {
+  def testForeachVersusIfDefined(): Unit = {
     val foreachNanos: Double = time(testForeach)
     val ifDefinedNanos: Double = time(testIfDefined)
     val ifNullNanos: Double = time(testIfNull)

--- a/daffodil-lib/src/test/scala/passera/test/TestULong.scala
+++ b/daffodil-lib/src/test/scala/passera/test/TestULong.scala
@@ -33,7 +33,7 @@ import java.math.{ BigInteger => JBigInt }
 
 class TestULong {
 
-  @Test def testULongToString1: Unit = {
+  @Test def testULongToString1(): Unit = {
     val mm1 = ULong(-1L)
     assertEquals("FFFFFFFFFFFFFFFF", mm1.toHexString.toUpperCase)
     assertEquals(ULong.MaxValueAsBigInt, mm1.toBigInt)
@@ -42,7 +42,7 @@ class TestULong {
   }
 
   // DAFFODIL-1714
-  @Test def testULongModulus1: Unit = {
+  @Test def testULongModulus1(): Unit = {
     for (i <- 0 to 16 ) {
       val numerator = ULong(i)
       val denominator = ULong(8)
@@ -51,20 +51,20 @@ class TestULong {
     }
   }
 
-  @Test def testULongModulus2: Unit = {
+  @Test def testULongModulus2(): Unit = {
     val mm1 = ULong(-1L)
     val remainder = mm1 % ULong(65536)
     assertEquals(ULong(0x0000FFFF), remainder)
   }
   
-  @Test def testULongModulus3: Unit = {
+  @Test def testULongModulus3(): Unit = {
     val mm1 = ULong(-1L)
     val mm2 = ULong(-2L)
     val remainder = mm1 % mm2
     assertEquals(ULong(1), remainder)
   }
 
-  @Test def testULongMostNegativeLong1: Unit = {
+  @Test def testULongMostNegativeLong1(): Unit = {
     val v = ULong(Long.MinValue)
     val vbi = v.toBigInt
     val vhex = vbi.toString(16)
@@ -74,7 +74,7 @@ class TestULong {
     assertEquals("9223372036854775808", v.toString)
   }
 
-  @Test def testULongMaxValue: Unit = {
+  @Test def testULongMaxValue(): Unit = {
     val v = ULong.MaxValue
     assertEquals("FFFFFFFFFFFFFFFF", v.toHexString.toUpperCase)
     assertEquals(ULong(0), v + ULong(1))
@@ -82,7 +82,7 @@ class TestULong {
     assertEquals(ULong(1), ULong(v1)) // preserves only 64 bits
   }
 
-  @Test def testULongFromBigInt: Unit = {
+  @Test def testULongFromBigInt(): Unit = {
     val zero = JBigInt.ZERO
     val one = JBigInt.ONE
     val two = JBigInt.valueOf(2)
@@ -96,7 +96,7 @@ class TestULong {
     assertEquals("7FFFFFFFFFFFFFFF", (ULong(Long.MinValue) - ULong(1)).toHexString.toUpperCase)
   }
 
-  @Test def testULongShift: Unit = {
+  @Test def testULongShift(): Unit = {
     // The >> operator is arithmetic shift, so for signed numbers this would sign extend,
     // but ULong is unsigned, so there is no difference between >> and >>> (logical shift right).
     assertEquals("7FFFFFFFFFFFFFFF", (ULong.MaxValue >> 1).toHexString.toUpperCase)
@@ -110,7 +110,7 @@ class TestULong {
     assertEquals("7FFFFFFFFFFFFFFF", (ULong.MaxValue << 1 >> 1).toHexString.toUpperCase)
   }
 
-  @Test def testULongFromHex: Unit = {
+  @Test def testULongFromHex(): Unit = {
     assertEquals("7FFFFFFFFFFFFFFF", ULong.fromHexString("7FFFFFFFFFFFFFFF").toHexString.toUpperCase)
   }
 }

--- a/daffodil-lib/src/test/scala/passera/test/UnsignedCheck.scala
+++ b/daffodil-lib/src/test/scala/passera/test/UnsignedCheck.scala
@@ -30,14 +30,12 @@ import org.scalacheck._
 // import org.scalacheck.ConsoleReporter
 import org.scalacheck.Prop._
 import passera.unsigned._
-
 import org.junit.Test
 import org.junit.Assert._
 
 import scala.language.implicitConversions
 
 class UnsignedCheck {
-  import Gen._
   import Arbitrary.arbitrary
 
   val zero = 0.toUInt
@@ -52,7 +50,7 @@ class UnsignedCheck {
   def genUInt: Gen[UInt] = for (n <- arbitrary[Int]) yield UInt(n)
   implicit def arbUInt: Arbitrary[UInt] = Arbitrary(genUInt)
 
-  @Test def testIntToString = {
+  @Test def testIntToString() = {
     assertTrue(
       forAll { n: Int => n >= 0 ==> (n.toUInt.toString == n.toString) }
     )
@@ -60,123 +58,123 @@ class UnsignedCheck {
 
   val nonNegLong = Gen.choose(0L, 0x00000000ffffffffL)
 
-  @Test def testLongToString = {
+  @Test def testLongToString() = {
     assertTrue(
       forAll(nonNegLong) { n => n.toUInt.toString == n.toString }
     )
   }
 
-  @Test def testToUIntTotoIntInverses = {
+  @Test def testToUIntTotoIntInverses() = {
     assertTrue(
       forAll { (a: Int) => a.toUInt.toInt == a }
     )
   }
 
-  @Test def testToIntTotoUIntInverses = {
+  @Test def testToIntTotoUIntInverses() = {
     assertTrue(
       forAll { (a: UInt) => a.toInt.toUInt == a }
     )
   }
 
-  @Test def testToUIntToDouble = {
+  @Test def testToUIntToDouble() = {
     assertTrue(
       forAll { (a: Int) => (a >= 0) ==> (a.toUInt.toDouble == a.toDouble) }
     )
   }
 
-  @Test def testGe0 = {
+  @Test def testGe0() = {
     assertTrue(
       forAll { (a: UInt) => a >= zero }
     )
   }
 
-  @Test def testAddCommutes = {
+  @Test def testAddCommutes() = {
     assertTrue(
       forAll { (a: UInt, b: UInt) => a + b == b + a }
     )
   }
 
-  @Test def testMulCommutes = {
+  @Test def testMulCommutes() = {
     assertTrue(
       forAll { (a: UInt, b: UInt) => a * b == b * a }
     )
   }
 
-  @Test def testZeroIdentityForAdd = {
+  @Test def testZeroIdentityForAdd() = {
     assertTrue(
       forAll { (a: UInt, b: UInt) => a + zero == a }
     )
   }
 
-  @Test def testOneIdentityForMul = {
+  @Test def testOneIdentityForMul() = {
     assertTrue(
       forAll { (a: UInt, b: UInt) => a * one == a }
     )
   }
 
-  @Test def testZeroIsZeroMul = {
+  @Test def testZeroIsZeroMul() = {
     assertTrue(
       forAll { (a: UInt, b: UInt) => a * zero == zero }
     )
   }
 
-  @Test def testAddAssociates = {
+  @Test def testAddAssociates() = {
     assertTrue(
       forAll { (a: UInt, b: UInt, c: UInt) => a + (b + c) == (a + b) + c }
     )
   }
 
-  @Test def testMulDistributesLeft = {
+  @Test def testMulDistributesLeft() = {
     assertTrue(
       forAll { (a: UInt, b: UInt, c: UInt) => a * (b + c) == (a * b) + (a * c) }
     )
   }
 
-  @Test def testMulDistributesRight = {
+  @Test def testMulDistributesRight() = {
     assertTrue(
       forAll { (a: UInt, b: UInt, c: UInt) => (a + b) * c == (a * c) + (b * c) }
     )
   }
 
 
-  @Test def testAddAndSub = {
+  @Test def testAddAndSub() = {
     assertTrue(
       forAll { (a: UInt, b: UInt) => a + (b - a) == b }
     )
   }
 
-  @Test def testAddAndSub2 = {
+  @Test def testAddAndSub2() = {
     assertTrue(
       forAll { (a: UInt, b: UInt) => (b - a) + a == b }
     )
   }
 
 
-  @Test def testDivAndShift = {
+  @Test def testDivAndShift() = {
     assertTrue(
       forAll { (a: UInt) => a / 2.toUInt == a >>> 1 }
     )
   }
 
-  @Test def testShift = {
+  @Test def testShift() = {
     assertTrue(
       forAll { (a: UInt) => a >> 1 == a >>> 1 }
     )
   }
 
-  @Test def testZeroFrac = {
+  @Test def testZeroFrac() = {
     assertTrue(
       forAll { (a: UInt, b: UInt) => (a < b && b != 0) ==> ((a / b) == 0) }
     )
   }
 
-  @Test def testNonzeroFrac = {
+  @Test def testNonzeroFrac() = {
     assertTrue(
       forAll { (a: UInt, b: UInt) => (a > b && b != 0) ==> ((a / b) > zero) }
     )
   }
 
-  @Test def testQr = {
+  @Test def testQr() = {
     assertTrue(
       forAll { (a: UInt, b: UInt) =>
         (b != 0) ==> {
@@ -188,131 +186,131 @@ class UnsignedCheck {
     )
   }
 
-  @Test def testLtAndGt = {
+  @Test def testLtAndGt() = {
     assertTrue(
       forAll { (a: UInt, b: UInt) => a < b == b > a }
     )
   }
 
-  @Test def testLeAndGe = {
+  @Test def testLeAndGe() = {
     assertTrue(
       forAll { (a: UInt, b: UInt) => a <= b == b >= a }
     )
   }
 
-  @Test def testLeAndLtAndEq = {
+  @Test def testLeAndLtAndEq() = {
     assertTrue(
       forAll { (a: UInt, b: UInt) => a <= b == (a < b || a == b) }
     )
   }
 
-  @Test def testGeAndGtAndEq = {
+  @Test def testGeAndGtAndEq() = {
     assertTrue(
       forAll { (a: UInt, b: UInt) => a >= b == (a > b || a == b) }
     )
   }
 
-  @Test def testLtAndGeAndNe = {
+  @Test def testLtAndGeAndNe() = {
     assertTrue(
       forAll { (a: UInt, b: UInt) => a < b == (a <= b && a != b) }
     )
   }
 
-  @Test def testGtAndGeAndNe = {
+  @Test def testGtAndGeAndNe() = {
     assertTrue(
       forAll { (a: UInt, b: UInt) => a > b == (a >= b && a != b) }
     )
   }
 
-  @Test def testLeAndNgt = {
+  @Test def testLeAndNgt() = {
     assertTrue(
       forAll { (a: UInt, b: UInt) => a <= b == !(a > b) }
     )
   }
 
-  @Test def testGeAndNlt = {
+  @Test def testGeAndNlt() = {
     assertTrue(
       forAll { (a: UInt, b: UInt) => a >= b == !(a < b) }
     )
   }
 
 
-  @Test def testLshiftInt = {
+  @Test def testLshiftInt() = {
     assertTrue(
       forAll { (a: Int, b: Int) => a.toUInt << (b & 0x1f) == (a << (b & 0x1f)).toUInt }
     )
   }
 
-  @Test def testLshiftLong = {
+  @Test def testLshiftLong() = {
     assertTrue(
       forAll { (a: Int, b: Long) => a.toUInt << (b & 0x1f) == (a << (b & 0x1f).toInt).toUInt }
     )
   }
 
-  @Test def testLshiftUInt = {
+  @Test def testLshiftUInt() = {
     assertTrue(
       forAll { (a: Int, b: Int) => a.toUInt << (b & 0x1f).toUInt == (a << (b & 0x1f)).toUInt }
     )
   }
 
-  @Test def testLshiftULong = {
+  @Test def testLshiftULong() = {
     assertTrue(
       forAll { (a: Int, b: Long) => a.toUInt << (b & 0x1f).toULong == (a << (b & 0x1f).toInt).toUInt }
     )
   }
 
 
-  @Test def testRshiftInt = {
+  @Test def testRshiftInt() = {
     assertTrue(
       forAll { (a: Int, b: Int) => a.toUInt >> (b & 0x1f) == (a >>> (b & 0x1f)).toUInt }
     )
   }
 
-  @Test def testRshiftLong = {
+  @Test def testRshiftLong() = {
     assertTrue(
       forAll { (a: Int, b: Long) => a.toUInt >> (b & 0x1f) == (a >>> (b & 0x1f).toInt).toUInt }
     )
   }
 
-  @Test def testRshiftUInt = {
+  @Test def testRshiftUInt() = {
     assertTrue(
       forAll { (a: Int, b: Int) => a.toUInt >> (b & 0x1f).toUInt == (a >>> (b & 0x1f)).toUInt }
     )
   }
 
-  @Test def testRshiftULong = {
+  @Test def testRshiftULong() = {
     assertTrue(
       forAll { (a: Int, b: Long) => a.toUInt >> (b & 0x1f).toULong == (a >>> (b & 0x1f).toInt).toUInt }
     )
   }
 
 
-  @Test def testZrshiftInt = {
+  @Test def testZrshiftInt() = {
     assertTrue(
       forAll { (a: Int, b: Int) => a.toUInt >>> (b & 0x1f) == (a >>> (b & 0x1f)).toUInt }
     )
   }
 
-  @Test def testZrshiftLong = {
+  @Test def testZrshiftLong() = {
     assertTrue(
       forAll { (a: Int, b: Long) => a.toUInt >>> (b & 0x1f).toInt == (a >>> (b & 0x1f).toInt).toUInt }
     )
   }
 
-  @Test def testZrshiftUInt = {
+  @Test def testZrshiftUInt() = {
     assertTrue(
       forAll { (a: Int, b: Int) => a.toUInt >>> (b & 0x1f).toUInt == (a >>> (b & 0x1f)).toUInt }
     )
   }
 
-  @Test def testZrshiftULong = {
+  @Test def testZrshiftULong() = {
     assertTrue(
       forAll { (a: Int, b: Long) => a.toUInt >>> (b & 0x1f).toULong == (a >>> (b & 0x1f).toInt).toUInt }
     )
   }
 
 
-  @Test def testRshiftAndZrshiftEquivalent = {
+  @Test def testRshiftAndZrshiftEquivalent() = {
     assertTrue(
       forAll { (a: Int, b: Int) => a.toUInt >> (b & 0x1f) == a.toUInt >>> (b & 0x1f) }
     )

--- a/daffodil-propgen/src/main/scala/org/apache/daffodil/propGen/PropertyGenerator.scala
+++ b/daffodil-propgen/src/main/scala/org/apache/daffodil/propGen/PropertyGenerator.scala
@@ -598,7 +598,7 @@ object Currency {
   def generateNonEnumStringInit(pgName: String, propInits: Seq[String]) = {
     val initFuncName = initialLowerCase(pgName)
     """
-  def """ + initFuncName + """Init() : Unit = {""" +
+  def """ + initFuncName + """Init(): Unit = {""" +
       propInits.foldLeft("")(_ + """
     """ + _) + """
   }

--- a/daffodil-propgen/src/test/scala/org/apache/daffodil/propGen/TestPropertyGenerator.scala
+++ b/daffodil-propgen/src/test/scala/org/apache/daffodil/propGen/TestPropertyGenerator.scala
@@ -65,7 +65,7 @@ class TestPropertyGenerator {
     val mx = pg.genAttributeGroup(sch)
     assertTrue(mx.contains(""" = convertToBoolean(findProperty("prefixIncludesPrefixLength").value)"""))
     assertTrue(mx.contains("""LengthKindMixin"""))
-    assertTrue(mx.contains("""def lengthPropertiesAGInit() : Unit = {"""))
+    assertTrue(mx.contains("""def lengthPropertiesAGInit(): Unit = {"""))
     assertTrue(mx.contains("""registerToStringFunction(()=>{getPropertyOption("lengthPattern") match {
         case None => ""
         case Some(value) => "lengthPattern='" + value.toString + "'"

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/debugger/InteractiveDebugger.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/debugger/InteractiveDebugger.scala
@@ -73,8 +73,8 @@ class InteractiveDebugger(runner: InteractiveDebuggerRunner, eCompilers: Express
 
   trait Disablable {
     var enabled = true
-    def disable = { enabled = false }
-    def enable = { enabled = true }
+    def disable() = { enabled = false }
+    def enable() = { enabled = true }
   }
 
   case class Breakpoint(id: Int, breakpoint: String) extends Disablable {

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/infoset/InfosetImpl.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/infoset/InfosetImpl.scala
@@ -157,7 +157,7 @@ sealed trait DINode {
    * use to require it be finalized or throw the appropriate
    * Array or Complex exception.
    */
-  def requireFinal: Unit
+  def requireFinal(): Unit
 }
 
 /**
@@ -935,7 +935,7 @@ sealed trait DIElement
   protected final var _isHidden = false
   final def isHidden: Boolean = _isHidden
 
-  override def setHidden: Unit = {
+  override def setHidden(): Unit = {
     _isHidden = true
   }
 
@@ -1015,7 +1015,7 @@ final class DIArray(
 
   private lazy val nfe = new InfosetArrayNotFinalException(this)
 
-  override def requireFinal: Unit = {
+  override def requireFinal(): Unit = {
     if (!isFinal) throw nfe
   }
 
@@ -1277,7 +1277,7 @@ sealed class DISimple(override val erd: ElementRuntimeData)
     }
   }
 
-  def resetValue = {
+  def resetValue(): Unit = {
     _isNilled = false
     _isNilledSet = false
     _isDefaulted = false
@@ -1402,7 +1402,7 @@ sealed class DISimple(override val erd: ElementRuntimeData)
    * implementation of this function, as DINode requires isFinal for parsing
    * and allowing the cleanup of unneeded DINodes.
    */
-  override def requireFinal: Unit = {
+  override def requireFinal(): Unit = {
     Assert.invariantFailed("Should not requireFinal a simple type")
   }
 
@@ -1461,7 +1461,7 @@ sealed class DIComplex(override val erd: ElementRuntimeData)
     }
   }
 
-  override def requireFinal: Unit = {
+  override def requireFinal(): Unit = {
     if (!isFinal) throw nfe
   }
 

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/infoset/JsonInfosetInputter.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/infoset/JsonInfosetInputter.scala
@@ -138,7 +138,7 @@ class JsonInfosetInputter private (input: Either[java.io.Reader, java.io.InputSt
     }
   }
 
-  override def fini: Unit = {
+  override def fini(): Unit = {
     jsp.close()
   }
 

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/infoset/SAXInfosetInputter.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/infoset/SAXInfosetInputter.scala
@@ -189,7 +189,7 @@ class SAXInfosetInputter(
 
   override val supportsNamespaces: Boolean = true
 
-  override def fini: Unit = {
+  override def fini(): Unit = {
     // do nothing
   }
 

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/infoset/XMLTextInfosetInputter.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/infoset/XMLTextInfosetInputter.scala
@@ -153,7 +153,7 @@ class XMLTextInfosetInputter private (input: Either[java.io.Reader, java.io.Inpu
     res
   }
 
-  override def fini: Unit = {
+  override def fini(): Unit = {
     xsr.close()
   }
 

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/DFDLDelimiter.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/DFDLDelimiter.scala
@@ -412,7 +412,6 @@ class Delimiter {
 
 abstract class DelimBase extends Base {
   def typeName: String
-  def print: Unit
   def printStr: String
   def allChars: Seq[Char]
   override def toString(): String = {
@@ -427,7 +426,7 @@ trait Base {
   var charPos: Int = -1
   var charPosEnd: Int = -1
 
-  def clear = {
+  def clear() = {
     isMatched = false
     charPos = -1
     charPosEnd = -1
@@ -445,9 +444,6 @@ class CharDelim(val char: Char, ignoreCase: Boolean) extends DelimBase {
   }
 
   lazy val typeName = "CharDelim"
-  def print = {
-    //Logger.log.debug(s"\t\t\t" + typeName + ": '" + char + "' d" + char.toInt + " isMatched: " + isMatched.toString()))
-  }
 
   def printStr = {
     val res = typeName + "(" + char + ")"
@@ -510,9 +506,6 @@ class NLDelim extends DelimBase with NL {
     }
   }
 
-  def print = {
-    //Logger.log.debug(s"\t\t\t" + typeName + ": NL" + " isMatched: " + isMatched.toString()))
-  }
   def printStr = {
     val res = typeName
     res
@@ -574,9 +567,7 @@ abstract class WSPBase extends DelimBase with WSP {
     }
     isMatched
   }
-  def print = {
-    //Logger.log.debug(s"\t\t\t" + typeName + ": WSPBase" + " isMatched: " + isMatched.toString()))
-  }
+
   def printStr = {
     val res = typeName
     res
@@ -585,9 +576,7 @@ abstract class WSPBase extends DelimBase with WSP {
 
 class WSPDelim extends WSPBase with WSP {
   override lazy val typeName = "WSPDelim"
-  override def print = {
-    //Logger.log.debug(s"\t\t\t" + typeName + ": WSP" + " isMatched: " + isMatched.toString()))
-  }
+
   override def printStr = {
     val res = typeName
     res
@@ -597,9 +586,7 @@ class WSPDelim extends WSPBase with WSP {
 
 class WSPPlusDelim extends WSPBase with WSP {
   override lazy val typeName = "WSP+Delim"
-  override def print = {
-    //Logger.log.debug(s"\t\t\t" + typeName + ": WSP+" + " isMatched: " + isMatched.toString()))
-  }
+
   override def printStr = {
     val res = typeName
     res
@@ -609,9 +596,7 @@ class WSPPlusDelim extends WSPBase with WSP {
 
 class WSPStarDelim extends WSPBase with WSP {
   override lazy val typeName = "WSP*Delim"
-  override def print = {
-    //Logger.log.debug(s"\t\t\t" + typeName + ": WSP*" + " isMatched: " + isMatched.toString()))
-  }
+
   override def printStr = {
     val res = typeName
     res
@@ -635,9 +620,6 @@ class WSPStarDelim extends WSPBase with WSP {
 class ESDelim extends DelimBase {
   override def checkMatch(charIn: Char): Boolean = Assert.impossible("We should never ask if a character matches an %ES;")
   override def allChars: Seq[Char] = Seq.empty
-  override def print: Unit = {
-    //do nothing
-  }
   override def printStr: String = typeName
   override def typeName: String = "ES"
   override def unparseValue(outputNewLine: String): String = ""

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/Evaluatable.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/Evaluatable.scala
@@ -187,7 +187,7 @@ abstract class Evaluatable[+T <: AnyRef](protected val ci: DPathCompileInfo, qNa
 
   @inline final def isCompiled = isCompiled_
 
-  @inline final def ensureCompiled: Unit = {
+  @inline final def ensureCompiled(): Unit = {
     ci.initialize
     if (!isCompiled)
       Assert.invariantFailed("not compiled Ev: " + this.qName)

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/ProcessorStateBases.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/ProcessorStateBases.scala
@@ -511,10 +511,10 @@ abstract class ParseOrUnparseState protected (
 
   private var _hiddenDepth = 0
 
-  def incrementHiddenDef = {
+  def incrementHiddenDef(): Unit = {
     _hiddenDepth += 1
   }
-  def decrementHiddenDef = {
+  def decrementHiddenDef(): Unit = {
     _hiddenDepth -= 1
   }
 

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/RuntimeData.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/RuntimeData.scala
@@ -141,9 +141,9 @@ sealed abstract class TermRuntimeData(
   /**
    * Cyclic structures require initialization
    */
-  lazy val initialize: Unit = initializeFunction
+  lazy val initialize: Unit = initializeFunction()
 
-  protected def initializeFunction: Unit = {
+  protected def initializeFunction(): Unit = {
     partialNextElementResolver
     dpathCompileInfo.initialize
   }
@@ -179,6 +179,7 @@ sealed abstract class TermRuntimeData(
 
   lazy val partialNextElementResolver =
     partialNextElementResolverDelay.value
+
 }
 
 sealed class NonTermRuntimeData(
@@ -786,6 +787,7 @@ sealed abstract class ModelGroupRuntimeData(
 
   final override def isRequiredScalar = true
   final override def isArray = false
+
 }
 
 /**
@@ -874,6 +876,7 @@ final class VariableRuntimeData(
    */
   lazy val initialize: Unit = {
     maybeDefaultValueExpr // demand this
+
   }
 
   lazy val maybeDefaultValueExpr: Maybe[CompiledExpression[AnyRef]] = maybeDefaultValueExprDelay.value

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/Suspension.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/Suspension.scala
@@ -201,7 +201,7 @@ trait Suspension
   private var done_ : Boolean = false
   private var isBlocked_ = false
 
-  final def setDone: Unit = {
+  final def setDone(): Unit = {
     done_ = true
   }
 

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/dfa/Registers.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/dfa/Registers.scala
@@ -131,7 +131,7 @@ class Registers() extends Poolable with Serializable {
     data1 = charIterator.peek2()
   }
 
-  def commitOneChar: Unit = {
+  def commitOneChar(): Unit = {
     if (charIterator.hasNext) charIterator.next()
   }
 

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/PState.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/PState.scala
@@ -131,7 +131,7 @@ class MPState private () {
 
   val escapeSchemeEVCache = new MStackOfMaybe[EscapeSchemeParserHelper]
 
-  private def init: Unit = {
+  private def init(): Unit = {
     arrayIndexStack.push(1L)
     groupIndexStack.push(1L)
     childIndexStack.push(1L)

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/unparsers/UState.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/unparsers/UState.scala
@@ -397,34 +397,31 @@ final class UStateForSuspension(
   override def withUnparserDataInputStream = mainUState.withUnparserDataInputStream
   override def withByteArrayOutputStream = mainUState.withByteArrayOutputStream
 
+  // $COVERAGE-OFF$
   override def advance: Boolean = die
   override def advanceAccessor: InfosetAccessor = die
   override def inspect: Boolean = die
   override def inspectAccessor: InfosetAccessor = die
-  override def fini: Unit = {
-    //do nothing
-  }
+  override def fini: Unit = die
   override def inspectOrError = die
   override def advanceOrError = die
   override def isInspectArrayEnd = die
-
   override def currentInfosetNodeStack = die
-  override def currentInfosetNodeMaybe = Maybe(currentInfosetNode)
-
   override def arrayIndexStack = die
   override def moveOverOneArrayIndexOnly() = die
-  override def arrayPos = occursIndex
-
   override def groupIndexStack = die
   override def moveOverOneGroupIndexOnly() = die
-  override def groupPos = 0 // was die, but this is called when copying state during debugging
-
   override def childIndexStack = die
   override def moveOverOneElementChildOnly() = die
-  override def childPos = 0 // was die, but this is called when copying state during debugging.
-
   override def pushDelimiters(node: DelimiterStackUnparseNode) = die
   override def popDelimiters() = die
+  // $COVERAGE-ON$
+
+  override def groupPos = 0 // was die, but this is called when copying state during debugging
+  override def currentInfosetNodeMaybe = Maybe(currentInfosetNode)
+  override def arrayPos = occursIndex
+  override def childPos = 0 // was die, but this is called when copying state during debugging.
+
   override def localDelimiters = delimiterStackMaybe.get.top
   override def allTerminatingMarkup = {
     delimiterStackMaybe.get.iterator.flatMap { dnode =>
@@ -543,8 +540,9 @@ final class UStateMain private (
   override def advanceAccessor: InfosetAccessor = inputter.advanceAccessor
   override def inspect: Boolean = inputter.inspect
   override def inspectAccessor: InfosetAccessor = inputter.inspectAccessor
-  override def fini: Unit = { inputter.fini }
-
+  // $COVERAGE-OFF$ // unused, but necessary to meet requirements of Cursor[T]
+  override def fini = Assert.usageError("Not to be used on UState")
+  // $COVERAGE-ON$
   /**
    * Use this so if there isn't an event we get a clean diagnostic message saying
    * that is what has gone wrong.

--- a/daffodil-runtime1/src/test/scala/org/apache/daffodil/dpath/TestRounding.scala
+++ b/daffodil-runtime1/src/test/scala/org/apache/daffodil/dpath/TestRounding.scala
@@ -26,7 +26,7 @@ import java.math.RoundingMode
 
 class TestRounding {
 
-  @Test def test_howToRoundFloatingPoint = {
+  @Test def test_howToRoundFloatingPoint() = {
     //
     // We ran into an issue where just passing the Float
     // to BigDecimal would change the value passed to it.

--- a/daffodil-runtime1/src/test/scala/org/apache/daffodil/dsom/TestEntityReplacer.scala
+++ b/daffodil-runtime1/src/test/scala/org/apache/daffodil/dsom/TestEntityReplacer.scala
@@ -24,13 +24,13 @@ import org.apache.daffodil.cookers.EntityReplacer
 
 class TestEntityReplacer {
 
-  @Test def testEmptyString = {
+  @Test def testEmptyString() = {
     EntityReplacer { e =>
       assertEquals(e.replaceAll(""), "")
     }
   }
 
-  @Test def testEscapeScheme = {
+  @Test def testEscapeScheme() = {
     EntityReplacer { er =>
       val f1 = intercept[Exception] { er.replaceAll("Text%Text") }
       assertTrue(f1.getMessage().contains("Invalid DFDL Entity (%Text) found in \"Text%Text\"")) // Works basic case
@@ -43,7 +43,7 @@ class TestEntityReplacer {
     }
   }
 
-  @Test def testEntityReplacement = {
+  @Test def testEntityReplacement() = {
     EntityReplacer { er =>
       assertEquals("Text\u0000Text", { er.replaceAll("Text%NUL;Text") }) // Works basic case
 
@@ -53,7 +53,7 @@ class TestEntityReplacer {
     }
   }
 
-  @Test def testHexadecimalCodePointReplacement = {
+  @Test def testHexadecimalCodePointReplacement() = {
     EntityReplacer { er =>
       assertEquals("Text\u0000Text", { er.replaceAll("Text%#x0000;Text") }) // Works basic case
       assertEquals("Text\u0000Text\u000D", { er.replaceAll("Text%#x0000;Text%#x000D;") }) // Works multiple hex
@@ -63,7 +63,7 @@ class TestEntityReplacer {
     }
   }
 
-  @Test def testDecimalCodePointReplacement = {
+  @Test def testDecimalCodePointReplacement() = {
     EntityReplacer { er =>
       assertEquals("TextAText", { er.replaceAll("Text%#65;Text") }) // Works basic case
       assertEquals("TextAText", { er.replaceAll("Text%#0000000000065;Text") }) // Works basic case w/ padding
@@ -75,7 +75,7 @@ class TestEntityReplacer {
     }
   }
 
-  @Test def testRawByteReplacement = {
+  @Test def testRawByteReplacement() = {
     EntityReplacer { er =>
       assertEquals("ÿ", { er.replaceAll("%#rFF;") })
       assertEquals("ÿ ú", { er.replaceAll("%#rFF; %#rFA;") })
@@ -85,7 +85,7 @@ class TestEntityReplacer {
     }
   }
 
-  @Test def testInvalidDfdlEntities = {
+  @Test def testInvalidDfdlEntities() = {
     EntityReplacer { er =>
       val f1 = intercept[Exception] { { er.replaceAll("%#rTT;") } }
       assertTrue(f1.getMessage().contains("Invalid DFDL Entity (%#rTT;) found in \"%#rTT;\"")) // Verify fails: Raw Byte
@@ -101,7 +101,7 @@ class TestEntityReplacer {
     }
   }
 
-  @Test def testAll = {
+  @Test def testAll() = {
     EntityReplacer { er =>
       val testString = new StringBuilder
       testString.append("Text#%%Text")
@@ -125,7 +125,7 @@ class TestEntityReplacer {
     }
   }
 
-  @Test def testMultiplePercents = {
+  @Test def testMultiplePercents() = {
     EntityReplacer { er =>
       val testString1 = "Text1%%%%%%%%%%Text2"
       val solution1 = "Text1%%%%%Text2"
@@ -169,7 +169,7 @@ class TestEntityReplacer {
     }
   }
 
-  @Test def testMultipleSemicolons = {
+  @Test def testMultipleSemicolons() = {
     EntityReplacer { er =>
       val testString1 = "Text1;;;;;;;;;;Text2"
       val testString2 = ";Text1;;;;;;;;;;Text2"
@@ -192,7 +192,7 @@ class TestEntityReplacer {
     }
   }
 
-  @Test def testSemiColonSP = {
+  @Test def testSemiColonSP() = {
     EntityReplacer { er =>
       val testString = ";%SP;"
       assertEquals("; ", { er.replaceAll(testString) })

--- a/daffodil-runtime1/src/test/scala/org/apache/daffodil/parser/TestCharsetDecoder2.scala
+++ b/daffodil-runtime1/src/test/scala/org/apache/daffodil/parser/TestCharsetDecoder2.scala
@@ -23,7 +23,7 @@ import org.apache.daffodil.processors.charset.CharsetUtils
 
 class TestCharsetDecoder2 {
 
-  @Test def testIfHasJava7DecoderBug: Unit = {
+  @Test def testIfHasJava7DecoderBug(): Unit = {
     if (CharsetUtils.hasJava7DecoderBug) fail("Java 7 Decoder bug detected. Daffodil requires Java 8 (or higher)")
   }
 }

--- a/daffodil-runtime1/src/test/scala/org/apache/daffodil/processors/input/TestDFDLRegularExpressions.scala
+++ b/daffodil-runtime1/src/test/scala/org/apache/daffodil/processors/input/TestDFDLRegularExpressions.scala
@@ -39,7 +39,7 @@ class TestDFDLRegularExpressions {
 
   def delims = "D|C|F"
 
-  @Test def testSameEscapeRegExNoPadding = {
+  @Test def testSameEscapeRegExNoPadding() = {
     val cp = DFDLRegularExpressions.getSameEscapeRegEx(escape, delim)
     def test(x: String) = x match {
       case cp(before, rubbish, delim, after) => {
@@ -79,7 +79,7 @@ class TestDFDLRegularExpressions {
     assertEquals(Some("before", "D"), test2("beforeEEEEDafter"))
   }
 
-  @Test def testSameEscapeRegExLeftJustified = {
+  @Test def testSameEscapeRegExLeftJustified() = {
     val cp = DFDLRegularExpressions.getSameEscapeRegExWithPadding(escape, delim, padChar, TextStringJustification.Left)
     def test(x: String) = x match {
       case cp(ee1s, before, ee2s, delimAfterPad, ee3s, delimAfterEEs, after) => {
@@ -135,7 +135,7 @@ class TestDFDLRegularExpressions {
     assertEquals(Some("before", "D"), test2("beforeEEEEDafter"))
   }
 
-  @Test def testSameEscapeRegExRightJustified = {
+  @Test def testSameEscapeRegExRightJustified() = {
     val cp = DFDLRegularExpressions.getSameEscapeRegExWithPadding(escape, delim, padChar, TextStringJustification.Right)
     def test(x: String) = x match {
       case cp(ee1s, before, ee2s, delimAfterPad, ee3s, delimAfterEEs, after) => {
@@ -194,7 +194,7 @@ class TestDFDLRegularExpressions {
     assertEquals(Some("before", "D"), test2("beforeEEEEDafter"))
   }
 
-  @Test def testSameEscapeRegExCenterJustified = {
+  @Test def testSameEscapeRegExCenterJustified() = {
     val cp = DFDLRegularExpressions.getSameEscapeRegExWithPadding(escape, delim, padChar, TextStringJustification.Center)
     def test(x: String) = x match {
       case cp(ee1s, before, ee2s, delimAfterPad, ee3s, delimAfterEEs, after) => {
@@ -253,7 +253,7 @@ class TestDFDLRegularExpressions {
     assertEquals(Some("before", "D"), test2("beforeEEEEDafter"))
   }
 
-  @Test def testEscapeRegExNoPadding = {
+  @Test def testEscapeRegExNoPadding() = {
     val cp = DFDLRegularExpressions.getEscapeRegEx(escape, escapeEscape, delim)
 
     def test(x: String) = x match {
@@ -286,7 +286,7 @@ class TestDFDLRegularExpressions {
     assertEquals(Some("beforeS", "D"), test2("beforeSDstillBeforeDafter"))
   }
 
-  @Test def testEscapeRegExLeftJustified = {
+  @Test def testEscapeRegExLeftJustified() = {
     val cp = DFDLRegularExpressions.getEscapeRegExWithPadding(escape, escapeEscape, delim, padChar, TextStringJustification.Left)
     def test(x: String) = x match {
       case cp(before, delim, after) => Some((before, delim))
@@ -311,7 +311,7 @@ class TestDFDLRegularExpressions {
     assertEquals(Some(("before", "F")), test2("beforeFafter"))
   }
 
-  @Test def testEscapeRegExRightJustified = {
+  @Test def testEscapeRegExRightJustified() = {
     val cp = DFDLRegularExpressions.getEscapeRegExWithPadding(escape, escapeEscape, delim, padChar, TextStringJustification.Right)
     def test(x: String) = x match {
       case cp(before, delim, after) => Some((before, delim))
@@ -336,7 +336,7 @@ class TestDFDLRegularExpressions {
     assertEquals(Some(("before", "F")), test2("beforeFafter"))
   }
 
-  @Test def testEscapeRegExCenterJustified = {
+  @Test def testEscapeRegExCenterJustified() = {
     val cp = DFDLRegularExpressions.getEscapeRegExWithPadding(escape, escapeEscape, delim, padChar, TextStringJustification.Center)
     def test(x: String) = x match {
       case cp(before, delim, after) => Some((before, delim))
@@ -367,7 +367,7 @@ class TestDFDLRegularExpressions {
     assertEquals(Some(("before", "F")), test2("beforeFafter"))
   }
 
-  @Test def testEscapeBlockRegExNoPadding = {
+  @Test def testEscapeBlockRegExNoPadding() = {
     val cp = DFDLRegularExpressions.getEscapeBlockRegEx(bStart, bEnd, escapeEscape, escape, delim)
     def test(x: String) = x match {
       case cp(before, delim, after, null, null, null) => {
@@ -447,7 +447,7 @@ class TestDFDLRegularExpressions {
     assertEquals(Some(("beforeDstillBeforeENstillBefore", "F", "after")), test2("TbeforeDstillBeforeENstillBeforeNFafter"))
   }
 
-  @Test def testEscapeBlockRegExLeftJustified = {
+  @Test def testEscapeBlockRegExLeftJustified() = {
     val cp = DFDLRegularExpressions.getEscapeBlockRegExWithPadding(bStart, bEnd, escapeEscape, escape, padChar, delim, TextStringJustification.Left)
     def test(x: String) = x match {
       case cp(before, delim, after, null, null, null) => {
@@ -543,7 +543,7 @@ class TestDFDLRegularExpressions {
     assertEquals(Some(("PPPTbefore", "F", "stillBeforeTstillBeforeSENPPPDafter")), test2("PPPTbeforeFstillBeforeTstillBeforeSENPPPDafter"))
   }
 
-  @Test def testEscapeBlockRegExRightJustified = {
+  @Test def testEscapeBlockRegExRightJustified() = {
     val cp = DFDLRegularExpressions.getEscapeBlockRegExWithPadding(bStart, bEnd, escapeEscape, escape, padChar, delim, TextStringJustification.Right)
     def test(x: String) = x match {
       case cp(before, delim, after, null, null, null) => {
@@ -634,7 +634,7 @@ class TestDFDLRegularExpressions {
     assertEquals(Some(("beforeDstillBeforeTstillBeforeSE", "F", "after")), test2("PPPTbeforeDstillBeforeTstillBeforeSENFafter"))
   }
 
-  @Test def testEscapeBlockRegExCenterJustified = {
+  @Test def testEscapeBlockRegExCenterJustified() = {
     val cp = DFDLRegularExpressions.getEscapeBlockRegExWithPadding(bStart, bEnd, escapeEscape, escape, padChar, delim, TextStringJustification.Center)
     def test(x: String) = x match {
       case cp(before, delim, after, null, null, null) => {

--- a/daffodil-runtime1/src/test/scala/org/apache/daffodil/processors/input/TestICU.scala
+++ b/daffodil-runtime1/src/test/scala/org/apache/daffodil/processors/input/TestICU.scala
@@ -36,7 +36,7 @@ class TestICU {
    * above 9 fractional seconds. Daffodil will only support 9, so these test
    * ensure that ICU can handle 9 fractional seconds.
    */
-  @Test def test_maxFractionalSeconds = {
+  @Test def test_maxFractionalSeconds() = {
     def parseFractionalSeconds(numFractionalSeconds: Int) = {
       val numOutFractionalSeconds = TextCalendarConstants.maxFractionalSeconds
       val inDataChar = "1"
@@ -75,7 +75,7 @@ class TestICU {
   // not have a regression of this issue. The old broken values that ICU would
   // create are commented out to show what used to be broken.
 
-  @Test def test_scientific_pos_inf = {
+  @Test def test_scientific_pos_inf() = {
     val dfs = new DecimalFormatSymbols()
     dfs.setInfinity("INF")
     dfs.setNaN("NaN")
@@ -87,7 +87,7 @@ class TestICU {
     assertEquals("INF", str)
   }
 
-  @Test def test_scientific_neg_inf = {
+  @Test def test_scientific_neg_inf() = {
     val dfs = new DecimalFormatSymbols()
     dfs.setInfinity("INF")
     dfs.setNaN("NaN")
@@ -99,7 +99,7 @@ class TestICU {
     assertEquals("-INF", str)
   }
 
-  @Test def test_scientific_nan = {
+  @Test def test_scientific_nan() = {
     val dfs = new DecimalFormatSymbols()
     dfs.setInfinity("INF")
     dfs.setNaN("NaN")
@@ -113,7 +113,7 @@ class TestICU {
 
   // The following test shows that ICU does not reqiure a positive pattern.
   // Because of this we manually check that a positive pattern exists.
-  @Test def test_missing_positive_pattern = {
+  @Test def test_missing_positive_pattern() = {
     // this should throw an exception if ICU ever adds back support for
     // requiring a positive pattern.
     val df = new DecimalFormat(";-000")
@@ -125,7 +125,7 @@ class TestICU {
   // after parse position are pad characters. If ICU ever fixes this bug and
   // updates parse position, this test should fail, and we no longer need to do
   // the manual check.
-  @Test def test_suffix_padding = {
+  @Test def test_suffix_padding() = {
     val df = new DecimalFormat("0 SUFFIX*_")
     val pos = new ParsePosition(0)
     val str = "123 SUFFIX____"
@@ -138,7 +138,7 @@ class TestICU {
   // This test shows the bug in ICU where it does not correctly handle
   // scientific notiation with an empty exponent separator. If ICU fixes this
   // bug, this test should fail. See DAFFODIL-1981
-  @Test def test_empty_exponent_separator = {
+  @Test def test_empty_exponent_separator() = {
     val dfs = new DecimalFormatSymbols()
     dfs.setExponentSeparator("")
     dfs.setGroupingSeparator(',')
@@ -155,7 +155,7 @@ class TestICU {
   // Shows that even if a decimal format pattern doesn't contain a decimal
   // point, the decimal format separator from the locale still has an effect
   // and can cause locale specific behavior
-  @Test def test_local_side_effect = {
+  @Test def test_local_side_effect() = {
 
     // Germany's locale has a decimal separator of ','
     val dfs = new DecimalFormatSymbols(java.util.Locale.GERMANY)

--- a/daffodil-runtime1/src/test/scala/org/apache/daffodil/processors/input/TestRegex.scala
+++ b/daffodil-runtime1/src/test/scala/org/apache/daffodil/processors/input/TestRegex.scala
@@ -33,7 +33,7 @@ class TestRegex extends RegexParsers {
   override def skipWhitespace = skipWS
   var skipWS = false // assign this to turn on/off whitespace skipping.
 
-  @Test def testEscapeRemoval_Blocks = {
+  @Test def testEscapeRemoval_Blocks() = {
     // Assumptions:
     //	1. Delimiter and padding removed
     //	2. Valid start-end blocks were already removed
@@ -66,7 +66,7 @@ class TestRegex extends RegexParsers {
     assertEquals("blah1ETblah2", test(removeEscapes, "blah1ETblah2"))
   }
 
-  @Test def testEscapeRemoval_SameCharacter = {
+  @Test def testEscapeRemoval_SameCharacter() = {
     // This might not be possible using regex replacement
     // may have to stick with existing code in DelimParser
     //
@@ -112,7 +112,7 @@ class TestRegex extends RegexParsers {
     assertEquals("text1text2", test("text1Etext2"))
   }
 
-  @Test def testEscapeRemoval_DiffCharacter = {
+  @Test def testEscapeRemoval_DiffCharacter() = {
     // Assumptions:
     //	1. Delimiter and padding removed
     //
@@ -146,7 +146,7 @@ class TestRegex extends RegexParsers {
   }
 
   // Need to capture everything to get length of parsed data
-  @Test def testParser_CaptureEverything = {
+  @Test def testParser_CaptureEverything() = {
     var testNum = 0
     def test(theParser: Parser[(Vector[String], String)], theInput: String, isPadLeft: Boolean, isPadRight: Boolean) = {
       testNum = testNum + 1
@@ -221,7 +221,7 @@ class TestRegex extends RegexParsers {
   }
 
   // Need to capture everything to get length of parsed data
-  @Test def testParserEscapeSchemes_DiffEscapesWithPaddingCapturesEverything = {
+  @Test def testParserEscapeSchemes_DiffEscapesWithPaddingCapturesEverything() = {
     var testNum = 0
     def test(theParser: Parser[(Vector[String], String)], theInput: String, isPadLeft: Boolean, isPadRight: Boolean) = {
       testNum = testNum + 1
@@ -320,7 +320,7 @@ class TestRegex extends RegexParsers {
   }
 
   // Need to capture everything
-  @Test def testParserEscapeSchemes_BlockEscapeWithPaddingCapturesEverything = {
+  @Test def testParserEscapeSchemes_BlockEscapeWithPaddingCapturesEverything() = {
     var testNum = 0
     def test(theParser: Parser[(Vector[String], String)], theInput: String, isPadLeft: Boolean, isPadRight: Boolean) = {
       testNum = testNum + 1
@@ -422,7 +422,7 @@ class TestRegex extends RegexParsers {
     //    assertEquals(Some("before1SNbefore2PP", ""), test(content, "Tbefore1SNbefore2PPN", false, false))
   }
 
-  @Test def testParserEscapeSchemes_BlockEscapeWithPadding = {
+  @Test def testParserEscapeSchemes_BlockEscapeWithPadding() = {
     var testNum = 0
     def test(theParser: Parser[(String, String)], theInput: String) = {
       testNum = testNum + 1
@@ -490,7 +490,7 @@ class TestRegex extends RegexParsers {
     assertEquals(Some("before1SNbefore2PP", ""), test(content, "Tbefore1SNbefore2PPN"))
   }
 
-  @Test def testParserEscapeSchemes_SameEscapeWithPadding = {
+  @Test def testParserEscapeSchemes_SameEscapeWithPadding() = {
     var testNum = 0
     def test(theParser: Parser[(String, String)], theInput: String) = {
       testNum = testNum + 1
@@ -745,7 +745,7 @@ class TestRegex extends RegexParsers {
     assertEquals(Some("EPPPbeforeE", "D"), test(contentCenterDelimReq, "EPPPbeforeEPPPDafter1Dafter2"))
   }
 
-  @Test def testParserEscapeSchemes_DiffEscapesWithPadding = {
+  @Test def testParserEscapeSchemes_DiffEscapesWithPadding() = {
     var testNum = 0
     def test(theParser: Parser[(String, String)], theInput: String) = {
       testNum = testNum + 1
@@ -969,7 +969,7 @@ class TestRegex extends RegexParsers {
     assertEquals(Some("beforePPPSE", "D"), test(contentRight, "PPPbeforePPPSEDstillbeforePPPDafter"))
   }
 
-  //  @Test def testParserEscapeSchemes_SameEscapeWithPadding = {
+  //  @Test def testParserEscapeSchemes_SameEscapeWithPadding() = {
   //    var testNum = 0
   //    def test(theParser: Parser[(String, String)], theInput: String) = {
   //      testNum = testNum + 1
@@ -1136,7 +1136,7 @@ class TestRegex extends RegexParsers {
   //    //      val ContentPattern = str.format(escape, delimiter, padChar).r
   //  }
 
-  //  @Test def testParserEscapeSchemes_DiffEscapesWithPadding = {
+  //  @Test def testParserEscapeSchemes_DiffEscapesWithPadding() = {
   //    var testNum = 0
   //    def test(theParser: Parser[(String, String)], theInput: String) = {
   //      testNum = testNum + 1
@@ -1254,7 +1254,7 @@ class TestRegex extends RegexParsers {
   //    assertEquals(Some("beforePPPSE", "D"), test(contentRightJustified, "PPPbeforePPPSEDstillbeforePPPDafter"))
   //  }
 
-  //  @Test def testParserEscapeSchemes = {
+  //  @Test def testParserEscapeSchemes() = {
   //    //                escEsc     esc       delim        padChar
   //    //val test = tester("""S""", """E""", """\_*D\_*""", """P""") // put any regex in there for the delimiter
   //    val escapeEscape = """S"""

--- a/daffodil-tdml-lib/src/main/scala/org/apache/daffodil/Tak.scala
+++ b/daffodil-tdml-lib/src/main/scala/org/apache/daffodil/Tak.scala
@@ -35,7 +35,7 @@ import org.apache.daffodil.util._
 
 object Tak {
 
-  def calibrate = {
+  def calibrate() = {
     if (takeons == 0.0) {
       testTak
     }
@@ -57,7 +57,7 @@ object Tak {
       z
   }
 
-  def testTak: Unit = {
+  def testTak(): Unit = {
     println("Calibrating takeon units")
     callCount = 0
     val nanos = Timer.getTimeNS { tak(21, 3, 21) }
@@ -68,7 +68,9 @@ object Tak {
     println("Done calibrating")
   }
 
+  // $COVERAGE-OFF$ // not part of any unit testing
   def main(args: Array[String]): Unit = {
-    testTak
+    testTak()
   }
+  // $COVERAGE-ON$
 }

--- a/daffodil-tdml-lib/src/main/scala/org/apache/daffodil/tdml/RunnerFactory.scala
+++ b/daffodil-tdml-lib/src/main/scala/org/apache/daffodil/tdml/RunnerFactory.scala
@@ -209,7 +209,7 @@ class Runner private (
    *  Call this from an @AfterClass method
    *  to drop any state (like the test suite object) so we don't leak
    */
-  def reset: Unit = {
+  def reset(): Unit = {
     // Note that we intentionally do not use getTS here for two reasons:
     //
     // 1) the DFDLTestSuite is lazily created only when a test is run--if no
@@ -234,7 +234,7 @@ class Runner private (
     debug
   }
 
-  def debug = {
+  def debug() = {
     getTS.setDebugging(true)
   }
 

--- a/daffodil-tdml-processor/src/main/scala/org/apache/daffodil/tdml/TDMLInfosetInputter.scala
+++ b/daffodil-tdml-processor/src/main/scala/org/apache/daffodil/tdml/TDMLInfosetInputter.scala
@@ -129,7 +129,7 @@ class TDMLInfosetInputter(val scalaInputter: ScalaXMLInfosetInputter, others: Se
     others.foreach(_.next)
   }
 
-  override def fini: Unit = {
+  override def fini(): Unit = {
     scalaInputter.fini
     others.foreach(_.fini)
   }

--- a/daffodil-tdml-processor/src/test/scala/org/apache/daffodil/tdml/TestExtVars1.scala
+++ b/daffodil-tdml-processor/src/test/scala/org/apache/daffodil/tdml/TestExtVars1.scala
@@ -24,7 +24,7 @@ object TestExtVars1 {
   val testDir = "org/apache/daffodil/tdml/"
   val runner = Runner(testDir, "testExtVars1.tdml")
 
-  @AfterClass def shutDown: Unit = {
+  @AfterClass def shutDown(): Unit = {
     runner.reset
   }
 }

--- a/daffodil-tdml-processor/src/test/scala/org/apache/daffodil/tdml/TestTDMLRunner2.scala
+++ b/daffodil-tdml-processor/src/test/scala/org/apache/daffodil/tdml/TestTDMLRunner2.scala
@@ -29,7 +29,7 @@ import org.junit.AfterClass
 object TestTDMLRunner2 {
   val runner = Runner("/test/tdml/", "tdmlQuoting.tdml")
 
-  @AfterClass def shutDown: Unit = {
+  @AfterClass def shutDown(): Unit = {
     runner.reset
   }
 }

--- a/daffodil-tdml-processor/src/test/scala/org/apache/daffodil/tdml/TestTDMLRunnerWarnings.scala
+++ b/daffodil-tdml-processor/src/test/scala/org/apache/daffodil/tdml/TestTDMLRunnerWarnings.scala
@@ -25,7 +25,7 @@ import org.junit.Assert.fail
 object TestTDMLRunnerWarnings {
   val runner = Runner("/test/tdml/", "testWarnings.tdml")
 
-  @AfterClass def shutDown: Unit = {
+  @AfterClass def shutDown(): Unit = {
     runner.reset
   }
 }

--- a/daffodil-test-ibm1/src/test/scala/org/apache/daffodil/TestNilled.scala
+++ b/daffodil-test-ibm1/src/test/scala/org/apache/daffodil/TestNilled.scala
@@ -24,7 +24,7 @@ object TestNilled {
   val testDir = "/test-suite/tresys-contributed/"
   val runner = Runner(testDir, "nilled.tdml")
 
-  @AfterClass def shutDown: Unit = {
+  @AfterClass def shutDown(): Unit = {
     runner.reset
   }
 }

--- a/daffodil-test-ibm1/src/test/scala/org/apache/daffodil/TestSepSuppression.scala
+++ b/daffodil-test-ibm1/src/test/scala/org/apache/daffodil/TestSepSuppression.scala
@@ -24,7 +24,7 @@ object TestSepSuppression {
   val testDir = "/test-suite/tresys-contributed/"
   val runner = Runner(testDir, "sepSuppression.tdml")
 
-  @AfterClass def shutDown: Unit = {
+  @AfterClass def shutDown(): Unit = {
     runner.reset
   }
 }

--- a/daffodil-test-ibm1/src/test/scala/org/apache/daffodil/TestSepSuppression2.scala
+++ b/daffodil-test-ibm1/src/test/scala/org/apache/daffodil/TestSepSuppression2.scala
@@ -24,7 +24,7 @@ object TestSepSuppression2 {
   val testDir = "/test-suite/tresys-contributed/"
   val runner2 = Runner(testDir, "sepSuppression2.tdml")
 
-  @AfterClass def shutDown: Unit = {
+  @AfterClass def shutDown(): Unit = {
     runner2.reset
   }
 }
@@ -44,5 +44,5 @@ class TestSepSuppression2 {
 
   @Test def test_ptLax3rt() = { runner2.runOneTest("ptLax3rt") }
 
-  @Test def test_testAnyEmptyTrailing1 = { runner2.runOneTest("testAnyEmptyTrailing1") }
+  @Test def test_testAnyEmptyTrailing1() = { runner2.runOneTest("testAnyEmptyTrailing1") }
 }

--- a/daffodil-test-ibm1/src/test/scala/org/apache/daffodil/TestUnseparated.scala
+++ b/daffodil-test-ibm1/src/test/scala/org/apache/daffodil/TestUnseparated.scala
@@ -24,7 +24,7 @@ object TestUnseparated {
   val testDir = "/test-suite/tresys-contributed/"
   val runner = Runner(testDir, "unseparated.tdml")
 
-  @AfterClass def shutDown: Unit = {
+  @AfterClass def shutDown(): Unit = {
     runner.reset
   }
 }

--- a/daffodil-test-ibm1/src/test/scala/org/apache/daffodil/TresysTests.scala
+++ b/daffodil-test-ibm1/src/test/scala/org/apache/daffodil/TresysTests.scala
@@ -50,7 +50,7 @@ object TresysTests {
   val runnerRD = Runner("/test-suite/tresys-contributed/", "runtime-diagnostics.tdml", compileAllTopLevel = true, validateTDMLFile = false)
   val runnerSQ = Runner("/test-suite/tresys-contributed/sequence.tdml")
 
-  @AfterClass def shutDown: Unit = {
+  @AfterClass def shutDown(): Unit = {
     runnerAF.reset
     runnerAG.reset
     runnerAP.reset

--- a/daffodil-test-ibm1/src/test/scala/org/apache/daffodil/TresysTests3.scala
+++ b/daffodil-test-ibm1/src/test/scala/org/apache/daffodil/TresysTests3.scala
@@ -37,7 +37,7 @@ object TresysTests3 {
   val runnerBC = Runner(testDir, "BC.tdml")
   val runnerBD = Runner(testDir, "BD.tdml")
 
-  @AfterClass def shutDown: Unit = {
+  @AfterClass def shutDown(): Unit = {
     runnerBF.reset
     runnerAH.reset
     runnerAM.reset

--- a/daffodil-test/src/test/scala/org/apache/daffodil/extensions/TestChoiceBranchKeyRanges.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/extensions/TestChoiceBranchKeyRanges.scala
@@ -25,7 +25,7 @@ object TestChoiceBranchKeyRanges {
 
   val runner = Runner(testDir, "choiceBranchKeyRanges.tdml", validateTDMLFile = true)
 
-  @AfterClass def shutDown: Unit = {
+  @AfterClass def shutDown(): Unit = {
     runner.reset
   }
 

--- a/daffodil-test/src/test/scala/org/apache/daffodil/extensions/TestInputTypeValueCalc.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/extensions/TestInputTypeValueCalc.scala
@@ -29,7 +29,7 @@ object TestInputTypeValueCalc {
   val fnRunner = Runner(testDir, "typeCalcFunctions.tdml", validateTDMLFile = false)
   val fnErrRunner = Runner(testDir, "typeCalcFunctionErrors.tdml", validateTDMLFile = false)
 
-  @AfterClass def shutDown: Unit = {
+  @AfterClass def shutDown(): Unit = {
     runner.reset
     exprRunner.reset
     fnRunner.reset

--- a/daffodil-test/src/test/scala/org/apache/daffodil/extensions/TestLookAhead.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/extensions/TestLookAhead.scala
@@ -25,7 +25,7 @@ object TestLookAhead {
 
   val runner = Runner(testDir, "lookAhead.tdml", validateTDMLFile = true)
 
-  @AfterClass def shutDown: Unit = {
+  @AfterClass def shutDown(): Unit = {
     runner.reset
   }
 

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section00/general/TestExpressionPropertyWarnings.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section00/general/TestExpressionPropertyWarnings.scala
@@ -24,7 +24,7 @@ object TestExpressionPropertyWarnings {
   val testDir = "/org/apache/daffodil/section00/general/"
   val runner = Runner(testDir, "testExpressionPropertyWarnings.tdml")
 
-  @AfterClass def shutDown: Unit = {
+  @AfterClass def shutDown(): Unit = {
     runner.reset
   }
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section00/general/TestFileBuffering.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section00/general/TestFileBuffering.scala
@@ -25,7 +25,7 @@ object TestUnparserFileBuffering {
   val testDir = "/org/apache/daffodil/section00/general/"
   val runner = Runner(testDir, "testUnparserFileBuffering.tdml")
 
-  @AfterClass def shutDown: Unit = {
+  @AfterClass def shutDown(): Unit = {
     runner.reset
   }
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section00/general/TestImportOtherAnnotationSchema.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section00/general/TestImportOtherAnnotationSchema.scala
@@ -25,7 +25,7 @@ object TestImportOtherAnnotationSchema {
   val testDir = "/org/apache/daffodil/section00/general/"
   val runner = Runner(testDir, "testImportOtherAnnotationSchema.tdml")
 
-  @AfterClass def shutDown: Unit = {
+  @AfterClass def shutDown(): Unit = {
     runner.reset
   }
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section00/general/TestTextBidi.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section00/general/TestTextBidi.scala
@@ -24,7 +24,7 @@ object TestTextBidi {
   val testDir = "/org/apache/daffodil/section00/general/"
   val runner = Runner(testDir, "testTextBidi.tdml")
 
-  @AfterClass def shutDown: Unit = {
+  @AfterClass def shutDown(): Unit = {
     runner.reset
   }
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section00/general/TestUnparserGeneral.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section00/general/TestUnparserGeneral.scala
@@ -25,7 +25,7 @@ object TestUnparserGeneral {
   val testDir = "/org/apache/daffodil/section00/general/"
   val runner = Runner(testDir, "testUnparserGeneral.tdml")
 
-  @AfterClass def shutDown: Unit = {
+  @AfterClass def shutDown(): Unit = {
     runner.reset
   }
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section00/general/TestUnparserGeneral2.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section00/general/TestUnparserGeneral2.scala
@@ -25,7 +25,7 @@ object TestUnparserGeneral2 {
   val testDir = "/org/apache/daffodil/section00/general/"
   val runner2 = Runner(testDir, "testUnparserBitOrderOVC.tdml")
 
-  @AfterClass def shutDown: Unit = {
+  @AfterClass def shutDown(): Unit = {
     runner2.reset
   }
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section00/general/TestUnparserSAX.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section00/general/TestUnparserSAX.scala
@@ -25,7 +25,7 @@ object TestUnparserSAX {
   val testDir = "/org/apache/daffodil/section00/general/"
   val runner2 = Runner(testDir, "testUnparserSAX.tdml")
 
-  @AfterClass def shutDown: Unit = {
+  @AfterClass def shutDown(): Unit = {
     runner2.reset
   }
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section02/processing_errors/ProcessingErrors.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section02/processing_errors/ProcessingErrors.scala
@@ -29,7 +29,7 @@ object TestProcessingErrors {
   val runner02 = Runner(testDir, "ProcessingErrors.tdml", validateTDMLFile = false, validateDFDLSchemas = false)
   val runner02Validate = Runner(testDir, "ProcessingErrors.tdml", validateTDMLFile = true, validateDFDLSchemas = true)
 
-  @AfterClass def shutDown: Unit = {
+  @AfterClass def shutDown(): Unit = {
     runner.reset
     runner02.reset
     runner02Validate.reset

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section02/processing_errors/ProcessingErrorsUnparse.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section02/processing_errors/ProcessingErrorsUnparse.scala
@@ -28,7 +28,7 @@ object TestProcessingErrorsUnparse {
   val runner02Validate = Runner(testDir, "ProcessingErrorsUnparse.tdml", validateTDMLFile = true, validateDFDLSchemas = true,
     compileAllTopLevel = true)
 
-  @AfterClass def shutDown: Unit = {
+  @AfterClass def shutDown(): Unit = {
     runner02.reset
     runner02Validate.reset
   }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section05/facets/TestFacets.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section05/facets/TestFacets.scala
@@ -18,7 +18,6 @@
 package org.apache.daffodil.section05.facets
 
 import org.junit.Test
-import org.junit._
 import org.apache.daffodil.tdml.Runner
 import org.junit.AfterClass
 
@@ -119,53 +118,53 @@ class TestFacets {
   @Test def test_arraysOccursOutOfRange_01(): Unit = { runner.runOneTest("arraysOccursOutOfRange_01") }
   @Test def test_arraysOccursOutOfRange_02(): Unit = { runner.runOneTest("arraysOccursOutOfRange_02") }
 
-  @Test def test_checkMinInclusive_Pass: Unit = { runner.runOneTest("checkMinInclusive_Pass") }
-  @Test def test_checkMaxInclusive_Pass: Unit = { runner.runOneTest("checkMaxInclusive_Pass") }
-  @Test def test_checkMinInclusive_Fail: Unit = { runner.runOneTest("checkMinInclusive_Fail") }
-  @Test def test_checkMaxInclusive_Fail: Unit = { runner.runOneTest("checkMaxInclusive_Fail") }
-  @Test def test_checkMaxInclusive_Pass_MaxInt: Unit = { runner.runOneTest("checkMaxInclusive_Pass_MaxInt") }
-  @Test def test_checkMaxInclusive_Fail_MaxInt: Unit = { runner.runOneTest("checkMaxInclusive_Fail_MaxInt") }
-  @Test def test_checkMinInclusive_Fail_MinInt: Unit = { runner.runOneTest("checkMinInclusive_Fail_MinInt") }
+  @Test def test_checkMinInclusive_Pass(): Unit = { runner.runOneTest("checkMinInclusive_Pass") }
+  @Test def test_checkMaxInclusive_Pass(): Unit = { runner.runOneTest("checkMaxInclusive_Pass") }
+  @Test def test_checkMinInclusive_Fail(): Unit = { runner.runOneTest("checkMinInclusive_Fail") }
+  @Test def test_checkMaxInclusive_Fail(): Unit = { runner.runOneTest("checkMaxInclusive_Fail") }
+  @Test def test_checkMaxInclusive_Pass_MaxInt(): Unit = { runner.runOneTest("checkMaxInclusive_Pass_MaxInt") }
+  @Test def test_checkMaxInclusive_Fail_MaxInt(): Unit = { runner.runOneTest("checkMaxInclusive_Fail_MaxInt") }
+  @Test def test_checkMinInclusive_Fail_MinInt(): Unit = { runner.runOneTest("checkMinInclusive_Fail_MinInt") }
 
-  @Test def test_checkMinInclusiveDecimal_Pass: Unit = { runner.runOneTest("checkMinInclusiveDecimal_Pass") }
-  @Test def test_checkMaxInclusiveDecimal_Pass: Unit = { runner.runOneTest("checkMaxInclusiveDecimal_Pass") }
-  @Test def test_checkMinInclusiveDecimal_Fail: Unit = { runner.runOneTest("checkMinInclusiveDecimal_Fail") }
-  @Test def test_checkMaxInclusiveDecimal_Fail: Unit = { runner.runOneTest("checkMaxInclusiveDecimal_Fail") }
+  @Test def test_checkMinInclusiveDecimal_Pass(): Unit = { runner.runOneTest("checkMinInclusiveDecimal_Pass") }
+  @Test def test_checkMaxInclusiveDecimal_Pass(): Unit = { runner.runOneTest("checkMaxInclusiveDecimal_Pass") }
+  @Test def test_checkMinInclusiveDecimal_Fail(): Unit = { runner.runOneTest("checkMinInclusiveDecimal_Fail") }
+  @Test def test_checkMaxInclusiveDecimal_Fail(): Unit = { runner.runOneTest("checkMaxInclusiveDecimal_Fail") }
 
-  @Test def test_checkMinExclusiveDecimal_Pass: Unit = { runner.runOneTest("checkMinExclusiveDecimal_Pass") }
-  @Test def test_checkMaxExclusiveDecimal_Pass: Unit = { runner.runOneTest("checkMaxExclusiveDecimal_Pass") }
-  @Test def test_checkMinExclusiveDecimal_Fail: Unit = { runner.runOneTest("checkMinExclusiveDecimal_Fail") }
-  @Test def test_checkMaxExclusiveDecimal_Fail: Unit = { runner.runOneTest("checkMaxExclusiveDecimal_Fail") }
+  @Test def test_checkMinExclusiveDecimal_Pass(): Unit = { runner.runOneTest("checkMinExclusiveDecimal_Pass") }
+  @Test def test_checkMaxExclusiveDecimal_Pass(): Unit = { runner.runOneTest("checkMaxExclusiveDecimal_Pass") }
+  @Test def test_checkMinExclusiveDecimal_Fail(): Unit = { runner.runOneTest("checkMinExclusiveDecimal_Fail") }
+  @Test def test_checkMaxExclusiveDecimal_Fail(): Unit = { runner.runOneTest("checkMaxExclusiveDecimal_Fail") }
 
-  @Test def test_checkMinExclusive_Fail: Unit = { runner.runOneTest("checkMinExclusive_Fail") }
-  @Test def test_checkMaxExclusive_Fail: Unit = { runner.runOneTest("checkMaxExclusive_Fail") }
-  @Test def test_checkMinExclusive_Pass: Unit = { runner.runOneTest("checkMinExclusive_Pass") }
-  @Test def test_checkMaxExclusive_Pass: Unit = { runner.runOneTest("checkMaxExclusive_Pass") }
-  @Test def test_checkCombining_Pass: Unit = { runner.runOneTest("checkCombining_Pass") }
-  @Test def test_checkCombining_Fail: Unit = { runner.runOneTest("checkCombining_Fail") }
-  @Test def test_checkCombining_Fail_1: Unit = { runner.runOneTest("checkCombining_Fail_1") }
+  @Test def test_checkMinExclusive_Fail(): Unit = { runner.runOneTest("checkMinExclusive_Fail") }
+  @Test def test_checkMaxExclusive_Fail(): Unit = { runner.runOneTest("checkMaxExclusive_Fail") }
+  @Test def test_checkMinExclusive_Pass(): Unit = { runner.runOneTest("checkMinExclusive_Pass") }
+  @Test def test_checkMaxExclusive_Pass(): Unit = { runner.runOneTest("checkMaxExclusive_Pass") }
+  @Test def test_checkCombining_Pass(): Unit = { runner.runOneTest("checkCombining_Pass") }
+  @Test def test_checkCombining_Fail(): Unit = { runner.runOneTest("checkCombining_Fail") }
+  @Test def test_checkCombining_Fail_1(): Unit = { runner.runOneTest("checkCombining_Fail_1") }
 
-  @Test def test_checkEnumeration_Pass: Unit = { runner.runOneTest("checkEnumeration_Pass") }
-  @Test def test_checkEnumeration_Fail: Unit = { runner.runOneTest("checkEnumeration_Fail") }
-  @Test def test_checkEnumeration_Pass_Subset: Unit = { runner.runOneTest("checkEnumeration_Pass_Subset") }
-  @Test def test_checkEnumeration_Fail_Subset: Unit = { runner.runOneTest("checkEnumeration_Fail_Subset") }
+  @Test def test_checkEnumeration_Pass(): Unit = { runner.runOneTest("checkEnumeration_Pass") }
+  @Test def test_checkEnumeration_Fail(): Unit = { runner.runOneTest("checkEnumeration_Fail") }
+  @Test def test_checkEnumeration_Pass_Subset(): Unit = { runner.runOneTest("checkEnumeration_Pass_Subset") }
+  @Test def test_checkEnumeration_Fail_Subset(): Unit = { runner.runOneTest("checkEnumeration_Fail_Subset") }
 
   // Satisfied that Date and Time should also work if DateTime works.
-  @Test def test_maxInclusive_Pass_DateTime: Unit = { runner.runOneTest("checkMaxInclusive_Pass_DateTime") }
-  @Test def test_maxInclusive_Fail_DateTime: Unit = { runner.runOneTest("checkMaxInclusive_Fail_DateTime") }
+  @Test def test_maxInclusive_Pass_DateTime(): Unit = { runner.runOneTest("checkMaxInclusive_Pass_DateTime") }
+  @Test def test_maxInclusive_Fail_DateTime(): Unit = { runner.runOneTest("checkMaxInclusive_Fail_DateTime") }
 
-  @Test def test_checkMinLength_Pass: Unit = { runner.runOneTest("checkMinLength_Pass") }
-  @Test def test_checkMinLength_Fail: Unit = { runner.runOneTest("checkMinLength_Fail") }
-  @Test def test_checkMinLength_Fail_NotString: Unit = { runner.runOneTest("checkMinLength_Fail_NotString") }
-  @Test def test_checkMinLength_Fail_Combining: Unit = { runner.runOneTest("checkMinLength_Fail_Combining") }
-  @Test def test_checkMinLength_Pass_Combining: Unit = { runner.runOneTest("checkMinLength_Pass_Combining") }
-  @Test def test_checkMaxLength_Pass: Unit = { runner.runOneTest("checkMaxLength_Pass") }
-  @Test def test_checkMaxLength_Fail: Unit = { runner.runOneTest("checkMaxLength_Fail") }
-  @Test def test_checkMaxLength_Fail_NotString: Unit = { runner.runOneTest("checkMaxLength_Fail_NotString") }
-  @Test def test_checkMaxLength_Fail_Combining: Unit = { runner.runOneTest("checkMaxLength_Fail_Combining") }
-  @Test def test_checkMaxLength_Pass_Combining: Unit = { runner.runOneTest("checkMaxLength_Pass_Combining") }
-  @Test def test_checkTotalDigits_Pass: Unit = { runner.runOneTest("checkTotalDigits_Pass") }
-  @Test def test_checkTotalDigits_Fail: Unit = { runner.runOneTest("checkTotalDigits_Fail") }
+  @Test def test_checkMinLength_Pass(): Unit = { runner.runOneTest("checkMinLength_Pass") }
+  @Test def test_checkMinLength_Fail(): Unit = { runner.runOneTest("checkMinLength_Fail") }
+  @Test def test_checkMinLength_Fail_NotString(): Unit = { runner.runOneTest("checkMinLength_Fail_NotString") }
+  @Test def test_checkMinLength_Fail_Combining(): Unit = { runner.runOneTest("checkMinLength_Fail_Combining") }
+  @Test def test_checkMinLength_Pass_Combining(): Unit = { runner.runOneTest("checkMinLength_Pass_Combining") }
+  @Test def test_checkMaxLength_Pass(): Unit = { runner.runOneTest("checkMaxLength_Pass") }
+  @Test def test_checkMaxLength_Fail(): Unit = { runner.runOneTest("checkMaxLength_Fail") }
+  @Test def test_checkMaxLength_Fail_NotString(): Unit = { runner.runOneTest("checkMaxLength_Fail_NotString") }
+  @Test def test_checkMaxLength_Fail_Combining(): Unit = { runner.runOneTest("checkMaxLength_Fail_Combining") }
+  @Test def test_checkMaxLength_Pass_Combining(): Unit = { runner.runOneTest("checkMaxLength_Pass_Combining") }
+  @Test def test_checkTotalDigits_Pass(): Unit = { runner.runOneTest("checkTotalDigits_Pass") }
+  @Test def test_checkTotalDigits_Fail(): Unit = { runner.runOneTest("checkTotalDigits_Fail") }
 
   @Test def test_minMaxInEx01(): Unit = { runner.runOneTest("minMaxInEx01") }
 
@@ -204,15 +203,15 @@ class TestFacets {
   @Test def test_maxOccursUnboundedPass(): Unit = { runner.runOneTest("checkMaxOccursUnbounded_Pass") }
 
   @Test def test_testBinary(): Unit = { runner.runOneTest("testBinary") }
-  @Test def test_totalDigits_Pass_Decimal: Unit = { runner.runOneTest("checkTotalDigits_Pass_Decimal") }
-  @Test def test_totalDigits_Pass_Negative: Unit = { runner.runOneTest("test_totalDigits_Pass_Negative") }
-  @Test def test_totalDigits_Fail_Decimal: Unit = { runner.runOneTest("checkTotalDigits_Fail_Decimal") }
-  @Test def test_totalDigits_Fail_Negative: Unit = { runner.runOneTest("test_totalDigits_Fail_Negative") }
-  @Test def test_fractionDigits_Pass: Unit = { runner.runOneTest("checkFractionDigits_Pass") }
-  @Test def test_fractionDigits_Fail: Unit = { runner.runOneTest("checkFractionDigits_Fail") }
-  @Test def test_fractionDigits_Pass_LessDigits: Unit = { runner.runOneTest("checkFractionDigits_Pass_LessDigits") }
-  @Test def test_totalDigitsAndFractionDigits_Pass: Unit = { runner.runOneTest("checkTotalDigitsFractionDigits_Pass") }
-  @Test def test_totalDigitsAndFractionDigits_Pass2: Unit = { runner.runOneTest("checkTotalDigitsFractionDigits_Pass2") }
+  @Test def test_totalDigits_Pass_Decimal(): Unit = { runner.runOneTest("checkTotalDigits_Pass_Decimal") }
+  @Test def test_totalDigits_Pass_Negative(): Unit = { runner.runOneTest("test_totalDigits_Pass_Negative") }
+  @Test def test_totalDigits_Fail_Decimal(): Unit = { runner.runOneTest("checkTotalDigits_Fail_Decimal") }
+  @Test def test_totalDigits_Fail_Negative(): Unit = { runner.runOneTest("test_totalDigits_Fail_Negative") }
+  @Test def test_fractionDigits_Pass(): Unit = { runner.runOneTest("checkFractionDigits_Pass") }
+  @Test def test_fractionDigits_Fail(): Unit = { runner.runOneTest("checkFractionDigits_Fail") }
+  @Test def test_fractionDigits_Pass_LessDigits(): Unit = { runner.runOneTest("checkFractionDigits_Pass_LessDigits") }
+  @Test def test_totalDigitsAndFractionDigits_Pass(): Unit = { runner.runOneTest("checkTotalDigitsFractionDigits_Pass") }
+  @Test def test_totalDigitsAndFractionDigits_Pass2(): Unit = { runner.runOneTest("checkTotalDigitsFractionDigits_Pass2") }
 
   @Test def test_fractionDigitsPass(): Unit = { runner.runOneTest("fractionDigitsPass") }
   @Test def test_fractionDigitsFail(): Unit = { runner.runOneTest("fractionDigitsFail") }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section05/facets/TestNulChars.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section05/facets/TestNulChars.scala
@@ -23,7 +23,7 @@ import org.junit.Test
 object TestNulChars {
   val runner = Runner("/org/apache/daffodil/section05/facets", "NulChars.tdml")
 
-  @AfterClass def shutDown = {
+  @AfterClass def shutDown() = {
     runner.reset
   }
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section05/facets/TestPatternRanges.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section05/facets/TestPatternRanges.scala
@@ -23,7 +23,7 @@ import org.junit.Test
 object TestPatternRanges {
   val runner = Runner("/org/apache/daffodil/section05/facets", "PatternRanges.tdml")
 
-  @AfterClass def shutDown = {
+  @AfterClass def shutDown() = {
     runner.reset
   }
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section05/simple_types/TestBoolean2.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section05/simple_types/TestBoolean2.scala
@@ -26,7 +26,7 @@ object TestBoolean2 {
 
   val runner = Runner(testDir, "Boolean.tdml")
 
-  @AfterClass def shutdown: Unit = {
+  @AfterClass def shutdown(): Unit = {
     runner.reset
   }
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section05/simple_types/TestEncodings.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section05/simple_types/TestEncodings.scala
@@ -26,7 +26,7 @@ object TestEncodings {
 
   val runner = Runner(testDir, "Encodings.tdml")
 
-  @AfterClass def shutdown: Unit = {
+  @AfterClass def shutdown(): Unit = {
     runner.reset
   }
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section05/simple_types/TestRuntimeCalendarLanguage.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section05/simple_types/TestRuntimeCalendarLanguage.scala
@@ -26,7 +26,7 @@ object TestRuntimeCalendarLanguage {
 
   val runner = Runner(testDir, "RuntimeCalendarLanguage.tdml")
 
-  @AfterClass def shutdown: Unit = {
+  @AfterClass def shutdown(): Unit = {
     runner.reset
   }
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section05/simple_types/TestUnions.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section05/simple_types/TestUnions.scala
@@ -26,7 +26,7 @@ object TestUnions {
 
   val runner = Runner(testDir, "unions.tdml")
 
-  @AfterClass def shutdown: Unit = {
+  @AfterClass def shutdown(): Unit = {
     runner.reset
   }
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section06/entities/TestEntities.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section06/entities/TestEntities.scala
@@ -29,7 +29,7 @@ object TestEntities {
   val runnerEntity = Runner(testDir, "entities_01.tdml")
   val runnerInvalid = Runner(testDir, "InvalidEntities.tdml")
 
-  @AfterClass def shutDown: Unit = {
+  @AfterClass def shutDown(): Unit = {
     runner.reset
     runner_01.reset
     runnerEntity.reset

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section06/namespaces/TestNamespaces.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section06/namespaces/TestNamespaces.scala
@@ -31,7 +31,7 @@ object TestNamespaces {
   val runner3 = Runner(testDir, "includeImport.tdml")
   val runnerWithSchemaValidation = Runner(testDir, "multiFile.tdml", validateTDMLFile = true, validateDFDLSchemas = true)
 
-  @AfterClass def shutDown: Unit = {
+  @AfterClass def shutDown(): Unit = {
     runner.reset
     runnerV.reset
     runner2.reset

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section07/annotations/TestAnnotations.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section07/annotations/TestAnnotations.scala
@@ -25,7 +25,7 @@ object TestAnnotations {
   val testDir = "/org/apache/daffodil/section07/annotations/"
   val runner = Runner(testDir, "annotations.tdml", validateTDMLFile = false)
 
-  @AfterClass def tearDown: Unit = {
+  @AfterClass def tearDown(): Unit = {
     runner.reset
   }
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section07/assertions/TestAssertions.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section07/assertions/TestAssertions.scala
@@ -25,7 +25,7 @@ object TestAssertions {
   val testDir = "/org/apache/daffodil/section07/assertions/"
   val runner = Runner(testDir, "assert.tdml", validateTDMLFile = false)
 
-  @AfterClass def tearDown: Unit = {
+  @AfterClass def tearDown(): Unit = {
     runner.reset
   }
 

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section07/property_syntax/TestPropertySyntax.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section07/property_syntax/TestPropertySyntax.scala
@@ -26,7 +26,7 @@ object TestPropertySyntax {
   val runner1 = Runner(testDir1, "PropertySyntax.tdml", validateTDMLFile = false, validateDFDLSchemas = false)
   val runner1V = Runner(testDir1, "PropertySyntax.tdml", validateTDMLFile = false)
 
-  @AfterClass def shutDown: Unit = {
+  @AfterClass def shutDown(): Unit = {
     runner1.reset
     runner1V.reset
   }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section07/variables/TestVariables.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section07/variables/TestVariables.scala
@@ -29,7 +29,7 @@ object TestVariables {
   val runner = Runner(testDir, "variables.tdml")
   val runner_01 = Runner(testDir, "variables_01.tdml")
 
-  @AfterClass def shutDown: Unit = {
+  @AfterClass def shutDown(): Unit = {
     runner.reset
     runner_01.reset
   }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section08/property_scoping/TestPropertyScoping.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section08/property_scoping/TestPropertyScoping.scala
@@ -26,7 +26,7 @@ object TestPropertyScoping {
   val runner = Runner(testDir, "PropertyScoping.tdml")
   val runner_01 = Runner(testDir, "PropertyScoping_01.tdml")
 
-  @AfterClass def shutDown: Unit = {
+  @AfterClass def shutDown(): Unit = {
     runner.reset
     runner_01.reset
   }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section10/representation_properties/TestRepProps.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section10/representation_properties/TestRepProps.scala
@@ -25,7 +25,7 @@ object TestRepProps {
   val testDir = "/org/apache/daffodil/section10/representation_properties/"
   val runner = Runner(testDir, "RepProps.tdml")
 
-  @AfterClass def shutDown: Unit = {
+  @AfterClass def shutDown(): Unit = {
     runner.reset
   }
 

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section10/representation_properties/TestRepProps2.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section10/representation_properties/TestRepProps2.scala
@@ -25,7 +25,7 @@ object TestRepProps2 {
   val testDir = "/org/apache/daffodil/section10/representation_properties/"
   val runner = Runner(testDir, "encodings.tdml")
 
-  @AfterClass def shutDown: Unit = {
+  @AfterClass def shutDown(): Unit = {
     runner.reset
   }
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section11/content_framing_properties/TestContentFramingProperties.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section11/content_framing_properties/TestContentFramingProperties.scala
@@ -26,7 +26,7 @@ object TestContentFramingProperties {
   private val testDir_02 = "/org/apache/daffodil/section11/content_framing_properties/"
   val runner2 = Runner(testDir_02, "ContentFramingProps.tdml")
 
-  @AfterClass def shutdown: Unit = {
+  @AfterClass def shutdown(): Unit = {
     runner2.reset
   }
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section12/aligned_data/TestAlignedData.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section12/aligned_data/TestAlignedData.scala
@@ -26,7 +26,7 @@ object TestAlignedData {
   val runner1 = Runner(testDir_01, "Aligned_Data.tdml")
   val runner2 = Runner(testDir_01, "BinaryInput_01.tdml")
 
-  @AfterClass def shutDown: Unit = {
+  @AfterClass def shutDown(): Unit = {
     runner1.reset
     runner2.reset
   }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section12/delimiter_properties/TestDelimiterProperties.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section12/delimiter_properties/TestDelimiterProperties.scala
@@ -26,7 +26,7 @@ object TestDelimiterProperties {
   val testDir_02 = "/org/apache/daffodil/section12/delimiter_properties/"
   val runner_02 = Runner(testDir_02, "DelimiterProperties.tdml")
 
-  @AfterClass def shutDown: Unit = {
+  @AfterClass def shutDown(): Unit = {
     runner_02.reset
   }
 

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section12/delimiter_properties/TestDelimiterPropertiesUnparse.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section12/delimiter_properties/TestDelimiterPropertiesUnparse.scala
@@ -26,7 +26,7 @@ object TestDelimiterPropertiesUnparse {
   val testDir_02 = "/org/apache/daffodil/section12/delimiter_properties/"
   val runner = Runner(testDir_02, "DelimiterPropertiesUnparse.tdml")
 
-  @AfterClass def shutDown: Unit = {
+  @AfterClass def shutDown(): Unit = {
     runner.reset
   }
 

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section12/lengthKind/TestLengthKindDelimited.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section12/lengthKind/TestLengthKindDelimited.scala
@@ -28,7 +28,7 @@ object TestLengthKindDelimited {
   val runnerAB = Runner(testDir, "AB.tdml")
   val runnerAN = Runner(testDir, "AN.tdml")
 
-  @AfterClass def shutDown: Unit = {
+  @AfterClass def shutDown(): Unit = {
     runner.reset
     runnerAB.reset
     runnerAN.reset

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section12/lengthKind/TestLengthKindEndOfParent2.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section12/lengthKind/TestLengthKindEndOfParent2.scala
@@ -25,7 +25,7 @@ object TestLengthKindEndOfParent2 {
   val testDir = "/org/apache/daffodil/section12/lengthKind/"
   val runner = Runner(testDir, "EndOfParentTests.tdml")
 
-  @AfterClass def shutDown: Unit = {
+  @AfterClass def shutDown(): Unit = {
     runner.reset
   }
 

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section12/lengthKind/TestLengthKindExplicit.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section12/lengthKind/TestLengthKindExplicit.scala
@@ -25,7 +25,7 @@ object TestLengthKindExplicit {
   val testDir = "/org/apache/daffodil/section12/lengthKind/"
   val runner = Runner(testDir, "ExplicitTests.tdml")
 
-  @AfterClass def shutDown: Unit = {
+  @AfterClass def shutDown(): Unit = {
     runner.reset
   }
 

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section12/lengthKind/TestLengthKindImplicit.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section12/lengthKind/TestLengthKindImplicit.scala
@@ -25,7 +25,7 @@ object TestLengthKindImplicit {
   val testDir = "/org/apache/daffodil/section12/lengthKind/"
   val runner_01 = Runner(testDir, "implicit.tdml")
 
-  @AfterClass def shutDown: Unit = {
+  @AfterClass def shutDown(): Unit = {
     runner_01.reset
   }
 

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section12/lengthKind/TestLengthKindPattern.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section12/lengthKind/TestLengthKindPattern.scala
@@ -29,7 +29,7 @@ object TestLengthKindPattern {
 
   val runnerAI = Runner(testDir, "AI.tdml")
 
-  @AfterClass def shutDown: Unit = {
+  @AfterClass def shutDown(): Unit = {
     runner.reset
     runnerAI.reset
   }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section12/lengthKind/TestLengthKindPrefixed.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section12/lengthKind/TestLengthKindPrefixed.scala
@@ -26,7 +26,7 @@ object TestLengthKindPrefixed {
 
   val runner = Runner(testDir, "PrefixedTests.tdml", validateTDMLFile = false, validateDFDLSchemas = false)
 
-  @AfterClass def shutDown: Unit = {
+  @AfterClass def shutDown(): Unit = {
     runner.reset
   }
 

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section12/length_properties/TestLengthProperties.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section12/length_properties/TestLengthProperties.scala
@@ -27,7 +27,7 @@ object TestLengthProperties {
 
   val runner_02 = Runner(testDir_02, "LengthProperties.tdml")
 
-  @AfterClass def shutDown: Unit = {
+  @AfterClass def shutDown(): Unit = {
     runner_02.reset
   }
 

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section13/boolean/TestBoolean.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section13/boolean/TestBoolean.scala
@@ -23,7 +23,7 @@ import org.junit.{AfterClass, Test}
 object TestBoolean {
   val runner = Runner("/org/apache/daffodil/section13/boolean/", "boolean.tdml")
 
-  @AfterClass def shutdown: Unit = { runner.reset }
+  @AfterClass def shutdown(): Unit = { runner.reset }
 
 }
 

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section13/nillable/TestNillable.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section13/nillable/TestNillable.scala
@@ -30,7 +30,7 @@ object TestNillable {
   val runnerLC = Runner(testDir, "literal-character-nils.tdml")
   val runnerEntity = Runner(testDir_01, "entities_01.tdml")
 
-  @AfterClass def shutDown: Unit = {
+  @AfterClass def shutDown(): Unit = {
     runnerAA.reset
     runnerLN.reset
     runnerEntity.reset

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section13/text_number_props/TestTextNumberPropsUnparse.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section13/text_number_props/TestTextNumberPropsUnparse.scala
@@ -26,7 +26,7 @@ object TestTextNumberPropsUnparse {
 
   val runner = Runner(testDir, "TextNumberPropsUnparse.tdml")
 
-  @AfterClass def shutDown: Unit = {
+  @AfterClass def shutDown(): Unit = {
     runner.reset
   }
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section14/occursCountKind/TestOCKImplicit.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section14/occursCountKind/TestOCKImplicit.scala
@@ -29,7 +29,7 @@ object TestOCKImplicit {
   val testDir = "/org/apache/daffodil/section14/occursCountKind/"
   val runner = Runner(testDir, "ockImplicit.tdml")
 
-  @AfterClass def shutDown: Unit = {
+  @AfterClass def shutDown(): Unit = {
     runner.reset
   }
 

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section14/sequence_groups/TestHiddenSequences.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section14/sequence_groups/TestHiddenSequences.scala
@@ -30,7 +30,7 @@ object TestHiddenSequences {
     validateDFDLSchemas = false,
     )
 
-  @AfterClass def shutDown: Unit = {
+  @AfterClass def shutDown(): Unit = {
     runner.reset
   }
 

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section14/sequence_groups/TestSequenceGroupInitiatedContent.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section14/sequence_groups/TestSequenceGroupInitiatedContent.scala
@@ -25,7 +25,7 @@ object TestSequenceGroupInitiatedContent {
   val testDir_01 = "/org/apache/daffodil/section14/sequence_groups/"
   val runner_01 = Runner(testDir_01, "SequenceGroupInitiatedContent.tdml")
 
-  @AfterClass def shutDown: Unit = {
+  @AfterClass def shutDown(): Unit = {
     runner_01.reset
   }
 

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section14/sequence_groups/TestSequenceGroupNestedArray.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section14/sequence_groups/TestSequenceGroupNestedArray.scala
@@ -27,7 +27,7 @@ object TestSequenceGroupNestedArray {
 
   val runner = Runner(testDir_01, "SequenceGroupNestedArray.tdml")
 
-  @AfterClass def shutDown: Unit = {
+  @AfterClass def shutDown(): Unit = {
     runner.reset
   }
 

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section14/sequence_groups/TestSequenceGroupUnparse.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section14/sequence_groups/TestSequenceGroupUnparse.scala
@@ -23,7 +23,7 @@ import org.junit.AfterClass
 
 object TestSequenceGroupUnparse {
   val runner = Runner("/org/apache/daffodil/section14/sequence_groups/SequenceGroupUnparse.tdml")
-  @AfterClass def shutDown: Unit = {
+  @AfterClass def shutDown(): Unit = {
     runner.reset
   }
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section14/sequence_groups/TestSequenceGroups.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section14/sequence_groups/TestSequenceGroups.scala
@@ -28,7 +28,7 @@ object TestSequenceGroups {
   val runner_01 = Runner(testDir_01, "SequenceGroupDelimiters.tdml")
   val runner_02 = Runner(testDir_01, "SequenceGroup.tdml", validateTDMLFile = false)
 
-  @AfterClass def shutDown: Unit = {
+  @AfterClass def shutDown(): Unit = {
     runner_01.reset
     runner_02.reset
   }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section14/sequence_groups/TestSequenceGroups3.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section14/sequence_groups/TestSequenceGroups3.scala
@@ -28,7 +28,7 @@ object TestSequenceGroups3 {
   val runner_01 = Runner(testDir_01, "SequenceGroupDelimiters.tdml")
   val runner_02 = Runner(testDir_01, "SequenceGroup.tdml", validateTDMLFile = false)
 
-  @AfterClass def shutDown: Unit = {
+  @AfterClass def shutDown(): Unit = {
     runner_01.reset
     runner_02.reset
   }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section14/unordered_sequences/TestUnorderedSequences.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section14/unordered_sequences/TestUnorderedSequences.scala
@@ -26,7 +26,7 @@ object TestUnorderedSequences {
   val runner = Runner(testDir, "UnorderedSequences.tdml")
   val runnerBE = Runner(testDir, "BE.tdml")
 
-  @AfterClass def shutDown: Unit = {
+  @AfterClass def shutDown(): Unit = {
     runner.reset
     runnerBE.reset
   }
@@ -37,38 +37,38 @@ class TestUnorderedSequences {
   import TestUnorderedSequences._
 
   //DFDL-1010
-  @Test def test_simple = { runner.runOneTest("test_simple") }
-  @Test def test_simple_fail_scalar = { runner.runOneTest("test_simple_fail_scalar") }
-  @Test def test_simple_min_max_occurs = { runner.runOneTest("test_simple_min_max_occurs") }
-  @Test def test_simple_min_max_occurs_fail = { runner.runOneTest("test_simple_min_max_occurs_fail") }
-  @Test def test_array_reference = { runner.runOneTest("test_array_reference") }
-  @Test def test_simple_delimited = { runner.runOneTest("test_simple_delimited") }
-  @Test def test_separated_infix = { runner.runOneTest("test_separated_infix") }
-  @Test def test_separated_prefix = { runner.runOneTest("test_separated_prefix") }
-  @Test def test_separated_postfix = { runner.runOneTest("test_separated_postfix") }
-  @Test def test_simple_nil = { runner.runOneTest("test_simple_nil") }
-  @Test def test_simple_optional_elem = { runner.runOneTest("test_simple_optional_elem") }
-  @Test def test_simple_invalid_path_to_branch = { runner.runOneTest("test_simple_invalid_path_to_branch") }
-  @Test def test_simple_invalid_path_to_branch_does_not_exist = { runner.runOneTest("test_simple_invalid_path_to_branch_does_not_exist") }
-  @Test def test_nested_valid_path_to_branch = { runner.runOneTest("test_nested_valid_path_to_branch") }
-  @Test def test_nested_multiple_valid_paths_to_branch = { runner.runOneTest("test_nested_multiple_valid_paths_to_branch") }
-  @Test def test_nested_multiple_invalid_paths_to_branch = { runner.runOneTest("test_nested_multiple_invalid_paths_to_branch") }
-  @Test def test_sde_element_element_ref = { runner.runOneTest("test_sde_element_element_ref") }
-  @Test def test_sde_optional_array_ock_parsed = { runner.runOneTest("test_sde_optional_array_ock_parsed") }
-  @Test def test_sde_unique_names_in_ns = { runner.runOneTest("test_sde_unique_names_in_ns") }
+  @Test def test_simple() = { runner.runOneTest("test_simple") }
+  @Test def test_simple_fail_scalar() = { runner.runOneTest("test_simple_fail_scalar") }
+  @Test def test_simple_min_max_occurs() = { runner.runOneTest("test_simple_min_max_occurs") }
+  @Test def test_simple_min_max_occurs_fail() = { runner.runOneTest("test_simple_min_max_occurs_fail") }
+  @Test def test_array_reference() = { runner.runOneTest("test_array_reference") }
+  @Test def test_simple_delimited() = { runner.runOneTest("test_simple_delimited") }
+  @Test def test_separated_infix() = { runner.runOneTest("test_separated_infix") }
+  @Test def test_separated_prefix() = { runner.runOneTest("test_separated_prefix") }
+  @Test def test_separated_postfix() = { runner.runOneTest("test_separated_postfix") }
+  @Test def test_simple_nil() = { runner.runOneTest("test_simple_nil") }
+  @Test def test_simple_optional_elem() = { runner.runOneTest("test_simple_optional_elem") }
+  @Test def test_simple_invalid_path_to_branch() = { runner.runOneTest("test_simple_invalid_path_to_branch") }
+  @Test def test_simple_invalid_path_to_branch_does_not_exist() = { runner.runOneTest("test_simple_invalid_path_to_branch_does_not_exist") }
+  @Test def test_nested_valid_path_to_branch() = { runner.runOneTest("test_nested_valid_path_to_branch") }
+  @Test def test_nested_multiple_valid_paths_to_branch() = { runner.runOneTest("test_nested_multiple_valid_paths_to_branch") }
+  @Test def test_nested_multiple_invalid_paths_to_branch() = { runner.runOneTest("test_nested_multiple_invalid_paths_to_branch") }
+  @Test def test_sde_element_element_ref() = { runner.runOneTest("test_sde_element_element_ref") }
+  @Test def test_sde_optional_array_ock_parsed() = { runner.runOneTest("test_sde_optional_array_ock_parsed") }
+  @Test def test_sde_unique_names_in_ns() = { runner.runOneTest("test_sde_unique_names_in_ns") }
 
-  @Test def test_empty_seq = { runner.runOneTest("test_empty_seq") }
+  @Test def test_empty_seq() = { runner.runOneTest("test_empty_seq") }
 
-  @Test def test_initiated_unordered1 = { runner.runOneTest("test_initiated_unordered1") }
-  @Test def test_initiated_unordered2 = { runner.runOneTest("test_initiated_unordered2") }
-  @Test def test_initiated_unordered3 = { runner.runOneTest("test_initiated_unordered3") }
+  @Test def test_initiated_unordered1() = { runner.runOneTest("test_initiated_unordered1") }
+  @Test def test_initiated_unordered2() = { runner.runOneTest("test_initiated_unordered2") }
+  @Test def test_initiated_unordered3() = { runner.runOneTest("test_initiated_unordered3") }
 
-  @Test def test_unordered_namespaces_01 = { runner.runOneTest("test_unordered_namespaces_01") }
+  @Test def test_unordered_namespaces_01() = { runner.runOneTest("test_unordered_namespaces_01") }
 
-  @Test def test_BE000 = { runnerBE.runOneTest("BE000") }
-  @Test def test_BE001 = { runnerBE.runOneTest("BE001") }
-  @Test def test_BE002 = { runnerBE.runOneTest("BE002") }
-  @Test def test_BE003 = { runnerBE.runOneTest("BE003") }
-  @Test def test_BE004 = { runnerBE.runOneTest("BE004") }
-  @Test def test_BE004_A = { runnerBE.runOneTest("BE004-A") }
+  @Test def test_BE000() = { runnerBE.runOneTest("BE000") }
+  @Test def test_BE001() = { runnerBE.runOneTest("BE001") }
+  @Test def test_BE002() = { runnerBE.runOneTest("BE002") }
+  @Test def test_BE003() = { runnerBE.runOneTest("BE003") }
+  @Test def test_BE004() = { runnerBE.runOneTest("BE004") }
+  @Test def test_BE004_A() = { runnerBE.runOneTest("BE004-A") }
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section15/choice_groups/TestChoice.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section15/choice_groups/TestChoice.scala
@@ -27,7 +27,7 @@ object TestChoice {
   val runnerCH = Runner(testDir, "choice.tdml")
   val runnerCE = Runner(testDir, "ChoiceLengthExplicit.tdml")
 
-  @AfterClass def shutDown: Unit = {
+  @AfterClass def shutDown(): Unit = {
     runnerCH.reset
     runnerCE.reset
   }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section15/choice_groups/TestChoice2.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section15/choice_groups/TestChoice2.scala
@@ -28,7 +28,7 @@ object TestChoice2 {
   val runner1773 = Runner(testDir, "choice1773.tdml")
   val runner2162 = Runner(testDir, "choice2162.tdml")
 
-  @AfterClass def shutDown: Unit = {
+  @AfterClass def shutDown(): Unit = {
     runner.reset
     runner1773.reset
     runner2162.reset

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section15/choice_groups/TestChoiceGroupInitiatedContent.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section15/choice_groups/TestChoiceGroupInitiatedContent.scala
@@ -25,7 +25,7 @@ object TestChoiceGroupInitiatedContent {
   val testDir_01 = "/org/apache/daffodil/section15/choice_groups/"
   val runner_01 = Runner(testDir_01, "ChoiceGroupInitiatedContent.tdml")
 
-  @AfterClass def shutDown: Unit = {
+  @AfterClass def shutDown(): Unit = {
     runner_01.reset
   }
 

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section15/choice_groups/TestChoiceNest.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section15/choice_groups/TestChoiceNest.scala
@@ -26,7 +26,7 @@ object TestChoiceNest {
 
   val runner = Runner(testDir, "choiceNests.tdml")
 
-  @AfterClass def shutDown: Unit = {
+  @AfterClass def shutDown(): Unit = {
     runner.reset
   }
 

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section15/choice_groups/TestHiddenChoices.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section15/choice_groups/TestHiddenChoices.scala
@@ -27,7 +27,7 @@ object TestHiddenChoices {
 
   val runner = Runner(testDir, "HiddenChoices.tdml", validateTDMLFile = true)
 
-  @AfterClass def shutDown: Unit = {
+  @AfterClass def shutDown(): Unit = {
     runner.reset
   }
 

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section16/array_optional_elem/TestArrayOptionalElem.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section16/array_optional_elem/TestArrayOptionalElem.scala
@@ -30,7 +30,7 @@ object TestArrayOptionalElem {
   val rBack = Runner(testDir, "backtracking.tdml")
   val runnerAC = Runner(testDir, "ArrayComb.tdml")
 
-  @AfterClass def shutDown: Unit = {
+  @AfterClass def shutDown(): Unit = {
     runner.reset
     runner01.reset
     rBack.reset

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section17/calc_value_properties/TestInputValueCalc.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section17/calc_value_properties/TestInputValueCalc.scala
@@ -29,7 +29,7 @@ object TestInputValueCalc {
   val runnerAQ = Runner(testDir, "AQ.tdml")
   val runnerAA = Runner(testDir, "AA.tdml")
 
-  @AfterClass def shutDown: Unit = {
+  @AfterClass def shutDown(): Unit = {
     runner.reset
     runnerAR.reset
     runnerAQ.reset

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section17/calc_value_properties/TestOutputValueCalc.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section17/calc_value_properties/TestOutputValueCalc.scala
@@ -28,7 +28,7 @@ object TestOutputValueCalc {
   val runner2 = Runner(testDir, "outputValueCalc2.tdml")
   val runner3 = Runner(testDir, "outputValueCalc3.tdml")
 
-  @AfterClass def shutdown: Unit = {
+  @AfterClass def shutdown(): Unit = {
     runner.reset
     runner2.reset
     runner3.reset

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section23/dfdl_expressions/TestDFDLExpressions.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section23/dfdl_expressions/TestDFDLExpressions.scala
@@ -64,21 +64,21 @@ object TestDFDLExpressions {
 class TestDFDLExpressions {
   import TestDFDLExpressions._
 
-  @Test def test_variableRefError: Unit = { runner4.runOneTest("variableRefError") }
+  @Test def test_variableRefError(): Unit = { runner4.runOneTest("variableRefError") }
 
-  @Test def test_byteOrderExpr1: Unit = { runner4.runOneTest("byteOrderExpr1") }
-  @Test def test_byteOrderExpr1b: Unit = { runner4.runOneTest("byteOrderExpr1b") }
-  @Test def test_byteOrderExpr2: Unit = { runner4.runOneTest("byteOrderExpr2") }
-  @Test def test_byteOrderExpr2b: Unit = { runner4.runOneTest("byteOrderExpr2b") }
-  @Test def test_byteOrderExpr3: Unit = { runner4.runOneTest("byteOrderExpr3") }
-  @Test def test_byteOrderExpr4: Unit = { runner4.runOneTest("byteOrderExpr4") }
-  @Test def test_byteOrderExpr5: Unit = { runner4.runOneTest("byteOrderExpr5") }
-  @Test def test_byteOrderExpr6: Unit = { runner4.runOneTest("byteOrderExpr6") }
-  @Test def test_byteOrderExpr7: Unit = { runner4.runOneTest("byteOrderExpr7") }
-  @Test def test_byteOrderExpr7b: Unit = { runner4.runOneTest("byteOrderExpr7b") }
-  @Test def test_byteOrderExpr7c: Unit = { runner4.runOneTest("byteOrderExpr7c") }
-  @Test def test_byteOrderExpr8: Unit = { runner4.runOneTest("byteOrderExpr8") }
-  @Test def test_byteOrderExpr9: Unit = { runner4.runOneTest("byteOrderExpr9") }
+  @Test def test_byteOrderExpr1(): Unit = { runner4.runOneTest("byteOrderExpr1") }
+  @Test def test_byteOrderExpr1b(): Unit = { runner4.runOneTest("byteOrderExpr1b") }
+  @Test def test_byteOrderExpr2(): Unit = { runner4.runOneTest("byteOrderExpr2") }
+  @Test def test_byteOrderExpr2b(): Unit = { runner4.runOneTest("byteOrderExpr2b") }
+  @Test def test_byteOrderExpr3(): Unit = { runner4.runOneTest("byteOrderExpr3") }
+  @Test def test_byteOrderExpr4(): Unit = { runner4.runOneTest("byteOrderExpr4") }
+  @Test def test_byteOrderExpr5(): Unit = { runner4.runOneTest("byteOrderExpr5") }
+  @Test def test_byteOrderExpr6(): Unit = { runner4.runOneTest("byteOrderExpr6") }
+  @Test def test_byteOrderExpr7(): Unit = { runner4.runOneTest("byteOrderExpr7") }
+  @Test def test_byteOrderExpr7b(): Unit = { runner4.runOneTest("byteOrderExpr7b") }
+  @Test def test_byteOrderExpr7c(): Unit = { runner4.runOneTest("byteOrderExpr7c") }
+  @Test def test_byteOrderExpr8(): Unit = { runner4.runOneTest("byteOrderExpr8") }
+  @Test def test_byteOrderExpr9(): Unit = { runner4.runOneTest("byteOrderExpr9") }
 
   //DFDL-1111
   //@Test def test_diagnostics_01() { runner.runOneTest("diagnostics_01") }
@@ -976,53 +976,53 @@ class TestDFDLExpressions {
   @Test def test_array_index_relative_path_subexpression_01(): Unit = { runner.runOneTest("array_index_relative_path_subexpression_01") }
 
   //DFDL-1702
-  @Test def test_mathPow01: Unit = { runner2.runOneTest("mathPow01") }
-  @Test def test_mathPow02: Unit = { runner2.runOneTest("mathPow02") }
-  @Test def test_mathPow03: Unit = { runner2.runOneTest("mathPow03") }
-  @Test def test_mathPow04: Unit = { runner2.runOneTest("mathPow04") }
-  @Test def test_mathPow05: Unit = { runner2.runOneTest("mathPow05") }
-  @Test def test_mathPow06: Unit = { runner2.runOneTest("mathPow06") }
-  @Test def test_mathPow07: Unit = { runner2.runOneTest("mathPow07") }
-  @Test def test_mathPow08: Unit = { runner2.runOneTest("mathPow08") }
-  @Test def test_mathPow09: Unit = { runner2.runOneTest("mathPow09") }
-  @Test def test_mathPow10: Unit = { runner2.runOneTest("mathPow10") }
-  @Test def test_mathPow11: Unit = { runner2.runOneTest("mathPow11") }
-  @Test def test_mathPow12: Unit = { runner2.runOneTest("mathPow12") }
-  @Test def test_mathPow13: Unit = { runner2.runOneTest("mathPow13") }
-  @Test def test_mathPow14: Unit = { runner2.runOneTest("mathPow14") }
-  @Test def test_mathPow15: Unit = { runner2.runOneTest("mathPow15") }
-  @Test def test_mathPow16: Unit = { runner2.runOneTest("mathPow16") }
-  @Test def test_mathPow17: Unit = { runner2.runOneTest("mathPow17") }
-  @Test def test_mathPow18: Unit = { runner2.runOneTest("mathPow18") }
-  @Test def test_mathPow19: Unit = { runner2.runOneTest("mathPow19") }
-  @Test def test_mathPow20: Unit = { runner2.runOneTest("mathPow20") }
-  @Test def test_mathPow21: Unit = { runner2.runOneTest("mathPow21") }
-  @Test def test_mathPow22: Unit = { runner2.runOneTest("mathPow22") }
-  @Test def test_mathPow23: Unit = { runner2.runOneTest("mathPow23") }
-  @Test def test_mathPow24: Unit = { runner2.runOneTest("mathPow24") }
-  @Test def test_mathPow25: Unit = { runner2.runOneTest("mathPow25") }
-  @Test def test_mathPow26: Unit = { runner2.runOneTest("mathPow26") }
-  @Test def test_mathPow27: Unit = { runner2.runOneTest("mathPow27") }
-  @Test def test_mathPow28: Unit = { runner2.runOneTest("mathPow28") }
-  @Test def test_mathPow29: Unit = { runner2.runOneTest("mathPow29") }
-  @Test def test_mathPow30: Unit = { runner2.runOneTest("mathPow30") }
-  @Test def test_mathPow31: Unit = { runner2.runOneTest("mathPow31") }
-  @Test def test_mathPow32: Unit = { runner2.runOneTest("mathPow32") }
-  @Test def test_mathPow33: Unit = { runner2.runOneTest("mathPow33") }
-  @Test def test_mathPow34: Unit = { runner2.runOneTest("mathPow34") }
+  @Test def test_mathPow01(): Unit = { runner2.runOneTest("mathPow01") }
+  @Test def test_mathPow02(): Unit = { runner2.runOneTest("mathPow02") }
+  @Test def test_mathPow03(): Unit = { runner2.runOneTest("mathPow03") }
+  @Test def test_mathPow04(): Unit = { runner2.runOneTest("mathPow04") }
+  @Test def test_mathPow05(): Unit = { runner2.runOneTest("mathPow05") }
+  @Test def test_mathPow06(): Unit = { runner2.runOneTest("mathPow06") }
+  @Test def test_mathPow07(): Unit = { runner2.runOneTest("mathPow07") }
+  @Test def test_mathPow08(): Unit = { runner2.runOneTest("mathPow08") }
+  @Test def test_mathPow09(): Unit = { runner2.runOneTest("mathPow09") }
+  @Test def test_mathPow10(): Unit = { runner2.runOneTest("mathPow10") }
+  @Test def test_mathPow11(): Unit = { runner2.runOneTest("mathPow11") }
+  @Test def test_mathPow12(): Unit = { runner2.runOneTest("mathPow12") }
+  @Test def test_mathPow13(): Unit = { runner2.runOneTest("mathPow13") }
+  @Test def test_mathPow14(): Unit = { runner2.runOneTest("mathPow14") }
+  @Test def test_mathPow15(): Unit = { runner2.runOneTest("mathPow15") }
+  @Test def test_mathPow16(): Unit = { runner2.runOneTest("mathPow16") }
+  @Test def test_mathPow17(): Unit = { runner2.runOneTest("mathPow17") }
+  @Test def test_mathPow18(): Unit = { runner2.runOneTest("mathPow18") }
+  @Test def test_mathPow19(): Unit = { runner2.runOneTest("mathPow19") }
+  @Test def test_mathPow20(): Unit = { runner2.runOneTest("mathPow20") }
+  @Test def test_mathPow21(): Unit = { runner2.runOneTest("mathPow21") }
+  @Test def test_mathPow22(): Unit = { runner2.runOneTest("mathPow22") }
+  @Test def test_mathPow23(): Unit = { runner2.runOneTest("mathPow23") }
+  @Test def test_mathPow24(): Unit = { runner2.runOneTest("mathPow24") }
+  @Test def test_mathPow25(): Unit = { runner2.runOneTest("mathPow25") }
+  @Test def test_mathPow26(): Unit = { runner2.runOneTest("mathPow26") }
+  @Test def test_mathPow27(): Unit = { runner2.runOneTest("mathPow27") }
+  @Test def test_mathPow28(): Unit = { runner2.runOneTest("mathPow28") }
+  @Test def test_mathPow29(): Unit = { runner2.runOneTest("mathPow29") }
+  @Test def test_mathPow30(): Unit = { runner2.runOneTest("mathPow30") }
+  @Test def test_mathPow31(): Unit = { runner2.runOneTest("mathPow31") }
+  @Test def test_mathPow32(): Unit = { runner2.runOneTest("mathPow32") }
+  @Test def test_mathPow33(): Unit = { runner2.runOneTest("mathPow33") }
+  @Test def test_mathPow34(): Unit = { runner2.runOneTest("mathPow34") }
 
   // DFDL-1771
-  @Test def test_expr_path_past_root1: Unit = { runner7.runOneTest("test_expr_path_past_root1") }
+  @Test def test_expr_path_past_root1(): Unit = { runner7.runOneTest("test_expr_path_past_root1") }
 
   // DFDL-1804
-  @Test def test_traceComplex: Unit = { runner7.runOneTest("traceComplex") }
+  @Test def test_traceComplex(): Unit = { runner7.runOneTest("traceComplex") }
 
   //DFDL-1076
   @Test def test_nilled_01(): Unit = { runner2.runOneTest("nilled_01") }
 
   // DFDL-1617 - should detect errors due to query-style expressions
-  @Test def test_query_style_01: Unit = { runner6.runOneTest("query_style_01") }
-  @Test def test_query_style_02: Unit = { runner6.runOneTest("query_style_02") }
+  @Test def test_query_style_01(): Unit = { runner6.runOneTest("query_style_01") }
+  @Test def test_query_style_02(): Unit = { runner6.runOneTest("query_style_02") }
 
   //DFDL-1221
   @Test def test_beyondRoot_01(): Unit = { runner.runOneTest("beyondRoot_01") }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section23/dfdl_expressions/TestDFDLExpressions2.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section23/dfdl_expressions/TestDFDLExpressions2.scala
@@ -42,7 +42,7 @@ object TestDFDLExpressions2 {
 
   val runner7 = Runner(testDir4, "expressions2.tdml", compileAllTopLevel = true)
 
-  @AfterClass def shutdown = {
+  @AfterClass def shutDown() = {
     runner.reset
     runner_fun.reset
     runner2.reset
@@ -61,67 +61,67 @@ class TestDFDLExpressions2 {
   @Test def test_dfdl_1669_unsignedLong_conversion(): Unit = { runner5.runOneTest("test_dfdl_1669_unsignedLong_conversion") }
 
   //DFDL-1657
-  @Test def test_valueLengthRef1: Unit = { runner6.runOneTest("valueLengthRef1") }
+  @Test def test_valueLengthRef1(): Unit = { runner6.runOneTest("valueLengthRef1") }
 
   //DFDL-1706
-  @Test def test_valueLengthDfdlLength: Unit = { runner6.runOneTest("valueLengthDfdlLength") }
-  @Test def test_valueLengthDfdlOccursCount: Unit = { runner6.runOneTest("valueLengthDfdlOccursCount") }
-  @Test def test_valueLengthDfdlEncoding: Unit = { runner6.runOneTest("valueLengthDfdlEncoding") }
+  @Test def test_valueLengthDfdlLength(): Unit = { runner6.runOneTest("valueLengthDfdlLength") }
+  @Test def test_valueLengthDfdlOccursCount(): Unit = { runner6.runOneTest("valueLengthDfdlOccursCount") }
+  @Test def test_valueLengthDfdlEncoding(): Unit = { runner6.runOneTest("valueLengthDfdlEncoding") }
 
   //DFDL-1691
-  @Test def test_div01: Unit = { runner.runOneTest("div01") }
-  @Test def test_div02: Unit = { runner.runOneTest("div02") }
-  @Test def test_div03: Unit = { runner.runOneTest("div03") }
-  @Test def test_div04: Unit = { runner.runOneTest("div04") }
-  @Test def test_div05: Unit = { runner.runOneTest("div05") }
-  @Test def test_div06: Unit = { runner.runOneTest("div06") }
-  @Test def test_div07: Unit = { runner.runOneTest("div07") }
-  @Test def test_div08: Unit = { runner.runOneTest("div08") }
-  @Test def test_div09: Unit = { runner.runOneTest("div09") }
-  @Test def test_div10: Unit = { runner.runOneTest("div10") }
-  @Test def test_div11: Unit = { runner.runOneTest("div11") }
-  @Test def test_div12: Unit = { runner.runOneTest("div12") }
-  @Test def test_div13: Unit = { runner.runOneTest("div13") }
-  @Test def test_div14: Unit = { runner.runOneTest("div14") }
-  @Test def test_div15: Unit = { runner.runOneTest("div15") }
-  @Test def test_div16: Unit = { runner.runOneTest("div16") }
-  @Test def test_div17: Unit = { runner.runOneTest("div17") }
-  @Test def test_div18: Unit = { runner.runOneTest("div18") }
-  @Test def test_div19: Unit = { runner.runOneTest("div19") }
-  @Test def test_div20: Unit = { runner.runOneTest("div20") }
-  @Test def test_div21: Unit = { runner.runOneTest("div21") }
-  @Test def test_div22: Unit = { runner.runOneTest("div22") }
-  @Test def test_div23: Unit = { runner.runOneTest("div23") }
-  @Test def test_div24: Unit = { runner.runOneTest("div24") }
+  @Test def test_div01(): Unit = { runner.runOneTest("div01") }
+  @Test def test_div02(): Unit = { runner.runOneTest("div02") }
+  @Test def test_div03(): Unit = { runner.runOneTest("div03") }
+  @Test def test_div04(): Unit = { runner.runOneTest("div04") }
+  @Test def test_div05(): Unit = { runner.runOneTest("div05") }
+  @Test def test_div06(): Unit = { runner.runOneTest("div06") }
+  @Test def test_div07(): Unit = { runner.runOneTest("div07") }
+  @Test def test_div08(): Unit = { runner.runOneTest("div08") }
+  @Test def test_div09(): Unit = { runner.runOneTest("div09") }
+  @Test def test_div10(): Unit = { runner.runOneTest("div10") }
+  @Test def test_div11(): Unit = { runner.runOneTest("div11") }
+  @Test def test_div12(): Unit = { runner.runOneTest("div12") }
+  @Test def test_div13(): Unit = { runner.runOneTest("div13") }
+  @Test def test_div14(): Unit = { runner.runOneTest("div14") }
+  @Test def test_div15(): Unit = { runner.runOneTest("div15") }
+  @Test def test_div16(): Unit = { runner.runOneTest("div16") }
+  @Test def test_div17(): Unit = { runner.runOneTest("div17") }
+  @Test def test_div18(): Unit = { runner.runOneTest("div18") }
+  @Test def test_div19(): Unit = { runner.runOneTest("div19") }
+  @Test def test_div20(): Unit = { runner.runOneTest("div20") }
+  @Test def test_div21(): Unit = { runner.runOneTest("div21") }
+  @Test def test_div22(): Unit = { runner.runOneTest("div22") }
+  @Test def test_div23(): Unit = { runner.runOneTest("div23") }
+  @Test def test_div24(): Unit = { runner.runOneTest("div24") }
 
-  @Test def test_idiv01: Unit = { runner.runOneTest("idiv01") }
-  @Test def test_idiv02: Unit = { runner.runOneTest("idiv02") }
-  @Test def test_idiv03: Unit = { runner.runOneTest("idiv03") }
-  @Test def test_idiv04: Unit = { runner.runOneTest("idiv04") }
-  @Test def test_idiv05: Unit = { runner.runOneTest("idiv05") }
-  @Test def test_idiv06: Unit = { runner.runOneTest("idiv06") }
-  @Test def test_idiv07: Unit = { runner.runOneTest("idiv07") }
-  @Test def test_idiv08: Unit = { runner.runOneTest("idiv08") }
-  @Test def test_idiv09: Unit = { runner.runOneTest("idiv09") }
-  @Test def test_idiv10: Unit = { runner.runOneTest("idiv10") }
-  @Test def test_idiv11: Unit = { runner.runOneTest("idiv11") }
-  @Test def test_idiv12: Unit = { runner.runOneTest("idiv12") }
-  @Test def test_idiv13: Unit = { runner.runOneTest("idiv13") }
-  @Test def test_idiv14: Unit = { runner.runOneTest("idiv14") }
-  @Test def test_idiv15: Unit = { runner.runOneTest("idiv15") }
-  @Test def test_idiv16: Unit = { runner.runOneTest("idiv16") }
-  @Test def test_idiv17: Unit = { runner.runOneTest("idiv17") }
-  @Test def test_idiv18: Unit = { runner.runOneTest("idiv18") }
-  @Test def test_idiv19: Unit = { runner.runOneTest("idiv19") }
-  @Test def test_idiv20: Unit = { runner.runOneTest("idiv20") }
+  @Test def test_idiv01(): Unit = { runner.runOneTest("idiv01") }
+  @Test def test_idiv02(): Unit = { runner.runOneTest("idiv02") }
+  @Test def test_idiv03(): Unit = { runner.runOneTest("idiv03") }
+  @Test def test_idiv04(): Unit = { runner.runOneTest("idiv04") }
+  @Test def test_idiv05(): Unit = { runner.runOneTest("idiv05") }
+  @Test def test_idiv06(): Unit = { runner.runOneTest("idiv06") }
+  @Test def test_idiv07(): Unit = { runner.runOneTest("idiv07") }
+  @Test def test_idiv08(): Unit = { runner.runOneTest("idiv08") }
+  @Test def test_idiv09(): Unit = { runner.runOneTest("idiv09") }
+  @Test def test_idiv10(): Unit = { runner.runOneTest("idiv10") }
+  @Test def test_idiv11(): Unit = { runner.runOneTest("idiv11") }
+  @Test def test_idiv12(): Unit = { runner.runOneTest("idiv12") }
+  @Test def test_idiv13(): Unit = { runner.runOneTest("idiv13") }
+  @Test def test_idiv14(): Unit = { runner.runOneTest("idiv14") }
+  @Test def test_idiv15(): Unit = { runner.runOneTest("idiv15") }
+  @Test def test_idiv16(): Unit = { runner.runOneTest("idiv16") }
+  @Test def test_idiv17(): Unit = { runner.runOneTest("idiv17") }
+  @Test def test_idiv18(): Unit = { runner.runOneTest("idiv18") }
+  @Test def test_idiv19(): Unit = { runner.runOneTest("idiv19") }
+  @Test def test_idiv20(): Unit = { runner.runOneTest("idiv20") }
 
-  @Test def test_add01: Unit = { runner.runOneTest("add01") }
+  @Test def test_add01(): Unit = { runner.runOneTest("add01") }
 
   // DFDL-1719
-  @Test def test_if_expression_type_01: Unit = { runner5.runOneTest("if_expression_type_01") }
-  @Test def test_if_expression_type_02: Unit = { runner5.runOneTest("if_expression_type_02") }
-  @Test def test_if_expression_type_03: Unit = { runner5.runOneTest("if_expression_type_03") }
-  @Test def test_if_expression_type_04: Unit = { runner5.runOneTest("if_expression_type_04") }
-  @Test def test_if_expression_type_05: Unit = { runner5.runOneTest("if_expression_type_05") }
-  @Test def test_if_expression_type_06: Unit = { runner5.runOneTest("if_expression_type_06") }
+  @Test def test_if_expression_type_01(): Unit = { runner5.runOneTest("if_expression_type_01") }
+  @Test def test_if_expression_type_02(): Unit = { runner5.runOneTest("if_expression_type_02") }
+  @Test def test_if_expression_type_03(): Unit = { runner5.runOneTest("if_expression_type_03") }
+  @Test def test_if_expression_type_04(): Unit = { runner5.runOneTest("if_expression_type_04") }
+  @Test def test_if_expression_type_05(): Unit = { runner5.runOneTest("if_expression_type_05") }
+  @Test def test_if_expression_type_06(): Unit = { runner5.runOneTest("if_expression_type_06") }
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section23/dfdl_expressions/TestDFDLExpressions3.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section23/dfdl_expressions/TestDFDLExpressions3.scala
@@ -26,7 +26,7 @@ object TestDFDLExpressions3 {
   val testDir = "org/apache/daffodil/section23/dfdl_expressions/"
   val runner = Runner(testDir, "expressions3.tdml")
 
-  @AfterClass def shutdown = {
+  @AfterClass def shutDown() = {
     runner.reset
   }
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section23/runtime_properties/TestDynamicSeparator.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section23/runtime_properties/TestDynamicSeparator.scala
@@ -26,7 +26,7 @@ object TestDynamicSeparator {
   val testDir = "org/apache/daffodil/section23/runtime_properties/"
   val runner = Runner(testDir, "dynamicSeparator.tdml")
 
-  @AfterClass def shutdown = {
+  @AfterClass def shutDown() = {
     runner.reset
   }
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section24/regular_expressions/TestRegularExpressions.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section24/regular_expressions/TestRegularExpressions.scala
@@ -25,7 +25,7 @@ object TestRegularExpressions {
   val testDir = "/org/apache/daffodil/section24/regular_expressions/"
   val runner = Runner(testDir, "RegularExpressions.tdml")
 
-  @AfterClass def shutDown: Unit = {
+  @AfterClass def shutDown(): Unit = {
     runner.reset
   }
 

--- a/daffodil-test/src/test/scala/org/apache/daffodil/udf/TestUdfsInSchemas.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/udf/TestUdfsInSchemas.scala
@@ -25,7 +25,7 @@ object TestUdfsInSchemas {
 
   val runner = Runner(testDir, "udfs.tdml", validateTDMLFile = true)
 
-  @AfterClass def shutDown: Unit = {
+  @AfterClass def shutDown(): Unit = {
     runner.reset
   }
 

--- a/daffodil-test/src/test/scala/org/apache/daffodil/unparser/TestParseUnparseMode.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/unparser/TestParseUnparseMode.scala
@@ -26,7 +26,7 @@ object TestParseUnparseMode {
   val runner = Runner(testDir, "parseUnparseModeTest.tdml",
     validateDFDLSchemas = false) // there are UPA errors in some test schemas
 
-  @AfterClass def shutDown: Unit = {
+  @AfterClass def shutDown(): Unit = {
     runner.reset
   }
 

--- a/daffodil-test/src/test/scala/org/apache/daffodil/usertests/RC-Test5.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/usertests/RC-Test5.scala
@@ -26,7 +26,7 @@ object RCTest5 {
   val runner = Runner(testDir, "test-5.tdml.xml")
   val runner6 = Runner(testDir, "test-6.tdml.xml")
 
-  @AfterClass def shutDown: Unit = {
+  @AfterClass def shutDown(): Unit = {
     runner.reset
     runner6.reset
   }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/usertests/TestCSV.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/usertests/TestCSV.scala
@@ -25,7 +25,7 @@ object TestCSV {
   val testDir = "/org/apache/daffodil/usertests/"
   val runner = Runner(testDir, "test-csv.tdml")
 
-  @AfterClass def shutDown: Unit = {
+  @AfterClass def shutDown(): Unit = {
     runner.reset
   }
 

--- a/daffodil-test/src/test/scala/org/apache/daffodil/usertests/TestSSPNeverDiagnostic.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/usertests/TestSSPNeverDiagnostic.scala
@@ -24,7 +24,7 @@ object TestSSPNeverDiagnostic {
   val testDir = "/org/apache/daffodil/usertests/"
   val runner = Runner(testDir, "testSSPNeverDiagnostic.tdml.xml")
 
-  @AfterClass def shutDown: Unit = {
+  @AfterClass def shutDown(): Unit = {
     runner.reset
   }
 

--- a/daffodil-test/src/test/scala/org/apache/daffodil/usertests/TestSepTests.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/usertests/TestSepTests.scala
@@ -25,7 +25,7 @@ object TestSepTests {
   val testDir = "/org/apache/daffodil/usertests/"
   val runner = Runner(testDir, "SepTests.tdml")
 
-  @AfterClass def shutDown: Unit = {
+  @AfterClass def shutDown(): Unit = {
     runner.reset
   }
 

--- a/daffodil-test/src/test/scala/org/apache/daffodil/usertests/TestUserSubmittedTests.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/usertests/TestUserSubmittedTests.scala
@@ -26,7 +26,7 @@ object TestUserSubmittedTests {
   val runner = Runner(testDir, "UserSubmittedTests.tdml")
   val runner2 = Runner(testDir, "nameDOB_test.tdml")
 
-  @AfterClass def shutDown: Unit = {
+  @AfterClass def shutDown(): Unit = {
     runner.reset
     runner2.reset
   }
@@ -93,7 +93,7 @@ class CustomTraceRunner extends TraceRunner {
     allTheLines
   }
 
-  override def init: Unit = { _lines = List.empty[String] }
+  override def init(): Unit = { _lines = List.empty[String] }
   override def lineOutput(line: String) = _lines ++ (line + "\n")
 
 }

--- a/test-stdLayout/src/test/scala/org1/TestOrg1.scala
+++ b/test-stdLayout/src/test/scala/org1/TestOrg1.scala
@@ -25,7 +25,7 @@ object TestOrg1 {
   val runner = Runner("org1", "testStdLayout.tdml")
   val runner2 = Runner("org1", "testSchemaFilesUnderSrcTest.tdml")
 
-  @AfterClass def shutDown: Unit = {
+  @AfterClass def shutDown(): Unit = {
     runner.reset
     runner2.reset
   }

--- a/test-stdLayout/src/test/scala/org2/TestOrg2.scala
+++ b/test-stdLayout/src/test/scala/org2/TestOrg2.scala
@@ -25,7 +25,7 @@ object TestOrg2 {
   val runner = Runner("org2", "testSchemaFilesUnderSrcTest2.tdml")
   val runner2 = Runner("org2", "testEmbeddedSchema.tdml")
 
-  @AfterClass def shutDown: Unit = {
+  @AfterClass def shutDown(): Unit = {
     runner.reset
     runner2.reset
   }

--- a/test-stdLayout/src/test/scala/org2/TestPayloadAndTypes.scala
+++ b/test-stdLayout/src/test/scala/org2/TestPayloadAndTypes.scala
@@ -24,7 +24,7 @@ import org.junit.AfterClass
 object TestPayloadAndTypes {
   val runner = Runner("org2", "testPayloadAndTypes.tdml")
 
-  @AfterClass def shutDown: Unit = {
+  @AfterClass def shutDown(): Unit = {
     runner.reset
   }
 }

--- a/tutorials/src/test/scala/org/apache/daffodil/tutorials/TestTutorials.scala
+++ b/tutorials/src/test/scala/org/apache/daffodil/tutorials/TestTutorials.scala
@@ -26,7 +26,7 @@ object TestTutorials {
   val runner4 = Runner("/", "tdmlTutorial.tdml.xml")
   val runner5 = Runner("/", "bugReportTemplate.tdml.xml")
 
-  @AfterClass def shutDown: Unit = {
+  @AfterClass def shutDown(): Unit = {
     runner1.reset
     runner4.reset
     runner5.reset


### PR DESCRIPTION
These 4 were added.
    "-Ywarn-infer-any",
    "-Ywarn-inaccessible",
    "-Ywarn-nullary-unit",
    "-Ywarn-unused-import"

Unwise to merge this until we're at a stable point. 

Honestly the warn-nullary-unit change was a bunch of lines of code changed for basically no value. 
It doesn't require that the calls to the functions be changed to also have the parentheses.

I.e., it wants

`def init(): Unit = { ... }`

but you can still, without warning call this by just saying `init`. No parentheses. 

DAFFODIL-2145