### PR TITLE
WIP: Add tests to reproduce DAFFODIL-2183, but they pass

### DIFF
--- a/daffodil-test/src/test/resources/org/apache/daffodil/section13/nillable/literal-value-nils-unparse.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section13/nillable/literal-value-nils-unparse.tdml
@@ -740,6 +740,24 @@
         </xs:choice>
       </xs:complexType>
     </xs:element>
+    
+    <xs:element name="doc4">
+      <xs:complexType>
+        <xs:sequence dfdl:separator="|" dfdl:separatorPosition="infix">
+          <xs:element name="person" maxOccurs="unbounded"
+                      dfdl:occursCountKind="implicit"
+                      dfdl:initiator="Person:" nillable="true"
+                      dfdl:nilValue="%ES;" dfdl:nilValueDelimiterPolicy="initiator">
+            <xs:complexType>
+              <xs:sequence dfdl:separator="," dfdl:separatorPosition="infix">
+                <xs:element name="name" type="xs:string" />
+                <xs:element name="age" type="xs:string" />
+              </xs:sequence>
+            </xs:complexType>
+          </xs:element>
+        </xs:sequence>
+      </xs:complexType>
+    </xs:element>
 
   </tdml:defineSchema>
 
@@ -811,6 +829,43 @@
 
     <tdml:document>
       <tdml:documentPart type="text"><![CDATA[]]></tdml:documentPart>
+    </tdml:document>
+
+  </tdml:unparserTestCase>
+
+<!--
+  Test Name: text_complex_nil4
+     Schema: nillableComplex
+       Root: doc4
+    Purpose: This test checks DAFFODIL-2183 is fixed
+-->
+
+  <tdml:unparserTestCase name="text_complex_nil4" root="doc4"
+    model="nillableComplex"
+    description="Verify complex elements can be nilllable">
+
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <doc4 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+          <person>
+            <name>John Doe</name>
+            <age>29</age>
+          </person>
+          <person>
+            <name>Sally Smith</name>
+            <age>34</age>
+          </person>
+          <person xsi:nil="true"></person>
+          <person>
+            <name>Bob Jones</name>
+            <age>51</age>
+          </person>
+        </doc4>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+
+    <tdml:document>
+      <tdml:documentPart type="text"><![CDATA[Person:John Doe,29|Person:Sally Smith,34|Person:|Person:Bob Jones,51]]></tdml:documentPart>
     </tdml:document>
 
   </tdml:unparserTestCase>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section13/nillable/literal-value-nils.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section13/nillable/literal-value-nils.tdml
@@ -366,6 +366,13 @@
 
   </tdml:defineSchema>
 
+<!--
+  Test Name: test_complex_nil
+     Schema: nillableComplex
+       Root: doc
+    Purpose: This test demonstrates parsing a complex literal nil.
+-->
+
   <tdml:parserTestCase name="test_complex_nil" root="doc"
     model="nillableComplex"
     description="Verify complex elements can be nilllable">

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section13/nillable/TestNillable.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section13/nillable/TestNillable.scala
@@ -57,17 +57,17 @@ class TestNillable {
   @Test def test_nillable1(): Unit = { runnerAA.runOneTest("nillable1") }
   @Test def test_edifact1a(): Unit = { runnerAA.runOneTest("edifact1a") }
 
-  @Test def test_text_nil_characterClass_04_parse() = { runnerLN.runOneTest("text_nil_characterClass_04_parse") }
+  @Test def test_text_nil_characterClass_04_parse(): Unit = { runnerLN.runOneTest("text_nil_characterClass_04_parse") }
 
   @Test def test_text_03(): Unit = { runnerLN.runOneTest("text_03") }
   @Test def test_text_03ic(): Unit = { runnerLN.runOneTest("text_03ic") }
   @Test def test_text_04(): Unit = { runnerLN.runOneTest("text_04") }
   @Test def test_text_05(): Unit = { runnerLN.runOneTest("text_05") }
-  @Test def test_text_06() = { runnerLN.runOneTest("text_06") }
-  @Test def test_binary_01() = { runnerLN.runOneTest("binary_01") }
-  @Test def test_padded_nils() = { runnerLN.runOneTest("test_padded_nils") }
+  @Test def test_text_06(): Unit = { runnerLN.runOneTest("text_06") }
+  @Test def test_binary_01(): Unit = { runnerLN.runOneTest("binary_01") }
+  @Test def test_padded_nils(): Unit = { runnerLN.runOneTest("test_padded_nils") }
 
-  @Test def test_nillable_ovc_01() = { runnerLN.runOneTest("nillable_ovc_01") }
+  @Test def test_nillable_ovc_01(): Unit = { runnerLN.runOneTest("nillable_ovc_01") }
 
   /* These should demonstrate that:
    *   DFDL Char Classes are not allowed for literalCharacter

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section13/nillable/TestNillableUnparse.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section13/nillable/TestNillableUnparse.scala
@@ -43,6 +43,7 @@ class TestNillableUnparse {
   @Test def test_text_complex_nil(): Unit = { runnerLN.runOneTest("text_complex_nil") }
   @Test def test_text_complex_nil2(): Unit = { runnerLN.runOneTest("text_complex_nil2") }
   @Test def test_text_complex_nil3(): Unit = { runnerLN.runOneTest("text_complex_nil3") }
+  @Test def test_text_complex_nil4(): Unit = { runnerLN.runOneTest("text_complex_nil4") }
 
   @Test def test_text_nil_only1(): Unit = { runnerLN.runOneTest("text_nil_only1") }
   @Test def test_text_nil_only2(): Unit = { runnerLN.runOneTest("text_nil_only2") }


### PR DESCRIPTION
The unparse test was supposed to fail with the error `Unparse Error: Element {}person does not have a value`, but it passes.

Can we get a new test case that proves the bug still exists?

DAFFODIL-2183
