### PR TITLE
Detect and error when duplicate tdml:defineConfig's exist

### DIFF
--- a/daffodil-tdml-processor/src/test/scala/org/apache/daffodil/tdml/TestTDMLRunner.scala
+++ b/daffodil-tdml-processor/src/test/scala/org/apache/daffodil/tdml/TestTDMLRunner.scala
@@ -727,4 +727,91 @@ f0 f1 f2 f3 f4 f5 f6 f7 f8 f9 fa fb fc fd fe ff
   //    assertEquals(expected, hexDigits)
   //  }
 
+  @Test def testDuplicateDefineSchema(): Unit = {
+    val testSuite =
+      <tdml:testSuite suiteName="theSuiteName" xmlns:tns={ tns } xmlns:tdml={ tdml } xmlns:dfdl={ dfdl } xmlns:xsd={ xsd } xmlns:xs={ xsd } xmlns:xsi={ xsi }>
+        <tdml:defineSchema name="dupSchema">
+          <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+          <dfdl:format ref="tns:GeneralFormat"/>
+          <xsd:element name="data" type="xsd:int" dfdl:lengthKind="explicit" dfdl:length="{ xs:unsignedInt(2) }"/>
+        </tdml:defineSchema>
+        <tdml:defineSchema name="dupSchema">
+          <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+          <dfdl:format ref="tns:GeneralFormat"/>
+          <xsd:element name="data" type="xsd:int" dfdl:lengthKind="explicit" dfdl:length="{ xs:unsignedInt(2) }"/>
+        </tdml:defineSchema>
+        <parserTestCase xmlns={ tdml } name="testCase" root="data" model="dupSchema">
+          <document>37</document>
+          <infoset>
+            <dfdlInfoset>
+              <data xmlns={ example }>37</data>
+            </dfdlInfoset>
+          </infoset>
+        </parserTestCase>
+      </tdml:testSuite>
+    lazy val ts = new DFDLTestSuite(testSuite)
+    val exc = intercept[Exception] {
+      ts.runOneTest("testCase")
+    }
+    assertTrue(exc.getMessage().contains("Duplicate definitions found for defineSchema: dupSchema"))
+  }
+
+  @Test def testDuplicateTestCase(): Unit = {
+    val testSuite =
+      <tdml:testSuite suiteName="theSuiteName" xmlns:tns={ tns } xmlns:tdml={ tdml } xmlns:dfdl={ dfdl } xmlns:xsd={ xsd } xmlns:xs={ xsd } xmlns:xsi={ xsi }>
+        <tdml:defineSchema name="mySchema">
+          <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+          <dfdl:format ref="tns:GeneralFormat"/>
+          <xsd:element name="data" type="xsd:int" dfdl:lengthKind="explicit" dfdl:length="{ xs:unsignedInt(2) }"/>
+        </tdml:defineSchema>
+        <parserTestCase xmlns={ tdml } name="dupTestCase" root="data" model="mySchema">
+          <document>37</document>
+          <infoset>
+            <dfdlInfoset>
+              <data xmlns={ example }>37</data>
+            </dfdlInfoset>
+          </infoset>
+        </parserTestCase>
+        <unparserTestCase xmlns={ tdml } name="dupTestCase" root="data" model="mySchema">
+          <document>37</document>
+          <infoset>
+            <dfdlInfoset>
+              <data xmlns={ example }>37</data>
+            </dfdlInfoset>
+          </infoset>
+        </unparserTestCase>
+      </tdml:testSuite>
+    lazy val ts = new DFDLTestSuite(testSuite)
+    val exc = intercept[Exception] {
+      ts.runOneTest("testCase")
+    }
+    assertTrue(exc.getMessage().contains("Duplicate definitions found for parser or unparser test cases: dupTestCase"))
+  }
+
+  @Test def testDuplicateDefineConfig(): Unit = {
+    val testSuite =
+      <tdml:testSuite suiteName="theSuiteName" xmlns:tns={ tns } xmlns:tdml={ tdml } xmlns:dfdl={ dfdl } xmlns:xsd={ xsd } xmlns:xs={ xsd } xmlns:xsi={ xsi }>
+        <tdml:defineSchema name="mySchema">
+          <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+          <dfdl:format ref="tns:GeneralFormat"/>
+          <xsd:element name="data" type="xsd:int" dfdl:lengthKind="explicit" dfdl:length="{ xs:unsignedInt(2) }"/>
+        </tdml:defineSchema>
+        <tdml:defineConfig name="dupConfig" />
+        <tdml:defineConfig name="dupConfig" />
+        <parserTestCase xmlns={ tdml } name="testCase" root="data" model="mySchema" config="dupConfig">
+          <document>37</document>
+          <infoset>
+            <dfdlInfoset>
+              <data xmlns={ example }>37</data>
+            </dfdlInfoset>
+          </infoset>
+        </parserTestCase>
+      </tdml:testSuite>
+    lazy val ts = new DFDLTestSuite(testSuite)
+    val exc = intercept[Exception] {
+      ts.runOneTest("testCase")
+    }
+    assertTrue(exc.getMessage().contains("Duplicate definitions found for defineConfig: dupConfig"))
+  }
+
 }

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section00/general/tunables.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section00/general/tunables.tdml
@@ -36,7 +36,7 @@
 		</daf:tunables>
 	</tdml:defineConfig>
 
-	<tdml:defineConfig name="cfg_defaultNamespace">
+	<tdml:defineConfig name="cfg_preferDefaultNamespace">
 		<daf:tunables xmlns="http://www.w3.org/2001/XMLSchema"
 			xmlns:xs="http://www.w3.org/2001/XMLSchema">
 			<daf:unqualifiedPathStepPolicy>preferDefaultNamespace</daf:unqualifiedPathStepPolicy>
@@ -167,73 +167,265 @@
 
 	</tdml:defineSchema>
 
-	<!-- Test name: unqualifiedPathStepPolicy_defaultNamespace_test_01 Schema: 
-		unqualifiedPathStepPolicy Purpose: Verifiy that Tunables now work when specified 
-		via TDML -->
-	<tdml:parserTestCase
-		name="unqualifiedPathStepPolicy_defaultNamespace_test_01" root="test_01"
-		model="unqualifiedPathStep" description="Tunables - Unqualified Path Step Policy"
-		config="cfg_defaultNamespace">
+  <!--
+    Test name: unqualifiedPathStepPolicy_test_01_defaultNamespace
+    Schema: unqualifiedPathStepPolicy
+    Purpose: Verifiy that unqualifiedPathStepPolicy works as expected
+  -->
+  <tdml:parserTestCase
+    name="unqualifiedPathStepPolicy_test_01_defaultNamespace" root="test_01"
+    model="unqualifiedPathStep" description="Tunables - Unqualified Path Step Policy"
+    config="cfg_defaultNamespace">
+    <tdml:document>
+      <tdml:documentPart type="text">12</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <ex:test_01 xmlns:ex="http://example.com">
+          <ex:a>
+            <ex:b>1</ex:b>
+            <c xmlns="">2</c>
+          </ex:a>
+          <s xmlns="">1</s>
+        </ex:test_01>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
 
-		<tdml:document>
-			<tdml:documentPart type="text">12</tdml:documentPart>
-		</tdml:document>
+  <!--
+    Test name: unqualifiedPathStepPolicy_test_01_preferDefaultNamespace
+    Schema: unqualifiedPathStepPolicy
+    Purpose: Verifiy that unqualifiedPathStepPolicy works as expected
+  -->
+  <tdml:parserTestCase
+    name="unqualifiedPathStepPolicy_test_01_preferDefaultNamespace" root="test_01"
+    model="unqualifiedPathStep" description="Tunables - Unqualified Path Step Policy"
+    config="cfg_preferDefaultNamespace">
+    <tdml:document>
+      <tdml:documentPart type="text">12</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <ex:test_01 xmlns:ex="http://example.com">
+          <ex:a>
+            <ex:b>1</ex:b>
+            <c xmlns="">2</c>
+          </ex:a>
+          <s xmlns="">1</s>
+        </ex:test_01>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
 
-		<tdml:infoset>
-			<tdml:dfdlInfoset>
-				<test_01 xmlns="http://example.com">
-					<a>
-						<b>1</b>
-						<c xmlns="">2</c>
-					</a>
-					<s xmlns="">1</s>
-				</test_01>
-			</tdml:dfdlInfoset>
-		</tdml:infoset>
-	</tdml:parserTestCase>
-	
-	<!-- Test name: unqualifiedPathStepPolicy_noNamespace_test_02 Schema: 
-		unqualifiedPathStepPolicy Purpose: Verifiy that Tunables now work when specified
-		via TDML. This also overrides the default tunable (defaultNamespace). -->
-	<tdml:parserTestCase
-		name="unqualifiedPathStepPolicy_noNamespace_test_02" root="test_02"
-		model="unqualifiedPathStep" description="Tunables - Unqualified Path Step Policy"
-		config="cfg_noNamespace">
+  <!--
+    Test name: unqualifiedPathStepPolicy_test_01_noNamespace
+    Schema: unqualifiedPathStepPolicy
+    Purpose: Verifiy that unqualifiedPathStepPolicy works as expected
+  -->
+  <tdml:parserTestCase
+    name="unqualifiedPathStepPolicy_test_01_noNamespace" root="test_01"
+    model="unqualifiedPathStep" description="Tunables - Unqualified Path Step Policy"
+    config="cfg_noNamespace">
+    <tdml:document>
+      <tdml:documentPart type="text">12</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <ex:test_01 xmlns:ex="http://example.com">
+          <ex:a>
+            <ex:b>1</ex:b>
+            <c xmlns="">2</c>
+          </ex:a>
+          <s xmlns="">1</s>
+        </ex:test_01>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
 
-		<tdml:document>
-			<tdml:documentPart type="text">12</tdml:documentPart>
-		</tdml:document>
+  <!--
+    Test name: unqualifiedPathStepPolicy_test_02_defaultNamespace
+    Schema: unqualifiedPathStepPolicy
+    Purpose: Verifiy that unqualifiedPathStepPolicy works as expected
+  -->
+  <tdml:parserTestCase
+    name="unqualifiedPathStepPolicy_test_02_defaultNamespace" root="test_02"
+    model="unqualifiedPathStep" description="Tunables - Unqualified Path Step Policy"
+    config="cfg_defaultNamespace">
+    <tdml:document>
+      <tdml:documentPart type="text">12</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <ex:test_02 xmlns:ex="http://example.com">
+          <ex:a>
+            <ex:b>1</ex:b>
+            <c xmlns="">2</c>
+          </ex:a>
+          <s xmlns="">1</s>
+        </ex:test_02>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
 
-		<tdml:errors>
-			<tdml:error>Schema Definition Error</tdml:error>
-		</tdml:errors>
-	</tdml:parserTestCase>
+  <!--
+    Test name: unqualifiedPathStepPolicy_test_02_preferDefaultNamespace
+    Schema: unqualifiedPathStepPolicy
+    Purpose: Verifiy that unqualifiedPathStepPolicy works as expected
+  -->
+  <tdml:parserTestCase
+    name="unqualifiedPathStepPolicy_test_02_preferDefaultNamespace" root="test_02"
+    model="unqualifiedPathStep" description="Tunables - Unqualified Path Step Policy"
+    config="cfg_preferDefaultNamespace">
+    <tdml:document>
+      <tdml:documentPart type="text">12</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <ex:test_02 xmlns:ex="http://example.com">
+          <ex:a>
+            <ex:b>1</ex:b>
+            <c xmlns="">2</c>
+          </ex:a>
+          <s xmlns="">1</s>
+        </ex:test_02>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
 
-	<!-- Test name: unqualifiedPathStepPolicy_defaultNamespace_test_02
-	     Schema: unqualifiedPathStepPolicy
-	     Purpose: Verify that Tunables now work when specified via TDML.
-	-->
-	<tdml:parserTestCase
-		name="unqualifiedPathStepPolicy_defaultNamespace_test_02" root="test_02"
-		model="unqualifiedPathStep" description="Tunables - Unqualified Path Step Policy"
-		config="cfg_defaultNamespace">
+  <!--
+    Test name: unqualifiedPathStepPolicy_test_02_noNamespace
+    Schema: unqualifiedPathStepPolicy
+    Purpose: Verifiy that unqualifiedPathStepPolicy works as expected
+  -->
+  <tdml:parserTestCase
+    name="unqualifiedPathStepPolicy_test_02_noNamespace" root="test_02"
+    model="unqualifiedPathStep" description="Tunables - Unqualified Path Step Policy"
+    config="cfg_noNamespace">
+    <tdml:document>
+      <tdml:documentPart type="text">12</tdml:documentPart>
+    </tdml:document>
+    <tdml:errors>
+      <tdml:error>Schema Definition Error</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
 
-		<tdml:document>
-			<tdml:documentPart type="text">12</tdml:documentPart>
-		</tdml:document>
+  <!--
+    Test name: unqualifiedPathStepPolicy_test_03_defaultNamespace
+    Schema: unqualifiedPathStepPolicy
+    Purpose: Verifiy that unqualifiedPathStepPolicy works as expected
+  -->
+  <tdml:parserTestCase
+    name="unqualifiedPathStepPolicy_test_03_defaultNamespace" root="test_03"
+    model="unqualifiedPathStep" description="Tunables - Unqualified Path Step Policy"
+    config="cfg_defaultNamespace">
+    <tdml:document>
+      <tdml:documentPart type="text">12</tdml:documentPart>
+    </tdml:document>
+    <tdml:errors>
+      <tdml:error>Schema Definition Error</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
 
-		<tdml:infoset>
-			<tdml:dfdlInfoset>
-				<test_02 xmlns="http://example.com">
-					<ex:a>
-						<ex:b>1</ex:b>
-						<c>2</c>
-					</ex:a>
-					<s>1</s>
-				</test_02>
-			</tdml:dfdlInfoset>
-		</tdml:infoset>
-	</tdml:parserTestCase>
+  <!--
+    Test name: unqualifiedPathStepPolicy_test_03_preferDefaultNamespace
+    Schema: unqualifiedPathStepPolicy
+    Purpose: Verifiy that unqualifiedPathStepPolicy works as expected
+  -->
+  <tdml:parserTestCase
+    name="unqualifiedPathStepPolicy_test_03_preferDefaultNamespace" root="test_03"
+    model="unqualifiedPathStep" description="Tunables - Unqualified Path Step Policy"
+    config="cfg_preferDefaultNamespace">
+    <tdml:document>
+      <tdml:documentPart type="text">12</tdml:documentPart>
+    </tdml:document>
+    <tdml:errors>
+      <tdml:error>Schema Definition Error</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+  <!--
+    Test name: unqualifiedPathStepPolicy_test_03_noNamespace
+    Schema: unqualifiedPathStepPolicy
+    Purpose: Verifiy that unqualifiedPathStepPolicy works as expected
+  -->
+  <tdml:parserTestCase
+    name="unqualifiedPathStepPolicy_test_03_noNamespace" root="test_03"
+    model="unqualifiedPathStep" description="Tunables - Unqualified Path Step Policy"
+    config="cfg_noNamespace">
+    <tdml:document>
+      <tdml:documentPart type="text">12</tdml:documentPart>
+    </tdml:document>
+    <tdml:errors>
+      <tdml:error>Schema Definition Error</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+  <!--
+    Test name: unqualifiedPathStepPolicy_test_04_defaultNamespace
+    Schema: unqualifiedPathStepPolicy
+    Purpose: Verifiy that unqualifiedPathStepPolicy works as expected
+  -->
+  <tdml:parserTestCase
+    name="unqualifiedPathStepPolicy_test_04_defaultNamespace" root="test_04"
+    model="unqualifiedPathStep" description="Tunables - Unqualified Path Step Policy"
+    config="cfg_defaultNamespace">
+    <tdml:document>
+      <tdml:documentPart type="text">12</tdml:documentPart>
+    </tdml:document>
+    <tdml:errors>
+      <tdml:error>Schema Definition Error</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+  <!--
+    Test name: unqualifiedPathStepPolicy_test_04_preferDefaultNamespace
+    Schema: unqualifiedPathStepPolicy
+    Purpose: Verifiy that unqualifiedPathStepPolicy works as expected
+  -->
+  <tdml:parserTestCase
+    name="unqualifiedPathStepPolicy_test_04_preferDefaultNamespace" root="test_04"
+    model="unqualifiedPathStep" description="Tunables - Unqualified Path Step Policy"
+    config="cfg_preferDefaultNamespace">
+    <tdml:document>
+      <tdml:documentPart type="text">12</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <ex:test_04 xmlns:ex="http://example.com">
+          <ex:a>
+            <ex:b>1</ex:b>
+            <c xmlns="">2</c>
+          </ex:a>
+          <s xmlns="">2</s>
+        </ex:test_04>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <!--
+    Test name: unqualifiedPathStepPolicy_test_04_noNamespace
+    Schema: unqualifiedPathStepPolicy
+    Purpose: Verifiy that unqualifiedPathStepPolicy works as expected
+  -->
+  <tdml:parserTestCase
+    name="unqualifiedPathStepPolicy_test_04_noNamespace" root="test_04"
+    model="unqualifiedPathStep" description="Tunables - Unqualified Path Step Policy"
+    config="cfg_noNamespace">
+    <tdml:document>
+      <tdml:documentPart type="text">12</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <ex:test_04 xmlns:ex="http://example.com">
+          <ex:a>
+            <ex:b>1</ex:b>
+            <c xmlns="">2</c>
+          </ex:a>
+          <s xmlns="">2</s>
+        </ex:test_04>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
 
 
 

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section00/general/TestGeneral.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section00/general/TestGeneral.scala
@@ -92,10 +92,18 @@ class TestGeneral {
     assertTrue(m.toLowerCase.contains("not found"))
   }
 
-  // DFDL-1143
-  @Test def test_unqualifiedPathStepPolicy_defaultNamespace_test_01(): Unit = { tunables_runner.runOneTest("unqualifiedPathStepPolicy_defaultNamespace_test_01") }
-  @Test def test_unqualifiedPathStepPolicy_noNamespace_test_02(): Unit = { tunables_runner.runOneTest("unqualifiedPathStepPolicy_noNamespace_test_02") }
-  @Test def test_unqualifiedPathStepPolicy_defaultNamespace_test_02(): Unit = { tunables_runner.runOneTest("unqualifiedPathStepPolicy_defaultNamespace_test_02") }
+  @Test def test_unqualifiedPathStepPolicy_test_01_defaultNamespace(): Unit = { tunables_runner.runOneTest("unqualifiedPathStepPolicy_test_01_defaultNamespace") }
+  @Test def test_unqualifiedPathStepPolicy_test_01_preferDefaultNamespace(): Unit = { tunables_runner.runOneTest("unqualifiedPathStepPolicy_test_01_preferDefaultNamespace") }
+  @Test def test_unqualifiedPathStepPolicy_test_01_noNamespace(): Unit = { tunables_runner.runOneTest("unqualifiedPathStepPolicy_test_01_noNamespace") }
+  @Test def test_unqualifiedPathStepPolicy_test_02_defaultNamespace(): Unit = { tunables_runner.runOneTest("unqualifiedPathStepPolicy_test_02_defaultNamespace") }
+  @Test def test_unqualifiedPathStepPolicy_test_02_preferDefaultNamespace(): Unit = { tunables_runner.runOneTest("unqualifiedPathStepPolicy_test_02_preferDefaultNamespace") }
+  @Test def test_unqualifiedPathStepPolicy_test_02_noNamespace(): Unit = { tunables_runner.runOneTest("unqualifiedPathStepPolicy_test_02_noNamespace") }
+  @Test def test_unqualifiedPathStepPolicy_test_03_defaultNamespace(): Unit = { tunables_runner.runOneTest("unqualifiedPathStepPolicy_test_03_defaultNamespace") }
+  @Test def test_unqualifiedPathStepPolicy_test_03_preferDefaultNamespace(): Unit = { tunables_runner.runOneTest("unqualifiedPathStepPolicy_test_03_preferDefaultNamespace") }
+  @Test def test_unqualifiedPathStepPolicy_test_03_noNamespace(): Unit = { tunables_runner.runOneTest("unqualifiedPathStepPolicy_test_03_noNamespace") }
+  @Test def test_unqualifiedPathStepPolicy_test_04_defaultNamespace(): Unit = { tunables_runner.runOneTest("unqualifiedPathStepPolicy_test_04_defaultNamespace") }
+  @Test def test_unqualifiedPathStepPolicy_test_04_preferDefaultNamespace(): Unit = { tunables_runner.runOneTest("unqualifiedPathStepPolicy_test_04_preferDefaultNamespace") }
+  @Test def test_unqualifiedPathStepPolicy_test_04_noNamespace(): Unit = { tunables_runner.runOneTest("unqualifiedPathStepPolicy_test_04_noNamespace") }
   
   @Test def test_maxOccursBoundsExceeded(): Unit = { tunables_runner.runOneTest("maxOccursBoundsExceeded") }
   @Test def test_textBidiYes(): Unit = { tunables_runner.runOneTest("textBidiYes") }


### PR DESCRIPTION
Also refactors similar detection of duplicate test case names and
embedded schemas to use the same function.

This found a single file, tunables.tdml, which had duplicate
configurations. This revealed that the tests for these particular
tunables did not cover all the intended cases, finding elements that
weren't even used in tests. Additional tests are added to cover all
different values of unqualifiedPathStepPolicy and ensure the tests
included in the file have the expected behavior.

DAFFODIL-2533