### PR TITLE
Add restrictions to delimiters for escapeCharacters

### DIFF
--- a/daffodil-core/src/main/scala/org/apache/daffodil/grammar/primitives/SequenceChild.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/grammar/primitives/SequenceChild.scala
@@ -96,8 +96,10 @@ abstract class SequenceChild(protected val sq: SequenceTermBase, child: Term, gr
 
   protected lazy val sepGram = {
     sscb match {
-      case _: PositionalLike =>
+      case _: PositionalLike => {
         sgtb.checkSeparatorTerminatorConflict
+        sgtb.checkDelimiterEscapeConflict(child)
+      }
       case _ => // ok
     }
     sq.sequenceSeparator

--- a/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/processors/unparsers/DelimitedUnparsers.scala
+++ b/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/processors/unparsers/DelimitedUnparsers.scala
@@ -66,7 +66,7 @@ sealed class StringDelimitedUnparser(
             val (result, _) = {
               if (scheme.isInstanceOf[EscapeSchemeCharUnparserHelper]) {
                 val theScheme = scheme.asInstanceOf[EscapeSchemeCharUnparserHelper]
-                val hasEscCharAsDelimiter = terminatingMarkup.exists(d => d.lookingFor.length == 1 && d.lookingFor(0) =#= theScheme.ec)
+                val hasEscCharAsDelimiter = terminatingMarkup.exists(d => d.lookingFor(0) =#= theScheme.ec)
                 val thingsToEscape = (terminatingMarkup ++ scheme.lookingFor).toArray
 
                 textUnparser.escapeCharacter(dis, fieldDFA, thingsToEscape, hasEscCharAsDelimiter, theScheme.ec, theScheme.eec, state)

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section07/escapeScheme/escapeScenarios.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section07/escapeScheme/escapeScenarios.tdml
@@ -18,7 +18,7 @@
 
 <testSuite suiteName="escapeScheme" xmlns="http://www.ibm.com/xmlns/dfdl/testData"
   xmlns:tns="http://example.com"
-  xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/" 
+  xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/"
   xmlns:dfdlx="http://www.ogf.org/dfdl/dfdl-1.0/extensions"
   xmlns:xs="http://www.w3.org/2001/XMLSchema"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -26,15 +26,15 @@
 
   <defineSchema name="es1">
     <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
-  
-    <dfdl:format ref="tns:GeneralFormat" lengthKind="delimited" 
+
+    <dfdl:format ref="tns:GeneralFormat" lengthKind="delimited"
         occursCountKind="implicit"/>
 
     <dfdl:defineEscapeScheme name="scenario1">
       <dfdl:escapeScheme escapeCharacter='/'
         escapeKind="escapeCharacter" escapeEscapeCharacter="/" extraEscapedCharacters="" generateEscapeBlock="whenNeeded" />
     </dfdl:defineEscapeScheme>
-   
+
     <xs:element name="e_infix">
       <xs:complexType>
         <xs:sequence dfdl:separator=";" dfdl:separatorPosition="infix">
@@ -43,7 +43,7 @@
         </xs:sequence>
       </xs:complexType>
     </xs:element>
-    
+
     <xs:element name="e_infix_never">
       <xs:complexType>
         <xs:sequence dfdl:separator=";" dfdl:separatorPosition="infix"
@@ -64,7 +64,7 @@
     </xs:element>
 
   </defineSchema>
-  
+
   <defineSchema name="es1-2">
     <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
     <dfdl:format ref="tns:GeneralFormat" lengthKind="delimited" documentFinalTerminatorCanBeMissing="no"/>
@@ -73,7 +73,7 @@
       <dfdl:escapeScheme escapeCharacter='/'
         escapeKind="escapeCharacter" escapeEscapeCharacter="/" extraEscapedCharacters="" generateEscapeBlock="whenNeeded" />
     </dfdl:defineEscapeScheme>
-   
+
     <xs:element name="e">
       <xs:complexType>
         <xs:sequence dfdl:separator="">
@@ -84,7 +84,7 @@
     </xs:element>
 
   </defineSchema>
-  
+
   <parserTestCase name="scenario1_1" model="es1"
     description="Section 13 - escapeCharacter - DFDL-13-029R" root="e_infix">
     <document>foo;bar</document>
@@ -110,7 +110,7 @@
       </dfdlInfoset>
     </infoset>
   </parserTestCase>
-  
+
   <parserTestCase name="scenario1_3" model="es1"
     description="Section 13 - escapeCharacter - DFDL-13-029R" root="e_infix">
     <document>foo/;bar</document>
@@ -122,7 +122,7 @@
       </dfdlInfoset>
     </infoset>
   </parserTestCase>
-  
+
   <parserTestCase name="scenario1_4" model="es1"
     description="Section 13 - escapeCharacter - DFDL-13-029R" root="e_infix">
     <document>foo//;bar</document>
@@ -135,7 +135,7 @@
       </dfdlInfoset>
     </infoset>
   </parserTestCase>
-  
+
   <parserTestCase name="scenario1_5" model="es1"
     description="Section 13 - escapeCharacter - DFDL-13-029R" root="e_infix"
     roundTrip="twoPass">
@@ -148,7 +148,7 @@
       </dfdlInfoset>
     </infoset>
   </parserTestCase>
-  
+
   <parserTestCase name="scenario1_6" model="es1"
     description="Section 13 - escapeCharacter - DFDL-13-029R" root="e_infix">
     <document>foo///;bar</document>
@@ -160,7 +160,7 @@
       </dfdlInfoset>
     </infoset>
   </parserTestCase>
-  
+
   <parserTestCase name="scenario1_7" model="es1"
     description="Section 13 - escapeCharacter - DFDL-13-029R" root="e_infix_never"
     roundTrip="onePass">
@@ -174,7 +174,7 @@
       </dfdlInfoset>
     </infoset>
   </parserTestCase>
-  
+
   <parserTestCase name="scenario1_7_postfix" model="es1"
     description="Section 13 - escapeCharacter - DFDL-13-029R" root="e_postfix">
     <document>foo;</document>
@@ -186,7 +186,7 @@
       </dfdlInfoset>
     </infoset>
   </parserTestCase>
-  
+
   <parserTestCase name="scenario1_8" model="es1"
     description="Section 13 - escapeCharacter - DFDL-13-029R" root="e_infix">
     <document>foo/;</document>
@@ -198,7 +198,7 @@
       </dfdlInfoset>
     </infoset>
   </parserTestCase>
-  
+
   <parserTestCase name="scenario1_8_req_term" model="es1-2"
     description="Section 13 - escapeCharacter - DFDL-13-029R" root="e">
     <document>foo/;</document>
@@ -206,7 +206,7 @@
       <error>Parse Error</error>
     </errors>
   </parserTestCase>
-  
+
   <parserTestCase name="scenario1_9" model="es1"
     description="Section 13 - escapeCharacter - DFDL-13-029R" root="e_infix_never"
     roundTrip="onePass">
@@ -220,7 +220,7 @@
       </dfdlInfoset>
     </infoset>
   </parserTestCase>
-  
+
   <parserTestCase name="scenario1_9_postfix" model="es1"
     description="Section 13 - escapeCharacter - DFDL-13-029R" root="e_postfix">
     <document>foo/;;</document>
@@ -232,7 +232,7 @@
       </dfdlInfoset>
     </infoset>
   </parserTestCase>
-  
+
   <parserTestCase name="scenario1_10" model="es1"
     description="Section 13 - escapeCharacter - DFDL-13-029R" root="e_infix_never"
     roundTrip="onePass">
@@ -246,7 +246,7 @@
       </dfdlInfoset>
     </infoset>
   </parserTestCase>
-  
+
   <parserTestCase name="scenario1_10_postfix" model="es1"
     description="Section 13 - escapeCharacter - DFDL-13-029R" root="e_postfix">
     <document>foo//;</document>
@@ -258,7 +258,7 @@
       </dfdlInfoset>
     </infoset>
   </parserTestCase>
-  
+
   <parserTestCase name="scenario1_11" model="es1"
     description="Section 13 - escapeCharacter - DFDL-13-029R" root="e_infix">
     <document>foo///;</document>
@@ -270,7 +270,7 @@
       </dfdlInfoset>
     </infoset>
   </parserTestCase>
-  
+
   <parserTestCase name="scenario1_11_postfix" model="es1"
     description="Section 13 - escapeCharacter - DFDL-13-029R" root="e_postfix">
     <document>foo///;</document>
@@ -278,7 +278,7 @@
       <error>Parse Error</error>
     </errors>
   </parserTestCase>
-  
+
   <parserTestCase name="scenario1_12" model="es1"
     description="Section 13 - escapeCharacter - DFDL-13-029R" root="e_infix"
     roundTrip="twoPass">
@@ -291,7 +291,7 @@
       </dfdlInfoset>
     </infoset>
   </parserTestCase>
-  
+
   <parserTestCase name="scenario1_12_postfix" model="es1"
     description="Section 13 - escapeCharacter - DFDL-13-029R" root="e_postfix">
     <document>foo/</document>
@@ -299,7 +299,7 @@
       <error>Parse Error</error>
     </errors>
   </parserTestCase>
-  
+
   <parserTestCase name="scenario1_13" model="es1"
     description="Section 13 - escapeCharacter - DFDL-13-029R" root="e_infix"
     roundTrip="twoPass">
@@ -312,7 +312,7 @@
       </dfdlInfoset>
     </infoset>
   </parserTestCase>
-  
+
   <parserTestCase name="scenario1_13_postfix" model="es1"
     description="Section 13 - escapeCharacter - DFDL-13-029R" root="e_postfix">
     <document>foo///</document>
@@ -320,7 +320,7 @@
       <error>Parse Error</error>
     </errors>
   </parserTestCase>
-  
+
   <defineSchema name="es2">
     <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
     <dfdl:format ref="tns:GeneralFormat" lengthKind="delimited" />
@@ -329,7 +329,7 @@
       <dfdl:escapeScheme escapeCharacter='/'
         escapeKind="escapeCharacter" escapeEscapeCharacter="$" extraEscapedCharacters="" generateEscapeBlock="whenNeeded" />
     </dfdl:defineEscapeScheme>
-   
+
     <xs:element name="e_infix">
       <xs:complexType>
         <xs:sequence dfdl:separator="$;" dfdl:separatorPosition="infix">
@@ -338,7 +338,7 @@
         </xs:sequence>
       </xs:complexType>
     </xs:element>
-    
+
    <xs:element name="e_infix_keepEmpty">
       <xs:complexType>
         <xs:sequence dfdl:separator="$;" dfdl:separatorPosition="infix">
@@ -348,7 +348,7 @@
         </xs:sequence>
       </xs:complexType>
     </xs:element>
-    
+
     <xs:element name="e_infix_never">
       <xs:complexType>
         <xs:sequence dfdl:separator="$;" dfdl:separatorPosition="infix"
@@ -369,7 +369,7 @@
     </xs:element>
 
   </defineSchema>
-  
+
   <defineSchema name="es2-2">
     <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
     <dfdl:format ref="tns:GeneralFormat" lengthKind="delimited" documentFinalTerminatorCanBeMissing="no"/>
@@ -378,7 +378,7 @@
       <dfdl:escapeScheme escapeCharacter='/'
         escapeKind="escapeCharacter" escapeEscapeCharacter="$" extraEscapedCharacters="" generateEscapeBlock="whenNeeded" />
     </dfdl:defineEscapeScheme>
-   
+
     <xs:element name="e">
       <xs:complexType>
         <xs:sequence dfdl:separator="">
@@ -389,238 +389,24 @@
     </xs:element>
 
   </defineSchema>
-  
+
   <parserTestCase name="scenario2_1" model="es2"
     description="Section 13 - escapeCharacter - DFDL-13-029R" root="e_infix">
     <document>foo$;bar</document>
-    <infoset>
-      <dfdlInfoset>
-        <tns:e_infix>
-          <x>foo</x>
-    <y>bar</y>
-  </tns:e_infix>
-      </dfdlInfoset>
-    </infoset>
+    <errors>
+      <error>Schema Definition Error</error>
+      <error>dfdl:terminator and dfdl:separator</error>
+      <error>may not begin with</error>
+      <error>dfdl:escapeEscapeCharacter</error>
+    </errors>
   </parserTestCase>
- 
-  <parserTestCase name="scenario2_2" model="es2"
-    description="Section 13 - escapeCharacter - DFDL-13-029R" root="e_infix">
-    <document>foo/$;bar</document>
-    <infoset>
-      <dfdlInfoset>
-        <tns:e_infix>
-          <x>foo$;bar</x>
-        </tns:e_infix>
-      </dfdlInfoset>
-    </infoset>
-  </parserTestCase>
-  
-  <parserTestCase name="scenario2_3" model="es2"
-    description="Section 13 - escapeCharacter - DFDL-13-029R" root="e_infix">
-    <document>foo$/$;bar</document>
-    <infoset>
-      <dfdlInfoset>
-        <tns:e_infix>
-          <x>foo/</x>
-          <y>bar</y>
-        </tns:e_infix>
-      </dfdlInfoset>
-    </infoset>
-  </parserTestCase>
-  
-  <parserTestCase name="scenario2_4" model="es2"
-    description="Section 13 - escapeCharacter - DFDL-13-029R" root="e_infix" roundTrip="false">
-    <!-- See DFDL-1556 for to make roundTrip="true" -->
-    <document>foo$$;bar</document>
-    <infoset>
-      <dfdlInfoset>
-        <tns:e_infix>
-          <x>foo$</x>
-          <y>bar</y>
-        </tns:e_infix>
-      </dfdlInfoset>
-    </infoset>
-  </parserTestCase>
-  
-  <parserTestCase name="scenario2_5" model="es2"
-    description="Section 13 - escapeCharacter - DFDL-13-029R" root="e_infix"
-    roundTrip="twoPass">
-    <document>foo//$;bar</document>
-    <infoset>
-      <dfdlInfoset>
-        <tns:e_infix>
-          <x>foo$;bar</x>
-        </tns:e_infix>
-      </dfdlInfoset>
-    </infoset>
-  </parserTestCase>
-  
-  <parserTestCase name="scenario2_6" model="es2"
-    description="Section 13 - escapeCharacter - DFDL-13-029R" root="e_infix"
-    roundTrip="twoPass">
-    <document>foo//////////bar</document>
-    <infoset>
-      <dfdlInfoset>
-        <tns:e_infix>
-          <x>foobar</x>
-  </tns:e_infix>
-      </dfdlInfoset>
-    </infoset>
-  </parserTestCase>
-  
-  <parserTestCase name="scenario2_7" model="es2"
-    description="Section 13 - escapeCharacter - DFDL-13-029R" root="e_infix" roundTrip="false">
-    <!-- See DFDL-1556 for to make roundTrip="true" -->
-    <document>foo$$$$$bar</document>
-    <infoset>
-      <dfdlInfoset>
-        <tns:e_infix>
-          <x>foo$$$$$bar</x>
-  </tns:e_infix>
-      </dfdlInfoset>
-    </infoset>
-  </parserTestCase>
-  
-  <parserTestCase name="scenario2_8" model="es2"
-    description="Section 13 - escapeCharacter - DFDL-13-029R" root="e_infix"
-    roundTrip="twoPass">
-    <document>foo$//;bar</document>
-    <infoset>
-      <dfdlInfoset>
-        <tns:e_infix>
-          <x>foo/;bar</x>
-  </tns:e_infix>
-      </dfdlInfoset>
-    </infoset>
-  </parserTestCase>
-  
-  <parserTestCase name="scenario2_9" model="es2"
-    description="Section 13 - escapeCharacter - DFDL-13-029R" root="e_infix" roundTrip="false">
-    <!-- See DFDL-1556 for to make roundTrip="true" -->
-    <document>foo$/$$;bar</document>
-    <infoset>
-      <dfdlInfoset>
-        <tns:e_infix>
-          <x>foo/$</x>
-    <y>bar</y>
-  </tns:e_infix>
-      </dfdlInfoset>
-    </infoset>
-  </parserTestCase>
-  
-  <parserTestCase name="scenario2_10" model="es2"
-    description="Section 13 - escapeCharacter - DFDL-13-029R" root="e_infix_never"
-    roundTrip="onePass">
-    <document>foo$;</document>
-    <infoset>
-      <dfdlInfoset>
-        <tns:e_infix_never>
-          <x>foo</x>
-          <y></y>
-        </tns:e_infix_never>
-      </dfdlInfoset>
-    </infoset>
-  </parserTestCase>
-  
-  <parserTestCase name="scenario2_10_postfix" model="es2"
-    description="Section 13 - escapeCharacter - DFDL-13-029R" root="e_postfix">
-    <document>foo$;</document>
-    <infoset>
-      <dfdlInfoset>
-        <tns:e_postfix>
-          <x>foo</x>
-  </tns:e_postfix>
-      </dfdlInfoset>
-    </infoset>
-  </parserTestCase>
-  
-  <parserTestCase name="scenario2_11" model="es2"
-    description="Section 13 - escapeCharacter - DFDL-13-029R" root="e_infix">
-    <document>foo/$;</document>
-    <infoset>
-      <dfdlInfoset>
-        <tns:e_infix>
-          <x>foo$;</x>
-  </tns:e_infix>
-      </dfdlInfoset>
-    </infoset>
-  </parserTestCase>
-  
+
   <parserTestCase name="scenario2_11_req_term" model="es2-2"
     description="Section 13 - escapeCharacter - DFDL-13-029R" root="e">
     <document>foo/$;</document>
     <errors>
       <error>Parse Error</error>
     </errors>
-  </parserTestCase>
-  
-  <parserTestCase name="scenario2_12" model="es2"
-    description="Section 13 - escapeCharacter - DFDL-13-029R" root="e_infix_never"
-    roundTrip="onePass">
-    <document>foo$/$;</document>
-    <infoset>
-      <dfdlInfoset>
-        <tns:e_infix_never>
-          <x>foo/</x>
-          <y></y>
-        </tns:e_infix_never>
-      </dfdlInfoset>
-    </infoset>
-  </parserTestCase>
-  
-  <parserTestCase name="scenario2_12_postfix" model="es2"
-    description="Section 13 - escapeCharacter - DFDL-13-029R" root="e_postfix">
-    <document>foo$/$;</document>
-    <infoset>
-      <dfdlInfoset>
-        <tns:e_postfix>
-          <x>foo/</x>
-        </tns:e_postfix>
-      </dfdlInfoset>
-    </infoset>
-  </parserTestCase>
-  
-  <parserTestCase name="scenario2_13" model="es2"
-    description="Section 13 - escapeCharacter - DFDL-13-029R" root="e_infix_keepEmpty" roundTrip="false">
-    <!-- See DAFFODIL-1556 for to make roundTrip="true" -->
-    <document>foo$$/$;</document>
-    <infoset>
-      <dfdlInfoset>
-        <tns:e_infix_keepEmpty>
-          <x>foo$/</x>
-          <!-- dfdlx:emptyElementParsePolicy 'treatAsEmpty' only creates empty
-               string elements if there is some non-zero-length syntax
-          <y></y>
-          -->
-        </tns:e_infix_keepEmpty>
-      </dfdlInfoset>
-    </infoset>
-  </parserTestCase>
-  
-  <parserTestCase name="scenario2_13_postfix" model="es2"
-    description="Section 13 - escapeCharacter - DFDL-13-029R" root="e_postfix" roundTrip="false">
-    <!-- See DAFFODIL-1556 for to make roundTrip="true" -->
-    <document>foo$$/$;</document>
-    <infoset>
-      <dfdlInfoset>
-        <tns:e_postfix>
-          <x>foo$/</x>
-        </tns:e_postfix>
-      </dfdlInfoset>
-    </infoset>
-  </parserTestCase>
-  
-  <parserTestCase name="scenario2_14" model="es2"
-    description="Section 13 - escapeCharacter - DFDL-13-029R" root="e_infix" roundTrip="false">
-    <!-- See DFDL-DAFFODIL for to make roundTrip="true" -->
-    <document>foo$$$//$;</document>
-    <infoset>
-      <dfdlInfoset>
-        <tns:e_infix>
-          <x>foo$$/$;</x>
-  </tns:e_infix>
-      </dfdlInfoset>
-    </infoset>
   </parserTestCase>
 
   <!-- This does get a parse error but it's a bit confusing - 'Delimiter not found!  Was looking for ($;) but found "$;" instead.' -->
@@ -641,7 +427,7 @@
       <dfdl:escapeScheme escapeCharacter='/'
         escapeKind="escapeCharacter" escapeEscapeCharacter="$" extraEscapedCharacters="" generateEscapeBlock="whenNeeded" />
     </dfdl:defineEscapeScheme>
-   
+
     <xs:element name="e_infix">
       <xs:complexType>
         <xs:sequence dfdl:separator="/;" dfdl:separatorPosition="infix">
@@ -650,324 +436,20 @@
         </xs:sequence>
       </xs:complexType>
     </xs:element>
-    
-    <xs:element name="e_infix_never">
-      <xs:complexType>
-        <xs:sequence dfdl:separator="/;" dfdl:separatorPosition="infix"
-          dfdl:separatorSuppressionPolicy="never">
-          <xs:element name="x" type="xs:string" dfdl:escapeSchemeRef="tns:scenario3" />
-          <xs:element name="y" type="xs:string" minOccurs="0" dfdl:escapeSchemeRef="tns:scenario3" />
-        </xs:sequence>
-      </xs:complexType>
-    </xs:element>
-    
+	</defineSchema>
 
-    <xs:element name="e_postfix">
-      <xs:complexType>
-        <xs:sequence dfdl:separator="/;" dfdl:separatorPosition="postfix">
-          <xs:element name="x" type="xs:string" dfdl:escapeSchemeRef="tns:scenario3" />
-          <xs:element name="y" type="xs:string" minOccurs="0" dfdl:escapeSchemeRef="tns:scenario3" />
-        </xs:sequence>
-      </xs:complexType>
-    </xs:element>
-
-  </defineSchema>
-  
-  <defineSchema name="es3-2">
-    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
-    <dfdl:format ref="tns:GeneralFormat" lengthKind="delimited" documentFinalTerminatorCanBeMissing="no"/>
-
-    <dfdl:defineEscapeScheme name="scenario3">
-      <dfdl:escapeScheme escapeCharacter='/'
-        escapeKind="escapeCharacter" escapeEscapeCharacter="$" extraEscapedCharacters="" generateEscapeBlock="whenNeeded" />
-    </dfdl:defineEscapeScheme>
-   
-    <xs:element name="e">
-      <xs:complexType>
-        <xs:sequence dfdl:separator="">
-          <xs:element name="x" type="xs:string" dfdl:escapeSchemeRef="tns:scenario3" dfdl:terminator="/;"/>
-          <xs:element name="y" type="xs:string" minOccurs="0" dfdl:escapeSchemeRef="tns:scenario3" dfdl:terminator="/;" />
-        </xs:sequence>
-      </xs:complexType>
-    </xs:element>
-
-  </defineSchema>
-  
   <parserTestCase name="scenario3_1" model="es3"
-    description="Section 13 - escapeCharacter - DFDL-13-029R" root="e_infix">
-    <document>foo/;bar</document>
-    <infoset>
-      <dfdlInfoset>
-        <tns:e_infix>
-          <x>foo</x>
-    <y>bar</y>
-  </tns:e_infix>
-      </dfdlInfoset>
-    </infoset>
-  </parserTestCase>
-  
-  <parserTestCase name="scenario3_2" model="es3"
-    description="Section 13 - escapeCharacter - DFDL-13-029R" root="e_infix"
-    roundTrip="twoPass">
-    <document>foo$/;bar</document>
-    <infoset>
-      <dfdlInfoset>
-        <tns:e_infix>
-          <x>foo/;bar</x>
-  </tns:e_infix>
-      </dfdlInfoset>
-    </infoset>
-  </parserTestCase>
-  
-  <parserTestCase name="scenario3_3" model="es3"
-    description="Section 13 - escapeCharacter - DFDL-13-029R" root="e_infix" roundTrip="false">
-    <!-- See DFDL-1556 for to make roundTrip="true" -->
-    <document>foo$$/;bar</document>
-    <infoset>
-      <dfdlInfoset>
-        <tns:e_infix>
-          <x>foo$/;bar</x>
-  </tns:e_infix>
-      </dfdlInfoset>
-    </infoset>
-  </parserTestCase>
-  
-  <parserTestCase name="scenario3_4" model="es3"
-    description="Section 13 - escapeCharacter - DFDL-13-029R" root="e_infix">
-    <document>foo//;bar</document>
-    <infoset>
-      <dfdlInfoset>
-        <tns:e_infix>
-          <x>foo/;bar</x>
-  </tns:e_infix>
-      </dfdlInfoset>
-    </infoset>
-  </parserTestCase>
-  
-  <parserTestCase name="scenario3_5" model="es3"
-    description="Section 13 - escapeCharacter - DFDL-13-029R" root="e_infix"
-    roundTrip="twoPass">
-    <document>foo///;bar</document>
-    <infoset>
-      <dfdlInfoset>
-        <tns:e_infix>
-          <x>foo/</x>
-    <y>bar</y>
-  </tns:e_infix>
-      </dfdlInfoset>
-    </infoset>
-  </parserTestCase>
-  
-  <parserTestCase name="scenario3_6" model="es3"
-    description="Section 13 - escapeCharacter - DFDL-13-029R" root="e_infix">
-    <document>foo$//;bar</document>
-    <infoset>
-      <dfdlInfoset>
-        <tns:e_infix>
-          <x>foo/</x>
-    <y>bar</y>
-  </tns:e_infix>
-      </dfdlInfoset>
-    </infoset>
-  </parserTestCase>
-  
-  <parserTestCase name="scenario3_7" model="es3"
-    description="Section 13 - escapeCharacter - DFDL-13-029R" root="e_infix">
-    <document>foo$///;bar</document>
-    <infoset>
-      <dfdlInfoset>
-        <tns:e_infix>
-          <x>foo//;bar</x>
-  </tns:e_infix>
-      </dfdlInfoset>
-    </infoset>
-  </parserTestCase>
-  
-  <parserTestCase name="scenario3_8" model="es3"
-    description="Section 13 - escapeCharacter - DFDL-13-029R" root="e_infix"
-    roundTrip="twoPass">
-    <document>foo$////;bar</document>
-    <infoset>
-      <dfdlInfoset>
-        <tns:e_infix>
-          <x>foo//</x>
-    <y>bar</y>
-  </tns:e_infix>
-      </dfdlInfoset>
-    </infoset>
-  </parserTestCase>
-  
-  <parserTestCase name="scenario3_9" model="es3"
-    description="Section 13 - escapeCharacter - DFDL-13-029R" root="e_infix"
-    roundTrip="twoPass">
-    <document>foo$///////;bar</document>
-    <infoset>
-      <dfdlInfoset>
-        <tns:e_infix>
-          <x>foo////;bar</x>
-  </tns:e_infix>
-      </dfdlInfoset>
-    </infoset>
-  </parserTestCase>
-  
-  <parserTestCase name="scenario3_10" model="es3"
-    description="Section 13 - escapeCharacter - DFDL-13-029R" root="e_infix_never"
-    roundTrip="onePass">
-    <document>foo/;</document>
-    <infoset>
-      <dfdlInfoset>
-        <tns:e_infix_never>
-          <x>foo</x>
-          <y></y>
-        </tns:e_infix_never>
-      </dfdlInfoset>
-    </infoset>
-  </parserTestCase>
-  
-  <parserTestCase name="scenario3_10_postfix" model="es3"
-    description="Section 13 - escapeCharacter - DFDL-13-029R" root="e_postfix">
-    <document>foo/;</document>
-    <infoset>
-      <dfdlInfoset>
-        <tns:e_postfix>
-          <x>foo</x>
-        </tns:e_postfix>
-      </dfdlInfoset>
-    </infoset>
-  </parserTestCase>
-  
-  <parserTestCase name="scenario3_11" model="es3"
-    description="Section 13 - escapeCharacter - DFDL-13-029R" root="e_infix"
-    roundTrip="twoPass">
-    <document>foo$/;</document>
-    <infoset>
-      <dfdlInfoset>
-        <tns:e_infix>
-          <x>foo/;</x>
-  </tns:e_infix>
-      </dfdlInfoset>
-    </infoset>
-  </parserTestCase>
-  
-  <parserTestCase name="scenario3_11_postfix" model="es3"
-    description="Section 13 - escapeCharacter - DFDL-13-029R" root="e_postfix">
-    <document>foo$/;</document>
-    <infoset>
-      <dfdlInfoset>
-        <tns:e_postfix>
-          <x>foo/;</x>
-  </tns:e_postfix>
-      </dfdlInfoset>
-    </infoset>
-  </parserTestCase>
-  
-  <parserTestCase name="scenario3_12" model="es3"
-    description="Section 13 - escapeCharacter - DFDL-13-029R" root="e_infix" roundTrip="false">
-    <!-- See DFDL-1556 for to make roundTrip="true" -->
-    <document>foo$$/;</document>
-    <infoset>
-      <dfdlInfoset>
-        <tns:e_infix>
-          <x>foo$/;</x>
-  </tns:e_infix>
-      </dfdlInfoset>
-    </infoset>
-  </parserTestCase>
-  
-  <parserTestCase name="scenario3_12_req_term" model="es3-2"
-    description="Section 13 - escapeCharacter - DFDL-13-029R" root="e">
-    <document>foo$$/;</document>
+    description="Section 13 - escapeCharacter - DFDL-13-029R" root="e_infix" roundTrip="true">
+    <document>foo$$/$;</document>
     <errors>
-      <error>Parse Error</error>
+      <error>Schema Definition Error</error>
+      <error>terminator</error>
+      <error>separator</error>
+      <error>may not begin</error>
+      <error>escapeCharacter</error>
     </errors>
   </parserTestCase>
 
-  <parserTestCase name="scenario3_13" model="es3"
-    description="Section 13 - escapeCharacter - DFDL-13-029R" root="e_infix_never" 
-    roundTrip="onePass">
-    <document>foo$//;</document>
-    <infoset>
-      <dfdlInfoset>
-        <tns:e_infix_never>
-          <x>foo/</x>
-          <y></y>
-        </tns:e_infix_never>
-      </dfdlInfoset>
-    </infoset>
-  </parserTestCase>
-  
-  <parserTestCase name="scenario3_13_postfix" model="es3"
-    description="Section 13 - escapeCharacter - DFDL-13-029R" root="e_postfix">
-    <document>foo$//;</document>
-    <infoset>
-      <dfdlInfoset>
-        <tns:e_postfix>
-          <x>foo/</x>
-  </tns:e_postfix>
-      </dfdlInfoset>
-    </infoset>
-  </parserTestCase>
-  
-  <parserTestCase name="scenario3_14" model="es3"
-    description="Section 13 - escapeCharacter - DFDL-13-029R" root="e_infix"
-    roundTrip="twoPass">
-    <document>foo$/$/$/;</document>
-    <infoset>
-      <dfdlInfoset>
-        <tns:e_infix>
-          <x>foo///;</x>
-  </tns:e_infix>
-      </dfdlInfoset>
-    </infoset>
-  </parserTestCase>
-  
-  <parserTestCase name="scenario3_14_req_term" model="es3-2"
-    description="Section 13 - escapeCharacter - DFDL-13-029R" root="e">
-    <document>foo$/$/$/;</document>
-    <errors>
-      <error>Parse Error</error>
-    </errors>
-  </parserTestCase>
-
-  <defineSchema name="es4">
-    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
-    <dfdl:format ref="tns:GeneralFormat" lengthKind="delimited" />
-
-    <dfdl:defineEscapeScheme name="scenario4">
-      <dfdl:escapeScheme escapeCharacter='/'
-        escapeKind="escapeCharacter" escapeEscapeCharacter="/" extraEscapedCharacters="" generateEscapeBlock="whenNeeded" />
-    </dfdl:defineEscapeScheme>
-   
-    <xs:element name="e_infix">
-      <xs:complexType>
-        <xs:sequence dfdl:separator="/;" dfdl:separatorPosition="infix">
-          <xs:element name="x" type="xs:string" dfdl:escapeSchemeRef="tns:scenario4" />
-          <xs:element name="y" type="xs:string" minOccurs="0" dfdl:escapeSchemeRef="tns:scenario4" />
-        </xs:sequence>
-      </xs:complexType>
-    </xs:element>
-    
-    <xs:element name="e_infix_never">
-      <xs:complexType>
-        <xs:sequence dfdl:separator="/;" dfdl:separatorPosition="infix"
-          dfdl:separatorSuppressionPolicy="never">
-          <xs:element name="x" type="xs:string" dfdl:escapeSchemeRef="tns:scenario4" />
-          <xs:element name="y" type="xs:string" minOccurs="0" dfdl:escapeSchemeRef="tns:scenario4" />
-        </xs:sequence>
-      </xs:complexType>
-    </xs:element>
-
-    <xs:element name="e_postfix">
-      <xs:complexType>
-        <xs:sequence dfdl:separator="/;" dfdl:separatorPosition="postfix">
-          <xs:element name="x" type="xs:string" dfdl:escapeSchemeRef="tns:scenario4" />
-          <xs:element name="y" type="xs:string" minOccurs="0" dfdl:escapeSchemeRef="tns:scenario4" />
-        </xs:sequence>
-      </xs:complexType>
-    </xs:element>
-
-  </defineSchema>
-  
   <defineSchema name="es4-2">
     <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
     <dfdl:format ref="tns:GeneralFormat" lengthKind="delimited" documentFinalTerminatorCanBeMissing="no"/>
@@ -976,7 +458,7 @@
       <dfdl:escapeScheme escapeCharacter='/'
         escapeKind="escapeCharacter" escapeEscapeCharacter="/" extraEscapedCharacters="" generateEscapeBlock="whenNeeded" />
     </dfdl:defineEscapeScheme>
-    
+
     <xs:element name="e">
       <xs:complexType>
         <xs:sequence dfdl:separator="">
@@ -987,7 +469,7 @@
     </xs:element>
 
   </defineSchema>
-  
+
   <defineSchema name="es5">
     <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
     <dfdl:format ref="tns:GeneralFormat" lengthKind="delimited" />
@@ -1006,93 +488,6 @@
     </xs:element>
   </defineSchema>
 
-  <parserTestCase name="scenario4_1" model="es4"
-    description="Section 13 - escapeCharacter - DFDL-13-029R" root="e_infix">
-    <document>foo/;bar</document>
-    <infoset>
-      <dfdlInfoset>
-        <tns:e_infix>
-          <x>foo</x>
-    <y>bar</y>
-  </tns:e_infix>
-      </dfdlInfoset>
-    </infoset>
-  </parserTestCase>
-  
-  <parserTestCase name="scenario4_2" model="es4"
-    description="Section 13 - escapeCharacter - DFDL-13-029R" root="e_infix">
-    <document>foo//;bar</document>
-    <infoset>
-      <dfdlInfoset>
-        <tns:e_infix>
-          <x>foo/;bar</x>
-  </tns:e_infix>
-      </dfdlInfoset>
-    </infoset>
-  </parserTestCase>
-  
-  <parserTestCase name="scenario4_3" model="es4"
-    description="Section 13 - escapeCharacter - DFDL-13-029R" root="e_infix">
-    <document>foo///;bar</document>
-    <infoset>
-      <dfdlInfoset>
-        <tns:e_infix>
-          <x>foo/</x>
-    <y>bar</y>
-  </tns:e_infix>
-      </dfdlInfoset>
-    </infoset>
-  </parserTestCase>
-  
-  <parserTestCase name="scenario4_4" model="es4"
-    description="Section 13 - escapeCharacter - DFDL-13-029R" root="e_infix">
-    <document>foo////bar</document>
-    <infoset>
-      <dfdlInfoset>
-        <tns:e_infix>
-          <x>foo//bar</x>
-  </tns:e_infix>
-      </dfdlInfoset>
-    </infoset>
-  </parserTestCase>
-  
-  <parserTestCase name="scenario4_5" model="es4"
-    description="Section 13 - escapeCharacter - DFDL-13-029R" root="e_infix">
-    <document>foo////;bar</document>
-    <infoset>
-      <dfdlInfoset>
-        <tns:e_infix>
-          <x>foo//;bar</x>
-  </tns:e_infix>
-      </dfdlInfoset>
-    </infoset>
-  </parserTestCase>
-  
-  <parserTestCase name="scenario4_6" model="es4"
-    description="Section 13 - escapeCharacter - DFDL-13-029R" root="e_infix">
-    <document>foo/////;bar</document>
-    <infoset>
-      <dfdlInfoset>
-        <tns:e_infix>
-          <x>foo//</x>
-    <y>bar</y>
-  </tns:e_infix>
-      </dfdlInfoset>
-    </infoset>
-  </parserTestCase>
-  
-  <parserTestCase name="scenario4_7" model="es4"
-    description="Section 13 - escapeCharacter - DFDL-13-029R" root="e_infix">
-    <document>foo</document>
-    <infoset>
-      <dfdlInfoset>
-        <tns:e_infix>
-          <x>foo</x>
-  </tns:e_infix>
-      </dfdlInfoset>
-    </infoset>
-  </parserTestCase>
-  
   <parserTestCase name="scenario4_7_req_term" model="es4-2"
     description="Section 13 - escapeCharacter - DFDL-13-029R" root="e">
     <document>foo</document>
@@ -1100,45 +495,7 @@
       <error>Parse Error</error>
     </errors>
   </parserTestCase>
-  
-  <parserTestCase name="scenario4_8" model="es4"
-    description="Section 13 - escapeCharacter - DFDL-13-029R" root="e_infix_never"
-    roundTrip="onePass">
-    <document>foo/;</document>
-    <infoset>
-      <dfdlInfoset>
-        <tns:e_infix_never>
-          <x>foo</x>
-          <y></y>
-        </tns:e_infix_never>
-      </dfdlInfoset>
-    </infoset>
-  </parserTestCase>
-  
-  <parserTestCase name="scenario4_8_postfix" model="es4"
-    description="Section 13 - escapeCharacter - DFDL-13-029R" root="e_postfix">
-    <document>foo/;</document>
-    <infoset>
-      <dfdlInfoset>
-        <tns:e_postfix>
-          <x>foo</x>
-  </tns:e_postfix>
-      </dfdlInfoset>
-    </infoset>
-  </parserTestCase>
-  
-  <parserTestCase name="scenario4_9" model="es4"
-    description="Section 13 - escapeCharacter - DFDL-13-029R" root="e_infix">
-    <document>foo//;</document>
-    <infoset>
-      <dfdlInfoset>
-        <tns:e_infix>
-          <x>foo/;</x>
-  </tns:e_infix>
-      </dfdlInfoset>
-    </infoset>
-  </parserTestCase>
-  
+
   <parserTestCase name="scenario4_9_req_term" model="es4-2"
     description="Section 13 - escapeCharacter - DFDL-13-029R" root="e">
     <document>foo//;</document>
@@ -1146,20 +503,7 @@
       <error>Parse Error</error>
     </errors>
   </parserTestCase>
-  
-  <parserTestCase name="scenario4_10" model="es4"
-    description="Section 13 - escapeCharacter - DFDL-13-029R" root="e_infix"
-    roundTrip="twoPass">
-    <document>foo///</document>
-    <infoset>
-      <dfdlInfoset>
-        <tns:e_infix>
-          <x>foo/</x>
-  </tns:e_infix>
-      </dfdlInfoset>
-    </infoset>
-  </parserTestCase>
-  
+
   <parserTestCase name="scenario4_10_req_term" model="es4-2"
     description="Section 13 - escapeCharacter - DFDL-13-029R" root="e">
     <document>foo///</document>
@@ -1168,52 +512,14 @@
     </errors>
   </parserTestCase>
 
-  <parserTestCase name="scenario4_11" model="es4"
-    description="Section 13 - escapeCharacter - DFDL-13-029R" root="e_infix_never" 
-    roundTrip="onePass">
-    <document>foo///;</document>
-    <infoset>
-      <dfdlInfoset>
-        <tns:e_infix_never>
-          <x>foo/</x>
-          <y></y>
-        </tns:e_infix_never>
-      </dfdlInfoset>
-    </infoset>
-  </parserTestCase>
-
-  <parserTestCase name="scenario4_11_postfix" model="es4"
-    description="Section 13 - escapeCharacter - DFDL-13-029R" root="e_postfix">
-    <document>foo///;</document>
-    <infoset>
-      <dfdlInfoset>
-        <tns:e_postfix>
-          <x>foo/</x>
-        </tns:e_postfix>
-      </dfdlInfoset>
-    </infoset>
-  </parserTestCase>
-  
-  <parserTestCase name="scenario4_12" model="es4"
-    description="Section 13 - escapeCharacter - DFDL-13-029R" root="e_infix">
-    <document>foo////;</document>
-    <infoset>
-      <dfdlInfoset>
-        <tns:e_infix>
-          <x>foo//;</x>
-        </tns:e_infix>
-      </dfdlInfoset>
-    </infoset>
-  </parserTestCase>
-  
-  <parserTestCase name="scenario4_12_req_term" model="es4-2"
+   <parserTestCase name="scenario4_12_req_term" model="es4-2"
     description="Section 13 - escapeCharacter - DFDL-13-029R" root="e">
     <document>foo////;</document>
     <errors>
       <error>Parse Error</error>
     </errors>
   </parserTestCase>
-  
+
   <!--
        Test Name: scenario5
           Schema: es5

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section07/escapeScheme/escapeSchemeUnparse.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section07/escapeScheme/escapeSchemeUnparse.tdml
@@ -262,38 +262,13 @@
         </ex:e5b>
       </tdml:dfdlInfoset>
     </tdml:infoset>
-    <tdml:document>test#double te##st</tdml:document>
+    <tdml:errors>
+      <tdml:error>Schema Definition Error</tdml:error>
+      <tdml:error>dfdl:terminator and dfdl:separator</tdml:error>
+      <tdml:error>may not begin with the dfdl:escapeCharacter</tdml:error>
+    </tdml:errors>
   </tdml:unparserTestCase>
   
-<!--
-      Test Name: unparseDelimitedEscapedString11
-      Schema: delimitedStringsEscapeScheme
-      Purpose: This test demonstrates unparsing a sequence of delimited strings with escape schemes
--->
-  <tdml:unparserTestCase name="unparseDelimitedEscapedString11" model="delimitedStringsEscapeScheme" root="e5">
-    <tdml:infoset>
-      <tdml:dfdlInfoset>
-        <ex:e5 xmlns:ex="http://example.com">
-          <ex:s1>test</ex:s1>
-          <ex:s2>double te#st</ex:s2>
-        </ex:e5>
-      </tdml:dfdlInfoset>
-    </tdml:infoset>
-    <tdml:document>test#double te##st</tdml:document>
-  </tdml:unparserTestCase>
-
-  <tdml:parserTestCase name="parseDelimitedEscapedString05" model="delimitedStringsEscapeScheme" root="e5">
-    <tdml:document>test#double te##st</tdml:document>
-    <tdml:infoset>
-      <tdml:dfdlInfoset>
-        <ex:e5 xmlns:ex="http://example.com">
-          <ex:s1>test</ex:s1>
-          <ex:s2>double te#st</ex:s2>
-        </ex:e5>
-      </tdml:dfdlInfoset>
-    </tdml:infoset>
-  </tdml:parserTestCase>
-
 <!--
       Test Name: unparseDelimitedEscapedString06
       Schema: delimitedStringsEscapeScheme
@@ -625,6 +600,55 @@
     <tdml:errors>
       <tdml:error>Schema Definition Error</tdml:error>
       <tdml:error>Invalid DFDL Entity</tdml:error>
+    </tdml:errors>
+  </tdml:unparserTestCase>
+
+  <tdml:defineSchema name="runtimeDelimiterEscapeConflict">
+    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+    <dfdl:format ref="ex:GeneralFormat" encoding="ascii" lengthUnits="bytes" outputNewLine="%CR;%LF;"/>
+    <dfdl:defineEscapeScheme name="pound2">
+      <dfdl:escapeScheme escapeCharacter='#'
+        escapeKind="escapeCharacter" escapeEscapeCharacter="/" extraEscapedCharacters="" generateEscapeBlock="whenNeeded" />
+    </dfdl:defineEscapeScheme>
+
+    <xs:element name="e1">
+      <xs:complexType>
+        <xs:sequence dfdl:separator=",">
+          <xs:element name="sep" type="xs:string" dfdl:lengthKind="explicit" dfdl:length="1" />
+          <xs:element name="seq">
+            <xs:complexType>
+              <xs:sequence dfdl:separator="{ ../ex:sep }">
+                <xs:element name="s1" type="xs:string" dfdl:lengthKind="delimited" dfdl:escapeSchemeRef="pound2"/>
+                <xs:element name="s2" type="xs:string" dfdl:lengthKind="delimited" dfdl:escapeSchemeRef="pound2"/>
+              </xs:sequence>
+            </xs:complexType>
+          </xs:element>
+        </xs:sequence>
+      </xs:complexType>
+    </xs:element>
+  </tdml:defineSchema>
+
+<!--
+      Test Name: runtimeUnparseDelimiterEscapeConflict
+      Schema: runtimeUnparseDelimiterEscapeConflict
+      Purpose: This test checks for a runtime SDE for a conflicting delimiter and escapeCharacter
+-->
+  <tdml:unparserTestCase name="runtimeUnparseDelimiterEscapeConflict" model="runtimeDelimiterEscapeConflict" root="e1">
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <ex:e1 xmlns:ex="http://example.com">
+          <ex:sep>#</ex:sep>
+          <ex:seq>
+            <ex:s1>test</ex:s1>
+            <ex:s2>test2</ex:s2>
+          </ex:seq>
+        </ex:e1>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+    <tdml:errors>
+      <tdml:error>Unparse Error</tdml:error>
+      <tdml:error>dfdl:terminator and dfdl:separator</tdml:error>
+      <tdml:error>may not begin with the dfdl:escapeCharacter</tdml:error>
     </tdml:errors>
   </tdml:unparserTestCase>
 

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section07/escapeScheme/TestEscapeScheme.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section07/escapeScheme/TestEscapeScheme.scala
@@ -84,63 +84,14 @@ class TestEscapeScheme {
   @Test def test_scenario1_13_postfix(): Unit = { runner2.runOneTest("scenario1_13_postfix") }
 
   @Test def test_scenario2_1(): Unit = { runner2.runOneTest("scenario2_1") }
-  @Test def test_scenario2_2(): Unit = { runner2.runOneTest("scenario2_2") }
-  @Test def test_scenario2_3(): Unit = { runner2.runOneTest("scenario2_3") }
-  @Test def test_scenario2_4(): Unit = { runner2.runOneTest("scenario2_4") }
-  @Test def test_scenario2_5(): Unit = { runner2.runOneTest("scenario2_5") }
-  @Test def test_scenario2_6(): Unit = { runner2.runOneTest("scenario2_6") }
-  @Test def test_scenario2_7(): Unit = { runner2.runOneTest("scenario2_7") }
-  @Test def test_scenario2_8(): Unit = { runner2.runOneTest("scenario2_8") }
-  @Test def test_scenario2_9(): Unit = { runner2.runOneTest("scenario2_9") }
-  @Test def test_scenario2_10(): Unit = { runner2.runOneTest("scenario2_10") }
-  @Test def test_scenario2_10_postfix(): Unit = { runner2.runOneTest("scenario2_10_postfix") }
-  @Test def test_scenario2_11(): Unit = { runner2.runOneTest("scenario2_11") }
   @Test def test_scenario2_11_req_term(): Unit = { runner2.runOneTest("scenario2_11_req_term") }
-  @Test def test_scenario2_12(): Unit = { runner2.runOneTest("scenario2_12") }
-  @Test def test_scenario2_12_postfix(): Unit = { runner2.runOneTest("scenario2_12_postfix") }
-  @Test def test_scenario2_13(): Unit = { runner2.runOneTest("scenario2_13") }
-  @Test def test_scenario2_13_postfix(): Unit = { runner2.runOneTest("scenario2_13_postfix") }
-  @Test def test_scenario2_14(): Unit = { runner2.runOneTest("scenario2_14") }
   @Test def test_scenario2_14_req_term(): Unit = { runner2.runOneTest("scenario2_14_req_term") }
 
   @Test def test_scenario3_1(): Unit = { runner2.runOneTest("scenario3_1") }
-  @Test def test_scenario3_2(): Unit = { runner2.runOneTest("scenario3_2") }
-  @Test def test_scenario3_3(): Unit = { runner2.runOneTest("scenario3_3") }
-  @Test def test_scenario3_4(): Unit = { runner2.runOneTest("scenario3_4") }
-  @Test def test_scenario3_5(): Unit = { runner2.runOneTest("scenario3_5") }
-  @Test def test_scenario3_6(): Unit = { runner2.runOneTest("scenario3_6") }
-  @Test def test_scenario3_7(): Unit = { runner2.runOneTest("scenario3_7") }
-  @Test def test_scenario3_8(): Unit = { runner2.runOneTest("scenario3_8") }
-  @Test def test_scenario3_9(): Unit = { runner2.runOneTest("scenario3_9") }
-  @Test def test_scenario3_10(): Unit = { runner2.runOneTest("scenario3_10") }
-  @Test def test_scenario3_10_postfix(): Unit = { runner2.runOneTest("scenario3_10_postfix") }
-  @Test def test_scenario3_11(): Unit = { runner2.runOneTest("scenario3_11") }
-  //DFDL-961
-  //@Test def test_scenario3_11_postfix() { runner2.runOneTest("scenario3_11_postfix") }
-  @Test def test_scenario3_12(): Unit = { runner2.runOneTest("scenario3_12") }
-  @Test def test_scenario3_12_req_term(): Unit = { runner2.runOneTest("scenario3_12_req_term") }
-  @Test def test_scenario3_13(): Unit = { runner2.runOneTest("scenario3_13") }
-  @Test def test_scenario3_13_postfix(): Unit = { runner2.runOneTest("scenario3_13_postfix") }
-  @Test def test_scenario3_14(): Unit = { runner2.runOneTest("scenario3_14") }
-  @Test def test_scenario3_14_req_term(): Unit = { runner2.runOneTest("scenario3_14_req_term") }
 
-  @Test def test_scenario4_1(): Unit = { runner2.runOneTest("scenario4_1") }
-  @Test def test_scenario4_2(): Unit = { runner2.runOneTest("scenario4_2") }
-  @Test def test_scenario4_3(): Unit = { runner2.runOneTest("scenario4_3") }
-  @Test def test_scenario4_4(): Unit = { runner2.runOneTest("scenario4_4") }
-  @Test def test_scenario4_5(): Unit = { runner2.runOneTest("scenario4_5") }
-  @Test def test_scenario4_6(): Unit = { runner2.runOneTest("scenario4_6") }
-  @Test def test_scenario4_7(): Unit = { runner2.runOneTest("scenario4_7") }
   @Test def test_scenario4_7_req_term(): Unit = { runner2.runOneTest("scenario4_7_req_term") }
-  @Test def test_scenario4_8(): Unit = { runner2.runOneTest("scenario4_8") }
-  @Test def test_scenario4_8_postfix(): Unit = { runner2.runOneTest("scenario4_8_postfix") }
-  @Test def test_scenario4_9(): Unit = { runner2.runOneTest("scenario4_9") }
   @Test def test_scenario4_9_req_term(): Unit = { runner2.runOneTest("scenario4_9_req_term") }
-  @Test def test_scenario4_10(): Unit = { runner2.runOneTest("scenario4_10") }
   @Test def test_scenario4_10_req_term(): Unit = { runner2.runOneTest("scenario4_10_req_term") }
-  @Test def test_scenario4_11(): Unit = { runner2.runOneTest("scenario4_11") }
-  @Test def test_scenario4_11_postfix(): Unit = { runner2.runOneTest("scenario4_11_postfix") }
-  @Test def test_scenario4_12(): Unit = { runner2.runOneTest("scenario4_12") }
   @Test def test_scenario4_12_req_term(): Unit = { runner2.runOneTest("scenario4_12_req_term") }
 
   @Test def test_scenario5_1(): Unit = { runner2.runOneTest("scenario5_1") }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section07/escapeScheme/TestEscapeSchemeUnparse.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section07/escapeScheme/TestEscapeSchemeUnparse.scala
@@ -44,7 +44,6 @@ class TestEscapeSchemeUnparse {
   @Test def test_unparseDelimitedEscapedString08(): Unit = { runner.runOneTest("unparseDelimitedEscapedString08") }
   @Test def test_unparseDelimitedEscapedString09(): Unit = { runner.runOneTest("unparseDelimitedEscapedString09") }
   @Test def test_unparseDelimitedEscapedString10(): Unit = { runner.runOneTest("unparseDelimitedEscapedString10") }
-  @Test def test_unparseDelimitedEscapedString11(): Unit = { runner.runOneTest("unparseDelimitedEscapedString11") }
   @Test def test_unparseDelimitedEscapedString12(): Unit = { runner.runOneTest("unparseDelimitedEscapedString12") }
   @Test def test_unparseDelimitedEscapedString13(): Unit = { runner.runOneTest("unparseDelimitedEscapedString13") }
   @Test def test_unparseDelimitedEscapedString14(): Unit = { runner.runOneTest("unparseDelimitedEscapedString14") }
@@ -71,6 +70,6 @@ class TestEscapeSchemeUnparse {
   @Test def test_parseDelimitedEscapedString01(): Unit = { runner.runOneTest("parseDelimitedEscapedString01") }
   @Test def test_parseDelimitedEscapedString03(): Unit = { runner.runOneTest("parseDelimitedEscapedString03") }
   @Test def test_parseDelimitedEscapedString04(): Unit = { runner.runOneTest("parseDelimitedEscapedString04") }
-  @Test def test_parseDelimitedEscapedString05(): Unit = { runner.runOneTest("parseDelimitedEscapedString05") }
 
+  @Test def test_runtimeUnparseDelimiterEscapeConflict(): Unit = { runner.runOneTest("runtimeUnparseDelimiterEscapeConflict") }
 }


### PR DESCRIPTION
This commit disallows separators/terminators that start with the same
character as the escapeCharacter. This was something that is missing
from the spec, but will likely be added in the near future. Having a
separator or terminator that starts with the escapeCharacter will cause
a Schema Definition Error to occur, which is how IBM's DFDL
implementation works. This change results in many tests being
redundant as it is no longer necessary to test these sort of edge
cases.

This also fixes a small issue that was preventing some escape scheme
tests from round tripping.

DAFFODIL-1556