### PR TITLE
If you try to start sbt in a windows command shell, you get the error

### DIFF
--- a/.sbtopts
+++ b/.sbtopts
@@ -13,4 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
--mem 4096
+#-mem 4096
+-J-Xms4096m
+-J-Xmx4096m
+-J-Xss4M
+-J-XX:ReservedCodeCacheSize=512m


### PR DESCRIPTION
Unregcognized option: -mem

By adding the following lines in the .sbtopts file:
+-J-Xms4096m
+-J-Xmx4096m
+-J-Xss4M
+-J-XX:ReservedCodeCacheSize=512m
sbt will start without any issue