### PR TITLE
Improve path expression error handling

### DIFF
--- a/daffodil-test/src/test/resources/org/apache/daffodil/section23/dfdl_expressions/expressions.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section23/dfdl_expressions/expressions.tdml
@@ -1304,7 +1304,67 @@
         </xs:sequence>
       </xs:complexType>
     </xs:element>
-    
+
+    <xs:element name="ocke5">
+      <xs:complexType>
+        <xs:sequence>
+          <xs:element name="arr1" maxOccurs="unbounded">
+            <xs:complexType>
+              <xs:sequence>
+                <xs:element name="field1" type="xs:string" />
+              </xs:sequence>
+            </xs:complexType>
+          </xs:element>
+          <xs:element name="arr2" type="xs:string" maxOccurs="unbounded"
+            dfdl:occursCountKind="expression"
+            dfdl:occursCount="{ xs:unsignedLong(does/not/exist) }" />
+        </xs:sequence>
+      </xs:complexType>
+    </xs:element>
+
+    <xs:element name="ocke6">
+      <xs:complexType>
+        <xs:sequence>
+          <xs:element name="arr1" maxOccurs="unbounded">
+            <xs:complexType>
+              <xs:sequence>
+                <xs:element name="field1" type="xs:string" />
+              </xs:sequence>
+            </xs:complexType>
+          </xs:element>
+          <xs:element name="arr2" type="xs:string" maxOccurs="unbounded"
+            dfdl:occursCountKind="expression"
+            dfdl:occursCount="{ xs:unsignedLong(../ex:arr1[does/not/exist]/field1) }" />
+        </xs:sequence>
+      </xs:complexType>
+    </xs:element>
+
+    <xs:element name="ocke7">
+      <xs:complexType>
+        <xs:sequence>
+          <xs:element name="arr2" maxOccurs="unbounded"
+            dfdl:occursCountKind="expression"
+            dfdl:occursCount="{ xs:unsignedLong(ex:count) }">
+            <xs:complexType>
+              <xs:sequence>
+                <xs:element name="count" type="xs:int" />
+              </xs:sequence>
+            </xs:complexType>
+          </xs:element>
+        </xs:sequence>
+      </xs:complexType>
+    </xs:element>
+
+    <xs:element name="ocke8">
+      <xs:complexType>
+        <xs:sequence>
+          <xs:element name="arr" type="xs:string" maxOccurs="unbounded"
+            dfdl:occursCountKind="expression"
+            dfdl:occursCount="{ xs:unsignedLong(..) }" />
+        </xs:sequence>
+      </xs:complexType>
+    </xs:element>
+
     <xs:element name="expr_space" dfdl:lengthKind="implicit">
       <xs:complexType>
         <xs:sequence dfdl:separator=",">
@@ -1580,7 +1640,83 @@
       </tdml:dfdlInfoset>
     </tdml:infoset>
   </tdml:parserTestCase>
-  
+
+  <!--
+       Test Name: ocke_step_dne
+          Schema: expressions-Embedded.dfdl.xsd
+          Purpose: This test demonstrates that we get an appropriate error message when an
+                   occursCountKind expression references a non existent path step
+  -->
+  <tdml:parserTestCase name="ocke_step_dne" root="ocke5"
+    model="expressions-Embedded.dfdl.xsd" description="occursCountKind expression - DFDL-23-011R">
+
+    <tdml:document><![CDATA[]]></tdml:document>
+    <tdml:errors>
+      <tdml:error>Schema Definition Error</tdml:error>
+      <tdml:error>Path expression</tdml:error>
+      <tdml:error>absolute</tdml:error>
+      <tdml:error>upward step</tdml:error>
+      <tdml:error>does/not/exist</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+  <!--
+       Test Name: ocke_array_index_step_dne
+          Schema: expressions-Embedded.dfdl.xsd
+          Purpose: This test demonstrates that we get an appropriate error message when an
+                   occursCountKind expression references a non existent path step inside
+                   an array index
+  -->
+  <tdml:parserTestCase name="ocke_array_index_step_dne" root="ocke6"
+    model="expressions-Embedded.dfdl.xsd" description="occursCountKind expression - DFDL-23-011R">
+
+    <tdml:document><![CDATA[]]></tdml:document>
+    <tdml:errors>
+      <tdml:error>Schema Definition Error</tdml:error>
+      <tdml:error>Path expression</tdml:error>
+      <tdml:error>absolute</tdml:error>
+      <tdml:error>upward step</tdml:error>
+      <tdml:error>does/not/exist</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+  <!--
+       Test Name: ocke_non_upward
+          Schema: expressions-Embedded.dfdl.xsd
+          Purpose: This test demonstrates that we get an appropriate error message when an
+                   occursCountKind expression uses a path that does not go upward
+  -->
+  <tdml:parserTestCase name="ocke_non_upward" root="ocke7"
+    model="expressions-Embedded.dfdl.xsd" description="occursCountKind expression - DFDL-23-011R">
+
+    <tdml:document><![CDATA[]]></tdml:document>
+    <tdml:errors>
+      <tdml:error>Schema Definition Error</tdml:error>
+      <tdml:error>Path expression</tdml:error>
+      <tdml:error>absolute</tdml:error>
+      <tdml:error>upward step</tdml:error>
+      <tdml:error>ex:count</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+  <!--
+       Test Name: ocke_single_upward
+          Schema: expressions-Embedded.dfdl.xsd
+          Purpose: This test demonstrates that we get an appropriate error message when an
+                   occursCountKind expression uses a path that is only a single upward step
+  -->
+  <tdml:parserTestCase name="ocke_single_upward" root="ocke8"
+    model="expressions-Embedded.dfdl.xsd" description="occursCountKind expression - DFDL-23-011R">
+
+    <tdml:document><![CDATA[]]></tdml:document>
+    <tdml:errors>
+      <tdml:error>Schema Definition Error</tdml:error>
+      <tdml:error>Complex</tdml:error>
+      <tdml:error>cannot be converted</tdml:error>
+      <tdml:error>xs:unsignedLong</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
 <!--
      Test Name: internal_space_preserved
         Schema: expressions-Embedded.dfdl.xsd

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section23/dfdl_expressions/TestDFDLExpressions.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section23/dfdl_expressions/TestDFDLExpressions.scala
@@ -231,6 +231,10 @@ class TestDFDLExpressions {
   @Test def test_ocke_rel2(): Unit = { runner.runOneTest("ocke_rel2") }
   @Test def test_ocke_rel3(): Unit = { runner.runOneTest("ocke_rel3") }
   @Test def test_ocke_rel4(): Unit = { runner.runOneTest("ocke_rel4") }
+  @Test def test_ocke_step_dne(): Unit = { runner.runOneTest("ocke_step_dne") }
+  @Test def test_ocke_array_index_step_dne(): Unit = { runner.runOneTest("ocke_array_index_step_dne") }
+  @Test def test_ocke_non_upward(): Unit = { runner.runOneTest("ocke_non_upward") }
+  @Test def test_ocke_single_upward(): Unit = { runner.runOneTest("ocke_single_upward") }
   @Test def test_internal_space_preserved(): Unit = { runner.runOneTest("internal_space_preserved") }
   @Test def test_internal_space_preserved2(): Unit = { runner.runOneTest("internal_space_preserved2") }
   @Test def test_internal_space_preserved3a(): Unit = { runner.runOneTest("internal_space_preserved3a") }


### PR DESCRIPTION
- The context of a dfdl:occursCountKind expression evaluation is
  actually not the element that the property lives on, but on the
  elements parent. This is because the element isn't created until the
  number of occurrences are known. This means that such expressions must
  either be absolute, or start with an ".." upward move. We previously
  had an assertion that checked this, but there's nothing actually
  preventing expressions without upward moves. This assertion is instead
  changed to an SDE.
- The conversions for path expressions were applied only on the last
  downward step. But this meant that if an expression path was made up
  of only upward steps, no conversions would occur. Such expressions are
  rarely reasonable, but are legal, and should usually result in an
  error. But because no conversions happened, where certain types of
  error checks occur, it meant it was possible to miss certain
  compile-time convertability checks, allowing for expressions to fail
  at runtime with a NullPointerExceptions. This modifies conversions to
  be applied to the entire path, instead of on the last downward step.
  This doesn't change what conversions are applied, only ensures that
  they are always applied.
- Additional refactorings related to path steps to make it a little more
  clear what's going on.

DAFFODIL-2553