### PR TITLE
Fix a C portability problem

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -43,19 +43,47 @@ commands (or set them to `true` to disable C compilation altogether)
 if you don't want `sbt compile` to call your C compiler with `cc` and
 `ar` as the default commands.
 
-## Fedora 34
+## CentOS 7
 
-You can use the `dnf` package manager to install most of the tools
+You can use the `yum` package manager to install most of the tools
 needed to build Daffodil:
 
-    sudo dnf install clang git java-11-openjdk-devel llvm make mxml-devel pkgconf
+    sudo yum install clang gcc git java-11-openjdk-devel llvm make pkgconfig
 
 If you want to use clang instead of gcc, you'll have to set your
 environment variables `CC` and `AR` to the clang binaries' names:
 
     export CC=clang AR=llvm-ar
 
-However, Fedora has no sbt package in its default repositories.
+However, CentOS has no [mxml-devel][Mini-XML] or [sbt][SBT] packages
+in its own repositories.  You'll have to install the latest [SBT]
+version following its website's instructions and you'll have to build
+the [Mini-XML] library from source:
+
+    git clone -b v3.2 https://github.com/michaelrsweet/mxml.git
+    # ./configure fails if you use CC=clang
+    unset CC AR
+    cd mxml
+    ./configure --prefix=/usr --disable-shared --disable-threads
+    make
+    sudo make install
+
+Now you can build Daffodil from source and the sbt and daffodil
+commands you type will be able to call the C compiler.
+
+## Fedora 34
+
+You can use the `dnf` package manager to install most of the tools
+needed to build Daffodil:
+
+    sudo dnf install clang gcc git java-11-openjdk-devel llvm make mxml-devel pkgconf
+
+If you want to use clang instead of gcc, you'll have to set your
+environment variables `CC` and `AR` to the clang binaries' names:
+
+    export CC=clang AR=llvm-ar
+
+However, Fedora has no [sbt][SBT] package in its own repositories.
 You'll have to install the latest [SBT] version following its
 website's instructions.
 
@@ -74,7 +102,7 @@ environment variables `CC` and `AR` to the clang binaries' names:
 
     export CC=clang-10 AR=llvm-ar-10
 
-However, Ubuntu has no sbt package in its default repositories.
+However, Ubuntu has no [sbt][SBT] package in its own repositories.
 You'll have to install the latest [SBT] version following its
 website's instructions.
 
@@ -93,7 +121,7 @@ libraries.
 You can use the `pacman` package manager to install most of the tools
 needed to build Daffodil:
 
-    pacman -S clang diffutils git make pkgconf
+    pacman -S clang diffutils gcc git make pkgconf
 
 If you want to use clang instead of gcc, you'll have to set your
 environment variables `CC` and `AR` to the clang binaries' names:
@@ -104,6 +132,8 @@ However, MSYS2 has no [libmxml-devel][Mini-XML] package so you'll have
 to build the [Mini-XML] library from source:
 
     git clone -b v3.2 https://github.com/michaelrsweet/mxml.git
+    # some daffodil tests fail if you build mxml with clang
+    unset CC AR
     cd mxml
     ./configure --prefix=/usr --disable-shared --disable-threads
     make

--- a/build.sbt
+++ b/build.sbt
@@ -82,7 +82,7 @@ lazy val runtime2         = Project("daffodil-runtime2", file("daffodil-runtime2
                                     (Compile / resourceDirectory).value / "org" / "apache" / "daffodil" / "runtime2" / "examples"
                                   )
                                 ),
-                                Compile / cFlags := (Compile / cFlags).value.withDefaultValue(Seq("-Wall", "-Wextra"))
+                                Compile / cFlags := (Compile / cFlags).value.withDefaultValue(Seq("-Wall", "-Wextra", "-pedantic", "-std=gnu99"))
                               )
 
 lazy val core             = Project("daffodil-core", file("daffodil-core")).configs(IntegrationTest)

--- a/daffodil-runtime2/src/main/resources/org/apache/daffodil/runtime2/c/Makefile
+++ b/daffodil-runtime2/src/main/resources/org/apache/daffodil/runtime2/c/Makefile
@@ -38,7 +38,7 @@ PROGRAM = ./daffodil
 HEADERS = libcli/*.h libruntime/*.h
 SOURCES = libcli/*.c libruntime/*.c
 INCLUDES = -Ilibcli -Ilibruntime
-CFLAGS = -g -Wall -Wextra
+CFLAGS = -g -Wall -Wextra -pedantic -std=gnu99
 LIBS = -lmxml
 
 $(PROGRAM): $(HEADERS) $(SOURCES)

--- a/daffodil-runtime2/src/main/resources/org/apache/daffodil/runtime2/c/libcli/daffodil_getopt.c
+++ b/daffodil-runtime2/src/main/resources/org/apache/daffodil/runtime2/c/libcli/daffodil_getopt.c
@@ -67,13 +67,13 @@ parse_daffodil_cli(int argc, char *argv[])
         {
         case 'h':
             error.code = CLI_HELP_USAGE;
-            error.s = exe;
+            error.arg.s = exe;
             return &error;
         case 'I':
             if (strcmp("xml", optarg) != 0)
             {
                 error.code = CLI_INVALID_INFOSET;
-                error.s = optarg;
+                error.arg.s = optarg;
                 return &error;
             }
             daffodil_parse.infoset_converter = optarg;
@@ -85,26 +85,27 @@ parse_daffodil_cli(int argc, char *argv[])
             break;
         case 'V':
             error.code = CLI_PROGRAM_VERSION;
-            error.s = daffodil_program_version;
+            error.arg.s = daffodil_program_version;
             return &error;
         case ':':
             error.code = CLI_MISSING_VALUE;
-            error.c = optopt;
+            error.arg.c = optopt;
             return &error;
         case '?':
             error.code = CLI_INVALID_OPTION;
-            error.c = optopt;
+            error.arg.c = optopt;
             return &error;
         default:
             // shouldn't happen unless programmer made error
             error.code = CLI_PROGRAM_ERROR;
-            error.d64 = opt;
+            error.arg.d64 = opt;
             return &error;
         }
     }
 
     // Get the command and the infile arg
-    for (int i = optind; i < argc; i++)
+    int i;
+    for (i = optind; i < argc; i++)
     {
         const char *arg = argv[i];
 
@@ -117,7 +118,7 @@ parse_daffodil_cli(int argc, char *argv[])
             else
             {
                 error.code = CLI_UNEXPECTED_ARGUMENT;
-                error.s = arg;
+                error.arg.s = arg;
                 return &error;
             }
         }
@@ -130,7 +131,7 @@ parse_daffodil_cli(int argc, char *argv[])
             else
             {
                 error.code = CLI_UNEXPECTED_ARGUMENT;
-                error.s = arg;
+                error.arg.s = arg;
                 return &error;
             }
         }
@@ -145,7 +146,7 @@ parse_daffodil_cli(int argc, char *argv[])
         else
         {
             error.code = CLI_INVALID_COMMAND;
-            error.s = arg;
+            error.arg.s = arg;
             return &error;
         }
     }
@@ -153,7 +154,7 @@ parse_daffodil_cli(int argc, char *argv[])
     if (DAFFODIL_MISSING_COMMAND == daffodil_cli.subcommand)
     {
         error.code = CLI_MISSING_COMMAND;
-        error.c = 0;
+        error.arg.c = 0;
         return &error;
     }
 

--- a/daffodil-runtime2/src/main/resources/org/apache/daffodil/runtime2/c/libcli/xml_reader.c
+++ b/daffodil-runtime2/src/main/resources/org/apache/daffodil/runtime2/c/libcli/xml_reader.c
@@ -57,7 +57,7 @@ strtobool(const char *numptr, const Error **errorptr)
     else
     {
         static Error error = {CLI_STRTOBOOL, {0}};
-        error.s = numptr;
+        error.arg.s = numptr;
         *errorptr = &error;
     }
 
@@ -80,19 +80,19 @@ strtodnum(const char *numptr, const Error **errorptr)
     if (errno != 0)
     {
         static Error error = {CLI_STRTOD_ERRNO, {0}};
-        error.s = numptr;
+        error.arg.s = numptr;
         *errorptr = &error;
     }
     else if (endptr == numptr)
     {
         static Error error = {CLI_STRTONUM_EMPTY, {0}};
-        error.s = numptr;
+        error.arg.s = numptr;
         *errorptr = &error;
     }
     else if (*endptr != '\0')
     {
         static Error error = {CLI_STRTONUM_NOT, {0}};
-        error.s = numptr;
+        error.arg.s = numptr;
         *errorptr = &error;
     }
 
@@ -115,19 +115,19 @@ strtofnum(const char *numptr, const Error **errorptr)
     if (errno != 0)
     {
         static Error error = {CLI_STRTOD_ERRNO, {0}};
-        error.s = numptr;
+        error.arg.s = numptr;
         *errorptr = &error;
     }
     else if (endptr == numptr)
     {
         static Error error = {CLI_STRTONUM_EMPTY, {0}};
-        error.s = numptr;
+        error.arg.s = numptr;
         *errorptr = &error;
     }
     else if (*endptr != '\0')
     {
         static Error error = {CLI_STRTONUM_NOT, {0}};
-        error.s = numptr;
+        error.arg.s = numptr;
         *errorptr = &error;
     }
 
@@ -151,25 +151,25 @@ strtonum(const char *numptr, intmax_t minval, intmax_t maxval, const Error **err
     if (errno != 0)
     {
         static Error error = {CLI_STRTOI_ERRNO, {0}};
-        error.s = numptr;
+        error.arg.s = numptr;
         *errorptr = &error;
     }
     else if (endptr == numptr)
     {
         static Error error = {CLI_STRTONUM_EMPTY, {0}};
-        error.s = numptr;
+        error.arg.s = numptr;
         *errorptr = &error;
     }
     else if (*endptr != '\0')
     {
         static Error error = {CLI_STRTONUM_NOT, {0}};
-        error.s = numptr;
+        error.arg.s = numptr;
         *errorptr = &error;
     }
     else if (value < minval || value > maxval)
     {
         static Error error = {CLI_STRTONUM_RANGE, {0}};
-        error.s = numptr;
+        error.arg.s = numptr;
         *errorptr = &error;
     }
 
@@ -192,25 +192,25 @@ strtounum(const char *numptr, uintmax_t maxval, const Error **errorptr)
     if (errno != 0)
     {
         static Error error = {CLI_STRTOI_ERRNO, {0}};
-        error.s = numptr;
+        error.arg.s = numptr;
         *errorptr = &error;
     }
     else if (endptr == numptr)
     {
         static Error error = {CLI_STRTONUM_EMPTY, {0}};
-        error.s = numptr;
+        error.arg.s = numptr;
         *errorptr = &error;
     }
     else if (*endptr != '\0')
     {
         static Error error = {CLI_STRTONUM_NOT, {0}};
-        error.s = numptr;
+        error.arg.s = numptr;
         *errorptr = &error;
     }
     else if (value > maxval)
     {
         static Error error = {CLI_STRTONUM_RANGE, {0}};
-        error.s = numptr;
+        error.arg.s = numptr;
         *errorptr = &error;
     }
 
@@ -271,7 +271,7 @@ xmlEndDocument(XMLReader *reader)
     {
         // This code path exits the program - no need to call mxmlDelete
         static Error error = {CLI_XML_LEFT, {0}};
-        error.s = mxmlGetElement(reader->node);
+        error.arg.s = mxmlGetElement(reader->node);
         return &error;
     }
 
@@ -302,7 +302,7 @@ xmlStartComplex(XMLReader *reader, const InfosetBase *base)
     if (name_from_xml && name_from_erd)
     {
         static Error error = {CLI_XML_MISMATCH, {0}};
-        error.s = name_from_erd;
+        error.arg.s = name_from_erd;
         return strcmp(name_from_xml, name_from_erd) == 0 ? NULL : &error;
     }
     else
@@ -388,7 +388,7 @@ xmlNumberElem(XMLReader *reader, const ERD *erd, void *number)
             default:
             {
                 static Error error_erd = {CLI_XML_ERD, {0}};
-                error_erd.d64 = typeCode;
+                error_erd.arg.d64 = typeCode;
                 return &error_erd;
             }
             }
@@ -396,7 +396,7 @@ xmlNumberElem(XMLReader *reader, const ERD *erd, void *number)
         else
         {
             static Error error = {CLI_XML_MISMATCH, {0}};
-            error.s = name_from_erd;
+            error.arg.s = name_from_erd;
             return &error;
         }
     }

--- a/daffodil-runtime2/src/main/resources/org/apache/daffodil/runtime2/c/libcli/xml_writer.c
+++ b/daffodil-runtime2/src/main/resources/org/apache/daffodil/runtime2/c/libcli/xml_writer.c
@@ -195,7 +195,7 @@ xmlNumberElem(XMLWriter *writer, const ERD *erd, const void *number)
     else
     {
         static Error error = {CLI_XML_ELEMENT, {0}};
-        error.s = name;
+        error.arg.s = name;
         return &error;
     }
 }

--- a/daffodil-runtime2/src/main/resources/org/apache/daffodil/runtime2/c/libruntime/errors.c
+++ b/daffodil-runtime2/src/main/resources/org/apache/daffodil/runtime2/c/libruntime/errors.c
@@ -65,7 +65,7 @@ add_diagnostic(Diagnostics *diagnostics, const Error *error)
         {
             Error *err = &diagnostics->array[diagnostics->length++];
             err->code = error->code;
-            err->s = error->s;
+            err->arg.s = error->arg.s;
             return true;
         }
     }
@@ -115,16 +115,16 @@ print_maybe_stop(const Error *error, int status)
     switch (lookup->field)
     {
     case FIELD_C:
-        fprintf(stderr, lookup->message, error->c);
+        fprintf(stderr, lookup->message, error->arg.c);
         break;
     case FIELD_D64:
-        fprintf(stderr, lookup->message, error->d64);
+        fprintf(stderr, lookup->message, error->arg.d64);
         break;
     case FIELD_S:
-        fprintf(stderr, lookup->message, error->s);
+        fprintf(stderr, lookup->message, error->arg.s);
         break;
     case FIELD_S_ON_STDOUT:
-        fprintf(stdout, lookup->message, error->s);
+        fprintf(stdout, lookup->message, error->arg.s);
         exit(EXIT_SUCCESS);
         break;
     case FIELD_ZZZ:
@@ -147,7 +147,8 @@ print_diagnostics(const Diagnostics *diagnostics)
 {
     if (diagnostics)
     {
-        for (size_t i = 0; i < diagnostics->length; i++)
+        size_t i;
+        for (i = 0; i < diagnostics->length; i++)
         {
             const Error *error = &diagnostics->array[i];
             print_maybe_stop(error, 0);

--- a/daffodil-runtime2/src/main/resources/org/apache/daffodil/runtime2/c/libruntime/errors.h
+++ b/daffodil-runtime2/src/main/resources/org/apache/daffodil/runtime2/c/libruntime/errors.h
@@ -67,7 +67,7 @@ typedef struct Error
         int         c;   // for %c
         int64_t     d64; // for %d64
         const char *s;   // for %s
-    };
+    } arg;
 } Error;
 
 // Limits - limits on how many elements static arrays can hold

--- a/daffodil-runtime2/src/main/resources/org/apache/daffodil/runtime2/c/libruntime/infoset.c
+++ b/daffodil-runtime2/src/main/resources/org/apache/daffodil/runtime2/c/libruntime/infoset.c
@@ -132,7 +132,8 @@ walkInfosetNode(const VisitEventHandler *handler, const InfosetBase *infoNode)
     const ERD **const childrenERDs = infoNode->erd->childrenERDs;
     const size_t *    offsets = infoNode->erd->offsets;
 
-    for (size_t i = 0; i < count && !error; i++)
+    size_t i;
+    for (i = 0; i < count && !error; i++)
     {
         const size_t offset = offsets[i];
         const ERD *  childERD = childrenERDs[i];

--- a/daffodil-runtime2/src/main/resources/org/apache/daffodil/runtime2/c/libruntime/infoset.h
+++ b/daffodil-runtime2/src/main/resources/org/apache/daffodil/runtime2/c/libruntime/infoset.h
@@ -26,22 +26,26 @@
 
 // Prototypes needed for compilation
 
-typedef struct ElementRuntimeData ERD;
-typedef struct InfosetBase        InfosetBase;
-typedef struct PState             PState;
-typedef struct UState             UState;
-typedef struct VisitEventHandler  VisitEventHandler;
+struct ERD;
+struct InfosetBase;
+struct PState;
+struct UState;
+struct VisitEventHandler;
 
-typedef void (*ERDInitSelf)(InfosetBase *infoNode);
-typedef void (*ERDParseSelf)(InfosetBase *infoNode, PState *pstate);
-typedef void (*ERDUnparseSelf)(const InfosetBase *infoNode, UState *ustate);
-typedef const Error *(*InitChoiceRD)(const InfosetBase *infoNode, const InfosetBase *rootElement);
+typedef void (*ERDInitSelf)(struct InfosetBase *infoNode);
+typedef void (*ERDParseSelf)(struct InfosetBase *infoNode, struct PState *pstate);
+typedef void (*ERDUnparseSelf)(const struct InfosetBase *infoNode, struct UState *ustate);
+typedef const Error *(*InitChoiceRD)(const struct InfosetBase *infoNode,
+                                     const struct InfosetBase *rootElement);
 
-typedef const Error *(*VisitStartDocument)(const VisitEventHandler *handler);
-typedef const Error *(*VisitEndDocument)(const VisitEventHandler *handler);
-typedef const Error *(*VisitStartComplex)(const VisitEventHandler *handler, const InfosetBase *base);
-typedef const Error *(*VisitEndComplex)(const VisitEventHandler *handler, const InfosetBase *base);
-typedef const Error *(*VisitNumberElem)(const VisitEventHandler *handler, const ERD *erd, const void *number);
+typedef const Error *(*VisitStartDocument)(const struct VisitEventHandler *handler);
+typedef const Error *(*VisitEndDocument)(const struct VisitEventHandler *handler);
+typedef const Error *(*VisitStartComplex)(const struct VisitEventHandler *handler,
+                                          const struct InfosetBase *      base);
+typedef const Error *(*VisitEndComplex)(const struct VisitEventHandler *handler,
+                                        const struct InfosetBase *      base);
+typedef const Error *(*VisitNumberElem)(const struct VisitEventHandler *handler, const struct ERD *erd,
+                                        const void *number);
 
 // NamedQName - name of an infoset element
 
@@ -73,13 +77,13 @@ enum TypeCode
 
 // ERD - element runtime data needed to parse/unparse objects
 
-typedef struct ElementRuntimeData
+typedef struct ERD
 {
     const NamedQName    namedQName;
     const enum TypeCode typeCode;
     const size_t        numChildren;
     const size_t *      offsets;
-    const ERD **        childrenERDs;
+    const struct ERD ** childrenERDs;
 
     const ERDInitSelf    initSelf;
     const ERDParseSelf   parseSelf;

--- a/daffodil-runtime2/src/main/resources/org/apache/daffodil/runtime2/c/libruntime/parsers.c
+++ b/daffodil-runtime2/src/main/resources/org/apache/daffodil/runtime2/c/libruntime/parsers.c
@@ -68,7 +68,7 @@
         else                                                                                                 \
         {                                                                                                    \
             static Error error = {ERR_PARSE_BOOL, {0}};                                                      \
-            error.d64 = (int64_t)buffer.i_val;                                                               \
+            error.arg.d64 = (int64_t)buffer.i_val;                                                           \
             pstate->error = &error;                                                                          \
         }                                                                                                    \
     }
@@ -103,9 +103,9 @@
 
 // Parse binary booleans, real numbers, and integers
 
-define_parse_endian_bool(be, 16);
-define_parse_endian_bool(be, 32);
-define_parse_endian_bool(be, 8);
+define_parse_endian_bool(be, 16)
+define_parse_endian_bool(be, 32)
+define_parse_endian_bool(be, 8)
 
 define_parse_endian_real(be, double, 64)
 define_parse_endian_real(be, float, 32)
@@ -120,9 +120,9 @@ define_parse_endian_integer(be, uint, 32)
 define_parse_endian_integer(be, uint, 64)
 define_parse_endian_integer(be, uint, 8)
 
-define_parse_endian_bool(le, 16);
-define_parse_endian_bool(le, 32);
-define_parse_endian_bool(le, 8);
+define_parse_endian_bool(le, 16)
+define_parse_endian_bool(le, 32)
+define_parse_endian_bool(le, 8)
 
 define_parse_endian_real(le, double, 64)
 define_parse_endian_real(le, float, 32)

--- a/daffodil-runtime2/src/main/resources/org/apache/daffodil/runtime2/c/libruntime/unparsers.c
+++ b/daffodil-runtime2/src/main/resources/org/apache/daffodil/runtime2/c/libruntime/unparsers.c
@@ -85,9 +85,9 @@
 
 // Unparse binary booleans, real numbers, and integers
 
-define_unparse_endian_bool(be, 16);
-define_unparse_endian_bool(be, 32);
-define_unparse_endian_bool(be, 8);
+define_unparse_endian_bool(be, 16)
+define_unparse_endian_bool(be, 32)
+define_unparse_endian_bool(be, 8)
 
 define_unparse_endian_real(be, double, 64)
 define_unparse_endian_real(be, float, 32)
@@ -102,9 +102,9 @@ define_unparse_endian_integer(be, uint, 32)
 define_unparse_endian_integer(be, uint, 64)
 define_unparse_endian_integer(be, uint, 8)
 
-define_unparse_endian_bool(le, 16);
-define_unparse_endian_bool(le, 32);
-define_unparse_endian_bool(le, 8);
+define_unparse_endian_bool(le, 16)
+define_unparse_endian_bool(le, 32)
+define_unparse_endian_bool(le, 8)
 
 define_unparse_endian_real(le, double, 64)
 define_unparse_endian_real(le, float, 32)

--- a/daffodil-runtime2/src/main/scala/org/apache/daffodil/runtime2/generators/CodeGeneratorState.scala
+++ b/daffodil-runtime2/src/main/scala/org/apache/daffodil/runtime2/generators/CodeGeneratorState.scala
@@ -263,7 +263,7 @@ class CodeGeneratorState {
       val declaration = s"    };"
       val initChoiceStatement =
         s"""    default:
-           |        error.d64 = key;
+           |        error.arg.d64 = key;
            |        return &error;
            |    }
            |
@@ -278,14 +278,14 @@ class CodeGeneratorState {
       val parseStatement =
         s"""    default:
            |        // Should never happen because initChoice would return an error first
-           |        error.d64 = (int64_t)instance->_choice;
+           |        error.arg.d64 = (int64_t)instance->_choice;
            |        pstate->error = &error;
            |        return;
            |    }""".stripMargin
       val unparseStatement =
         s"""    default:
            |        // Should never happen because initChoice would return an error first
-           |        error.d64 = (int64_t)instance->_choice;
+           |        error.arg.d64 = (int64_t)instance->_choice;
            |        ustate->error = &error;
            |        return;
            |    }""".stripMargin


### PR DESCRIPTION
Some older C compilers (e.g., gcc 4.8.2 on CentOS 7) don't allow a
local variable to be declared inside a for loop condition.  It's much
easier to move the declaration outside the for loop condition than it
is to override the compiler with a different driver name or the
correct driver options.

DAFFODIL-2507