### PR TITLE
dfdl prefix properties on dfdl annotation elements should generate us…

### DIFF
--- a/daffodil-test/src/test/resources/org/apache/daffodil/section00/general/dfdlFormatPrefixedAttributesSDE.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section00/general/dfdlFormatPrefixedAttributesSDE.tdml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<tdml:testSuite
+  xmlns:tdml="http://www.ibm.com/xmlns/dfdl/testData"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/"
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns:fn="http://www.w3.org/2005/xpath-functions"
+  xmlns:daf="urn:ogf:dfdl:2013:imp:daffodil.apache.org:2018:ext"
+  xmlns:dfdlx="http://www.ogf.org/dfdl/dfdl-1.0/extensions"
+  xmlns:ex="http://example.com"
+  xmlns:tns="http://example.com">
+
+  <tdml:defineSchema name="s1">
+    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+    <dfdl:format ref="ex:GeneralFormat" dfdl:lengthKind="delimited"/>
+    <xs:element name="root" type="xs:string"/>
+  </tdml:defineSchema>
+
+<!--
+        Test Name: dfdl_format_prefixed_attributes_sde
+        Schema: s1
+        Root: root
+        Purpose:
+        Daffodil should issue a specific diagnostic whenever it finds dfdl: prefixed attributes in
+        the annotation elements dfdl:format, dfdl:element, dfdl:simpleType, dfdl:sequence, dfdl:choice, etc.
+        It should point out specifically that the author probably wanted to remove the prefix dfdl:
+-->
+    <tdml:parserTestCase name="dfdl_format_prefixed_attributes_sde" root="root"  model="s1" description="">
+        <tdml:document />
+        <tdml:errors>
+            <tdml:error>Schema Definition Error</tdml:error>
+            <tdml:error>dfdl:lengthKind</tdml:error>
+        </tdml:errors>
+    </tdml:parserTestCase>
+</tdml:testSuite>

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section00/general/TestDFDLFormatPrefixedAttributesSDE.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section00/general/TestDFDLFormatPrefixedAttributesSDE.scala
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.daffodil.section00.general
+
+import org.apache.daffodil.tdml.Runner
+import org.junit.{AfterClass, Test}
+
+object TestDFDLFormatPrefixedAttributesSDE {
+
+  val testDir = "/org/apache/daffodil/section00/general/"
+  val runner = Runner(testDir, "dfdlFormatPrefixedAttributesSDE.tdml", validateTDMLFile = false)
+
+  @AfterClass def tearDown(): Unit = {
+    runner.reset
+  }
+}
+
+
+class TestDFDLFormatPrefixedAttributesSDE {
+
+  import TestDFDLFormatPrefixedAttributesSDE._
+
+  @Test def test_dfdl_format_prefixed_attributes_sde(): Unit = {
+    runner.runOneTest("dfdl_format_prefixed_attributes_sde")
+  }
+}


### PR DESCRIPTION
…eful diagnostic

-Added TestDefError.scala file and disabled validateTDML setting to allow the parser to go through the whole file and pickup the TDML error.
-Added generalSchemaDefinitionError.tdml test to catch the TDML "SAXParseException" error