### PR TITLE
Fix max length check for xs:hexBinary

### DIFF
--- a/daffodil-propgen/src/main/resources/org/apache/daffodil/xsd/dafext.xsd
+++ b/daffodil-propgen/src/main/resources/org/apache/daffodil/xsd/dafext.xsd
@@ -132,12 +132,14 @@
         <xs:element name="blobChunkSizeInBytes" default="4096" minOccurs="0">
           <xs:annotation>
             <xs:documentation>
-              When reading/writing blob data, the maximum number of bytes to read/write at a time.
+              When reading/writing blob data, the maximum number of bytes to read/write
+              at a time. This is also used when parsing xs:hexBinary data.
             </xs:documentation>
           </xs:annotation>
           <xs:simpleType>
             <xs:restriction base="xs:int">
               <xs:minInclusive value="1" />
+              <xs:maxInclusive value="268435455" /> <!-- Limit to (MaxInt / 8) because some places convert this tunable to bits -->
             </xs:restriction>
           </xs:simpleType>
         </xs:element>
@@ -259,6 +261,18 @@
               backwards compatability.
             </xs:documentation>
           </xs:annotation>
+        </xs:element>
+        <xs:element name="maxHexBinaryLengthInBytes" default="2147483647" minOccurs="0">
+          <xs:annotation>
+            <xs:documentation>
+              The maximum size allowed for an xs:hexBinary element.
+            </xs:documentation>
+          </xs:annotation>
+          <xs:simpleType>
+            <xs:restriction base="xs:int">
+              <xs:minInclusive value="1" />
+            </xs:restriction>
+          </xs:simpleType>
         </xs:element>
         <xs:element name="maxLengthForVariableLengthDelimiterDisplay" default="10" minOccurs="0">
           <xs:annotation>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section00/general/tunables.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section00/general/tunables.tdml
@@ -92,6 +92,13 @@
 		</daf:tunables>
 	</tdml:defineConfig>
 
+	<tdml:defineConfig name="cfg_smallMaxHexBinary">
+		<daf:tunables xmlns="http://www.w3.org/2001/XMLSchema"
+			xmlns:xs="http://www.w3.org/2001/XMLSchema">
+			<daf:maxHexBinaryLengthInBytes>10</daf:maxHexBinaryLengthInBytes>
+		</daf:tunables>
+	</tdml:defineConfig>
+
 	<tdml:defineSchema name="unqualifiedPathStep" elementFormDefault="unqualified">
 		<xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd" />
 
@@ -558,6 +565,34 @@
         </ex:root>
       </tdml:dfdlInfoset>
     </tdml:infoset>
+
+  </tdml:parserTestCase>
+
+  <tdml:defineSchema name="smallMaxHexBinary">
+    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd" />
+
+    <dfdl:format ref="ex:GeneralFormat" />
+
+    <xs:element name="root" type="xs:hexBinary" dfdl:lengthKind="explicit" dfdl:length="11" />
+
+  </tdml:defineSchema>
+
+  <tdml:parserTestCase
+    name="maxHexBinaryError" root="root"
+    model="smallMaxHexBinary"
+    config="cfg_smallMaxHexBinary">
+
+    <tdml:document>
+      <tdml:documentPart type="text"></tdml:documentPart>
+    </tdml:document>
+
+    <tdml:errors>
+      <tdml:error>Parse Error</tdml:error>
+      <tdml:error>xs:hexBinary</tdml:error>
+      <tdml:error>maximum</tdml:error>
+      <tdml:error>10</tdml:error>
+      <tdml:error>11</tdml:error>
+    </tdml:errors>
 
   </tdml:parserTestCase>
 

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section05/simple_types/SimpleTypes.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section05/simple_types/SimpleTypes.tdml
@@ -21,6 +21,7 @@
   xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/" xmlns:xs="http://www.w3.org/2001/XMLSchema"
   xmlns:dfdlx="http://www.ogf.org/dfdl/dfdl-1.0/extensions"
   xmlns:ex="http://example.com" xmlns:tns="http://example.com"
+  xmlns:daf="urn:ogf:dfdl:2013:imp:daffodil.apache.org:2018:ext"
   defaultRoundTrip="true">
 
   <tdml:defineSchema name="SimpleTypes-Embedded.dfdl.xsd">
@@ -4298,7 +4299,32 @@
       </tdml:dfdlInfoset>
     </tdml:infoset>
   </tdml:parserTestCase>
- 
+
+  <tdml:defineConfig name="cfg_smallBlobChunkSize">
+    <daf:tunables xmlns="http://www.w3.org/2001/XMLSchema"
+      xmlns:xs="http://www.w3.org/2001/XMLSchema">
+      <daf:blobChunkSizeInBytes>1</daf:blobChunkSizeInBytes>
+    </daf:tunables>
+  </tdml:defineConfig>
+
+  <!--
+    Test name: hexBinary_01_chunk
+    Schema: SimpleTypes-binary
+    Purpose: This document demonstrates the use of the hexBinary simple type with tunables set to test chunking
+  -->
+
+  <tdml:parserTestCase name="hexBinary_01_chunk" root="hb_01" config="cfg_smallBlobChunkSize"
+      model="SimpleTypes-binary" description="Section 5 Simple Types - hexBinary - DFDL-5-025R" roundTrip="true">
+    <tdml:document>
+      <tdml:documentPart type="byte"><![CDATA[a1b1c1d1]]></tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <hb_01>A1B1C1D1</hb_01>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
   <!--
     Test name: hexBinary_rep
     Schema: HexBinary

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section00/general/TestGeneral.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section00/general/TestGeneral.scala
@@ -107,5 +107,6 @@ class TestGeneral {
   @Test def test_encodingErrorPolicyError(): Unit = { tunables_runner.runOneTest("encodingErrorPolicyError") }
   @Test def test_requireEncodingErrorPolicyTrue(): Unit = { tunables_runner.runOneTest("requireEncodingErrorPolicyTrue") }
   @Test def test_requireEncodingErrorPolicyFalse(): Unit = { tunables_runner.runOneTest("requireEncodingErrorPolicyFalse") }
+  @Test def test_maxHexBinaryError(): Unit = { tunables_runner.runOneTest("maxHexBinaryError") }
 
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section05/simple_types/TestSimpleTypes.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section05/simple_types/TestSimpleTypes.scala
@@ -47,6 +47,7 @@ class TestSimpleTypes {
   @Test def test_hexBinary_fromString(): Unit = { runner.runOneTest("hexBinary_fromString") } //roundTrip
 
   @Test def test_hexBinary_01(): Unit = { runner.runOneTest("hexBinary_01") } //roundTrip
+  @Test def test_hexBinary_01_chunk(): Unit = { runner.runOneTest("hexBinary_01_chunk") } //roundTrip
   @Test def test_hexBinary_Delimited_01(): Unit = { runner.runOneTest("hexBinary_Delimited_01") } //roundTrip
   @Test def test_hexBinary_Delimited_01a(): Unit = { runner.runOneTest("hexBinary_Delimited_01a") } //roundTrip
   @Test def test_hexBinary_Delimited_02(): Unit = { runner.runOneTest("hexBinary_Delimited_02") } //roundTrip


### PR DESCRIPTION
Because xs:hexBinary simple elements are stored as Java Byte arrays,
they have a max size limitation of MaxInt bytes. We do this check, but
incorrectly check against the length in bits instead of the length in
bytes. That means we really enforce a limitation of MaxInt bits for
xs:hexBinary, which is 256 MB, instead of the real max of 2GB. This
fixes that caclulation and improves the error message to mention this
maximum size and the calculated length.

DAFFODIL-2532