### PR TITLE
Fix TCP/network input stream hangs on isAtEnd

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -15,8 +15,8 @@
  * limitations under the License.
  */
 
-import sbt.io.Path.flatRebase
 import sbtcc._
+
 import scala.collection.immutable.ListSet
 
 // Silence an errant sbt linter warning about unused sbt settings. For some
@@ -86,7 +86,7 @@ lazy val runtime2         = Project("daffodil-runtime2", file("daffodil-runtime2
                               )
 
 lazy val core             = Project("daffodil-core", file("daffodil-core")).configs(IntegrationTest)
-                              .dependsOn(runtime1Unparser, udf, lib % "test->test", runtime1 % "test->test")
+                              .dependsOn(runtime1Unparser, udf, lib % "test->test", runtime1 % "test->test", io % "test->test")
                               .settings(commonSettings)
 
 lazy val japi             = Project("daffodil-japi", file("daffodil-japi")).configs(IntegrationTest)

--- a/daffodil-cli/src/main/scala/org/apache/daffodil/Main.scala
+++ b/daffodil-cli/src/main/scala/org/apache/daffodil/Main.scala
@@ -976,14 +976,15 @@ object Main extends Logging {
                 }
                 output.flush()
 
-                if (loc.isAtEnd) {
+                if (!inStream.hasData()) {
+                  // not even 1 more bit is available.
                   // do not try to keep parsing, nothing left to parse
                   keepParsing = false
                   error = false
                 } else {
-                  // remaining data exists
-
+                  // There is more data available.
                   if (parseOpts.stream.toOption.get) {
+                    // Streaming mode
                     if (lastParseBitPosition == loc.bitPos0b) {
                       // this parse consumed no data, that means this would get
                       // stuck in an infinite loop if we kept trying to stream,
@@ -998,13 +999,16 @@ object Main extends Logging {
                       keepParsing = false
                       error = true
                     } else {
+                      // last parse did consume data, and we know there is more
+                      // data to come, so try to parse again.
                       lastParseBitPosition = loc.bitPos0b
                       keepParsing = true
                       error = false
                       output.write(0) // NUL-byte separates streams
                     }
                   } else {
-                    // not streaming, show left over data warning
+                    // not streaming mode, and there is more data available,
+                    // so show left over data warning
                     val Dump = new DataDumper
                     val bitsAlreadyConsumed = loc.bitPos0b % 8
                     val firstByteString = if (bitsAlreadyConsumed != 0) {

--- a/daffodil-core/src/test/scala/org/apache/daffodil/api/TestParseIndividualMessages.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/api/TestParseIndividualMessages.scala
@@ -1,0 +1,213 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.daffodil.api
+
+import org.apache.daffodil.Implicits.intercept
+import org.apache.daffodil.io.SocketPairTestRig
+import org.apache.daffodil.util.SchemaUtils
+import org.apache.daffodil.util.TestUtils
+import org.junit.Assert._
+import org.junit.Test
+
+import java.io.InputStream
+import java.io.OutputStream
+import scala.concurrent.Await
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+import scala.concurrent.TimeoutException
+import scala.concurrent.duration.DurationInt
+import scala.xml.Node
+
+
+/**
+ * Shows that we can parse exactly 1 message from a TCP network socket
+ * without blocking for bytes past the end of the messsage.
+ *
+ * This only works for DFDL schemas of formats that are specified length.
+ */
+class TestParseIndividualMessages {
+
+  //
+  // DFDL schema for element e1 which occupies exactly 4 bytes.
+  //
+  val exactly4ByteSch = SchemaUtils.dfdlTestSchema(
+      <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
+      <dfdl:format representation="binary" byteOrder="bigEndian" binaryNumberRep="binary" ref="tns:GeneralFormat"/>,
+      <xs:element name="e1" type="xs:string" dfdl:lengthKind="explicit" dfdl:length="4"/>)
+
+  /**
+   * Test shows that at least for simple fixed-length data, Daffodil parse returns
+   * without requiring more bytes to be read than the exact length required.
+   */
+  @Test def testDaffodilParseFromNetwork1(): Unit = {
+    val sptr = new SocketPairTestRig {
+      override def test(pos: OutputStream, cis: InputStream): Unit = {
+
+        val dp = TestUtils.compileSchema(exactly4ByteSch)
+
+        //
+        // Write exactly 4 bytes to producer network stream
+        //
+        pos.write("1234".getBytes)
+        pos.flush()
+
+        //
+        // Daffodil parse element e1 from consumer input stream
+        //
+        // If we need more than 4 bytes to successfully parse (we shouldn't for this schema)
+        // then this will hang, because only 4 bytes are in fact available.
+        //
+        // Caution: if debugging, this will timeout if you stop inside here!
+        //
+        val (pr: DFDL.ParseResult, xml: Node) =
+        SocketPairTestRig.withTimeout("Daffodil parse") {
+          TestUtils.runDataProcessorOnInputStream(dp, cis, areTracing = false)
+        }
+
+        assertFalse(pr.isError)
+        assertEquals("1234", xml.text)
+        assertEquals(33, pr.resultState.currentLocation.bitPos1b)
+      }
+    }
+    sptr.run()
+  }
+
+  //
+  // DFDL schema for delimited element.
+  //
+  private def delimitedSchema(term: String) = SchemaUtils.dfdlTestSchema(
+      <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
+      <dfdl:format representation="text" ref="tns:GeneralFormat"/>,
+      <xs:element name="e1" type="xs:string" dfdl:lengthKind="delimited"
+                  dfdl:terminator={ term } />)
+
+  /**
+   * Helper so we can test various delimiter-oriented scenarios.
+   *
+   * @param stringData          Data to write. Should be small enough that the parse will block.
+   * @param terminator          String to use as terminating delimiter of element. Can be more than one delimiter.
+   * @param followingDataString Data to write which should unblock the parse.
+   */
+  private def testHelperDaffodilParseDelimitedFromNetwork(
+    data: String,
+    terminator: String,
+    followingDataString: String) = {
+    val sptr = new SocketPairTestRig {
+      override def test(pos: OutputStream, cis: InputStream): Unit = {
+
+        val dp = TestUtils.compileSchema(delimitedSchema(terminator))
+
+        // Write the data. Should be too short to satisfy the parse.
+        //
+        pos.write(data.getBytes)
+        pos.flush()
+
+        val fut = Future {
+          TestUtils.runDataProcessorOnInputStream(dp, cis, areTracing = false)
+        }
+
+        Thread.sleep(100)
+        assertFalse(fut.isCompleted)
+        //
+        // Writing additional character(s) should unblock the parse.
+        //
+        pos.write(followingDataString.getBytes)
+        pos.flush()
+        val (pr, xml) = Await.result(fut, 100.milliseconds)
+        if (!pr.isError) {
+          assertEquals("1234", xml.text)
+        } else {
+          //parse failed.
+          val diagString = pr.getDiagnostics.map {
+            _.getMessage()
+          }.mkString("\n")
+          fail("Parse failed, but did not time-out.\n" + diagString)
+        }
+      }
+    }
+    sptr.run()
+  }
+
+  /**
+   * This test fails (and so is commented out) but *should* pass.
+   *
+   * Test (when it works) shows that for delimited data, we block seeking more data,
+   * but once the need for a terminator with longest match is satisfied
+   * the parse is unblocked.
+   */
+  // @Test // DAFFODIL-2504 - this fails looking for more data than is needed for terminator.
+  def testDaffodilParseFromNetworkDelimited1(): Unit = {
+    intercept[TimeoutException] {
+      testHelperDaffodilParseDelimitedFromNetwork("1234", "$", "$")
+    }
+    fail("if we get here, then we intercepted a TimeoutException, which means Daffodil was hung.")
+  }
+
+  /**
+   * This test works, and it should work.
+   *
+   * It characterizes that currently we need to be able to read
+   * not only the terminator, but 7 more characters, in order for the reads associated with the delimiter
+   * scanning to be satisfied.
+   *
+   * We're not supposed to need 7 characters though. Only 1 character should do it.
+   */
+  @Test // DAFFODIL-2504
+  def testDaffodilParseFromNetworkDelimited1b(): Unit = {
+    testHelperDaffodilParseDelimitedFromNetwork("1234", "$",
+      "$1234567")
+  }
+
+  /**
+   * This test fails (and so is commented out) but *should* pass.
+   *
+   * Test (when it works) shows that for delimited data, we block seeking more data,
+   * but once the need for a terminator with longest match is satisfied
+   * the parse is unblocked.
+   *
+   * This variant has 2 options for terminator, $ or $$, and one is a prefix of the other
+   * So this test insures that getting a shorter delimiter match doesn't unblock
+   * when getting more data might match a longer delimiter.
+   *
+   * The test then subsequently provides the character for that longer delimiter
+   * which should unblock daffodil.
+   */
+  // @Test // DAFFODIL-2504 - this fails looking for more data than is needed for terminator.
+  def testDaffodilParseFromNetworkDelimited2(): Unit = {
+    intercept[TimeoutException] {
+      testHelperDaffodilParseDelimitedFromNetwork("1234$", "$ $$", "$")
+    }
+    fail("If we get here, we intercepted a TimeoutException, which means Daffodil is hung.")
+  }
+
+  /**
+   * This test works, and it should work.
+   *
+   * It characterizes that currently we need to be able to read
+   * not only the longest possible terminator, but 7 more characters,
+   * in order for the reads associated with the delimiter
+   * scanning to be satisfied.
+   *
+   * We're not supposed to need 7 characters though. Only 1 character should do it.
+   */
+  @Test // DAFFODIL-2504 - this shouldn't require 7 more characters.
+  def testDaffodilParseFromNetworkDelimited2b(): Unit = {
+    testHelperDaffodilParseDelimitedFromNetwork("1234$", "$ $$", "$1234567")
+  }
+
+}

--- a/daffodil-core/src/test/scala/org/apache/daffodil/dsom/TestBinaryInput_01.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/dsom/TestBinaryInput_01.scala
@@ -17,50 +17,22 @@
 
 package org.apache.daffodil.dsom
 
-import java.math.{ BigInteger => JBigInt }
+import java.math.{BigInteger => JBigInt}
 import java.nio.ByteBuffer
-import java.nio.CharBuffer
-import java.nio.LongBuffer
-
-import org.apache.daffodil.api.DaffodilTunables
 import org.apache.daffodil.io.DataInputStream
+import org.apache.daffodil.io.FakeFormatInfo
 import org.apache.daffodil.io.FormatInfo
 import org.apache.daffodil.io.InputSourceDataInputStream
-import org.apache.daffodil.processors.charset.BitsCharsetDecoder
-import org.apache.daffodil.processors.charset.BitsCharsetEncoder
-import org.apache.daffodil.schema.annotation.props.gen.BinaryFloatRep
 import org.apache.daffodil.schema.annotation.props.gen.BitOrder
 import org.apache.daffodil.schema.annotation.props.gen.ByteOrder
-import org.apache.daffodil.schema.annotation.props.gen.EncodingErrorPolicy
-import org.apache.daffodil.schema.annotation.props.gen.UTF16Width
-import org.apache.daffodil.util.Maybe
-import org.apache.daffodil.util.MaybeInt
 import org.apache.daffodil.util.Misc
 import org.junit.After
 import org.junit.Test
-
 import org.junit.Assert.assertEquals
 
 // Do no harm number 16 of 626 fail in regression, 154 in total of 797
 
 class TestBinaryInput_01 {
-
-  class FakeFormatInfo(val bitOrder: BitOrder, val byteOrder: ByteOrder) extends FormatInfo {
-    def encoder: BitsCharsetEncoder = ???
-    def decoder: BitsCharsetDecoder = ???
-    def reportingDecoder: BitsCharsetDecoder = ???
-    def replacingDecoder: BitsCharsetDecoder = ???
-    def fillByte: Byte = ???
-
-    def binaryFloatRep: BinaryFloatRep = ???
-    def maybeCharWidthInBits: MaybeInt = ???
-    def maybeUTF16Width: Maybe[UTF16Width] = ???
-    def encodingMandatoryAlignmentInBits: Int = ???
-    def encodingErrorPolicy: EncodingErrorPolicy = ???
-    def tunable: DaffodilTunables = ???
-    def regexMatchBuffer: CharBuffer = ???
-    def regexMatchBitPositionBuffer: LongBuffer = ???
-  }
 
   var startOver: DataInputStream.Mark = null
   var dis: DataInputStream = null

--- a/daffodil-io/src/main/scala/org/apache/daffodil/io/DataInputStream.scala
+++ b/daffodil-io/src/main/scala/org/apache/daffodil/io/DataInputStream.scala
@@ -263,9 +263,34 @@ trait DataInputStream
   /**
    * Determines whether the input stream has this much more data.
    *
-   * Does not advance the position
+   * Does not advance the position.
+   *
+   * On a network input stream, this may block to determine if the stream
+   * contains enough data or is at end-of-data.
    */
   def isDefinedForLength(nBits: Long): Boolean
+
+  /**
+   * Returns true if the input stream has at least 1 bit of data.
+   *
+   * Does not advance the position.
+   *
+   * Returns true immediately if the input stream has available data that
+   * has not yet been consumed.
+   *
+   * On a network input stream, this may block to determine if the stream
+   * contains data or is at end-of-data.
+   *
+   * This is used when parsing multiple elements from a stream to see if there
+   * is data or not before calling parse().
+   *
+   * It may also be used after a parse() operation that is intended to consume
+   * the entire data stream (such as for a file) to determine if all data has
+   * been consumed or some data is left-over.
+   *
+   * This is equivalent to calling isDefinedForLength(1)
+   */
+  def hasData(): Boolean
 
   /**
    * Returns a byte array containing the bits between the current bit position

--- a/daffodil-io/src/main/scala/org/apache/daffodil/io/StringDataInputStreamForUnparse.scala
+++ b/daffodil-io/src/main/scala/org/apache/daffodil/io/StringDataInputStreamForUnparse.scala
@@ -47,8 +47,6 @@ final class StringDataInputStreamForUnparse
     dis = InputSourceDataInputStream(ba)
   }
 
-  private def doNotUse = Assert.usageError("Not to be called on " + Misc.getNameFromClass(this))
-
   override def asIteratorChar: DataInputStream.CharIterator = {
     Assert.usage(dis != null, "Must call reset(str) before any other method.")
     dis.asIteratorChar
@@ -66,6 +64,9 @@ final class StringDataInputStreamForUnparse
   override def getSomeString(nChars: Long,finfo: FormatInfo): Maybe[String] = dis.getSomeString(nChars, finfo)
   override def getString(nChars: Long,finfo: FormatInfo): Maybe[String] = dis.getString(nChars, finfo)
 
+  // $COVERAGE-OFF$ Nothing should be calling these.
+  private def doNotUse = Assert.usageError("Not to be called on " + Misc.getNameFromClass(this))
+
   override def futureData(nBytesRequested: Int): java.nio.ByteBuffer = doNotUse
   override def getBinaryDouble(finfo: FormatInfo): Double = doNotUse
   override def getBinaryFloat(finfo: FormatInfo): Float = doNotUse
@@ -79,7 +80,9 @@ final class StringDataInputStreamForUnparse
   override def setBitLimit0b(bitLimit0b: MaybeULong): Boolean = doNotUse
   override def setDebugging(setting: Boolean): Unit = doNotUse
   override def isDefinedForLength(length: Long): Boolean = doNotUse
+  override def hasData: Boolean = doNotUse
   override def skip(nBits: Long, finfo: FormatInfo): Boolean = doNotUse
   override def resetBitLimit0b(savedBitLimit0b: MaybeULong): Unit = doNotUse
+  // $COVERAGE-ON$
   override def validateFinalStreamState: Unit = {} // does nothing
 }

--- a/daffodil-io/src/test/scala/org/apache/daffodil/io/FormatInfoForUnitTest.scala
+++ b/daffodil-io/src/test/scala/org/apache/daffodil/io/FormatInfoForUnitTest.scala
@@ -89,3 +89,28 @@ class FormatInfoForUnitTest private ()
     }
   }
 }
+
+/**
+ * Supplies only bitOrder and byteOrder. Everything else unimplemented.
+ * @param bitOrder
+ * @param byteOrder
+ */
+class FakeFormatInfo(val bitOrder: BitOrder, val byteOrder: ByteOrder) extends FormatInfo {
+  def encoder: BitsCharsetEncoder = ???
+  def decoder: BitsCharsetDecoder = ???
+  def reportingDecoder: BitsCharsetDecoder = ???
+  def replacingDecoder: BitsCharsetDecoder = ???
+  def fillByte: Byte = ???
+
+  def binaryFloatRep: BinaryFloatRep = ???
+  def maybeCharWidthInBits: MaybeInt = ???
+  def maybeUTF16Width: Maybe[UTF16Width] = ???
+  def encodingMandatoryAlignmentInBits: Int = ???
+  def encodingErrorPolicy: EncodingErrorPolicy = ???
+  def tunable: DaffodilTunables = ???
+  def regexMatchBuffer: CharBuffer = ???
+  def regexMatchBitPositionBuffer: LongBuffer = ???
+}
+
+object FakeFormatInfo_MSBF_BE extends FakeFormatInfo(BitOrder.MostSignificantBitFirst, ByteOrder.BigEndian)
+object FakeFormatInfo_LSBF_LE extends FakeFormatInfo(BitOrder.LeastSignificantBitFirst, ByteOrder.LittleEndian)

--- a/daffodil-io/src/test/scala/org/apache/daffodil/io/SocketPairTestRig.scala
+++ b/daffodil-io/src/test/scala/org/apache/daffodil/io/SocketPairTestRig.scala
@@ -1,0 +1,246 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.daffodil.io
+
+import org.apache.daffodil.Implicits.intercept
+import org.apache.daffodil.io.SocketPairTestRig.timeLimit
+import org.apache.daffodil.io.SocketPairTestRig.withTimeout
+import org.junit.Assert.assertEquals
+import org.junit.Assert.fail
+import org.junit.Test
+
+import java.io.InputStream
+import java.io.OutputStream
+import java.net.ServerSocket
+import java.net.Socket
+import scala.concurrent.Await
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+import scala.concurrent.TimeoutException
+import scala.concurrent.duration.DurationInt
+import scala.concurrent.duration.FiniteDuration
+import scala.util.Try
+
+
+/**
+ * Test rig sets up TCP socket unidirectional between a producer
+ * output stream, and a consumer input stream.
+ */
+abstract class SocketPairTestRig {
+
+  /**
+   * Override with test logic method. This logic can read and write from the argument
+   * streams. The fact that these are socket connections means there is some buffering
+   * there. But you cannot write an infinite amount of data to producer without causing
+   * trouble with consuming all the operating system buffering, and once that happens
+   * the write will block.
+   *
+   * @param producerOutputStream
+   * @param consumerInputStream
+   */
+  protected def test(producerOutputStream: OutputStream, consumerInputStream: InputStream): Unit
+
+  def run(): Unit = {
+    val serverSocket = new ServerSocket(0) // 0 means to allocate an unused port
+    val port = serverSocket.getLocalPort()
+    val csf = Future {
+      serverSocket.accept() // start accepting connections for consumer
+    }
+    val psf = Future {
+      val useLoopBack: String = null
+      new Socket(useLoopBack, port) // connect producer
+    }
+    val (producerSocket, consumerSocket) = Await.result(psf zip csf, 1000.milliseconds)
+    assert(producerSocket.isConnected)
+    assert(consumerSocket.isConnected)
+    try {
+      val producerOutputStream = producerSocket.getOutputStream()
+      val consumerInputStream = consumerSocket.getInputStream()
+
+      // one way connection (no reverse flow control)
+      // NOTE: Can't do this. It seems to cause the other direction
+      // to also close.
+      // producerSocket.getInputStream().close()
+      // consumerSocket.getOutputStream().close()
+
+      test(producerOutputStream, consumerInputStream)
+    } catch {
+      case th: Throwable =>
+        throw th // good place for a breakpoint - but keep in mind tests use timeouts
+    } finally {
+      producerSocket.close()
+      consumerSocket.close()
+      serverSocket.close() // assumption is that this frees up the port
+    }
+  }
+}
+
+object SocketPairTestRig {
+
+  val timeLimit = 1000.milliseconds
+
+  /**
+   * Runs test code with a timeout. Intended for use with tests that
+   * could hang if there are bugs where Daffodil does a blocking read
+   * that it shouldn't.
+   *
+   * @param whatTimedOutDescription Description of what we're testing. Ex: "Daffodil parse"
+   * @param testThunk               The test code that could hang. Shouldn't, but could.
+   * @tparam T Return type of the testThunk
+   * @return the result of the testThunk
+   */
+  def withTimeout[T](
+    whatTimedOutDescription: String)(testThunk: => T): T = {
+    Try(withTimeout(testThunk)).recover {
+      case e: TimeoutException =>
+        fail(whatTimedOutDescription + " timed out.")
+        ??? // ??? because scala doesn't know fail never returns.
+    }.get
+  }
+
+  /**
+   * Doesn't have the fail(...) built in, so we can
+   * write tests that expect a timeout rather than fail on a timeout.
+   * @param testThunk
+   * @tparam T
+   * @return
+   */
+  def withTimeout[T](testThunk: => T): T =
+    withTimeout(timeLimit)(testThunk)
+
+  /**
+   * Gives control over the timeout limit
+   */
+  def withTimeout[T](limitMillis: FiniteDuration)(testThunk: => T): T =
+    Await.result(Future(testThunk), limitMillis)
+
+}
+
+
+/**
+ * Shows that we can read from a TCP network socket
+ * without blocking for bytes past the end of what we read.
+ */
+class TestSocketPairTestRig {
+
+  /**
+   * Test the test rig. Make sure we can send a byte, and receive that byte,
+   * and if we close the producer stream, we get EOD on the
+   * consumer.
+   */
+  @Test def testSocketPairTestRig1(): Unit = {
+    val sptr = new SocketPairTestRig {
+      override def test(pos: OutputStream, cis: InputStream): Unit = {
+        pos.write(0x31)
+        pos.close()
+        val i: Int = cis.read()
+        assertEquals(0x31, i)
+        val j = cis.read()
+        assertEquals(-1, j)
+      }
+    }
+    sptr.run()
+  }
+
+  /**
+   * Test showing that when a blocking read on the consumer input stream
+   * in fact blocks, that we can detect this via timeout.
+   */
+  @Test def testHangDetection1(): Unit = {
+    val sptr = new SocketPairTestRig {
+      override def test(pos: OutputStream, cis: InputStream): Unit = {
+
+        //
+        // Write exactly 4 bytes to producer network stream
+        //
+        pos.write("1234".getBytes)
+        pos.flush()
+
+        //
+        // read 4 bytes. Should not hang.
+        //
+        // Caution: if debugging, this will timeout if you stop inside here!
+        //
+        val nRead = withTimeout("Read 4 bytes") {
+          val buf = new Array[Byte](4)
+          cis.read(buf, 0, 4)
+          assertEquals("1234".getBytes.toSeq, buf.toSeq)
+        }
+        //
+        // read 1 more byte. This will hang, and timeout.
+        //
+        intercept[TimeoutException] {
+          withTimeout(100.milliseconds) {
+            val buf = new Array[Byte](1)
+            cis.read(buf, 0, 1)
+          }
+          fail("Failed to throw exception")
+        }
+      }
+    }
+    sptr.run()
+  }
+
+  /**
+   * Test showing that a blocking read that hangs on the consumer stream
+   * will eventually be satisfied by something else writing to the producer stream.
+   */
+  @Test def testHangDetection2(): Unit = {
+    val sptr = new SocketPairTestRig {
+      override def test(pos: OutputStream, cis: InputStream): Unit = {
+
+        //
+        // Write exactly 3 bytes to producer network stream
+        //
+        pos.write("123".getBytes)
+        pos.flush()
+
+        var buf = new Array[Byte](4)
+        var nRead = withTimeout("Read 4 bytes") {
+          //
+          // This won't hang
+          //
+          cis.read(buf, 0, 4)
+        }
+        assertEquals(3, nRead)
+        assertEquals("123".getBytes.toSeq, buf.toSeq.slice(0, 3))
+
+        //
+        // In parallel, wait a bit, then write another byte.
+        //
+        Future {
+          Thread.sleep(timeLimit.toMillis / 10) // wait 1/10 of the normal timeout
+          pos.write("4".getBytes)
+          pos.flush()
+        }
+        //
+        // This won't hang. We'll wait long enough that our
+        // blocking read will get satisfied when the write above
+        // finally happens.
+        //
+        buf = new Array[Byte](1)
+        nRead = withTimeout {
+          cis.read(buf, 0, 1)
+        }
+        assertEquals('4'.toByte, buf(0))
+        assertEquals(1, nRead)
+      }
+    }
+    sptr.run()
+  }
+}

--- a/daffodil-io/src/test/scala/org/apache/daffodil/io/TestInputSourceDataInputStream.scala
+++ b/daffodil-io/src/test/scala/org/apache/daffodil/io/TestInputSourceDataInputStream.scala
@@ -62,6 +62,12 @@ class TestInputSourceDataInputStream {
   def assertEqualsTyped(expected: Float, actual: Float, threshold: Float) = assertEquals(expected, actual, threshold)
   def assertEqualsTyped(expected: Double, actual: Double, threshold: Double) = assertEquals(expected, actual, threshold)
 
+  @Test def testByteBufferInputSource1(): Unit = {
+    val dis = InputSourceDataInputStream(ten)
+    // provides codecov for this method for ByteBufferInputSource
+    assertTrue(dis.hasReachedEndOfData)
+  }
+
   @Test def testBitAndBytePos0: Unit = {
     val dis = InputSourceDataInputStream(ten)
     0L assertEqualsTyped (dis.bitPos0b)

--- a/daffodil-io/src/test/scala/org/apache/daffodil/io/TestInputSourceDataInputStream2.scala
+++ b/daffodil-io/src/test/scala/org/apache/daffodil/io/TestInputSourceDataInputStream2.scala
@@ -74,7 +74,7 @@ class TestInputSourceDataInputStream2 {
     assertEquals(81, dis.bitLimit1b.get)
     assertEquals(10, dis.bytePos0b)
     dis.reset(m1)
-    assertFalse(dis.isDefinedForLength(1))
+    assertFalse(dis.hasData())
     dis.asInstanceOf[InputSourceDataInputStream].resetBitLimit0b(MaybeULong(10 * 8))
     arr = dis.getByteArray(5 * 8, finfo)
     assertEquals(5, arr.size)

--- a/daffodil-io/src/test/scala/org/apache/daffodil/io/TestInputSourceDataInputStream8.scala
+++ b/daffodil-io/src/test/scala/org/apache/daffodil/io/TestInputSourceDataInputStream8.scala
@@ -1,0 +1,170 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.daffodil.io
+
+
+import org.apache.daffodil.Implicits.intercept
+import org.apache.daffodil.util.MaybeULong
+import org.apache.daffodil.util.Misc
+import org.junit.Assert._
+import org.junit.Test
+
+import java.io.ByteArrayInputStream
+import java.io.InputStream
+import java.io.OutputStream
+
+/**
+ * Tests about detecting end-of-data, and
+ * insuring proper behavior for InputSourceDataInputStream
+ * with respect to reading unnecessary data.
+ *
+ * These cover the fix for DAFFODIL-2502, where users observed
+ * Daffodil would hang because of calls to isAtEnd.
+ */
+class TestInputSourceDataInputStream8 {
+
+  /**
+   * Test provides coverage of special detection in I/O layer
+   * of a incorrectly behaving InputStream.
+   */
+  @Test def testReadZeroBytesDetected(): Unit = {
+    //
+    // an InputStream where the read(buf, off, len) call returns 0
+    // meaning no data available temporarily.
+    // This is a badly behaving input stream. The API
+    // is supposed to be BLOCKING.
+    //
+    val badIS = new InputStream {
+      override def read() = ???
+      override def read(buf: Array[Byte], off: Int, len: Int): Int = {
+        assertTrue(len > 0)
+        0
+      }
+    }
+    val isdis = InputSourceDataInputStream(badIS)
+    val e = intercept[InputStreamReadZeroError] {
+      isdis.hasData()
+    }
+    assertTrue(e.getMessage().toLowerCase.contains("illegal"))
+  }
+
+  @deprecated("Tests isAtEnd", "3.1.0")
+  @Test def testIsAtEndEmpty1(): Unit = {
+    val emptyIS = new InputStream {
+      override def read() = ???
+      override def read(buf: Array[Byte], off: Int, len: Int): Int = {
+        assertTrue(len > 0)
+        -1 // nothing here
+      }
+    }
+    val isdis = InputSourceDataInputStream(emptyIS)
+    //
+    // before we attempt to read anything, we're not at end.
+    assertFalse(isdis.hasReachedEndOfData)
+    // this must attempt to read, and will get end-of-data
+    assertTrue(isdis.isAtEnd())
+    // so now we know we're at the end-of-data
+    assertTrue(isdis.hasReachedEndOfData)
+  }
+
+  @deprecated("Tests isAtEnd", "3.1.0")
+  @Test def testIsAtEndWholeByte1(): Unit = {
+    val oneByteIS = new ByteArrayInputStream("A".getBytes)
+    val isdis = InputSourceDataInputStream(oneByteIS)
+    //
+    // before we attempt to read anything, we're not at end.
+    assertFalse(isdis.hasReachedEndOfData)
+    // this must attempt to read, and will get end-of-data
+    assertTrue(isdis.hasData())
+    assertEquals(0, isdis.bitPos0b)
+    assertEquals(0,isdis.getUnsignedLong(1,FakeFormatInfo_MSBF_BE).toLong)
+    // we've only consumed 1 bit meaning
+    // we should have only fetched 1 byte and this will NOT encounter end of data yet.
+    assertFalse(isdis.hasReachedEndOfData)
+    // now retrieve next 7 bits. We still won't be at end of data
+    assertEquals('A',isdis.getUnsignedLong(7,FakeFormatInfo_MSBF_BE).toChar)
+    assertFalse(isdis.hasReachedEndOfData)
+    // try to read one more bit. That will not succeed, but now we'll be at end.
+    assertTrue(isdis.isAtEnd())
+    assertFalse(isdis.hasData())
+    assertTrue(isdis.hasReachedEndOfData)
+  }
+
+  @Test def testIsAtEndPartialByte1(): Unit = {
+    val oneByteIS = new ByteArrayInputStream(Misc.hex2Bytes("FF"))
+    val isdis = InputSourceDataInputStream(oneByteIS)
+    isdis.setBitLimit0b(MaybeULong(1))
+    //
+    // before we attempt to read anything, we're not at end.
+    assertFalse(isdis.hasReachedEndOfData)
+    assertTrue(isdis.isDefinedForLength(1)) // matches the bit limit set above
+    assertEquals(0, isdis.bitPos0b)
+    assertEquals(1,isdis.getUnsignedLong(1,FakeFormatInfo_MSBF_BE).toLong)
+    // we've only consumed 1 bit meaning
+    // we should have only fetched 1 byte and this will NOT encounter end of data yet.
+    assertFalse(isdis.hasReachedEndOfData)
+    assertEquals(1, isdis.bitPos0b)
+    // try to read 7 more bits.
+    // it will not succeed due to the bit limit, but
+    // it is still not enough for us to have hit end of data
+    assertFalse(isdis.isDefinedForLength(7))
+    assertFalse(isdis.hasReachedEndOfData)
+    // but, if we try to read 8 more bits, that puts us past the end of data
+    // except, since there's a bit limit, we'll never touch the underlying
+    // input source, so we still won't have gotten an end-of-data
+    assertFalse(isdis.isDefinedForLength(8))
+    assertFalse(isdis.hasReachedEndOfData)
+    // if we remove the bit limit however, ...
+    isdis.setBitLimit0b(MaybeULong.Nope)
+    // 7 more bits of the first byte are available
+    assertTrue(isdis.isDefinedForLength(7))
+    // but if we even test for bits beyond that, we'll encounter the end-of-data
+    assertFalse(isdis.isDefinedForLength(8))
+    assertTrue(isdis.hasReachedEndOfData)
+  }
+
+  /**
+   * This test shows that for a TCP stream, if 1 byte is sent,
+   * then if you attempt to read more than that many bytes, it will
+   * return just the 1 byte.
+   *
+   * This isn't testing Daffodil code, it's a test that assures us
+   * that the underlying I/O layer of the JVM/Java/Scala has the
+   * behavior we depend on.
+   *
+   * Our I/O layer depends on this behavior to avoid blocking
+   * on reads that attempt to fill a bucket (for efficiency) when
+   * there is temporarily less than that much data on a network
+   * TCP stream.
+   */
+  @Test def networkReadPartial1(): Unit = {
+    val sptr = new SocketPairTestRig {
+      override def test(pos: OutputStream, cis: InputStream): Unit = {
+        assertEquals(0, cis.available())
+        pos.write(0x31)
+        pos.flush()
+        val buf = new Array[Byte](4)
+        val nRead: Int = cis.read(buf, 0, 4)
+        assertEquals(1, nRead)
+        assertEquals(0x31, buf(0))
+      }
+    }
+    sptr.run()
+  }
+
+}

--- a/daffodil-io/src/test/scala/org/apache/daffodil/layers/TestBase64.scala
+++ b/daffodil-io/src/test/scala/org/apache/daffodil/layers/TestBase64.scala
@@ -66,7 +66,6 @@ W1vdXMgcXVvdGVzIG9yIHNvbmcgbHlyaWNzIG9yIGFueXRoaW5nIGxpa2UgdGhhdCBpbnRyb2R1Y
     pairs.foreach {
       case (exp, act) => {
         if (exp != act) {
-          println("differ at character %s (0-based). Expected '%s' got '%s'.".format(i, exp, act))
           failed = true
         }
         i += 1
@@ -92,7 +91,7 @@ W1vdXMgcXVvdGVzIG9yIHNvbmcgbHlyaWNzIG9yIGFueXRoaW5nIGxpa2UgdGhhdCBpbnRyb2R1Y
     val data = b64Text.dropRight(3)
 
     intercept[IllegalArgumentException] {
-      println(new String(java.util.Base64.getMimeDecoder.decode(data)))
+      java.util.Base64.getMimeDecoder.decode(data)
     }
 
   }
@@ -203,7 +202,6 @@ W1vdXMgcXVvdGVzIG9yIHNvbmcgbHlyaWNzIG9yIGFueXRoaW5nIGxpa2UgdGhhdCBpbnRyb2R1Y
     pairs.foreach {
       case (exp, act) => {
         if (exp != act) {
-          println("differ at character %s (0-based). Expected '%s' got '%s'.".format(i, exp, act))
           failed = true
         }
         i += 1

--- a/daffodil-io/src/test/scala/org/apache/daffodil/layers/TestJavaIOStreams.scala
+++ b/daffodil-io/src/test/scala/org/apache/daffodil/layers/TestJavaIOStreams.scala
@@ -140,7 +140,6 @@ ZSBzaG9ydCB2ZWhlbWVuY2Ugb2YgYW55IGNhcm5hbCBwbGVhc3VyZS4="""
     val gzipBufferSize = 1
     val decodedStream = new java.util.zip.GZIPInputStream(inputStream, gzipBufferSize)
     val lines = IOUtils.readLines(decodedStream, StandardCharsets.ISO_8859_1).asScala.toSeq
-    lines.foreach { println }
     assertEquals(1, lines.length)
     assertEquals(expected, lines(0))
     val additionalLines = IOUtils.readLines(inputStream, StandardCharsets.ISO_8859_1).asScala.toSeq
@@ -172,7 +171,6 @@ ZSBzaG9ydCB2ZWhlbWVuY2Ugb2YgYW55IGNhcm5hbCBwbGVhc3VyZS4="""
     val gzipBufferSize = 1
     val decodedStream = new java.util.zip.GZIPInputStream(inputStream, gzipBufferSize)
     val lines = IOUtils.readLines(decodedStream, StandardCharsets.ISO_8859_1).asScala.toSeq
-    lines.foreach { println }
     assertEquals(1, lines.length)
     assertEquals(expected, lines(0))
     val additionalLines = IOUtils.readLines(inputStream, StandardCharsets.ISO_8859_1).asScala.toSeq

--- a/daffodil-io/src/test/scala/org/apache/daffodil/layers/TestLimitingJavaIOStreams.scala
+++ b/daffodil-io/src/test/scala/org/apache/daffodil/layers/TestLimitingJavaIOStreams.scala
@@ -133,7 +133,6 @@ ZSBzaG9ydCB2ZWhlbWVuY2Ugb2YgYW55IGNhcm5hbCBwbGVhc3VyZS4="""
 
     val decodedStream = new java.util.zip.GZIPInputStream(limitedStream, 5)
     val lines = IOUtils.readLines(decodedStream, iso8859).asScala.toSeq
-    lines.foreach { println }
     assertEquals(1, lines.length)
     assertEquals(expected, lines(0))
     val additionalLines = IOUtils.readLines(inputStream, iso8859).asScala.toSeq

--- a/daffodil-japi/src/main/java/org/apache/daffodil/japi/package-info.java
+++ b/daffodil-japi/src/main/java/org/apache/daffodil/japi/package-info.java
@@ -151,11 +151,11 @@
  * InputSourceDataInputStream is = new InputSourceDataInputStream(dataStream);
  * JDOMInfosetOutputter jdomOutputter = new JDOMInfosetOutputter();
  * boolean keepParsing = true;
- * while (keepParsing) {
+ * while (keepParsing && is.hasData()) {
  *   jdomOutputter.reset();
  *   ParseResult pr = dp.parse(is, jdomOutputter);
  *   ...
- *   keepParsing = !pr.location().isAtEnd() && !pr.isError();
+ *   keepParsing = !pr.isError();
  * }
  * }</pre>
  *
@@ -214,12 +214,12 @@
  * SAXHandler contentHandler = new SAXHandler();
  * xmlReader.setContentHandler(contentHandler);
  * Boolean keepParsing = true;
- * while (keepParsing) {
+ * while (keepParsing && is.hasData()) {
  *   contentHandler.reset();
  *   xmlReader.parse(is);
  *   val pr = xmlReader.getProperty(DaffodilParseXMLReader.DAFFODIL_SAX_URN_PARSERESULT());
  *   ...
- *   keepParsing = !pr.location().isAtEnd() && !pr.isError();
+ *   keepParsing = !pr.isError();
  * }
  * }
  * </pre>

--- a/daffodil-japi/src/main/scala/org/apache/daffodil/japi/Daffodil.scala
+++ b/daffodil-japi/src/main/scala/org/apache/daffodil/japi/Daffodil.scala
@@ -490,10 +490,19 @@ class DataLocation private[japi] (dl: SDataLocation) {
   override def toString() = dl.toString
 
   /**
-   * Determine if this data location is at the end of the input data
+   * Determine if we're positioned at the end of data.
    *
-   * @return true if this represents the end of the input data, false otherwise
+   * Blocks until either one byte of data can be read, or end-of-data
+   * is encountered.
+   *
+   * It is generally not advised to use this on network TCP data streams
+   * as it will block waiting for the sender of data to provide more data
+   * or close the stream.
+   *
+   * @return boolean indicating whether we are known to be positioned at
+   *         the end of data.
    */
+  @deprecated("Use comparison of bitPos1b() with expected position instead.", "3.1.0")
   def isAtEnd() = dl.isAtEnd
 
   /**

--- a/daffodil-japi/src/main/scala/org/apache/daffodil/japi/io/InputSourceDataInputStream.scala
+++ b/daffodil-japi/src/main/scala/org/apache/daffodil/japi/io/InputSourceDataInputStream.scala
@@ -20,7 +20,7 @@ package org.apache.daffodil.japi.io
 import java.io.InputStream
 import java.nio.ByteBuffer
 
-import org.apache.daffodil.io.{ InputSourceDataInputStream => SInputSourceDataInputStream }
+import org.apache.daffodil.io.{InputSourceDataInputStream => SInputSourceDataInputStream}
 
 /**
  * Provides Daffodil with byte data from an InputStream, ByteBuffer, or byte
@@ -28,7 +28,7 @@ import org.apache.daffodil.io.{ InputSourceDataInputStream => SInputSourceDataIn
  *
  * @param dis the underlying Scala InputSourceDataInputStream
  */
-class InputSourceDataInputStream private[japi] (private [japi] val dis: SInputSourceDataInputStream) {
+class InputSourceDataInputStream private[japi](private[japi] val dis: SInputSourceDataInputStream) {
 
   /**
    * Create an InputSourceDataInputStream from a java.io.InputStream
@@ -38,10 +38,30 @@ class InputSourceDataInputStream private[japi] (private [japi] val dis: SInputSo
   /**
    * Create an InputSourceDataInputStream from a java.nio.ByteBuffer
    */
-  def this(bb: ByteBuffer) = this(SInputSourceDataInputStream(bb)) 
+  def this(bb: ByteBuffer) = this(SInputSourceDataInputStream(bb))
 
   /**
    * Create an InputSourceDataInputStream from a byte array
    */
-  def this(arr: Array[Byte]) = this(SInputSourceDataInputStream(arr)) 
+  def this(arr: Array[Byte]) = this(SInputSourceDataInputStream(arr))
+
+  /**
+   * Returns true if the input stream has at least 1 bit of data.
+   *
+   * Does not advance the position.
+   *
+   * Returns true immediately if the input stream has available data that
+   * has not yet been consumed.
+   *
+   * On a network input stream, this may block to determine if the stream
+   * contains data or is at end-of-data.
+   *
+   * This is used when parsing multiple elements from a stream to see if there
+   * is data or not before calling parse().
+   *
+   * It may also be used after a parse() operation that is intended to consume
+   * the entire data stream (such as for a file) to determine if all data has
+   * been consumed or some data is left-over.
+   */
+  def hasData(): Boolean = dis.isDefinedForLength(1)
 }

--- a/daffodil-japi/src/test/java/org/apache/daffodil/example/TestJavaAPI.java
+++ b/daffodil-japi/src/test/java/org/apache/daffodil/example/TestJavaAPI.java
@@ -26,13 +26,18 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.nio.channels.Channels;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.channels.WritableByteChannel;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
 import org.apache.daffodil.japi.*;
 import org.apache.daffodil.japi.infoset.XMLTextInfosetOutputter;
 import org.jdom2.output.Format;
@@ -109,7 +114,6 @@ public class TestJavaAPI {
         ParseResult res = dp.parse(dis, outputter);
         boolean err = res.isError();
         assertFalse(err);
-        assertTrue(res.location().isAtEnd());
         assertEquals(0, lw.errors.size());
         assertEquals(0, lw.warnings.size());
         assertTrue(lw.others.size() > 0);
@@ -157,14 +161,17 @@ public class TestJavaAPI {
         parser = parser.withDebuggerRunner(debugger);
         parser = parser.withDebugging(true);
 
-        java.io.File file = getResource("/test/japi/myData.dat");
-        java.io.FileInputStream fis = new java.io.FileInputStream(file);
-        InputSourceDataInputStream dis = new InputSourceDataInputStream(fis);
+        File data = getResource("/test/japi/myData.dat");
+        // This test uses a byte array here, just so as to be sure to exercise
+        // the constructor for creating an InputSourceDataInputStream from a byte array
+        // and byte buffer.
+        byte[] ba = FileUtils.readFileToByteArray(data);
+        ByteBuffer bb = ByteBuffer.wrap(ba);
+        InputSourceDataInputStream dis = new InputSourceDataInputStream(bb);
         JDOMInfosetOutputter outputter = new JDOMInfosetOutputter();
         ParseResult res = parser.parse(dis, outputter);
         boolean err = res.isError();
         assertFalse(err);
-        assertTrue(res.location().isAtEnd());
         assertEquals(0, lw.errors.size());
         assertEquals(0, lw.warnings.size());
         assertTrue(lw.others.size() > 0);
@@ -238,8 +245,11 @@ public class TestJavaAPI {
         dp = reserializeDataProcessor(dp);
 
         java.io.File file = getResource("/test/japi/myDataBroken.dat");
-        java.io.FileInputStream fis = new java.io.FileInputStream(file);
-        InputSourceDataInputStream dis = new InputSourceDataInputStream(fis);
+        // This test uses a byte array here, just so as to be sure to exercise
+        // the constructor for creating an InputSourceDataInputStream from a byte array
+        // and byte buffer.
+        byte[] ba = FileUtils.readFileToByteArray(file);
+        InputSourceDataInputStream dis = new InputSourceDataInputStream(ba);
         JDOMInfosetOutputter outputter = new JDOMInfosetOutputter();
         ParseResult res = dp.parse(dis, outputter);
 
@@ -295,7 +305,6 @@ public class TestJavaAPI {
         ParseResult res = dp.parse(dis, outputter);
         boolean err = res.isError();
         assertFalse(err);
-        assertFalse(res.location().isAtEnd());
         assertEquals(2, res.location().bytePos1b());
         assertEquals(9, res.location().bitPos1b());
 
@@ -336,7 +345,6 @@ public class TestJavaAPI {
         ParseResult res = parser.parse(dis, outputter);
         boolean err = res.isError();
         assertFalse(err);
-        assertFalse(res.location().isAtEnd());
         assertEquals(2, res.location().bytePos1b());
         assertEquals(9, res.location().bitPos1b());
 
@@ -365,7 +373,6 @@ public class TestJavaAPI {
         ParseResult res = dp.parse(dis, outputter);
         boolean err = res.isError();
         assertFalse(err);
-        assertFalse(res.location().isAtEnd());
         assertEquals(5, res.location().bytePos1b());
         assertEquals(33, res.location().bitPos1b());
 
@@ -394,7 +401,6 @@ public class TestJavaAPI {
         ParseResult res = dp.parse(dis, outputter);
         boolean err = res.isError();
         assertFalse(err);
-        assertTrue(!res.location().isAtEnd());
         assertEquals(5, res.location().bytePos1b());
         assertEquals(33, res.location().bitPos1b());
 
@@ -468,7 +474,6 @@ public class TestJavaAPI {
         ParseResult res = dp.parse(dis, outputter);
         boolean err = res.isError();
         assertFalse(err);
-        assertTrue(res.location().isAtEnd());
 
         java.io.ByteArrayOutputStream bos = new java.io.ByteArrayOutputStream();
         java.nio.channels.WritableByteChannel wbc = java.nio.channels.Channels.newChannel(bos);
@@ -511,7 +516,6 @@ public class TestJavaAPI {
         ParseResult res = dp.parse(dis, outputter);
         boolean err = res.isError();
         assertFalse(err);
-        assertTrue(res.location().isAtEnd());
 
         java.io.ByteArrayOutputStream bos = new java.io.ByteArrayOutputStream();
         java.nio.channels.WritableByteChannel wbc = java.nio.channels.Channels.newChannel(bos);
@@ -550,7 +554,6 @@ public class TestJavaAPI {
         ParseResult res = dp.parse(dis, outputter);
         boolean err = res.isError();
         assertFalse(err);
-        assertTrue(res.location().isAtEnd());
 
         org.jdom2.Document doc1 = outputter.getResult();
 
@@ -602,7 +605,6 @@ public class TestJavaAPI {
         org.jdom2.Element rootNode = doc.getRootElement();
         org.jdom2.Element hidden = rootNode.getChild("hiddenElement", rootNode.getNamespace());
         assertTrue(null == hidden);
-        assertTrue(res.location().isAtEnd());
     }
 
     /**
@@ -643,7 +645,6 @@ public class TestJavaAPI {
         assertTrue(null == rootE2);
         org.jdom2.Element rootE3 = rootNode.getChild("e3", null);
         assertTrue(null == rootE3);
-        assertTrue(res.location().isAtEnd());
     }
 
     @Test
@@ -671,7 +672,6 @@ public class TestJavaAPI {
         ParseResult res = dp.parse(dis, outputter);
         boolean err = res.isError();
         assertFalse(err);
-        assertTrue(res.location().isAtEnd());
 
         assertEquals(0, lw2.errors.size());
         assertEquals(0, lw2.warnings.size());
@@ -763,7 +763,6 @@ public class TestJavaAPI {
         boolean containsVar1Value = docString.contains("externallySet");
         assertTrue(containsVar1);
         assertTrue(containsVar1Value);
-        assertTrue(res.location().isAtEnd());
 
         assertEquals(0, lw.errors.size());
         assertEquals(0, lw.warnings.size());
@@ -836,7 +835,6 @@ public class TestJavaAPI {
         assertTrue(res.isError());
         assertFalse(res.isProcessingError());
         assertTrue(res.isValidationError());
-        assertTrue(res.location().isAtEnd());
 
         java.util.List<Diagnostic> diags = res.getDiagnostics();
         assertEquals(1, diags.size());
@@ -863,7 +861,8 @@ public class TestJavaAPI {
         assertTrue(res.isError());
         assertFalse(res.isProcessingError());
         assertTrue(res.isValidationError());
-        assertTrue(res.location().isAtEnd());
+        long actualLength = res.location().bytePos1b() - 1;
+        assertEquals(file.length(), actualLength);
 
         java.util.List<Diagnostic> diags = res.getDiagnostics();
         assertEquals(3, diags.size());
@@ -905,7 +904,6 @@ public class TestJavaAPI {
       res = dp.parse(input, outputter);
       err = res.isError();
       assertFalse(err);
-      assertFalse(res.location().isAtEnd());
       assertEquals(5, res.location().bytePos1b());
       assertEquals("data", outputter.getResult().getRootElement().getText());
 
@@ -913,7 +911,6 @@ public class TestJavaAPI {
       res = dp.parse(input, outputter);
       err = res.isError();
       assertFalse(err);
-      assertFalse(res.location().isAtEnd());
       assertEquals(9, res.location().bytePos1b());
       assertEquals("left", outputter.getResult().getRootElement().getText());
 
@@ -921,7 +918,7 @@ public class TestJavaAPI {
       res = dp.parse(input, outputter);
       err = res.isError();
       assertFalse(err);
-      assertTrue(res.location().isAtEnd());
+      assertFalse(input.hasData());
       assertEquals(13, res.location().bytePos1b());
       assertEquals("over", outputter.getResult().getRootElement().getText());
     }
@@ -999,7 +996,6 @@ public class TestJavaAPI {
         String infosetSAXString = new  org.jdom2.output.XMLOutputter(pretty).outputString(contentHandler.getDocument());
 
         assertFalse(err);
-        assertTrue(resSAX.location().isAtEnd());
         assertTrue(diags.isEmpty());
         assertEquals(infosetDPString, infosetSAXString);
 
@@ -1111,8 +1107,6 @@ public class TestJavaAPI {
         boolean containsVar1Value = docString.contains("var1ValueFromMap");
         assertTrue(containsVar1);
         assertTrue(containsVar1Value);
-
-        assertTrue(res.location().isAtEnd());
 
         assertEquals(0, lw.errors.size());
         assertEquals(0, lw.warnings.size());

--- a/daffodil-lib/src/main/scala/org/apache/daffodil/api/Diagnostic.scala
+++ b/daffodil-lib/src/main/scala/org/apache/daffodil/api/Diagnostic.scala
@@ -224,7 +224,10 @@ abstract class Diagnostic protected (
  */
 trait DataLocation {
   def toString: String
+
+  @deprecated("Use comparison of bitPos1b with expected position instead.", "3.1.0")
   def isAtEnd: Boolean
+
   def bitPos1b: Long
   def bytePos1b: Long
 }

--- a/daffodil-lib/src/main/scala/org/apache/daffodil/exceptions/Assert.scala
+++ b/daffodil-lib/src/main/scala/org/apache/daffodil/exceptions/Assert.scala
@@ -45,13 +45,17 @@ abstract class ThinException protected (dummy: Int, cause: Throwable, fmt: Strin
   def this(cause: Throwable) = this(1, cause, null)
 }
 
-abstract class UnsuppressableException(m: String) extends Exception(m) {
-  def this() = this("") // no arg constructor also.
+// $COVERAGE-OFF$ These exception objects should never be created by tests.
+abstract class UnsuppressableException(m: String, th: Throwable) extends Exception(m, th) {
+  def this(msg: String) = this(msg, null)
+  def this(th: Throwable) = this(null, th)
 }
+
 class UsageException(m: String) extends UnsuppressableException(m)
 class NotYetImplementedException(m: String) extends UnsuppressableException("Not yet implemented: " + m)
-class Abort(m: String) extends UnsuppressableException(m) {
-  def this(th: Throwable) = this(th.getMessage())
+class Abort(m: String, th: Throwable) extends UnsuppressableException(m, th) {
+  def this(th: Throwable) = this(null, th)
+  def this(m: String) = this(m, null)
 }
 
 class Assert {
@@ -64,6 +68,7 @@ class Assert {
     throw x
   }
 }
+// $COVERAGE-ON$
 
 object Assert extends Assert {
 
@@ -102,9 +107,12 @@ object Assert extends Assert {
   /**
    * Conditional behavior for NYIs
    */
-  def notYetImplemented(): Nothing = macro AssertMacros.notYetImplementedMacro0
   def notYetImplemented(testThatWillThrowIfTrue: Boolean): Unit = macro AssertMacros.notYetImplementedMacro1
   def notYetImplemented(testThatWillThrowIfTrue: Boolean, msg: String): Unit = macro AssertMacros.notYetImplementedMacro2
+
+  // $COVERAGE-OFF$ These unconditional assertions should never get executed by tests.
+
+  def notYetImplemented(): Nothing = macro AssertMacros.notYetImplementedMacro0
   //
   // Throughout this file, specifying return type Nothing
   // gets rid of many spurious (scala compiler bug) dead code
@@ -174,5 +182,6 @@ object Assert extends Assert {
   def invariantFailed(msg: String = "") = {
     abort("Invariant broken. " + msg)
   }
+  // $COVERAGE-ON$
 
 }

--- a/daffodil-lib/src/test/scala/org/apache/daffodil/util/TestCoroutines.scala
+++ b/daffodil-lib/src/test/scala/org/apache/daffodil/util/TestCoroutines.scala
@@ -1,0 +1,173 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.daffodil.util
+
+import org.junit.Test
+import org.junit.Assert._
+import org.apache.daffodil.Implicits._
+
+private class TestException(e: String) extends Exception(e)
+
+private class TestInvertControl {
+
+  /**
+   * We need JInt because Int is not subtype of AnyRef
+   * but Coroutines requires T <: AnyRef
+   */
+  type JInt = java.lang.Integer
+
+  def sprintln(s: String): Unit = {
+    /*
+     * Uncomment this for verbose messsaging so you can see what is going on.
+     */
+    // println(s)
+  }
+
+  /**
+   * Simulates some library that takes a callback function
+   *
+   * Note that this library is allowed to be NON THREAD SAFE.
+   */
+  class NotThreadSafeLibrary[T]() {
+    def doIt(l: Seq[T]) : Unit = {
+      sprintln("NotThreadSafeLibrary running")
+      l.foreach { x =>
+        sprintln("NotThreadSafeLibrary calling back with " + x)
+        handleEvent(x)
+      }
+      sprintln("NotThreadSafeLibrary done (normal)")
+    }
+
+    private var handleEvent: T => Any = _
+
+    def setHandler(f: T => Any) : Unit = {
+      handleEvent = f
+    }
+  }
+
+  /**
+   * Illustrates how to use the InvertControl class
+   */
+  @Test def test1() : Unit = {
+
+    val cb = new NotThreadSafeLibrary[JInt]() // some non-safe library that gets a callback handler
+    //
+    // Wrap the initial call that starts the library in the
+    // InvertControl class.
+    //
+    val iter = new InvertControl[JInt](
+      // this argument is the code to call to run the library
+      cb.doIt(List(1, 2, 3))
+      // not executed until we start iterating
+    )
+    assertTrue(iter.isMain)
+    //
+    // define a handler as the library requires
+    //
+    def handler(i: JInt) : Unit = {
+      // sprintln("handler called on: " + i)
+      //
+      // handler must call the callback function of the InvertControl
+      // instance
+      //
+      iter.setNext(i)
+    }
+    //
+    // Don't forget to tell the library that this is your handler
+    //
+    cb.setHandler(handler) // setting callback handler.
+
+    sprintln("asking for first element")
+    var i = iter.next() // library runs until first callback.
+    sprintln("got first element")
+    assertEquals(1, i)
+    sprintln("asking for second element")
+    i = iter.next()
+    sprintln("got second element")
+    assertEquals(2, i)
+    sprintln("asking for third element")
+    i = iter.next()
+    sprintln("got third element")
+    assertEquals(3, i)
+    assertFalse(iter.hasNext)
+    sprintln("done")
+  }
+
+  /**
+   * Illustrates exception in generator ends up back on the consumer.
+   */
+  @Test def test2() : Unit = {
+
+    val cb = new NotThreadSafeLibrary[JInt]() // some non-safe library that gets a callback handler
+    //
+    // Wrap the initial call that starts the library in the
+    // InvertControl class.
+    //
+    lazy val iter: InvertControl[JInt] = new InvertControl[JInt]({
+      // this argument is the code to call to run the library
+      var wasThrown = false
+      try {
+        cb.doIt(List(1, 2, 3)) // not executed until we start iterating
+      } catch {
+        case e: TestException =>
+          // iter.setFinal(e)
+          wasThrown = true
+      }
+      assertTrue(wasThrown)
+      sprintln("NotThreadSafeLibrary exiting")
+    })
+
+    //
+    // define a handler as the library requires
+    //
+    def handler(i: JInt) : Unit = {
+      sprintln("handler called on: " + i)
+      //
+      // handler must call the callback function of the InvertControl
+      // instance
+      //
+      if (i == 3) {
+        val e = new TestException("you had to give me a three?")
+        sprintln("NotThreadSafeLibrary throwing :" + e)
+        throw e
+      }
+      iter.setNext(i)
+    }
+    //
+    // Don't forget to tell the library that this is your handler
+    //
+    cb.setHandler(handler) // setting callback handler.
+
+    sprintln("asking for first element")
+    var i = iter.next() // library runs until first callback.
+    sprintln("got first element")
+    assertEquals(1, i)
+    sprintln("asking for second element")
+    i = iter.next()
+    sprintln("got second element")
+    assertEquals(2, i)
+    sprintln("asking for third element")
+    val e = intercept[NoSuchElementException] {
+      i = iter.next()
+      fail()
+    }
+    sprintln("consumer caught exception: " + e)
+    assertFalse(iter.hasNext)
+    sprintln("consumer done")
+  }
+
+}

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/api/DFDLParserUnparser.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/api/DFDLParserUnparser.scala
@@ -19,8 +19,8 @@ package org.apache.daffodil.api
 
 import org.apache.daffodil.processors.ProcessorResult
 import org.apache.daffodil.processors.Success
-import java.io.File
 
+import java.io.File
 import org.apache.daffodil.processors.VariableMap
 import org.apache.daffodil.externalvars.Binding
 import org.apache.daffodil.infoset.InfosetInputter
@@ -29,6 +29,7 @@ import org.apache.daffodil.infoset.InfosetOutputter
 import org.apache.daffodil.processors.Failure
 import org.apache.daffodil.io.InputSourceDataInputStream
 import org.apache.daffodil.util.Coroutine
+import org.apache.daffodil.util.MainCoroutine
 import org.apache.daffodil.util.Maybe
 import org.apache.daffodil.util.Maybe.Nope
 import org.xml.sax.SAXException
@@ -246,7 +247,9 @@ object DFDL {
     def parse(ab: Array[Byte]): Unit
   }
 
-  trait DaffodilUnparseContentHandler extends org.xml.sax.ContentHandler with ProducerCoroutine {
+  trait DaffodilUnparseContentHandler
+    extends  ProducerCoroutine
+    with org.xml.sax.ContentHandler {
     def getUnparseResult: UnparseResult
     def enableInputterResolutionOfRelativeInfosetBlobURIs(): Unit
   }
@@ -316,12 +319,7 @@ object DFDL {
     }
   }
 
-  trait ProducerCoroutine extends Coroutine[Array[SAXInfosetEvent]] {
-    override def isMain = true
-    override protected def run(): Unit = {
-      throw new Error("Main thread co-routine run method should not be called.")
-    }
-  }
+  trait ProducerCoroutine extends MainCoroutine[Array[SAXInfosetEvent]]
 
   trait ConsumerCoroutine extends Coroutine[Array[SAXInfosetEvent]]
 

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/dsom/CompiledExpression1.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/dsom/CompiledExpression1.scala
@@ -102,7 +102,7 @@ abstract class CompiledExpression[+T <: AnyRef](
    *
    * isConstant must be true or this will throw.
    */
-  @deprecated("2016-02-18", "Code should just call evaluate(...) on an Evaluatable object.")
+  @deprecated("Code should just call evaluate(...) on an Evaluatable object.", "2016-02-18")
   def constant: T
   def isConstant: Boolean
 

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/layers/LayerTransformer.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/layers/LayerTransformer.scala
@@ -216,7 +216,7 @@ class JavaIOInputStream(s: InputSourceDataInputStream, finfo: FormatInfo)
     }
   }
 
-  override def available(): Int = 1
+  override def available(): Int = 0
 
   override def close(): Unit = {
     // do nothing

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/DataLoc.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/DataLoc.scala
@@ -17,8 +17,7 @@
 
 package org.apache.daffodil.processors
 
-import org.apache.daffodil.Implicits._; object INoWarn { ImplicitsSuppressUnusedImportWarning() }
-import org.apache.daffodil.util._
+import org.apache.daffodil.io.InputSourceDataInputStream
 import org.apache.daffodil.exceptions._
 import org.apache.daffodil.schema.annotation.props.gen.BitOrder
 import org.apache.daffodil.util.Maybe
@@ -33,8 +32,22 @@ import org.apache.daffodil.util.MaybeULong
 import org.apache.daffodil.api.DataLocation
 import org.apache.daffodil.processors.parsers.PState
 
-class DataLoc(val bitPos1b: Long, bitLimit1b: MaybeULong, val isAtEnd: Boolean, eitherStream: Either[DataOutputStream, DataInputStream],
+class DataLoc(
+  val bitPos1b: Long,
+  bitLimit1b: MaybeULong,
+  eitherStream: Either[DataOutputStream, DataInputStream],
   val maybeERD: Maybe[ElementRuntimeData]) extends DataLocation {
+
+  // $COVERAGE-OFF$
+  @deprecated("Use bitPos1b to compare with expected position (possibly bitLimit1b).", "3.1.0")
+  override def isAtEnd = {
+    eitherStream match {
+      case Right(isdis: InputSourceDataInputStream) => isdis.isAtEnd
+      case Left(_) => Assert.usageError("isAtEnd not defined for unparsing.")
+      case Right(s) => Assert.invariantFailed("Unknown kind of data stream: " + s)
+    }
+  }
+  // $COVERAGE-ON$
 
   // override def toString = "DataLoc(bitPos1b='%s', bitLimit1b='%s')".format(bitPos1b, bitLimit1b)
   override def toString() = {

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/PState.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/PState.scala
@@ -20,10 +20,7 @@ package org.apache.daffodil.processors.parsers
 import java.nio.channels.Channels
 import java.nio.file.Files
 import java.nio.file.Path
-
-import scala.Right
 import scala.collection.mutable
-
 import org.apache.daffodil.api.DFDL
 import org.apache.daffodil.api.DaffodilTunables
 import org.apache.daffodil.api.DataLocation
@@ -288,8 +285,7 @@ final class PState private (
   }
 
   def currentLocation: DataLocation = {
-    val isAtEnd = !dataInputStream.isDefinedForLength(1)
-    new DataLoc(bitPos1b, bitLimit1b, isAtEnd, Right(dataInputStream), Maybe(thisElement.runtimeData))
+    new DataLoc(bitPos1b, bitLimit1b, Right(dataInputStream), Maybe(thisElement.runtimeData))
   }
 
   def bitPos0b = dataInputStream.bitPos0b

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/unparsers/UState.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/unparsers/UState.scala
@@ -20,9 +20,6 @@ package org.apache.daffodil.processors.unparsers
 import java.io.ByteArrayOutputStream
 import java.nio.CharBuffer
 import java.nio.LongBuffer
-
-import scala.Left
-
 import org.apache.daffodil.api.DFDL
 import org.apache.daffodil.api.DaffodilTunables
 import org.apache.daffodil.api.DataLocation
@@ -166,8 +163,7 @@ abstract class UState(
   def currentLocation: DataLocation = {
     val m = maybeCurrentInfosetElement
     val mrd = if (m.isDefined) Maybe(m.value.runtimeData) else Nope
-    val isAtEnd = false // TODO: this isn't right, but what does it mean to be at the end? Nothing appears to use this value when unparsing
-    new DataLoc(bitPos1b, bitLimit1b, isAtEnd, Left(dataOutputStream), mrd)
+    new DataLoc(bitPos1b, bitLimit1b, Left(dataOutputStream), mrd)
   }
 
   lazy val unparseResult = new UnparseResult(dataProc.get, this)

--- a/daffodil-sapi/src/main/scala/org/apache/daffodil/sapi/Daffodil.scala
+++ b/daffodil-sapi/src/main/scala/org/apache/daffodil/sapi/Daffodil.scala
@@ -456,10 +456,19 @@ class DataLocation private[sapi] (dl: SDataLocation) {
   override def toString() = dl.toString
 
   /**
-   * Determine if this data location is at the end of the input data
+   * Determine if we're positioned at the end of data.
    *
-   * @return true if this represents the end of the input data, false otherwise
+   * Blocks until either one byte of data can be read, or end-of-data
+   * is encountered.
+   *
+   * It is generally not advised to use this on network TCP data streams
+   * as it will block waiting for the sender of data to provide more data
+   * or close the stream.
+   *
+   * @return boolean indicating whether we are known to be positioned at
+   *         the end of data.
    */
+  @deprecated("Use comparison of bitPos1b() with expected position instead.", "3.1.0")
   def isAtEnd() = dl.isAtEnd
 
   /**

--- a/daffodil-sapi/src/main/scala/org/apache/daffodil/sapi/io/InputSourceDataInputStream.scala
+++ b/daffodil-sapi/src/main/scala/org/apache/daffodil/sapi/io/InputSourceDataInputStream.scala
@@ -43,5 +43,26 @@ class InputSourceDataInputStream private[sapi] (private [sapi] val dis: SInputSo
   /**
    * Create an InputSourceDataInputStream from a byte array
    */
-  def this(arr: Array[Byte]) = this(SInputSourceDataInputStream(arr)) 
+  def this(arr: Array[Byte]) = this(SInputSourceDataInputStream(arr))
+
+
+  /**
+   * Returns true if the input stream has at least 1 bit of data.
+   *
+   * Does not advance the position.
+   *
+   * Returns true immediately if the input stream has available data that
+   * has not yet been consumed.
+   *
+   * On a network input stream, this may block to determine if the stream
+   * contains data or is at end-of-data.
+   *
+   * This is used when parsing multiple elements from a stream to see if there
+   * is data or not before calling parse().
+   *
+   * It may also be used after a parse() operation that is intended to consume
+   * the entire data stream (such as for a file) to determine if all data has
+   * been consumed or some data is left-over.
+   */
+  def hasData(): Boolean = dis.isDefinedForLength(1)
 }

--- a/daffodil-sapi/src/main/scala/org/apache/daffodil/sapi/package.scala
+++ b/daffodil-sapi/src/main/scala/org/apache/daffodil/sapi/package.scala
@@ -134,11 +134,11 @@ package org.apache.daffodil
  * val is = new InputSourceDataInputStream(dataStream)
  * val scalaOutputter = new ScalaXMLInfosetOutputter()
  * val keepParsing = true
- * while (keepParsing) {
+ * while (keepParsing && is.hasData()) {
  *   scalaOutputter.reset()
  *   val pr = dp.parse(is, jdomOutputter)
  *   ...
- *   keepParsing = !pr.location().isAtEnd() && !pr.isError()
+ *   keepParsing = !pr.isError()
  * }
  * }}}
  *
@@ -193,12 +193,12 @@ package org.apache.daffodil
  * val contentHandler = new SAXHandler()
  * xmlReader.setContentHandler(contentHandler)
  * val keepParsing = true
- * while (keepParsing) {
+ * while (keepParsing && is.hasData()) {
  *   contentHandler.reset()
  *   xmlReader.parse(is)
  *   val pr = xmlReader.getProperty(DaffodilParseXMLReader.DAFFODIL_SAX_URN_PARSERESULT)
  *   ...
- *   keepParsing = !pr.location().isAtEnd() && !pr.isError()
+ *   keepParsing = !pr.isError()
  * }
  * }}}
  *

--- a/daffodil-sapi/src/test/scala/org/apache/daffodil/example/TestScalaAPI.scala
+++ b/daffodil-sapi/src/test/scala/org/apache/daffodil/example/TestScalaAPI.scala
@@ -17,10 +17,12 @@
 
 package org.apache.daffodil.example
 
+import org.apache.commons.io.FileUtils
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Assert.fail
+
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
 import java.io.ObjectInputStream
@@ -28,7 +30,6 @@ import java.io.ObjectOutputStream
 import java.io.File
 import java.nio.channels.Channels
 import java.nio.file.Paths
-
 import org.junit.Test
 import org.apache.daffodil.sapi.Daffodil
 import org.apache.daffodil.sapi.DataProcessor
@@ -46,6 +47,8 @@ import org.apache.daffodil.sapi.DaffodilUnhandledSAXException
 import org.apache.daffodil.sapi.DaffodilUnparseErrorSAXException
 import org.apache.daffodil.sapi.SAXErrorHandlerForSAPITest
 import org.apache.daffodil.sapi.infoset.XMLTextInfosetOutputter
+
+import java.nio.ByteBuffer
 
 class TestScalaAPI {
 
@@ -133,7 +136,6 @@ class TestScalaAPI {
     val res = dp.parse(input, outputter)
     val err = res.isError()
     assertFalse(err)
-    assertTrue(res.location().isAtEnd())
     assertEquals(0, lw.errors.size)
     assertEquals(0, lw.warnings.size)
 
@@ -185,13 +187,16 @@ class TestScalaAPI {
     .withDebugging(true)
     .withValidationMode(ValidationMode.Off)
     val file = getResource("/test/sapi/myData.dat")
-    val fis = new java.io.FileInputStream(file)
-    val input = new InputSourceDataInputStream(fis)
+    // This test uses a byte array here, just so as to be sure to exercise
+    // the constructor for creating an InputSourceDataInputStream from a byte array
+    // and byte buffer.
+    val ba = FileUtils.readFileToByteArray(file)
+    val bb = ByteBuffer.wrap(ba)
+    val input = new InputSourceDataInputStream(bb)
     val outputter = new ScalaXMLInfosetOutputter()
     val res = parser.parse(input, outputter)
     val err = res.isError()
     assertFalse(err)
-    assertTrue(res.location().isAtEnd())
 
     lw.errors.foreach(println)
     lw.warnings.foreach(println)
@@ -232,8 +237,11 @@ class TestScalaAPI {
     val dp = reserializeDataProcessor(dp1)
 
     val file = getResource("/test/sapi/myDataBroken.dat")
-    val fis = new java.io.FileInputStream(file)
-    val input = new InputSourceDataInputStream(fis)
+    // This test uses a byte array here, just so as to be sure to exercise
+    // the constructor for creating an InputSourceDataInputStream from a byte array
+    // and byte buffer.
+    val ba = FileUtils.readFileToByteArray(file)
+    val input = new InputSourceDataInputStream(ba)
     val outputter = new ScalaXMLInfosetOutputter()
     val res = dp.parse(input, outputter)
 
@@ -282,7 +290,6 @@ class TestScalaAPI {
     val res = dp.parse(input, outputter)
     val err = res.isError()
     assertFalse(err)
-    assertFalse(res.location().isAtEnd())
     assertEquals(2, res.location().bytePos1b())
     assertEquals(9, res.location().bitPos1b())
 
@@ -323,7 +330,6 @@ class TestScalaAPI {
     val res = parser.parse(input, outputter)
     val err = res.isError()
     assertFalse(err)
-    assertFalse(res.location().isAtEnd())
     assertEquals(2, res.location().bytePos1b())
     assertEquals(9, res.location().bitPos1b())
 
@@ -352,7 +358,6 @@ class TestScalaAPI {
     val res = dp.parse(input, outputter)
     val err = res.isError()
     assertFalse(err)
-    assertFalse(res.location().isAtEnd())
     assertEquals(5, res.location().bytePos1b())
     assertEquals(33, res.location().bitPos1b())
 
@@ -383,7 +388,6 @@ class TestScalaAPI {
     val res = dp.parse(input, outputter)
     val err = res.isError()
     assertFalse(err)
-    assertTrue(!res.location().isAtEnd())
     assertEquals(5, res.location().bytePos1b())
     assertEquals(33, res.location().bitPos1b())
 
@@ -456,7 +460,6 @@ class TestScalaAPI {
     val res = dp.parse(input, outputter)
     val err = res.isError()
     assertFalse(err)
-    assertTrue(res.location().isAtEnd())
 
     val bos = new java.io.ByteArrayOutputStream()
     val wbc = java.nio.channels.Channels.newChannel(bos)
@@ -500,7 +503,6 @@ class TestScalaAPI {
     val res = dp.parse(input, outputter)
     val err = res.isError()
     assertFalse(err)
-    assertTrue(res.location().isAtEnd())
 
     val bos = new java.io.ByteArrayOutputStream()
     val wbc = java.nio.channels.Channels.newChannel(bos)
@@ -589,7 +591,6 @@ class TestScalaAPI {
     val node = outputter.getResult
     val hidden = node \\ "hiddenElement"
     assertTrue(hidden.isEmpty)
-    assertTrue(res.location().isAtEnd())
   }
 
   /**
@@ -623,7 +624,6 @@ class TestScalaAPI {
     assertTrue(rootE2.isEmpty)
     val rootE3 = rootNode \ "e3"
     assertTrue(rootE3.isEmpty)
-    assertTrue(res.location().isAtEnd())
   }
 
   @Test
@@ -652,7 +652,6 @@ class TestScalaAPI {
     val res = dp.parse(input, outputter)
     val err = res.isError()
     assertFalse(err)
-    assertTrue(res.location().isAtEnd())
 
     lw2.errors.foreach(println)
     lw2.warnings.foreach(println)
@@ -745,7 +744,6 @@ class TestScalaAPI {
     assertTrue(var1ValueNode.size == 1)
     val var1ValueText = var1ValueNode.text
     assertTrue(var1ValueText == "externallySet")
-    assertTrue(res.location().isAtEnd())
 
     lw.errors.foreach(println)
     lw.warnings.foreach(println)
@@ -857,7 +855,6 @@ class TestScalaAPI {
     assertTrue(res.isError())
     assertFalse(res.isProcessingError())
     assertTrue(res.isValidationError())
-    assertTrue(res.location().isAtEnd())
 
     val diags = res.getDiagnostics
     assertEquals(1, diags.size)
@@ -883,7 +880,8 @@ class TestScalaAPI {
     assertTrue(res.isError())
     assertFalse(res.isProcessingError())
     assertTrue(res.isValidationError())
-    assertTrue(res.location().isAtEnd())
+    val actualLength = res.location.bytePos1b - 1
+    assertEquals(file.length, actualLength)
 
     val diags = res.getDiagnostics
     assertEquals(3, diags.size)
@@ -924,7 +922,6 @@ class TestScalaAPI {
     res = dp.parse(input, outputter)
     err = res.isError()
     assertFalse(err)
-    assertFalse(res.location().isAtEnd())
     assertEquals(5, res.location().bytePos1b())
     assertEquals("data", outputter.getResult.text)
 
@@ -932,7 +929,6 @@ class TestScalaAPI {
     res = dp.parse(input, outputter)
     err = res.isError()
     assertFalse(err)
-    assertFalse(res.location().isAtEnd())
     assertEquals(9, res.location().bytePos1b())
     assertEquals("left", outputter.getResult.text)
 
@@ -940,7 +936,7 @@ class TestScalaAPI {
     res = dp.parse(input, outputter)
     err = res.isError()
     assertFalse(err)
-    assertTrue(res.location().isAtEnd())
+    assertFalse(input.hasData())
     assertEquals(13, res.location().bytePos1b())
     assertEquals("over", outputter.getResult.text)
   }
@@ -1021,7 +1017,6 @@ class TestScalaAPI {
     val infosetSAXString = new org.jdom2.output.XMLOutputter(pretty).outputString(infosetSAX)
 
     assertFalse(err)
-    assertTrue(resSAX.location().isAtEnd())
     assertTrue(diags.isEmpty)
     assertEquals(infosetDPString, infosetSAXString)
 

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section12/lengthKind/ExplicitTests.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section12/lengthKind/ExplicitTests.tdml
@@ -598,7 +598,7 @@
       <tdml:documentPart type="text"><![CDATA[000118Ridgewood Circle    Rochester           NY123]]></tdml:documentPart>
     </tdml:document>
     <tdml:errors>
-      <tdml:error>6467715096</tdml:error>
+      <tdml:error>6467715464</tdml:error>
       <tdml:error>insufficient</tdml:error>
       <tdml:error>parse error</tdml:error>
     </tdml:errors>


### PR DESCRIPTION
Change isAtEnd contract. Does not look ahead to see if next byte/bit causes the stream to hit EOF.
That behavior is incompatible with network TCP streams of input.

Added test rig and tests showing isAtEnd hangs on network
TCP stream when no bytes are available at that time.

Cleanup: InputSource now throws a very specific exception in the case
where an InputStream provided by caller misbehaves.

Cleanup: Exception class derivations improved to
allow cause or message, not only messages.

Cleanup: Coroutines improved to allow the kinds of objects passed to, and
returned (from resume or resumeFinal) to be different for
different coroutines.

Cleanup: Missing tests - improve coverage.
Coroutines unit tests added back (these had been missing).

Cleanup: Layering - fixed bad available() implementation.

DAFFODIL-2502, DAFFODIL-2503, DAFFODIL-2504