### PR TITLE
Fix unordered sequences with discriminated content

### DIFF
--- a/daffodil-core/src/main/scala/org/apache/daffodil/grammar/primitives/SequenceCombinator.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/grammar/primitives/SequenceCombinator.scala
@@ -121,8 +121,6 @@ class OrderedSequence(sq: SequenceTermBase, sequenceChildrenArg: Seq[SequenceChi
 class UnorderedSequence(sq: SequenceTermBase, sequenceChildrenArg: Seq[SequenceChild], alternatives: Seq[Gram])
   extends SequenceCombinator(sq, sequenceChildrenArg) {
 
-  import SeparatedSequenceChildBehavior._
-
   private lazy val sepMtaGram = sq.delimMTA
   // Note that we actually only ever use one of these depending on
   // various factors. If there is an optional separator and a suspension is
@@ -152,43 +150,16 @@ class UnorderedSequence(sq: SequenceTermBase, sequenceChildrenArg: Seq[SequenceC
 
   override lazy val parser: Parser = {
 
-    lazy val choiceParser = new ChoiceParser(srd, parsers.toVector)
-
     sq.hasSeparator match {
       case true => {
-        lazy val groupHelper = new NonPositionalGroupSeparatedSequenceChildParseResultHelper(
-          srd,
-          NonPositional,
-          true, // Due to the nature of UOSeqs, could potentially be empty
-          false) // and does not have required syntax
-
-        lazy val groupParser = new GroupSeparatedUnorderedSequenceChildParser(
-          choiceParser,
-          srd,
-          srd, // Won't actually be used
-          sepParser,
-          sq.separatorPosition,
-          groupHelper)
-
         new UnorderedSeparatedSequenceParser(
           srd, sq.separatorPosition, sepParser,
-          Vector(groupParser))
+          sequenceChildren.flatMap { _.optSequenceChildParser })
       }
       case false => {
-        lazy val groupHelper = new GroupUnseparatedSequenceChildParseResultHelper(
-          srd,
-          true, // Due to the nature of UOSeqs, could potentially be empty
-          false) // and does not have required syntax
-
-        lazy val groupParser = new ScalarUnorderedUnseparatedSequenceChildParser(
-          choiceParser,
-          srd,
-          srd, // Won't actually be used
-          groupHelper)
-
         new UnorderedUnseparatedSequenceParser(
           srd,
-          Vector(groupParser))
+          sequenceChildren.flatMap { _.optSequenceChildParser })
       }
     }
   }

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/SeparatedSequenceParsers.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/SeparatedSequenceParsers.scala
@@ -60,17 +60,6 @@ sealed abstract class ScalarOrderedSeparatedSequenceChildParser(
   with Separated
   with NonRepeatingSequenceChildParser
 
-sealed abstract class ScalarUnorderedSeparatedSequenceChildParser(
-  childParser: Parser,
-  srd: SequenceRuntimeData,
-  trd: TermRuntimeData,
-  override val sep: Parser,
-  override val spos: SeparatorPosition,
-  override val parseResultHelper: SeparatedSequenceChildParseResultHelper)
-  extends SequenceChildParser(childParser, srd, trd)
-  with Separated
-  with NonRepeatingUnorderedSequenceChildParser
-
 final class ScalarOrderedElementSeparatedSequenceChildParser(
   childParser: Parser,
   srd: SequenceRuntimeData,
@@ -88,15 +77,6 @@ final class GroupSeparatedSequenceChildParser(
   spos: SeparatorPosition,
   prh: SeparatedSequenceChildParseResultHelper)
   extends ScalarOrderedSeparatedSequenceChildParser(childParser, srd, mrd, sep, spos, prh)
-
-final class GroupSeparatedUnorderedSequenceChildParser(
-  childParser: Parser,
-  srd: SequenceRuntimeData,
-  val mrd: ModelGroupRuntimeData,
-  sep: Parser,
-  spos: SeparatorPosition,
-  prh: SeparatedSequenceChildParseResultHelper)
-  extends ScalarUnorderedSeparatedSequenceChildParser(childParser, srd, mrd, sep, spos, prh)
 
 final class RepOrderedExactlyNSeparatedSequenceChildParser(
   childParser: Parser,
@@ -134,7 +114,7 @@ final class OrderedSeparatedSequenceParser(
   spos: SeparatorPosition,
   sep: Parser,
   childrenArg: Vector[SequenceChildParser])
-  extends SequenceParserBase(rd, childrenArg) {
+  extends SequenceParserBase(rd, childrenArg, isOrdered = true) {
 
   override lazy val childProcessors = (sep +: childrenArg.asInstanceOf[Seq[Parser]]).toVector
 }
@@ -143,8 +123,8 @@ final class UnorderedSeparatedSequenceParser(
   rd: SequenceRuntimeData,
   spos: SeparatorPosition,
   sep: Parser,
-  choiceParser: Vector[SequenceChildParser])
-  extends SequenceParserBase(rd, choiceParser, false) {
+  childrenArg: Vector[SequenceChildParser])
+  extends SequenceParserBase(rd, childrenArg, isOrdered = false) {
 
-  override lazy val childProcessors = sep +: choiceParser
+  override lazy val childProcessors = (sep +: childrenArg.asInstanceOf[Seq[Parser]]).toVector
 }

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/SequenceChildBases.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/SequenceChildBases.scala
@@ -229,15 +229,6 @@ trait NonRepeatingSequenceChildParser { self: SequenceChildParser =>
 
 }
 
-trait NonRepeatingUnorderedSequenceChildParser { self: SequenceChildParser =>
-
-  def pouStatus: PoUStatus = PoUStatus.HasPoU
-
-  def maybeStaticRequiredOptionalStatus: Maybe[RequiredOptionalStatus] =
-    Maybe(RequiredOptionalStatus.Optional)
-
-}
-
 /**
  * For computed elements, and for groups (which commonly will be sequences)
  * which contain only other non-represented entities, or executable

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/UnseparatedSequenceParsers.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/UnseparatedSequenceParsers.scala
@@ -43,15 +43,6 @@ class ScalarOrderedUnseparatedSequenceChildParser(
   with Unseparated
   with NonRepeatingSequenceChildParser
 
-class ScalarUnorderedUnseparatedSequenceChildParser(
-  override val childParser: Parser,
-  override val srd: SequenceRuntimeData,
-  override val trd: TermRuntimeData,
-  override val parseResultHelper: UnseparatedSequenceChildParseResultHelper)
-  extends SequenceChildParser(childParser, srd, trd)
-  with Unseparated
-  with NonRepeatingUnorderedSequenceChildParser
-
 class RepOrderedExactlyNUnseparatedSequenceChildParser(
   childParser: Parser,
   srd: SequenceRuntimeData,
@@ -79,7 +70,7 @@ class RepOrderedWithMinMaxUnseparatedSequenceChildParser(
   with Unseparated
 
 class OrderedUnseparatedSequenceParser(rd: SequenceRuntimeData, childParsersArg: Vector[SequenceChildParser])
-  extends SequenceParserBase(rd, childParsersArg)
+  extends SequenceParserBase(rd, childParsersArg, isOrdered = true)
 
 class UnorderedUnseparatedSequenceParser(rd: SequenceRuntimeData, choiceParser: Vector[SequenceChildParser])
-  extends SequenceParserBase(rd, choiceParser, false)
+  extends SequenceParserBase(rd, choiceParser, isOrdered = false)

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section14/unordered_sequences/UnorderedSequences.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section14/unordered_sequences/UnorderedSequences.tdml
@@ -938,7 +938,8 @@
     <tdml:document><![CDATA[X:not expectedFINAL]]></tdml:document>
     <tdml:errors>
       <tdml:error>Parse Error</tdml:error>
-      <tdml:error>FINAL</tdml:error>
+      <tdml:error>Assertion</tdml:error>
+      <tdml:error>the expected message</tdml:error>
     </tdml:errors>
   </tdml:parserTestCase>
 

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section14/unordered_sequences/TestUnorderedSequencesNew.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section14/unordered_sequences/TestUnorderedSequencesNew.scala
@@ -58,11 +58,9 @@ class TestUnorderedSequencesNew {
 
   @Test def test_empty_seq = { runner.runOneTest("test_empty_seq") }
 
-  // DAFFODIL-2512
-  //@Test def test_initiated_unordered1 = { runner.runOneTest("test_initiated_unordered1") }
+  @Test def test_initiated_unordered1 = { runner.runOneTest("test_initiated_unordered1") }
   @Test def test_initiated_unordered2 = { runner.runOneTest("test_initiated_unordered2") }
-  // DAFFODIL-2512
-  //@Test def test_initiated_unordered3 = { runner.runOneTest("test_initiated_unordered3") }
+  @Test def test_initiated_unordered3 = { runner.runOneTest("test_initiated_unordered3") }
 
   @Test def test_BE000 = { runnerBE.runOneTest("BE000") }
   @Test def test_BE001 = { runnerBE.runOneTest("BE001") }


### PR DESCRIPTION
We currently implement unordered sequences as an repetition of a choice
of the sequence branches. The problem with this approach is that the
ChoiceParser handles discriminated content/resolved points of
uncertainty, and by the time the ChoiceParser returns back to the
SequenceParser we no longer know if the ChoiceParser failed because all
alternatives failed or because a branch was discriminated and it failed.
Although they are both failures, the SequenceParser needs to know the
difference so that diagnostics can be returned correctly.

This changes how unordered sequences are handled to not use the
ChoiceParser at all. Instead, we add special casing to the
SequenceParser so that unordered sequence branches are just treated as
required scalar elements. We parse these alternatives within a point of
uncertainty created by the sequence parser, so that it can know whether
a sequence branch was discriminated or not. This allows proper handling
of failures, diagnostics, and backtracking.

DAFFODIL-2512