### PR TITLE
Check for single commit in pull requests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: Daffodil CI
+name: CI
 
 # Run CI when pushing a commit to master or creating a pull request or
 # adding another commit to a pull request or reopening a pull request.
@@ -24,9 +24,10 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
-# Build Daffodil and run some checks.
-
 jobs:
+
+  # Build Daffodil and run some checks.
+
   check:
     name: Java ${{ matrix.java_version }}, Scala ${{ matrix.scala_version }}, ${{ matrix.os }}
     strategy:
@@ -168,3 +169,24 @@ jobs:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         with:
           args: -Dproject.settings=.sonar-project.properties
+
+
+  # Ensure pull requests only have a single commit
+
+  single-commit:
+    name: Single Commit Pull Request
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check Single Commit
+        uses: actions/github-script@v4.0.2
+        with:
+          script: |
+            const commits = await github.pulls.listCommits({
+              ...context.repo,
+              pull_number: context.issue.number,
+            });
+            core.info("Number of commits in this pull request: " + commits.data.length);
+            if (commits.data.length > 1) {
+              core.setFailed("If approved with two +1's, squash this pull request into one commit");
+            }

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 <!-- markdownlint-disable line-length -->
 <!-- markdownlint-disable no-inline-html -->
 [<img src="https://daffodil.apache.org/assets/themes/apache/img/apache-daffodil-logo.svg" height="85" align="left" alt="Apache Daffodil"/>][Website]
-[<img src="https://img.shields.io/github/workflow/status/apache/daffodil/Daffodil%20CI/master.svg" align="right"/>][GitHub Actions]
+[<img src="https://img.shields.io/github/workflow/status/apache/daffodil/CI/master.svg" align="right"/>][GitHub Actions]
 <br clear="right" />
 [<img src="https://img.shields.io/codecov/c/github/apache/daffodil/master.svg" align="right"/>][CodeCov]
 <br clear="right" />


### PR DESCRIPTION
- Also shorten the workflow name. In some displays, github truncates the
  workflow + job name to the point where you only see a few letters of
  the job name if the workflow is too long, making it hard to tell which
  job is which.

DAFFODIL-2252