### PR TITLE
Fixes to release candidate container

### DIFF
--- a/containers/release-candidate/Dockerfile
+++ b/containers/release-candidate/Dockerfile
@@ -15,7 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM registry.fedoraproject.org/fedora-minimal:30
+FROM registry.fedoraproject.org/fedora-minimal:34
 
 WORKDIR /root
 

--- a/containers/release-candidate/README.md
+++ b/containers/release-candidate/README.md
@@ -27,7 +27,7 @@ To build the Daffodil release candidate container image:
 
 To use the container image to build a release run the following:
 
-    podman run -it \
+    podman run -it --privileged \
       -v ~/.gitconfig:/root/.gitconfig \
       -v ~/.gnupg/:/root/.gnupg/ \
       -v ~/.ssh/:/root/.ssh/ \

--- a/containers/release-candidate/daffodil-release-candidate
+++ b/containers/release-candidate/daffodil-release-candidate
@@ -77,6 +77,9 @@ fi
 
 export GPG_TTY=$(tty)
 export WIX=/root/wix311/
+export LANG=en_US.UTF-8
+export CC=clang
+export AR=llvm-ar
 
 
 read -p "Pre Release label (e.g. rc1): " PRE_RELEASE
@@ -112,8 +115,8 @@ fi
 TEST_GIT_DIR=/tmp/test-git-sign
 mkdir -p $TEST_GIT_DIR
 pushd $TEST_GIT_DIR &> /dev/null
-git init .
-git commit --allow-empty --allow-empty-message -m "test"
+git init -b main .
+git commit --allow-empty --allow-empty-message -m "Test Commit"
 git tag -as -u $PGP_SIGNING_KEY_ID -m "Test Signed Tag"  test-tag
 if [ $? -ne 0 ]; then
    echo -e "\n!!! Unable to sign git tag with given key: $PGP_SIGNING_KEY !!!\n"

--- a/containers/release-candidate/setup-container.sh
+++ b/containers/release-candidate/setup-container.sh
@@ -21,12 +21,35 @@ export WINEDEBUG=-all
 #delete stuff in homedir
 rm ~/*
 
-#install dependencies
-curl https://bintray.com/sbt/rpm/rpm -o /etc/yum.repos.d/bintray-sbt-rpm.repo
-microdnf install git svn sbt java-1.8.0-devel wine winetricks unzip rpm-build rpm-sign vim-minimal
+# sbt rpm is self hosted
+cat <<EOF > /etc/yum.repos.d/sbt-rpm.repo
+[sbt-rpm]
+name=sbt-rpm
+baseurl=https://repo.scala-sbt.org/scalasbt/rpm
+gpgcheck=0
+repo_gpgcheck=0
+enabled=1
+EOF
+
+# install dependencies
+microdnf -y install \
+  clang \
+  git \
+  java-1.8.0-devel \
+  llvm \
+  mxml-devel \
+  pinentry \
+  rpm-build \
+  rpm-sign \
+  sbt \
+  subversion \
+  unzip \
+  vim-minimal \
+  wine \
+  winetricks
 
 # install wix
-curl -L https://github.com/wixtoolset/wix3/releases/download/wix3111rtm/wix311-binaries.zip -o wix311-binaries.zip
+curl -L https://github.com/wixtoolset/wix3/releases/download/wix3112rtm/wix311-binaries.zip -o wix311-binaries.zip
 mkdir wix311
 unzip wix311-binaries.zip -d wix311/
 rm wix311-binaries.zip


### PR DESCRIPTION
- Update release candidate container to Fedora 33 since it  packages
  provides packages for new runtime2 dependencies
- Install pinentry and set a UTF-8 LANG, needed to get gpg signing to
  work in F33
- Install clang and mxml-devel. Building a release candidate compiles
  runtime2 libraries, so a compiler and mxml lib is required. Change
  /usr/bin/cc to point to clang instead of gcc.
- Update SBT rpm repo location. Bintray has been deprecated, the SBT rpm
  is now self hosted. Also, no longer curl directly to a repo
  config--instead write the expected file contents. Although not likely,
  this mitigates a potential attack vector
- Specify a branch when init-ing the test git repo to hide a warning
  about changes to default git branch names

DAFFODIL-2506