### PR TITLE
[RFC] Remove the outputValueCalc CompiledExpression from ElementRuntimeData

### DIFF
--- a/daffodil-core/src/main/scala/org/apache/daffodil/compiler/Compiler.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/compiler/Compiler.scala
@@ -385,8 +385,12 @@ class Compiler private (var validateDFDLSchemas: Boolean,
   /**
    * For convenient unit testing allow a literal XML node.
    */
-  def compileNode(xml: Node, optTmpDir: Option[File] = None): ProcessorFactory = {
-    compileSource(UnitTestSchemaSource(xml, "anon", optTmpDir), None, None)
+  def compileNode(
+    xml: Node,
+    optTmpDir: Option[File] = None,
+    optRootName: Option[String] = None,
+    optRootNamespace: Option[String] = None): ProcessorFactory = {
+    compileSource(UnitTestSchemaSource(xml, "anon", optTmpDir), optRootName, optRootNamespace)
   }
 
 }

--- a/daffodil-core/src/main/scala/org/apache/daffodil/grammar/ElementBaseGrammarMixin.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/grammar/ElementBaseGrammarMixin.scala
@@ -1199,7 +1199,7 @@ trait ElementBaseGrammarMixin
         inputValueCalcPrim, dfdlScopeEnd, EmptyGram)
     }
 
-  protected final lazy val ovcCompiledExpression = { // ovcValueCalcObject.expr
+  final lazy val ovcCompiledExpression = {
     val exprProp = outputValueCalcOption.asInstanceOf[Found]
     val exprText = exprProp.value
     val exprNamespaces = exprProp.location.namespaces

--- a/daffodil-core/src/main/scala/org/apache/daffodil/grammar/primitives/ElementCombinator.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/grammar/primitives/ElementCombinator.scala
@@ -114,7 +114,8 @@ class ElementCombinator(
         uSetVars,
         eBeforeUnparser,
         eUnparser,
-        eAfterUnparser)
+        eAfterUnparser,
+        context.ovcCompiledExpression)
     } else if ((context.lengthKind _eq_ LengthKind.Explicit) ||
       (context.isSimpleType &&
         (context.lengthKind _eq_ LengthKind.Implicit) &&

--- a/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/ChoiceTermRuntime1Mixin.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/ChoiceTermRuntime1Mixin.scala
@@ -17,20 +17,20 @@
 
 package org.apache.daffodil.runtime1
 
+import org.apache.daffodil.api.WarnID
+import org.apache.daffodil.dpath.NodeInfo
 import org.apache.daffodil.dsom.ChoiceTermBase
+import org.apache.daffodil.dsom.ElementBase
 import org.apache.daffodil.dsom.ExpressionCompilers
 import org.apache.daffodil.dsom.SequenceTermBase
 import org.apache.daffodil.dsom.Term
-import org.apache.daffodil.infoset.ChoiceBranchStartEvent
-import org.apache.daffodil.processors.ChoiceRuntimeData
-import org.apache.daffodil.infoset.ChoiceBranchEvent
 import org.apache.daffodil.exceptions.Assert
-import org.apache.daffodil.infoset.ChoiceBranchEndEvent
-import org.apache.daffodil.api.WarnID
-import org.apache.daffodil.processors.ChoiceDispatchKeyEv
-import org.apache.daffodil.dpath.NodeInfo
-import org.apache.daffodil.processors.ElementRuntimeData
 import org.apache.daffodil.grammar.Gram
+import org.apache.daffodil.infoset.ChoiceBranchEndEvent
+import org.apache.daffodil.infoset.ChoiceBranchEvent
+import org.apache.daffodil.infoset.ChoiceBranchStartEvent
+import org.apache.daffodil.processors.ChoiceDispatchKeyEv
+import org.apache.daffodil.processors.ChoiceRuntimeData
 import org.apache.daffodil.util.Delay
 
 trait ChoiceTermRuntime1Mixin { self: ChoiceTermBase =>
@@ -136,7 +136,7 @@ trait ChoiceTermRuntime1Mixin { self: ChoiceTermBase =>
               // because if so, we have a true ambiguity here.
               case sg: SequenceTermBase => {
                 val nonOVCEltChildren = sg.groupMembers.filter {
-                  case erd: ElementRuntimeData => erd.outputValueCalcExpr.isEmpty
+                  case eb: ElementBase => !eb.isOutputValueCalc
                   case _ => false
                 }
                 nonOVCEltChildren.length > 0

--- a/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/ElementBaseRuntime1Mixin.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/ElementBaseRuntime1Mixin.scala
@@ -204,7 +204,6 @@ trait ElementBaseRuntime1Mixin { self: ElementBase =>
       // unparser specific items
       //
       optTruncateSpecifiedLengthString,
-      if (isOutputValueCalc) Some(ovcCompiledExpression) else None,
       maybeBinaryFloatRepEv,
       maybeByteOrderEv,
       fillByteEv,

--- a/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/SchemaSetRuntime1Mixin.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/SchemaSetRuntime1Mixin.scala
@@ -90,7 +90,7 @@ trait SchemaSetRuntime1Mixin {
     if (xpath != "/") root.notYetImplemented("""Path must be "/". Other path support is not yet implemented.""")
     val rootERD = root.elementRuntimeData
     root.schemaDefinitionUnless(
-      rootERD.outputValueCalcExpr.isEmpty,
+      !rootERD.dpathElementCompileInfo.isOutputValueCalc,
       "The root element cannot have the dfdl:outputValueCalc property.")
     val validationMode = ValidationMode.Off
     val p = if (!root.isError) parser else null

--- a/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/processors/unparsers/ElementUnparser.scala
+++ b/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/processors/unparsers/ElementUnparser.scala
@@ -18,6 +18,7 @@
 package org.apache.daffodil.processors.unparsers
 
 import org.apache.daffodil.dpath.SuspendableExpression
+import org.apache.daffodil.dsom.CompiledExpression
 import org.apache.daffodil.exceptions.Assert
 import org.apache.daffodil.infoset.DIComplex
 import org.apache.daffodil.infoset.DISimple
@@ -311,12 +312,11 @@ class ElementSpecifiedLengthUnparser(
  * For dfdl:outputValueCalc elements.
  */
 class ElementOVCSpecifiedLengthUnparserSuspendableExpression(
-  callingUnparser: ElementOVCSpecifiedLengthUnparser)
+  callingUnparser: ElementOVCSpecifiedLengthUnparser,
+  override val expr: CompiledExpression[AnyRef])
   extends SuspendableExpression {
 
   override def rd = callingUnparser.erd
-
-  override lazy val expr = rd.outputValueCalcExpr.get
 
   override final protected def processExpressionResult(state: UState, v: DataValuePrimitive): Unit = {
     val diSimple = state.currentInfosetNode.asSimple
@@ -340,7 +340,8 @@ class ElementOVCSpecifiedLengthUnparser(
   setVarUnparsers: Array[Unparser],
   eBeforeUnparser: Maybe[Unparser],
   eUnparser: Maybe[Unparser],
-  eAfterUnparser: Maybe[Unparser])
+  eAfterUnparser: Maybe[Unparser],
+  expr: CompiledExpression[AnyRef])
   extends ElementUnparserBase(
     context,
     setVarUnparsers,
@@ -354,9 +355,9 @@ class ElementOVCSpecifiedLengthUnparser(
   override lazy val runtimeDependencies = maybeTargetLengthEv.toList.toVector
 
   private def suspendableExpression =
-    new ElementOVCSpecifiedLengthUnparserSuspendableExpression(this)
+    new ElementOVCSpecifiedLengthUnparserSuspendableExpression(this, expr)
 
-  Assert.invariant(context.outputValueCalcExpr.isDefined)
+  Assert.invariant(context.dpathElementCompileInfo.isOutputValueCalc)
 
   override def runContentUnparser(state: UState): Unit = {
     computeTargetLength(state) // must happen before run() so that we can take advantage of knowing the length

--- a/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/processors/unparsers/NilEmptyCombinatorUnparsers.scala
+++ b/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/processors/unparsers/NilEmptyCombinatorUnparsers.scala
@@ -39,7 +39,7 @@ case class SimpleNilOrValueUnparser(
     // suspends, this call to isNilled will throw a InfosetNoDataException
     // because _isNilled has not been set yet. Rather than having to deal with
     // suspending, only check isNilled for non-OVC elements.
-    if (ctxt.outputValueCalcExpr.isEmpty && inode.isNilled) nilUnparser.unparse1(state)
+    if (!ctxt.dpathElementCompileInfo.isOutputValueCalc && inode.isNilled) nilUnparser.unparse1(state)
     else valueUnparser.unparse1(state)
   }
 }

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/dpath/DPath.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/dpath/DPath.scala
@@ -205,7 +205,7 @@ final class RuntimeExpressionDPath[T <: AnyRef](qn: NamedQName, tt: NodeInfo.Kin
         whereBlockedInfo.block(noSibling.diSimple, noSibling.info, 0, noSibling)
       case noArrayIndex: InfosetArrayIndexOutOfBoundsException =>
         whereBlockedInfo.block(noArrayIndex.diArray, noArrayIndex.diArray.erd.dpathElementCompileInfo, noArrayIndex.index, noArrayIndex)
-      case nd: InfosetNoDataExceptionBase if nd.erd.outputValueCalcExpr.isDefined => {
+      case nd: InfosetNoDataExceptionBase if nd.erd.dpathElementCompileInfo.isOutputValueCalc => {
         // we got a no-data exception from an element with outputValueCalc
         // that is, some OVC element requested the value of another OVC element
         val ovc = new OutputValueCalcEvaluationException(nd)

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/infoset/InfosetInputter.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/infoset/InfosetInputter.scala
@@ -418,7 +418,7 @@ abstract class InfosetInputter
         if (txt != null && txt != "") {
           UnparseError(One(elem.erd.schemaFileLocation), Nope, "Nilled simple element %s has content", erd.namedQName.toExtendedSyntax)
         }
-      } else if (erd.outputValueCalcExpr.isEmpty) {
+      } else if (!erd.dpathElementCompileInfo.isOutputValueCalc) {
         val primType = elem.erd.optPrimType.get
         val obj = try {
           primType.fromXMLString(txt)

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/RuntimeData.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/RuntimeData.scala
@@ -588,7 +588,6 @@ sealed class ElementRuntimeData(
   // Unparser-specific arguments
   //
   val optTruncateSpecifiedLengthString: Option[Boolean],
-  val outputValueCalcExpr: Option[CompiledExpression[AnyRef]],
   val maybeBinaryFloatRepEv: Maybe[BinaryFloatRepEv],
   val maybeByteOrderEv: Maybe[ByteOrderEv],
   fillByteEvArg: FillByteEv,
@@ -665,7 +664,7 @@ sealed abstract class ErrorERD(local: String, namespaceURI: String)
       null, // override val unqualifiedPathStepPolicy : UnqualifiedPathStepPolicy,
       null, // typeCalcMap: TypeCalcMap,
       null, // val sscd: String),
-      false), // val hasOutputValueCalc: Boolean
+      false), // val isOutputValueCalc: Boolean
     null, // SchemaFileLocation
     local, // diagnosticDebugName: String,
     local, // pathArg: => String,
@@ -693,7 +692,6 @@ sealed abstract class ErrorERD(local: String, namespaceURI: String)
     null, // optIgnoreCaseArg: => Option[YesNo],
     DataValue.NoValue, // optDefaultValueArg: => DataValuePrimitiveOrUseNilForDefaultOrNull,
     null, // optTruncateSpecifiedLengthStringArg: => Option[Boolean],
-    null, // outputValueCalcExprArg: => Option[CompiledExpression[AnyRef]],
     Nope, // maybeBinaryFloatRepEvArg: => Maybe[BinaryFloatRepEv],
     Nope, // maybeByteOrderEvArg: => Maybe[ByteOrderEv],
     null, // fillByteEvArg => FillByteEv

--- a/daffodil-test/src/test/resources/org/apache/daffodil/unparser/parseUnparseModeTest.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/unparser/parseUnparseModeTest.tdml
@@ -56,6 +56,7 @@
     </tdml:infoset>
     <tdml:errors>
       <tdml:error>Schema Definition Warning</tdml:error>
+      <tdml:error>UPA Violation</tdml:error>
       <tdml:error>multiple choice</tdml:error>
     </tdml:errors>
   </tdml:unparserTestCase>


### PR DESCRIPTION
When checkAllTopLevel is true, it results in creating ElementRuntimeData
objets for every element, even those that aren't reachable from the root
element. And because the outputValcCalc CompiledExpression lives on the
ERD, it means all OVCs are forced to be compiled, and are required to be
valid within their local context.

However, some OVC expression are intentionally not valid within their
local context. They instead are expected to reach out of global
group/element that they are defined in, and access some other element
outside of that group/element where it is references. So
compiling/checking OVC expressions outside of the context of the root
element doesn't really make sense.

This solves this problem by moving the OVC CompiledExpression out of the
ERD, and accessing/compiling it only when an unparser is actually
created for that element. This means it will only be compiled and
checked in the correct context of where it is actually used.

DAFFODIL-2552