### PR TITLE
Ensure newlines are output when debugger displays hidden groups

### DIFF
--- a/daffodil-cli/src/it/scala/org/apache/daffodil/debugger/TestCLIDebugger.scala
+++ b/daffodil-cli/src/it/scala/org/apache/daffodil/debugger/TestCLIDebugger.scala
@@ -203,9 +203,14 @@ class TestCLIdebugger {
       shell.expect(contains("(debug)"))
       shell.sendLine("set removeHidden false")
       shell.sendLine("display info infoset")
+      shell.sendLine("step")
+      shell.sendLine("step")
+      // intentionally look for a newline to make sure normally hidden elements
+      // are output with a trailing newline when the debugger displays them
+      shell.expect(contains("<sneaky></sneaky>\n"))
       shell.sendLine("break g")
       shell.sendLine("continue")
-      shell.expect(contains("<sneaky>5</sneaky>"))
+      shell.expect(contains("<sneaky>5</sneaky>\n"))
       shell.sendLine("quit")
       Util.expectExitCode(ExitCode.Failure, shell)
     } finally {

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/infoset/InfosetImpl.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/infoset/InfosetImpl.scala
@@ -1485,8 +1485,6 @@ sealed class DIComplex(override val erd: ElementRuntimeData)
     else Nope
   }
 
-  var hasVisibleChildren = false
-
   final def getChild(erd: ElementRuntimeData, tunable: DaffodilTunables): InfosetElement = {
     getChild(erd.dpathElementCompileInfo.namedQName, tunable)
   }
@@ -1592,7 +1590,6 @@ sealed class DIComplex(override val erd: ElementRuntimeData)
   }
 
   override def addChild(e: InfosetElement, tunable: DaffodilTunables): Unit = {
-    if (!e.isHidden && !hasVisibleChildren) hasVisibleChildren = true
     if (e.runtimeData.isArray) {
       val childERD = e.runtimeData
       val needsNewArray =


### PR DESCRIPTION
The debugger uses the XMLTextInfosetOutputter to display the infoset,
which uses hasVisibleChildren to determine when to output newlines in
complex elements--empty complex elements should not output a newline.

However, hasVisibleChildren assumes hidden elements won't ever be
output, but that isn't the case in the debugger. This means that when
the debugger outputs an infoset, newlines aren't correctly output within
hidden groups of empty complex elements.

Since the hasVisibleChildren variable is only used in the
XMLTextInfosetOutputter, and since it doesn't work with the debugger,
this patch just removes it. It is replaced with state added to the
infoset outputter to keep track of when to output newlines when
outputting XML.

DAFFODIL-2554