### PR TITLE
Improve setting of external variables

### DIFF
--- a/daffodil-cli/src/it/scala/org/apache/daffodil/parsing/TestCLIParsing.scala
+++ b/daffodil-cli/src/it/scala/org/apache/daffodil/parsing/TestCLIParsing.scala
@@ -188,6 +188,27 @@ class TestCLIparsing {
     }
   }
 
+  @Test def test_CLI_Parsing_SimpleParse_extVars_error(): Unit = {
+
+    val schemaFile = Util.daffodilPath("daffodil-test/src/test/resources/org/apache/daffodil/section07/external_variables/external_variables.dfdl.xsd")
+    val testSchemaFile = if (Util.isWindows) Util.cmdConvert(schemaFile) else schemaFile
+
+    val shell = Util.startIncludeErrors("")
+
+    try {
+      val cmd = String.format("echo 0,1,2| %s parse -s %s -r row2 -DdoesNotExist=1", Util.binPath, testSchemaFile)
+      shell.sendLine(cmd)
+
+      shell.expectIn(1, contains("definition not found"))
+      shell.expectIn(1, contains("doesNotExist"))
+
+      shell.sendLine("exit")
+      shell.expect(eof)
+    } finally {
+      shell.close()
+    }
+  }
+
   @Test def test_3227_CLI_Parsing_SimpleParse_DFDL1197_fix(): Unit = {
     val schemaFile = Util.daffodilPath("daffodil-test/src/test/resources/org/apache/daffodil/section12/delimiter_properties/testOptionalInfix.dfdl.xsd")
     val testSchemaFile = if (Util.isWindows) Util.cmdConvert(schemaFile) else schemaFile

--- a/daffodil-cli/src/main/scala/org/apache/daffodil/Main.scala
+++ b/daffodil-cli/src/main/scala/org/apache/daffodil/Main.scala
@@ -82,6 +82,7 @@ import org.apache.daffodil.processors.DaffodilParseOutputStreamContentHandler
 import org.apache.daffodil.processors.DataLoc
 import org.apache.daffodil.processors.DataProcessor
 import org.apache.daffodil.processors.HasSetDebugger
+import org.apache.daffodil.processors.ExternalVariableException
 import org.apache.daffodil.schema.annotation.props.gen.BitOrder
 import org.apache.daffodil.tdml.DFDLTestSuite
 import org.apache.daffodil.tdml.TDMLException
@@ -1587,6 +1588,10 @@ object Main extends Logging {
         1
       }
       case e: InvalidParserException => {
+        log(LogLevel.Error, "%s", e.getMessage())
+        1
+      }
+      case e: ExternalVariableException => {
         log(LogLevel.Error, "%s", e.getMessage())
         1
       }

--- a/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/VariableMapFactory.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/VariableMapFactory.scala
@@ -17,9 +17,7 @@
 
 package org.apache.daffodil.grammar
 
-import org.apache.daffodil.dsom._
-import org.apache.daffodil.externalvars.Binding
-import org.apache.daffodil.exceptions.ThrowsSDE
+import org.apache.daffodil.dsom.DFDLDefineVariable
 import org.apache.daffodil.processors.VariableMap
 
 object VariableMapFactory {
@@ -28,9 +26,5 @@ object VariableMapFactory {
     val vrds = dvs.map { _.variableRuntimeData }
     val vmap = new VariableMap(vrds)
     vmap
-  }
-
-  def setExternalVariables(currentVMap: VariableMap, bindings: Seq[Binding], referringContext: ThrowsSDE) = {
-    bindings.foreach(b => currentVMap.setExtVariable(b.varQName, b.varValue, referringContext))
   }
 }

--- a/daffodil-core/src/test/scala/org/apache/daffodil/dsom/TestExternalVariablesNew.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/dsom/TestExternalVariablesNew.scala
@@ -17,26 +17,28 @@
 
 package org.apache.daffodil.dsom
 
-import org.junit.Test
-import org.apache.daffodil.Implicits.ns2String
-import org.apache.daffodil.compiler.Compiler
-import org.apache.daffodil.processors.VariableMap
-import org.apache.daffodil.util.SchemaUtils
-import org.apache.daffodil.xml.XMLUtils
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
-import org.junit.Assert._
-import org.junit.Test
-import org.apache.daffodil.xml.NS
+import java.nio.channels.Channels
+
 import scala.xml.Node
-import org.apache.daffodil.externalvars.ExternalVariablesLoader
+
 import org.apache.daffodil.Implicits._
+import org.apache.daffodil.Implicits.ns2String
 import org.apache.daffodil.api.UnitTestSchemaSource
-import org.apache.daffodil.xml.QName
-import org.apache.daffodil.util.Misc
+import org.apache.daffodil.compiler.Compiler
+import org.apache.daffodil.externalvars.ExternalVariablesLoader
 import org.apache.daffodil.infoset.ScalaXMLInfosetOutputter
 import org.apache.daffodil.io.InputSourceDataInputStream
-import java.nio.channels.Channels
+import org.apache.daffodil.processors.ExternalVariableException
+import org.apache.daffodil.processors.VariableMap
+import org.apache.daffodil.util.Misc
+import org.apache.daffodil.util.SchemaUtils
+import org.apache.daffodil.xml.NS
+import org.apache.daffodil.xml.QName
+import org.apache.daffodil.xml.XMLUtils
+import org.junit.Assert._
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
 
 /**
  * Tests for compiler-oriented XPath interface aka CompiledExpression
@@ -296,14 +298,14 @@ class TestExternalVariablesNew {
     val sset = pf.sset
     val variables = ExternalVariablesLoader.mapToBindings(vars)
 
-    val sde = intercept[SchemaDefinitionError] {
+    val exception = intercept[ExternalVariableException] {
       pf.onPath("/").withExternalVariables(variables)
     }
-    val msg = sde.getMessage()
-    if (!msg.contains("var3 is ambiguous")) {
-      println(msg)
-      fail()
-    }
+
+    val msg = exception.getMessage()
+    assertTrue(msg.contains("var3 is ambiguous"))
+    assertTrue(msg.contains("tns:var3"))
+    assertTrue(msg.contains("{}var3"))
   }
 
   @Test def test_data_processor_vmap_copy(): Unit = {

--- a/daffodil-japi/src/test/resources/test/japi/mySchemaWithComplexVars1.dfdl.xsd
+++ b/daffodil-japi/src/test/resources/test/japi/mySchemaWithComplexVars1.dfdl.xsd
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<xs:schema
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/"
+  xmlns:ex1="http://example.com/1"
+  xmlns:ex2="http://example.com/2"
+  targetNamespace="http://example.com/1">
+
+  <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd" />
+  <xs:import schemaLocation="mySchemaWithComplexVars2.dfdl.xsd" namespace="http://example.com/2" />
+
+  <xs:annotation>
+    <xs:appinfo source="http://www.ogf.org/dfdl/">
+      <dfdl:format ref="ex1:GeneralFormat" />
+      <dfdl:defineVariable name="var" external="true" type="xs:int">1</dfdl:defineVariable>
+    </xs:appinfo>
+  </xs:annotation>
+
+  <xs:element name="root">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="ex1var" dfdl:inputValueCalc="{ $ex1:var }" type="xs:int" />
+        <xs:element name="ex2var" dfdl:inputValueCalc="{ $ex2:var }" type="xs:int" />
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  
+</xs:schema>

--- a/daffodil-japi/src/test/resources/test/japi/mySchemaWithComplexVars2.dfdl.xsd
+++ b/daffodil-japi/src/test/resources/test/japi/mySchemaWithComplexVars2.dfdl.xsd
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<xs:schema
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/"
+  xmlns:ex2="http://example.com/2"
+  targetNamespace="http://example.com/2">
+    
+  <xs:annotation>
+    <xs:appinfo source="http://www.ogf.org/dfdl/">
+      <dfdl:defineVariable name="var" external="false" type="xs:int">1</dfdl:defineVariable>
+    </xs:appinfo>
+  </xs:annotation>
+  
+</xs:schema>

--- a/daffodil-sapi/src/main/scala/org/apache/daffodil/sapi/Daffodil.scala
+++ b/daffodil-sapi/src/main/scala/org/apache/daffodil/sapi/Daffodil.scala
@@ -17,50 +17,50 @@
 
 package org.apache.daffodil.sapi
 
-import org.apache.daffodil.compiler.{ Compiler => SCompiler }
-import org.apache.daffodil.sapi.debugger._
-import org.apache.daffodil.sapi.logger._
-import org.apache.daffodil.sapi.packageprivate._
-import org.apache.daffodil.sapi.infoset._
-import org.apache.daffodil.sapi.io.InputSourceDataInputStream
-import org.apache.daffodil.debugger.{ InteractiveDebugger => SInteractiveDebugger }
-import org.apache.daffodil.debugger.{ TraceDebuggerRunner => STraceDebuggerRunner }
 import java.io.File
+import java.net.URI
 import java.nio.channels.Channels
 import java.nio.channels.ReadableByteChannel
 import java.nio.channels.WritableByteChannel
 
+import org.apache.daffodil.api.DFDL.{ DaffodilUnhandledSAXException => SDaffodilUnhandledSAXException }
+import org.apache.daffodil.api.DFDL.{ DaffodilUnparseErrorSAXException => SDaffodilUnparseErrorSAXException }
+import org.apache.daffodil.api.URISchemaSource
+import org.apache.daffodil.api.Validator
 import org.apache.daffodil.api.{ DataLocation => SDataLocation }
 import org.apache.daffodil.api.{ Diagnostic => SDiagnostic }
 import org.apache.daffodil.api.{ LocationInSchemaFile => SLocationInSchemaFile }
 import org.apache.daffodil.api.{ WithDiagnostics => SWithDiagnostics }
-import org.apache.daffodil.api.DFDL.{ DaffodilUnhandledSAXException => SDaffodilUnhandledSAXException }
-import org.apache.daffodil.api.DFDL.{ DaffodilUnparseErrorSAXException => SDaffodilUnparseErrorSAXException }
+import org.apache.daffodil.compiler.{ Compiler => SCompiler }
+import org.apache.daffodil.compiler.{ InvalidParserException => SInvalidParserException }
 import org.apache.daffodil.compiler.{ ProcessorFactory => SProcessorFactory }
-import org.apache.daffodil.processors.{ DataProcessor => SDataProcessor }
+import org.apache.daffodil.debugger.Debugger
+import org.apache.daffodil.debugger.{ InteractiveDebugger => SInteractiveDebugger }
+import org.apache.daffodil.debugger.{ TraceDebuggerRunner => STraceDebuggerRunner }
+import org.apache.daffodil.dsom.ExpressionCompilers
+import org.apache.daffodil.dsom.walker.RootView
+import org.apache.daffodil.externalvars.{ Binding, ExternalVariablesLoader }
 import org.apache.daffodil.processors.{ DaffodilParseXMLReader => SDaffodilParseXMLReader }
 import org.apache.daffodil.processors.{ DaffodilUnparseContentHandler => SDaffodilUnparseContentHandler }
+import org.apache.daffodil.processors.{ DataProcessor => SDataProcessor }
+import org.apache.daffodil.processors.{ ExternalVariableException => SExternalVariableException }
+import org.apache.daffodil.processors.{ InvalidUsageException => SInvalidUsageException }
 import org.apache.daffodil.processors.{ ParseResult => SParseResult }
 import org.apache.daffodil.processors.{ UnparseResult => SUnparseResult }
+import org.apache.daffodil.sapi.ValidationMode.ValidationMode
+import org.apache.daffodil.sapi.debugger._
+import org.apache.daffodil.sapi.infoset._
+import org.apache.daffodil.sapi.io.InputSourceDataInputStream
+import org.apache.daffodil.sapi.logger._
+import org.apache.daffodil.sapi.packageprivate._
+import org.apache.daffodil.util.Maybe
+import org.apache.daffodil.util.Maybe._
+import org.apache.daffodil.util.MaybeULong
 import org.apache.daffodil.util.{ ConsoleWriter => SConsoleWriter }
 import org.apache.daffodil.util.{ FileWriter => SFileWriter }
 import org.apache.daffodil.util.{ LogWriter => SLogWriter }
 import org.apache.daffodil.util.{ LoggingDefaults => SLoggingDefaults }
 import org.apache.daffodil.util.{ NullLogWriter => SNullLogWriter }
-import org.apache.daffodil.externalvars.{ Binding, ExternalVariablesLoader }
-import org.apache.daffodil.dsom.ExpressionCompilers
-import org.apache.daffodil.dsom.walker.RootView
-import org.apache.daffodil.compiler.{ InvalidParserException => SInvalidParserException }
-import org.apache.daffodil.processors.{ InvalidUsageException => SInvalidUsageException }
-import java.net.URI
-
-import org.apache.daffodil.api.URISchemaSource
-import org.apache.daffodil.api.Validator
-import org.apache.daffodil.debugger.Debugger
-import org.apache.daffodil.sapi.ValidationMode.ValidationMode
-import org.apache.daffodil.util.Maybe
-import org.apache.daffodil.util.Maybe._
-import org.apache.daffodil.util.MaybeULong
 import org.apache.daffodil.xml.NS
 import org.apache.daffodil.xml.XMLUtils
 
@@ -605,10 +605,16 @@ class DataProcessor private[sapi] (private var dp: SDataProcessor)
    * @see <a target="_blank" href='https://daffodil.apache.org/configuration/'>Daffodil Configuration File</a> - Daffodil configuration file format
    *
    * @param extVars file to read DFDL variables from.
+   * @throws ExternalVariableException if an error occurs while setting an external variable
    */
   @deprecated("Use withExternalVariables.", "2.6.0")
-  def setExternalVariables(extVars: File): Unit =
-    dp = dp.withExternalVariables(extVars)
+  @throws(classOf[ExternalVariableException])
+  def setExternalVariables(extVars: File): Unit = {
+    //$COVERAGE-OFF$
+    try { dp = dp.withExternalVariables(extVars) }
+    catch { case e: SExternalVariableException => throw new ExternalVariableException(e.getMessage) }
+    //$COVERAGE-ON$
+  }
 
   /**
    * Obtain a new [[DataProcessor]] with external variables read from a Daffodil configuration file
@@ -616,9 +622,13 @@ class DataProcessor private[sapi] (private var dp: SDataProcessor)
    * @see <a target="_blank" href='https://daffodil.apache.org/configuration/'>Daffodil Configuration File</a> - Daffodil configuration file format
    *
    * @param extVars file to read DFDL variables from.
+   * @throws ExternalVariableException if an error occurs while setting an external variable
    */
-  def withExternalVariables(extVars: File): DataProcessor =
-    copy(dp = dp.withExternalVariables(extVars))
+  @throws(classOf[ExternalVariableException])
+  def withExternalVariables(extVars: File): DataProcessor = {
+    try { copy(dp = dp.withExternalVariables(extVars)) }
+    catch { case e: SExternalVariableException => throw new ExternalVariableException(e.getMessage) }
+  }
 
   /**
    * Set the value of multiple DFDL variables
@@ -629,10 +639,16 @@ class DataProcessor private[sapi] (private var dp: SDataProcessor)
    *                define a namespace for the variable. If preceded with "{}",
    *                then no namespace is used. If not preceded by anything,
    *                then Daffodil will figure out the namespace.
+   * @throws ExternalVariableException if an error occurs while setting an external variable
    */
   @deprecated("Use withExternalVariables.", "2.6.0")
-  def setExternalVariables(extVars: Map[String, String]) =
-    dp = dp.withExternalVariables(extVars)
+  @throws(classOf[ExternalVariableException])
+  def setExternalVariables(extVars: Map[String, String]) = {
+    //$COVERAGE-OFF$
+    try { dp = dp.withExternalVariables(extVars) }
+    catch { case e: SExternalVariableException => throw new ExternalVariableException(e.getMessage) }
+    //$COVERAGE-ON$
+  }
 
   /**
    *  Obtain a new [[DataProcessor]] with multiple DFDL variables set.
@@ -643,10 +659,13 @@ class DataProcessor private[sapi] (private var dp: SDataProcessor)
    *                define a namespace for the variable. If preceded with "{}",
    *                then no namespace is used. If not preceded by anything,
    *                then Daffodil will figure out the namespace.
+   * @throws ExternalVariableException if an error occurs while setting an external variable
    */
-  def withExternalVariables(extVars: Map[String, String]): DataProcessor =
-    copy(dp = dp.withExternalVariables(extVars))
-
+  @throws(classOf[ExternalVariableException])
+  def withExternalVariables(extVars: Map[String, String]): DataProcessor = {
+    try {copy(dp = dp.withExternalVariables(extVars)) }
+    catch { case e: SExternalVariableException => throw new ExternalVariableException(e.getMessage) }
+  }
 
 
   /**
@@ -842,6 +861,15 @@ class InvalidParserException(cause: org.apache.daffodil.compiler.InvalidParserEx
  * This exception will be thrown as a result of an invalid usage of the Daffodil API
  */
 class InvalidUsageException(cause: org.apache.daffodil.processors.InvalidUsageException) extends Exception(cause.getMessage(), cause.getCause())
+
+/**
+ * This exception will be thrown if an error occurs when setting an external variable. Example of errors include:
+ * - Ambiguity in variable to set
+ * - Variable definition not found in a schema
+ * - Variable value does not have a valid type with regards to the variable type
+ * - Variable cannot be set externally
+ */
+class ExternalVariableException private[sapi] (message: String) extends Exception(message)
 
 /**
  * This exception will be thrown when unparseResult.isError returns true during a SAX Unparse

--- a/daffodil-sapi/src/test/resources/test/sapi/mySchemaWithComplexVars1.dfdl.xsd
+++ b/daffodil-sapi/src/test/resources/test/sapi/mySchemaWithComplexVars1.dfdl.xsd
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<xs:schema
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/"
+  xmlns:ex1="http://example.com/1"
+  xmlns:ex2="http://example.com/2"
+  targetNamespace="http://example.com/1">
+
+  <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd" />
+  <xs:import schemaLocation="mySchemaWithComplexVars2.dfdl.xsd" namespace="http://example.com/2" />
+
+  <xs:annotation>
+    <xs:appinfo source="http://www.ogf.org/dfdl/">
+      <dfdl:format ref="ex1:GeneralFormat" />
+      <dfdl:defineVariable name="var" external="true" type="xs:int">1</dfdl:defineVariable>
+    </xs:appinfo>
+  </xs:annotation>
+
+  <xs:element name="root">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="ex1var" dfdl:inputValueCalc="{ $ex1:var }" type="xs:int" />
+        <xs:element name="ex2var" dfdl:inputValueCalc="{ $ex2:var }" type="xs:int" />
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  
+</xs:schema>

--- a/daffodil-sapi/src/test/resources/test/sapi/mySchemaWithComplexVars2.dfdl.xsd
+++ b/daffodil-sapi/src/test/resources/test/sapi/mySchemaWithComplexVars2.dfdl.xsd
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<xs:schema
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/"
+  xmlns:ex2="http://example.com/2"
+  targetNamespace="http://example.com/2">
+    
+  <xs:annotation>
+    <xs:appinfo source="http://www.ogf.org/dfdl/">
+      <dfdl:defineVariable name="var" external="false" type="xs:int">1</dfdl:defineVariable>
+    </xs:appinfo>
+  </xs:annotation>
+  
+</xs:schema>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section07/external_variables/external_variables.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section07/external_variables/external_variables.tdml
@@ -159,19 +159,6 @@
 	</tdml:defineConfig>
 
 	<!-- Overrides define variables -->
-	<tdml:parserTestCase name="external_var_dne"
-		root="c" model="v" config="cfg_err"
-		description="Should error, attempting to bind to a non-existent variable">
-
-		<tdml:document />
-
-		<tdml:errors>
-      <tdml:error>Schema Definition Error</tdml:error>
-      <tdml:error>unknown variable</tdml:error>
-    </tdml:errors>
-	</tdml:parserTestCase>
-
-	<!-- Overrides define variables -->
 	<tdml:parserTestCase name="override_define_vars_01"
 		root="c" model="v" config="cfg_01"
 		description="Use of defineVariable and extVariable - DFDL-7-091R">
@@ -294,21 +281,6 @@
 			<daf:bind name="ex:v_with_default">2</daf:bind>
 		</daf:externalVariableBindings>
 	</tdml:defineConfig>
-
-	<!-- Should error. One of the variables is not set to external, yet we attempt 
-		to set it externally. -->
-	<tdml:parserTestCase name="override_define_vars_03"
-		root="c" model="v3" config="config_03"
-		description="Use of defineVariable, extVariable, and setVariable - DFDL-7-091R">
-
-		<tdml:document />
-
-		<tdml:errors>
-			<tdml:error>Cannot set variable</tdml:error>
-			<tdml:error>v_no_default</tdml:error>
-			<tdml:error>externally</tdml:error>
-		</tdml:errors>
-	</tdml:parserTestCase>
 
 	<tdml:defineSchema name="v4">
 		<dfdl:defineVariable name="v_no_default" type="xsd:int"

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section07/external_variables/TestExternalVariables.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section07/external_variables/TestExternalVariables.scala
@@ -44,10 +44,6 @@ class TestExternalVariables {
     runner.runOneTest("override_define_vars_02")
   }
 
-  @Test def test_override_define_vars_03(): Unit = {
-    runner.runOneTest("override_define_vars_03")
-  }
-
   @Test def test_override_define_vars_04(): Unit = {
     runner.runOneTest("override_define_vars_04")
   }
@@ -70,9 +66,5 @@ class TestExternalVariables {
 
   @Test def test_set_predefined_var(): Unit = {
     runner.runOneTest("set_predefined_var")
-  }
-
-  @Test def test_external_var_dne(): Unit = {
-    runner.runOneTest("external_var_dne")
   }
 }


### PR DESCRIPTION
- Fix an exception when a schema contains at least one variable are
  marked as external="false" and you try to set any variable (external
  or not) without providing a namespace for the variable. This is very
  common with the CLI or the withExternalVariables API that accepts a
  Map.
- Modify setExternalVariables so that it allows setting the same
  variable multiple times externally. This allows changing the same
  variable in between different calls to parse/unparse.
- When you try to set an external variable and either that variable is
  not externally settable or the variable is not defined, then we
  currently throw an SDE. But SDE's really shouldn't be thrown. We don't
  want to add this SDE to the DataProcessors diagnostics because then
  isError would be true and the DataProcessor could no longer be used.
  Instead, this adds a new ExternalVariableException that is thrown. The
  Java and Scala API's are modified to use this exception. Also modifies
  the CLI to check for this new exception and error.
- Remove VariableUtils.convert function. This is only used in places
  where a conversion isn't needed because the variable is already
  converted from DPath, or we need special logic if the conversion fails
  to create the rite exception.
- Remove VariableMapFactory.setExternalVariables--this function is not
  used anywhere.
- Modify the TDML Runner to no longer catch external variable errors and
  make them part of diagnostics. Instead the TDML runner just tosses the
  error as a TDMLException. New API/CLI tests are added to test the
  various ways that setting external variables can fail and make sure we
  get the correct API exception.

DAFFODIL-2480