### PR TITLE
Add dfdlx:runtimeProperties extension

### DIFF
--- a/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/ElementBaseRuntime1Mixin.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/ElementBaseRuntime1Mixin.scala
@@ -209,7 +209,8 @@ trait ElementBaseRuntime1Mixin { self: ElementBase =>
       fillByteEv,
       maybeCheckByteAndBitOrderEv,
       maybeCheckBitOrderAndCharsetEv,
-      isQuasiElement)
+      isQuasiElement,
+      runtimeProperties)
     newERD
   }.value
 

--- a/daffodil-core/src/test/scala/org/apache/daffodil/general/TestRuntimeProperties.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/general/TestRuntimeProperties.scala
@@ -1,0 +1,231 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.daffodil.general
+
+import org.junit.Test
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+
+import org.apache.daffodil.Implicits.intercept
+import org.apache.daffodil.dpath.NodeInfo
+import org.apache.daffodil.infoset.DISimple
+import org.apache.daffodil.infoset.ScalaXMLInfosetInputter
+import org.apache.daffodil.infoset.ScalaXMLInfosetOutputter
+import org.apache.daffodil.io.InputSourceDataInputStream
+import org.apache.daffodil.util.SchemaUtils
+import org.apache.daffodil.util.TestUtils
+
+/**
+ * Test InfosetOutputter that extends the ScalaXMLInfosetOutputter and redacts
+ * words specified in the dfdlx:runtimeProperties extension
+ */
+class RedactingScalaXMLInfosetOutputter
+  extends ScalaXMLInfosetOutputter {
+
+  override def startSimple(diSimple: DISimple): Boolean = {
+    super.startSimple(diSimple)
+
+    val runtimeProperties = diSimple.erd.runtimeProperties
+
+    val redactions = Option(runtimeProperties.get("redact")).map { value => value.split(",") }
+    if (redactions.isDefined) {
+      val thisElem = stack.top.last.asInstanceOf[scala.xml.Elem]
+      var text = thisElem.child(0).asInstanceOf[scala.xml.Text].data
+      val redactWord = runtimeProperties.getOrDefault("redactWord", "")
+      redactions.get.foreach { redaction =>
+        text = text.replace(redaction, redactWord)
+      }
+      val newChild = Seq(new scala.xml.Text(text))
+      val newElem = thisElem.copy(child = newChild)
+      stack.top(stack.top.size - 1) = newElem
+    }
+    true
+  }
+}
+
+/**
+ * Test InfosetInputter that extends the ScalaXMLInfosetInputter and redacts
+ * words specified in the dfdlx:runtimeProperties extension
+ */
+class RedactingScalaXMLInfosetInputter(rootNode: scala.xml.Node)
+  extends ScalaXMLInfosetInputter(rootNode) {
+
+  override def getSimpleText(primType: NodeInfo.Kind, runtimeProperties: java.util.Map[String, String]): String = {
+    var text = super.getSimpleText(primType, runtimeProperties)
+
+    val redactions = Option(runtimeProperties.get("redact")).map { value => value.split(",") }
+    if (redactions.isDefined) {
+      val redactWord = runtimeProperties.getOrDefault("redactWord", "")
+      redactions.get.foreach { redaction =>
+        text = text.replace(redaction, redactWord)
+      }
+    }
+    text
+  }
+}
+
+class TestRuntimeProperties {
+
+  val testSchema1 = SchemaUtils.dfdlTestSchema(
+    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
+    <dfdl:format ref="tns:GeneralFormat" lengthKind="delimited"/>,
+    <xs:element name="root">
+      <xs:complexType>
+        <xs:sequence dfdl:separator=",">
+          <xs:element name="filtered" type="xs:string" dfdlx:runtimeProperties="redact=foo,baz redactWord=REDACTED" />
+          <xs:element name="unFiltered" type="xs:string" />
+        </xs:sequence>
+      </xs:complexType>
+    </xs:element>
+  )
+
+  @Test def testRuntimeProperties_01(): Unit = {
+
+    val data = "foo bar baz,foo bar baz"
+    val expected =
+      <root xmlns="http://example.com">
+        <filtered>REDACTED bar REDACTED</filtered>
+        <unFiltered>foo bar baz</unFiltered>
+      </root>
+
+    val input = InputSourceDataInputStream(data.getBytes("UTF-8"))
+    val outputter = new RedactingScalaXMLInfosetOutputter()
+
+    val dp = TestUtils.compileSchema(testSchema1)
+    val pr = dp.parse(input, outputter)
+
+    assertFalse(pr.isError)
+    val actual = outputter.getResult()
+    TestUtils.assertEqualsXMLElements(expected, actual)
+  }
+
+  @Test def testRuntimeProperties_02(): Unit = {
+
+    val infoset =
+      <root xmlns="http://example.com">
+        <filtered>foo bar baz</filtered>
+        <unFiltered>foo bar baz</unFiltered>
+      </root>
+    val expected = "REDACTED bar REDACTED,foo bar baz"
+
+    val inputter = new RedactingScalaXMLInfosetInputter(infoset)
+    val output = new java.io.ByteArrayOutputStream()
+
+    val dp = TestUtils.compileSchema(testSchema1)
+    val ur = dp.unparse(inputter, output)
+
+    assertFalse(ur.isError)
+    
+    val actual = output.toString("UTF-8")
+    assertEquals(expected, actual)
+  }
+
+  val testSchemaBad1 = SchemaUtils.dfdlTestSchema(
+    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
+    <dfdl:format ref="tns:GeneralFormat" lengthKind="delimited"/>,
+    <xs:element name="root" dfdlx:runtimeProperties="redact=foo,baz">
+      <xs:complexType>
+        <xs:sequence dfdl:separator=",">
+          <xs:element name="filtered" type="xs:string" />
+          <xs:element name="unFiltered" type="xs:string" />
+        </xs:sequence>
+      </xs:complexType>
+    </xs:element>
+  )
+
+  @Test def testRuntimeProperties_03(): Unit = {
+    val ex = intercept[Exception] {
+      TestUtils.compileSchema(testSchemaBad1)
+    }
+    val msg = ex.getMessage()
+
+    assertTrue(msg.contains("Schema Definition Error"))
+    assertTrue(msg.contains("dfdlx:runtimeProperties"))
+    assertTrue(msg.contains("simple type"))
+  }
+
+  val testSchemaBad2 = SchemaUtils.dfdlTestSchema(
+    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
+    <dfdl:format ref="tns:GeneralFormat" lengthKind="delimited"/>,
+    <xs:element name="root">
+      <xs:complexType>
+        <xs:sequence dfdl:separator=",">
+          <xs:element name="filtered" type="xs:string" dfdlx:runtimeProperties="redact=" />
+          <xs:element name="unFiltered" type="xs:string" />
+        </xs:sequence>
+      </xs:complexType>
+    </xs:element>
+  )
+
+  @Test def testRuntimeProperties_04(): Unit = {
+    val ex = intercept[Exception] {
+      TestUtils.compileSchema(testSchemaBad2)
+    }
+    val msg = ex.getMessage()
+
+    assertTrue(msg.contains("Schema Definition Error"))
+    assertTrue(msg.contains("dfdlx:runtimeProperties"))
+    assertTrue(msg.contains("key=value"))
+  }
+
+  val testSchema2 = SchemaUtils.dfdlTestSchema(
+    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>,
+    <dfdl:format ref="tns:GeneralFormat" lengthKind="delimited"/>,
+    <xs:element name="root">
+      <xs:complexType>
+        <xs:sequence dfdl:separator=",">
+          <xs:element name="filtered" type="xs:string">
+            <xs:annotation>
+              <xs:appinfo source="http://www.ogf.org/dfdl/">
+                <dfdl:element>
+                  <dfdl:property name="dfdlx:runtimeProperties">
+                    redact=foo,baz
+                    redactWord=REDACTED
+                  </dfdl:property>
+                </dfdl:element>
+              </xs:appinfo>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="unFiltered" type="xs:string" />
+        </xs:sequence>
+      </xs:complexType>
+    </xs:element>
+  )
+
+  @Test def testRuntimeProperties_05(): Unit = {
+
+    val data = "foo bar baz,foo bar baz"
+    val expected =
+      <root xmlns="http://example.com">
+        <filtered>REDACTED bar REDACTED</filtered>
+        <unFiltered>foo bar baz</unFiltered>
+      </root>
+
+    val input = InputSourceDataInputStream(data.getBytes("UTF-8"))
+    val outputter = new RedactingScalaXMLInfosetOutputter()
+
+    val dp = TestUtils.compileSchema(testSchema2)
+    val pr = dp.parse(input, outputter)
+
+    assertFalse(pr.isError)
+    val actual = outputter.getResult()
+    TestUtils.assertEqualsXMLElements(expected, actual)
+  }
+
+}

--- a/daffodil-core/src/test/scala/org/apache/daffodil/processor/TestSAXParseUnparseAPI.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/processor/TestSAXParseUnparseAPI.scala
@@ -195,7 +195,7 @@ class TestSAXParseUnparseAPI {
     assertTrue(sii.hasNext())
     sii.next()
     assertEquals(StartElement, sii.getEventType())
-    val stxt = sii.getSimpleText(NodeInfo.String)
+    val stxt = sii.getSimpleText(NodeInfo.String, java.util.Collections.emptyMap())
     assertEquals("&", stxt)
   }
 }

--- a/daffodil-japi/src/main/scala/org/apache/daffodil/japi/infoset/Infoset.scala
+++ b/daffodil-japi/src/main/scala/org/apache/daffodil/japi/infoset/Infoset.scala
@@ -17,6 +17,7 @@
 
 package org.apache.daffodil.japi.infoset
 
+import org.apache.daffodil.exceptions.Assert
 import org.apache.daffodil.infoset.{ InfosetOutputter => SInfosetOutputter }
 import org.apache.daffodil.infoset.{ InfosetInputter => SInfosetInputter }
 import org.apache.daffodil.infoset.{ ScalaXMLInfosetOutputter => SScalaXMLInfosetOutputter }
@@ -73,6 +74,13 @@ abstract class InfosetInputter extends SInfosetInputter {
    * the event contains complex data, it is an error and should throw
    * NonTextFoundInSimpleContentException. If the element does not have any
    * simple content, this should return either null or the empty string.
+   */
+  def getSimpleText(primType: NodeInfo.Kind, runtimeProperties: java.util.Map[String,String]): String =
+    getSimpleText(primType)
+
+  /**
+   * See getSimpleText(primType, runtimeProperties), which has a default
+   * implementation to call this function without the runtimeProperties Map
    */
   def getSimpleText(primType: NodeInfo.Kind): String
 
@@ -440,7 +448,14 @@ abstract class InfosetInputterProxy extends InfosetInputter {
   override def getEventType() = infosetInputter.getEventType()
   override def getLocalName() = infosetInputter.getLocalName()
   override def getNamespaceURI() = infosetInputter.getNamespaceURI()
-  override def getSimpleText(primType: NodeInfo.Kind) = infosetInputter.getSimpleText(primType)
+  override def getSimpleText(primType: NodeInfo.Kind, runtimeProperties: java.util.Map[String,String]): String = {
+    infosetInputter.getSimpleText(primType, runtimeProperties)
+  }
+  override def getSimpleText(primType: NodeInfo.Kind) = {
+    //$COVERAGE-OFF$
+    Assert.impossible()
+    //$COVERAGE-ON$
+  }
   override def hasNext() = infosetInputter.hasNext()
   override def isNilled() = infosetInputter.isNilled()
   override def next() = infosetInputter.next()

--- a/daffodil-japi/src/test/java/org/apache/daffodil/example/TestInfosetEvent.java
+++ b/daffodil-japi/src/test/java/org/apache/daffodil/example/TestInfosetEvent.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.daffodil.example;
+
+// TODO: Shouldn't need to import things not in the japi package
+import org.apache.daffodil.dpath.NodeInfo;
+import org.apache.daffodil.infoset.InfosetInputterEventType;
+import org.apache.daffodil.infoset.InfosetInputterEventType.EndDocument$;
+import org.apache.daffodil.infoset.InfosetInputterEventType.EndElement$;
+import org.apache.daffodil.infoset.InfosetInputterEventType.StartDocument$;
+import org.apache.daffodil.infoset.InfosetInputterEventType.StartElement$;
+
+
+public class TestInfosetEvent {
+
+    InfosetInputterEventType eventType;
+    String localName;
+    String namespaceURI;
+    String simpleText;
+    // null means no null state specified ( which is required for
+    // non-nullable elements). Boolean.TRUE or Boolean.FALSE means it is
+    // nullable and has the given value
+    Boolean isNilled;
+
+    public TestInfosetEvent(InfosetInputterEventType _eventType, String _localName, String _namespaceURI, String _simpleText, Boolean _isNilled) {
+        this.eventType = _eventType;
+        this.localName = _localName;
+        this.namespaceURI = _namespaceURI;
+        this.simpleText = _simpleText;
+        this.isNilled = _isNilled;
+    }
+
+    public boolean equals(Object o) {
+        if (!(o instanceof TestInfosetEvent)) {
+            return false;
+        }
+        TestInfosetEvent that = (TestInfosetEvent)o;
+        return
+            this.eventType == that.eventType &&
+            java.util.Objects.equals(this.localName, that.localName) &&
+            java.util.Objects.equals(this.namespaceURI, that.namespaceURI) &&
+            java.util.Objects.equals(this.simpleText, that.simpleText) &&
+            java.util.Objects.equals(this.isNilled, that.isNilled);
+
+    }
+
+    static TestInfosetEvent startDocument() {
+        return new TestInfosetEvent (StartDocument$.MODULE$, null, null, null, null);
+    }
+
+    static TestInfosetEvent startComplex(String name, String namespace) {
+        return startComplex(name, namespace, null);
+    }
+
+    static TestInfosetEvent startComplex(String name, String namespace, Boolean isNilled) {
+        return new TestInfosetEvent (StartElement$.MODULE$, name, namespace, null, isNilled);
+    }
+
+    static TestInfosetEvent startSimple(String name, String namespace, String text) {
+        return startSimple(name, namespace, text, null);
+    }
+
+    static TestInfosetEvent startSimple(String name, String namespace, String text, Boolean isNilled) {
+        return new TestInfosetEvent (StartElement$.MODULE$, name, namespace, text, isNilled);
+    }
+
+    static TestInfosetEvent endComplex(String name, String namespace) {
+        return new TestInfosetEvent (EndElement$.MODULE$, name, namespace, null, null);
+    }
+
+    static TestInfosetEvent endSimple(String name, String namespace) {
+        return new TestInfosetEvent (EndElement$.MODULE$, name, namespace, null, null);
+    }
+
+    static TestInfosetEvent endDocument() {
+        return new TestInfosetEvent (EndDocument$.MODULE$, null, null, null, null);
+    }
+}

--- a/daffodil-japi/src/test/java/org/apache/daffodil/example/TestInfosetInputter.java
+++ b/daffodil-japi/src/test/java/org/apache/daffodil/example/TestInfosetInputter.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.daffodil.example;
+
+import org.apache.daffodil.japi.infoset.InfosetInputter;
+
+// TODO: Shouldn't need to import things not in the japi package
+import org.apache.daffodil.dpath.NodeInfo;
+import org.apache.daffodil.infoset.InfosetInputterEventType;
+
+
+public class TestInfosetInputter extends InfosetInputter {
+
+    private TestInfosetEvent[] events;
+    private int curEventIndex;
+
+    TestInfosetInputter(TestInfosetEvent... _events) {
+        events = _events;
+        curEventIndex = 0;
+    }
+
+    @Override
+    public InfosetInputterEventType getEventType() {
+        return events[curEventIndex].eventType;
+    }
+
+    @Override
+    public String getLocalName() {
+        return events[curEventIndex].localName;
+    }
+
+    @Override
+    public String getNamespaceURI() {
+        return events[curEventIndex].namespaceURI;
+    }
+
+    @Override
+    public String getSimpleText(NodeInfo.Kind primType) {
+        return events[curEventIndex].simpleText;
+    }
+
+    // TODO: This should return a MaybeBoolean, but that is Scala value class
+    // with underlying type being an int, so this must return an int. Returning
+    // 1 means true, 0 is false, and -1 is not set
+    @Override
+    public int isNilled() {
+        Boolean isNilled = events[curEventIndex].isNilled;
+        if (isNilled == null) { return -1; }
+        else return isNilled ? 1 : 0;
+    }
+
+    @Override
+    public boolean hasNext() {
+        return curEventIndex + 1 < this.events.length;
+    }
+
+    @Override
+    public void next() {
+        curEventIndex++;
+    }
+
+    @Override
+    public boolean supportsNamespaces() {
+        return true;
+    }
+
+    @Override
+    public void fini() {
+        // noop
+    }
+}

--- a/daffodil-japi/src/test/java/org/apache/daffodil/example/TestInfosetOutputter.java
+++ b/daffodil-japi/src/test/java/org/apache/daffodil/example/TestInfosetOutputter.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.daffodil.example;
+
+import java.util.ArrayList;
+
+import org.apache.daffodil.japi.infoset.InfosetOutputter;
+
+// TODO: Shouldn't need to import things not in the japi package
+import org.apache.daffodil.infoset.DIArray;
+import org.apache.daffodil.infoset.DIComplex;
+import org.apache.daffodil.infoset.DISimple;
+
+
+public class TestInfosetOutputter extends InfosetOutputter {
+
+    public ArrayList<TestInfosetEvent> events;
+
+    TestInfosetOutputter() {
+        events = new ArrayList<>();
+    }
+
+    @Override
+    public void reset() {
+        events = new ArrayList<>();
+    }
+
+    @Override
+    public boolean startDocument() {
+        events.add(TestInfosetEvent.startDocument());
+        return true;
+    }
+
+    @Override
+    public boolean endDocument() {
+        events.add(TestInfosetEvent.endDocument());
+        return true;
+    }
+
+    @Override
+    public boolean startSimple(DISimple diSimple) {
+        events.add(
+            TestInfosetEvent.startSimple(
+                diSimple.erd().name(),
+                diSimple.erd().namedQName().namespace().toString(),
+                diSimple.dataValueAsString(),
+                diSimple.erd().isNillable() ? diSimple.isNilled() : null));
+        return true;
+    }
+
+    @Override
+    public boolean endSimple(DISimple diSimple) {
+        events.add(
+            TestInfosetEvent.endSimple(
+                diSimple.erd().name(),
+                diSimple.erd().namedQName().namespace().toString()));
+        return true;
+    }
+
+    @Override
+    public boolean startComplex(DIComplex diComplex) {
+        events.add(
+            TestInfosetEvent.startComplex(
+                diComplex.erd().name(),
+                diComplex.erd().namedQName().namespace().toString(),
+                diComplex.erd().isNillable() ? diComplex.isNilled() : null));
+        return true;
+    }
+
+    @Override
+    public boolean endComplex(DIComplex diComplex) {
+        events.add(
+            TestInfosetEvent.endComplex(
+                diComplex.erd().name(),
+                diComplex.erd().namedQName().namespace().toString()));
+        return true;
+    }
+
+    @Override
+    public boolean startArray(DIArray diArray) {
+        return true;
+    }
+
+    @Override
+    public boolean endArray(DIArray diArray) {
+        return true;
+    }
+}

--- a/daffodil-propgen/src/main/resources/org/apache/daffodil/xsd/DFDL_part2_attributes.xsd
+++ b/daffodil-propgen/src/main/resources/org/apache/daffodil/xsd/DFDL_part2_attributes.xsd
@@ -1036,6 +1036,7 @@
     <xsd:attributeGroup ref="dfdl:DefaultValueControlAGQualified" />
     <xsd:attributeGroup ref="dfdl:OccursAGQualified" />
     <xsd:attributeGroup ref="dfdl:CalculatedValueAGQualified" />
+    <xsd:attributeGroup ref="dfdlx:RuntimePropertiesAGQualified" />
   </xsd:attributeGroup>
 
   <!-- dfdl:group takes the union of dfdl:sequence and dfdl:choice properties -->
@@ -1066,7 +1067,7 @@
     <xsd:attributeGroup ref="dfdl:BooleanTextAGQualified" />
     <xsd:attributeGroup ref="dfdl:BooleanBinaryAGQualified" />
     <xsd:attributeGroup ref="dfdlx:SimpleTypeValueCalcAGQualified" />
-    <xsd:attributeGroup ref="dfdlx:ObjectAGQualified" />
+    <xsd:attributeGroup ref="dfdlx:ObjectKindAGQualified" />
   </xsd:attributeGroup>
 
   <xsd:attributeGroup name="LayeringAGQualified">

--- a/daffodil-propgen/src/main/resources/org/apache/daffodil/xsd/DFDL_part3_model.xsd
+++ b/daffodil-propgen/src/main/resources/org/apache/daffodil/xsd/DFDL_part3_model.xsd
@@ -328,6 +328,7 @@
     <xsd:attributeGroup ref="dfdl:NillableAG" />
     <xsd:attributeGroup ref="dfdl:DefaultValueControlAG" />
     <xsd:attributeGroup ref="dfdl:OccursAG" />
+    <xsd:attributeGroup ref="dfdlx:RuntimePropertiesAG" />
   </xsd:attributeGroup>
   
    <xsd:attributeGroup name="ElementAG">
@@ -363,7 +364,7 @@
     <xsd:attributeGroup ref="dfdl:BooleanTextAG" />
     <xsd:attributeGroup ref="dfdl:BooleanBinaryAG" />
     <xsd:attributeGroup ref="dfdlx:SimpleTypeValueCalcAG" />
-    <xsd:attributeGroup ref="dfdlx:ObjectAG" />
+    <xsd:attributeGroup ref="dfdlx:ObjectKindAG" />
   </xsd:attributeGroup>
 
 </xsd:schema>

--- a/daffodil-propgen/src/main/resources/org/apache/daffodil/xsd/dfdlx.xsd
+++ b/daffodil-propgen/src/main/resources/org/apache/daffodil/xsd/dfdlx.xsd
@@ -45,6 +45,7 @@
       <xs:enumeration value="dfdlx:repType"/>
       <xs:enumeration value="dfdlx:repValueRanges"/>
       <xs:enumeration value="dfdlx:repValues"/>
+      <xs:enumeration value="dfdlx:runtimeProperties"/>
     </xs:restriction>
   </xs:simpleType>
 
@@ -129,11 +130,11 @@
     <xs:attribute form="qualified" name="layerBoundaryMark" type="dfdl:ListOfDFDLStringLiteral_Or_DFDLExpression" />
   </xs:attributeGroup>
 
-  <xs:attributeGroup name="ObjectAG">
-    <xs:attribute form="qualified" name="ObjectKind" type="dfdlx:ObjectKindType" />
+  <xs:attributeGroup name="ObjectKindAG">
+    <xs:attribute form="qualified" name="objectKind" type="dfdlx:ObjectKindType" />
   </xs:attributeGroup>
 
-  <xs:attributeGroup name="ObjectAGQualified">
+  <xs:attributeGroup name="ObjectKindAGQualified">
     <xs:attribute form="qualified" name="objectKind" type="dfdlx:ObjectKindType" />
   </xs:attributeGroup>
 
@@ -142,6 +143,28 @@
       <xs:enumeration value="bytes"/>
       <xs:enumeration value="chars"/>
     </xs:restriction>
+  </xs:simpleType>
+
+  <xs:attributeGroup name="RuntimePropertiesAG">
+    <xs:attribute form="qualified" name="runtimeProperties" type="dfdlx:RuntimePropertiesType" />
+  </xs:attributeGroup>
+
+  <xs:attributeGroup name="RuntimePropertiesAGQualified">
+    <xs:attribute form="qualified" name="runtimeProperties" type="dfdlx:RuntimePropertiesType" />
+  </xs:attributeGroup>
+
+  <xs:simpleType name="RuntimePropertiesType">
+    <xs:restriction base="dfdlx:KVList" />
+  </xs:simpleType>
+
+  <xs:simpleType name="KVList">
+    <xs:list>
+      <xs:simpleType>
+        <xs:restriction base="xs:token">
+          <xs:pattern value="[a-zA-Z_][a-zA-Z0-9_]*=\S*"/>
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:list>
   </xs:simpleType>
 
 </xs:schema>

--- a/daffodil-propgen/src/main/scala/org/apache/daffodil/propGen/PropertyGenerator.scala
+++ b/daffodil-propgen/src/main/scala/org/apache/daffodil/propGen/PropertyGenerator.scala
@@ -243,9 +243,14 @@ class PropertyGenerator(arg: Node) {
       val notFormatProperties = List("ref", "type", "name", "test", "defaultValue", "message", "baseFormat")
       val notScopedFormatProperties = List("inputValueCalc", "outputValueCalc", "hiddenGroupRef") // do these by-hand since they are not scoped.
       val excludedBecauseDoneByHand =
-        List("separatorSuppressionPolicy", "separatorPolicy",
-          "textStandardExponentRep", "textStandardExponentCharacter",
-          "textOutputMinLength")
+        List(
+          "runtimeProperties",
+          "separatorPolicy",
+          "separatorSuppressionPolicy",
+          "textOutputMinLength",
+          "textStandardExponentCharacter",
+          "textStandardExponentRep",
+        )
       val exclusions = notFormatProperties ++ notScopedFormatProperties ++ excludedBecauseDoneByHand
       if (exclusions.contains(rawName)) {
         Nil

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/infoset/InfosetInputter.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/infoset/InfosetInputter.scala
@@ -121,7 +121,7 @@ abstract class InfosetInputter
    * NonTextFoundInSimpleContentException. If the element does not have any
    * simple content, this should return either null or the empty string.
    */
-  def getSimpleText(primType: NodeInfo.Kind): String
+  def getSimpleText(primType: NodeInfo.Kind, runtimeProperties: java.util.Map[String,String]): String
 
   /**
    * Determine if the current event is nilled. This will only be called when
@@ -409,7 +409,7 @@ abstract class InfosetInputter
     if (erd.isSimpleType) {
       val txt =
         try {
-          getSimpleText(erd.optPrimType.get)
+          getSimpleText(erd.optPrimType.get, erd.runtimeProperties)
         } catch {
           case ex: NonTextFoundInSimpleContentException =>
             UnparseError(One(elem.erd.schemaFileLocation), Nope, ex.getMessage())

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/infoset/JDOMInfosetInputter.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/infoset/JDOMInfosetInputter.scala
@@ -81,7 +81,7 @@ class JDOMInfosetInputter(doc: Document)
 
   override def getNamespaceURI(): String = stack.top._1.getNamespace.getURI
 
-  override def getSimpleText(primType: NodeInfo.Kind): String = {
+  override def getSimpleText(primType: NodeInfo.Kind, runtimePropertes: java.util.Map[String, String]): String = {
     val text =
       if (stack.top._2.hasNext) {
         val child = stack.top._2.next

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/infoset/JsonInfosetInputter.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/infoset/JsonInfosetInputter.scala
@@ -120,7 +120,7 @@ class JsonInfosetInputter private (input: Either[java.io.Reader, java.io.InputSt
     null
   }
 
-  override def getSimpleText(primType: NodeInfo.Kind): String = {
+  override def getSimpleText(primType: NodeInfo.Kind, runtimeProperties: java.util.Map[String, String]): String = {
     if (jsp.getCurrentToken() == JsonToken.VALUE_NULL) {
       null
     } else {

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/infoset/SAXInfosetInputter.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/infoset/SAXInfosetInputter.scala
@@ -90,7 +90,7 @@ class SAXInfosetInputter(
 
   override def getNamespaceURI(): String = batchedInfosetEvents(currentIndex).namespaceURI.orNull
 
-  override def getSimpleText(primType: NodeInfo.Kind): String = {
+  override def getSimpleText(primType: NodeInfo.Kind, runtimeProperties: java.util.Map[String, String]): String = {
     val res = if (batchedInfosetEvents(currentIndex).simpleText.isDefined) {
       batchedInfosetEvents(currentIndex).simpleText.get
     } else {

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/infoset/ScalaXMLInfosetInputter.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/infoset/ScalaXMLInfosetInputter.scala
@@ -73,7 +73,7 @@ class ScalaXMLInfosetInputter(rootNode: Node)
 
   override def getNamespaceURI(): String = stack.top._1.namespace
 
-  override def getSimpleText(primType: NodeInfo.Kind): String = {
+  override def getSimpleText(primType: NodeInfo.Kind, runtimeProperties: java.util.Map[String, String]): String = {
     val text = {
       val sb = new StringBuilder()
       val iter: Iterator[Node] = stack.top._2

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/infoset/W3CDOMInfosetInputter.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/infoset/W3CDOMInfosetInputter.scala
@@ -84,7 +84,7 @@ class W3CDOMInfosetInputter(doc: Document)
 
   override def getNamespaceURI(): String = stack.top._1.getNamespaceURI
 
-  override def getSimpleText(primType: NodeInfo.Kind): String = {
+  override def getSimpleText(primType: NodeInfo.Kind, runtimeProperties: java.util.Map[String, String]): String = {
     val text =
       if (stack.top._2.hasNext) {
         val child = stack.top._2.next

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/infoset/XMLTextInfosetInputter.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/infoset/XMLTextInfosetInputter.scala
@@ -115,7 +115,7 @@ class XMLTextInfosetInputter private (input: Either[java.io.Reader, java.io.Inpu
     xsr.getNamespaceURI()
   }
 
-  override def getSimpleText(primType: NodeInfo.Kind): String = {
+  override def getSimpleText(primType: NodeInfo.Kind, runtimeProperties: java.util.Map[String, String]): String = {
     val txt =
       try {
         xsr.getElementText()

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/RuntimeData.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/RuntimeData.scala
@@ -593,7 +593,8 @@ sealed class ElementRuntimeData(
   fillByteEvArg: FillByteEv,
   maybeCheckByteAndBitOrderEvArg: Maybe[CheckByteAndBitOrderEv],
   maybeCheckBitOrderAndCharsetEvArg: Maybe[CheckBitOrderAndCharsetEv],
-  val isQuasiElement: Boolean)
+  val isQuasiElement: Boolean,
+  val runtimeProperties: java.util.Map[String,String])
   extends TermRuntimeData(positionArg, partialNextElementResolverDelay,
     encInfo, dpathElementCompileInfo, isRepresentedArg, couldHaveTextArg, alignmentValueInBitsArg, hasNoSkipRegionsArg,
     defaultBitOrderArg, optIgnoreCaseArg, fillByteEvArg,
@@ -697,7 +698,8 @@ sealed abstract class ErrorERD(local: String, namespaceURI: String)
     null, // fillByteEvArg => FillByteEv
     Nope, // maybeCheckByteAndBitOrderEvArg: => Maybe[CheckByteAndBitOrderEv],
     Nope, // maybeCheckBitOrderAndCharsetEvArg: => Maybe[CheckBitOrderAndCharsetEv],
-    false // isQuasiElementArg: => Boolean
+    false, // isQuasiElementArg: => Boolean
+    null, // runtimeProperties: java.util.Map[String,String]
   ) {
 
   override def toString() = Misc.getNameFromClass(this) + "(" + this.namedQName.toExtendedSyntax + ")"

--- a/daffodil-sapi/src/main/scala/org/apache/daffodil/sapi/infoset/Infoset.scala
+++ b/daffodil-sapi/src/main/scala/org/apache/daffodil/sapi/infoset/Infoset.scala
@@ -17,6 +17,7 @@
 
 package org.apache.daffodil.sapi.infoset
 
+import org.apache.daffodil.exceptions.Assert
 import org.apache.daffodil.infoset.{ InfosetOutputter => SInfosetOutputter }
 import org.apache.daffodil.infoset.{ InfosetInputter => SInfosetInputter }
 import org.apache.daffodil.infoset.{ ScalaXMLInfosetOutputter => SScalaXMLInfosetOutputter }
@@ -73,6 +74,13 @@ abstract class InfosetInputter extends SInfosetInputter {
    * the event contains complex data, it is an error and should throw
    * NonTextFoundInSimpleContentException. If the element does not have any
    * simple content, this should return either null or the empty string.
+   */
+  override def getSimpleText(primType: NodeInfo.Kind, runtimeProperties: java.util.Map[String, String]): String =
+    getSimpleText(primType)
+
+  /**
+   * See getSimpleText(primType, runtimeProperties), which has a default
+   * implementation to call this function without the runtimeProperties Map
    */
   def getSimpleText(primType: NodeInfo.Kind): String
 
@@ -440,7 +448,14 @@ abstract class InfosetInputterProxy extends InfosetInputter {
   override def getEventType() = infosetInputter.getEventType()
   override def getLocalName() = infosetInputter.getLocalName()
   override def getNamespaceURI() = infosetInputter.getNamespaceURI()
-  override def getSimpleText(primType: NodeInfo.Kind) = infosetInputter.getSimpleText(primType: NodeInfo.Kind)
+  override def getSimpleText(primType: NodeInfo.Kind, runtimeProperties: java.util.Map[String, String]): String = {
+    infosetInputter.getSimpleText(primType, runtimeProperties)
+  }
+  override def getSimpleText(primType: NodeInfo.Kind) = {
+    //$COVERAGE-OFF$
+    Assert.impossible()
+    //$COVERAGE-ON$
+  }
   override def hasNext() = infosetInputter.hasNext()
   override def isNilled() = infosetInputter.isNilled()
   override def next() = infosetInputter.next()

--- a/daffodil-sapi/src/test/scala/org/apache/daffodil/example/TestInfosetInputterOutputter.scala
+++ b/daffodil-sapi/src/test/scala/org/apache/daffodil/example/TestInfosetInputterOutputter.scala
@@ -1,0 +1,145 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.daffodil.example
+
+import scala.collection.mutable.ArrayBuffer
+
+import org.apache.daffodil.sapi.infoset.InfosetInputter
+import org.apache.daffodil.sapi.infoset.InfosetOutputter
+
+// TODO: Shouldn't need to import things not in the sapi package
+import org.apache.daffodil.dpath.NodeInfo
+import org.apache.daffodil.infoset.DIArray
+import org.apache.daffodil.infoset.DIComplex
+import org.apache.daffodil.infoset.DISimple
+import org.apache.daffodil.infoset.InfosetInputterEventType
+import org.apache.daffodil.infoset.InfosetInputterEventType.EndDocument
+import org.apache.daffodil.infoset.InfosetInputterEventType.EndElement
+import org.apache.daffodil.infoset.InfosetInputterEventType.StartDocument
+import org.apache.daffodil.infoset.InfosetInputterEventType.StartElement
+import org.apache.daffodil.util.MaybeBoolean
+
+case class TestInfosetEvent(
+  eventType: InfosetInputterEventType,
+  localName: String = null,
+  namespaceURI: String = null,
+  simpleText: String = null,
+  isNilled: MaybeBoolean = MaybeBoolean.Nope,
+)
+
+object TestInfosetEvent {
+
+  def startDocument() =
+    TestInfosetEvent(StartDocument)
+
+  def startComplex(name: String, namespace: String, isNilled: MaybeBoolean = MaybeBoolean.Nope) =
+    TestInfosetEvent(StartElement, name, namespace, null, isNilled)
+
+  def startSimple(name: String, namespace: String, text: String, isNilled: MaybeBoolean = MaybeBoolean.Nope) =
+    TestInfosetEvent(StartElement, name, namespace, text, isNilled)
+
+  def endComplex(name: String, namespace: String) =
+    TestInfosetEvent(EndElement, name, namespace)
+
+  def endSimple(name: String, namespace: String) =
+    TestInfosetEvent(EndElement, name, namespace)
+
+  def endDocument() =
+    TestInfosetEvent(EndDocument)
+}
+
+
+case class TestInfosetInputter(events: TestInfosetEvent*) extends InfosetInputter {
+
+  var curEventIndex = 0
+
+  override def getEventType(): InfosetInputterEventType = events(curEventIndex).eventType
+  override def getLocalName(): String = events(curEventIndex).localName
+  override def getNamespaceURI(): String = events(curEventIndex).namespaceURI
+  override def getSimpleText(primType: NodeInfo.Kind) = events(curEventIndex).simpleText
+  override def isNilled(): MaybeBoolean = events(curEventIndex).isNilled
+
+  override def hasNext(): Boolean = curEventIndex + 1 < events.length
+  override def next(): Unit = curEventIndex += 1
+
+  override val supportsNamespaces = true
+
+  override def fini(): Unit = {}
+}
+
+case class TestInfosetOutputter() extends InfosetOutputter {
+
+  val events = new ArrayBuffer[TestInfosetEvent]()
+
+  override def reset(): Unit = {
+    events.clear()
+  }
+
+  override def startDocument(): Boolean = {
+    events.append(TestInfosetEvent.startDocument())
+    true
+  }
+
+  override def endDocument(): Boolean = {
+    events.append(TestInfosetEvent.endDocument())
+    true
+  }
+
+  override def startSimple(diSimple: DISimple): Boolean = {
+    events.append(
+      TestInfosetEvent.startSimple(
+        diSimple.erd.name,
+        diSimple.erd.namedQName.namespace,
+        diSimple.dataValueAsString,
+        if (diSimple.erd.isNillable) MaybeBoolean(diSimple.isNilled) else MaybeBoolean.Nope))
+    true
+  }
+
+  override def endSimple(diSimple: DISimple): Boolean = {
+    events.append(
+      TestInfosetEvent.endSimple(
+        diSimple.erd.name,
+        diSimple.erd.namedQName.namespace))
+    true
+  }
+
+  override def startComplex(diComplex: DIComplex): Boolean = {
+    events.append(
+      TestInfosetEvent.startComplex(
+        diComplex.erd.name,
+        diComplex.erd.namedQName.namespace,
+        if (diComplex.erd.isNillable) MaybeBoolean(diComplex.isNilled) else MaybeBoolean.Nope))
+    true
+  }
+
+  override def endComplex(diComplex: DIComplex): Boolean = {
+    events.append(
+      TestInfosetEvent.endComplex(
+        diComplex.erd.name,
+        diComplex.erd.namedQName.namespace))
+    true
+  }
+
+  override def startArray(diArray: DIArray): Boolean = {
+    true
+  }
+
+  override def endArray(diArray: DIArray): Boolean = {
+    true
+  }
+}

--- a/daffodil-tdml-processor/src/main/scala/org/apache/daffodil/tdml/TDMLInfosetInputter.scala
+++ b/daffodil-tdml-processor/src/main/scala/org/apache/daffodil/tdml/TDMLInfosetInputter.scala
@@ -64,11 +64,11 @@ class TDMLInfosetInputter(val scalaInputter: ScalaXMLInfosetInputter, others: Se
     res
   }
 
-  override def getSimpleText(primType: NodeInfo.Kind): String = {
-    val res = scalaInputter.getSimpleText(primType)
+  override def getSimpleText(primType: NodeInfo.Kind, runtimeProperties: java.util.Map[String, String]): String = {
+    val res = scalaInputter.getSimpleText(primType, runtimeProperties)
     val resIsEmpty = res == null || res == ""
     val otherStrings = others.map { i =>
-      val firstVersion = i.getSimpleText(primType)
+      val firstVersion = i.getSimpleText(primType, runtimeProperties)
       val finalVersion = i match {
         case _ if (firstVersion eq null) => ""
         // the json infoset inputter maintains CRLF/CR, but XML converts CRLF/CR to


### PR DESCRIPTION
New dfdlx:runtimeProperties is a space-separated list of key=value
pairs. The pairs are converted to a Map and made available on the
ElementRuntimeData for which the properties is specified. This Map can
be accessed by custom implementations of InfosetInputters and
InfosetOutputters to allow modifications and custom behaviors to the
text of simple types.

The property is only valid on dfdl:element and xs:element tags for
simple types.

Also changed "Object" to "ObjectKind" to make it more clear that it
describes the dfdlx:objectKind extension property.

DAFFODIL-2537