### PR TITLE
Resolve Apache Conscious Language Checker findings

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@
 <!-- markdownlint-disable line-length -->
 <!-- markdownlint-disable no-inline-html -->
 [<img src="https://daffodil.apache.org/assets/themes/apache/img/apache-daffodil-logo.svg" height="85" align="left" alt="Apache Daffodil"/>][Website]
-[<img src="https://img.shields.io/github/workflow/status/apache/daffodil/CI/master.svg" align="right"/>][GitHub Actions]
+[<img src="https://img.shields.io/github/workflow/status/apache/daffodil/CI/main.svg" align="right"/>][GitHub Actions]
 <br clear="right" />
-[<img src="https://img.shields.io/codecov/c/github/apache/daffodil/master.svg" align="right"/>][CodeCov]
+[<img src="https://img.shields.io/codecov/c/github/apache/daffodil/main.svg" align="right"/>][CodeCov]
 <br clear="right" />
 [<img src="https://img.shields.io/maven-central/v/org.apache.daffodil/daffodil-core_2.12.svg?color=brightgreen&label=version" align="right"/>][Releases]
 <br clear="both" />
@@ -106,7 +106,7 @@ Apache Daffodil is licensed under the [Apache License, v2.0].
 [Command Line Interface]: https://daffodil.apache.org/cli/
 [DFDL specification]: https://daffodil.apache.org/docs/dfdl/
 [Daffodil JIRA]: https://issues.apache.org/jira/projects/DAFFODIL/
-[Github Actions]: https://github.com/apache/daffodil/actions?query=branch%3Amaster+
+[Github Actions]: https://github.com/apache/daffodil/actions?query=branch%3Amain+
 [Releases]: http://daffodil.apache.org/releases/
 [SBT]: https://www.scala-sbt.org/
 [Website]: https://daffodil.apache.org/

--- a/containers/release-candidate/daffodil-release-candidate
+++ b/containers/release-candidate/daffodil-release-candidate
@@ -41,7 +41,7 @@ Options:
   -n, --dry-run [alt]   Run all commands but do not actually publish anything.
                         Can optionally provide an alternative github repo and
                         branch of the form "user/repo@branch" instead of the
-                        default "apache/daffodil@master"
+                        default "apache/daffodil@main"
   -h, --help            Display this help and exit
 USAGE
 }
@@ -50,7 +50,7 @@ DRY_RUN=false
 
 DAFFODIL_CODE_USER="apache"
 DAFFODIL_CODE_REPO="daffodil"
-DAFFODIL_CODE_BRANCH="master"
+DAFFODIL_CODE_BRANCH="main"
 
 DAFFODIL_SITE_REPO="daffodil-site"
 
@@ -293,7 +293,7 @@ else
 set -x
 cd $DAFFODIL_DIST_DIR && svn ci --username $APACHE_USERNAME -m 'Staging Apache Daffodil $VERSION-$PRE_RELEASE'
 cd $DAFFODIL_CODE_DIR && git push origin v$VERSION-$PRE_RELEASE
-cd $DAFFODIL_SITE_DIR && git push origin master
+cd $DAFFODIL_SITE_DIR && git push origin main
 EOF
   chmod +x /root/complete-release
 

--- a/daffodil-cli/bin.LICENSE
+++ b/daffodil-cli/bin.LICENSE
@@ -574,8 +574,8 @@ is subject to the terms and conditions of the following licenses.
      #  and others. All Rights Reserved.
      #
      # Project: https://github.com/veer66/lao-dictionary
-     # Dictionary: https://github.com/veer66/lao-dictionary/blob/master/Lao-Dictionary.txt
-     # License: https://github.com/veer66/lao-dictionary/blob/master/Lao-Dictionary-LICENSE.txt
+     # Dictionary: https://github.com/veer66/lao-dictionary/blob/2c2344310636f548b09d854362ab2e2e666369e0/Lao-Dictionary.txt
+     # License: https://github.com/veer66/lao-dictionary/blob/2c2344310636f548b09d854362ab2e2e666369e0/Lao-Dictionary-LICENSE.txt
      #              (copied below)
      #
      #  This file is derived from the above dictionary, with slight
@@ -758,7 +758,7 @@ is subject to the terms and conditions of the following licenses.
   This product bundles 'JLine', including the following files:
     - lib/org.jline.jline-<VERSION>.jar
   These files are available under a BSD-3-Clause license. For details, see
-  https://github.com/jline/jline3/blob/master/LICENSE.txt
+  https://github.com/jline/jline3/blob/jline-parent-3.20.0/LICENSE.txt
 
     Copyright (c) 2002-2018, the original author or authors.
     All rights reserved.
@@ -1202,7 +1202,7 @@ is subject to the terms and conditions of the following licenses.
       in the version distributed with Saxon is the removal of code that Saxon does not need.)
 
 
-      (This license is published at https://github.com/hrldcpr/pcollections/blob/master/LICENSE)
+      (This license is published at https://github.com/hrldcpr/pcollections/blob/v3.1.4/LICENSE)
 
       MIT License
 

--- a/daffodil-core/src/test/scala/org/apache/daffodil/dsom/TestBinaryInput_01.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/dsom/TestBinaryInput_01.scala
@@ -175,16 +175,16 @@ class TestBinaryInput_01 {
 
   @Test
   def testBufferBigIntBigEndianExtraction(): Unit = {
-    val (dis, finfo) = fromString("Something in the way she moves, ", BE, msbFirst)
+    val (dis, finfo) = fromString("Thirty-two character long string", BE, msbFirst)
     val bigInt = getBigInt(finfo, dis, 0, 256)
-    assertEquals(new JBigInt("37738841482167102822784581157237036764884875846207476558974346160344516471840"),
+    assertEquals(new JBigInt("38178759144797737047702418052138682097409903778432721523410841200294898527847"),
       bigInt)
   }
 
   @Test
   def testBufferBigIntLittleEndianExtraction(): Unit = {
-    val (dis, finfo) = fromString("Something in the way she moves, ", LE, msbFirst)
-    assertEquals(new JBigInt("14552548861771956163454220823873430243364312915206513831353612029437431082835"),
+    val (dis, finfo) = fromString("Thirty-two character long string", LE, msbFirst)
+    assertEquals(new JBigInt("46783304350265979503919546124020768339208030665592297039403372142674722777172"),
       getBigInt(finfo, dis, 0, 256))
   }
 

--- a/daffodil-io/src/test/scala/org/apache/daffodil/layers/TestJavaIOStreams.scala
+++ b/daffodil-io/src/test/scala/org/apache/daffodil/layers/TestJavaIOStreams.scala
@@ -50,16 +50,19 @@ import java.io.ByteArrayOutputStream
 class TestJavaIOStreams {
   Assert.usage(scala.util.Properties.isJavaAtLeast("1.8"))
 
-  val text = """Man is distinguished, not only by his reason, but by this singular passion from
-other animals, which is a lust of the mind, that by a perseverance of delight
-in the continued and indefatigable generation of knowledge, exceeds the short
-vehemence of any carnal pleasure.""".replace("\r\n", "\n").replace("\n", " ")
+  val text = """Daffodil is an open source implementation of the DFDL
+specification that uses these DFDL schemas to parse fixed format data into an
+infoset, which is most commonly represented as either XML or JSON. This
+allows the use of well-established XML or JSON technologies and libraries to
+consume, inspect, and manipulate fixed format data in existing solutions.""".replace("\r\n", "\n").replace("\n", " ")
 
-  val b64Text = """TWFuIGlzIGRpc3Rpbmd1aXNoZWQsIG5vdCBvbmx5IGJ5IGhpcyByZWFzb24sIGJ1dCBieSB0aGlz
-IHNpbmd1bGFyIHBhc3Npb24gZnJvbSBvdGhlciBhbmltYWxzLCB3aGljaCBpcyBhIGx1c3Qgb2Yg
-dGhlIG1pbmQsIHRoYXQgYnkgYSBwZXJzZXZlcmFuY2Ugb2YgZGVsaWdodCBpbiB0aGUgY29udGlu
-dWVkIGFuZCBpbmRlZmF0aWdhYmxlIGdlbmVyYXRpb24gb2Yga25vd2xlZGdlLCBleGNlZWRzIHRo
-ZSBzaG9ydCB2ZWhlbWVuY2Ugb2YgYW55IGNhcm5hbCBwbGVhc3VyZS4="""
+  val b64Text = """RGFmZm9kaWwgaXMgYW4gb3BlbiBzb3VyY2UgaW1wbGVtZW50YXRpb24gb2YgdGhlIERGREwgc3Bl
+Y2lmaWNhdGlvbiB0aGF0IHVzZXMgdGhlc2UgREZETCBzY2hlbWFzIHRvIHBhcnNlIGZpeGVkIGZv
+cm1hdCBkYXRhIGludG8gYW4gaW5mb3NldCwgd2hpY2ggaXMgbW9zdCBjb21tb25seSByZXByZXNl
+bnRlZCBhcyBlaXRoZXIgWE1MIG9yIEpTT04uIFRoaXMgYWxsb3dzIHRoZSB1c2Ugb2Ygd2VsbC1l
+c3RhYmxpc2hlZCBYTUwgb3IgSlNPTiB0ZWNobm9sb2dpZXMgYW5kIGxpYnJhcmllcyB0byBjb25z
+dW1lLCBpbnNwZWN0LCBhbmQgbWFuaXB1bGF0ZSBmaXhlZCBmb3JtYXQgZGF0YSBpbiBleGlzdGlu
+ZyBzb2x1dGlvbnMuCg=="""
 
   val zipped = {
     val baos = new ByteArrayOutputStream()

--- a/daffodil-io/src/test/scala/org/apache/daffodil/layers/TestLimitingJavaIOStreams.scala
+++ b/daffodil-io/src/test/scala/org/apache/daffodil/layers/TestLimitingJavaIOStreams.scala
@@ -49,16 +49,19 @@ class TestLimitingJavaIOStreams {
   val iso8859 = StandardCharsets.ISO_8859_1
   val utf8 = StandardCharsets.ISO_8859_1
 
-  val text = """Man is distinguished, not only by his reason, but by this singular passion from
-other animals, which is a lust of the mind, that by a perseverance of delight
-in the continued and indefatigable generation of knowledge, exceeds the short
-vehemence of any carnal pleasure.""".replace("\r\n", "\n").replace("\n", " ")
+  val text = """Daffodil is an open source implementation of the DFDL
+specification that uses these DFDL schemas to parse fixed format data into an
+infoset, which is most commonly represented as either XML or JSON. This
+allows the use of well-established XML or JSON technologies and libraries to
+consume, inspect, and manipulate fixed format data in existing solutions.""".replace("\r\n", "\n").replace("\n", " ")
 
-  val b64Text = """TWFuIGlzIGRpc3Rpbmd1aXNoZWQsIG5vdCBvbmx5IGJ5IGhpcyByZWFzb24sIGJ1dCBieSB0aGlz
-IHNpbmd1bGFyIHBhc3Npb24gZnJvbSBvdGhlciBhbmltYWxzLCB3aGljaCBpcyBhIGx1c3Qgb2Yg
-dGhlIG1pbmQsIHRoYXQgYnkgYSBwZXJzZXZlcmFuY2Ugb2YgZGVsaWdodCBpbiB0aGUgY29udGlu
-dWVkIGFuZCBpbmRlZmF0aWdhYmxlIGdlbmVyYXRpb24gb2Yga25vd2xlZGdlLCBleGNlZWRzIHRo
-ZSBzaG9ydCB2ZWhlbWVuY2Ugb2YgYW55IGNhcm5hbCBwbGVhc3VyZS4="""
+  val b64Text = """RGFmZm9kaWwgaXMgYW4gb3BlbiBzb3VyY2UgaW1wbGVtZW50YXRpb24gb2YgdGhlIERGREwgc3Bl
+Y2lmaWNhdGlvbiB0aGF0IHVzZXMgdGhlc2UgREZETCBzY2hlbWFzIHRvIHBhcnNlIGZpeGVkIGZv
+cm1hdCBkYXRhIGludG8gYW4gaW5mb3NldCwgd2hpY2ggaXMgbW9zdCBjb21tb25seSByZXByZXNl
+bnRlZCBhcyBlaXRoZXIgWE1MIG9yIEpTT04uIFRoaXMgYWxsb3dzIHRoZSB1c2Ugb2Ygd2VsbC1l
+c3RhYmxpc2hlZCBYTUwgb3IgSlNPTiB0ZWNobm9sb2dpZXMgYW5kIGxpYnJhcmllcyB0byBjb25z
+dW1lLCBpbnNwZWN0LCBhbmQgbWFuaXB1bGF0ZSBmaXhlZCBmb3JtYXQgZGF0YSBpbiBleGlzdGlu
+ZyBzb2x1dGlvbnMuCg=="""
 
   val zipped = {
     val baos = new ByteArrayOutputStream()
@@ -72,7 +75,7 @@ ZSBzaG9ydCB2ZWhlbWVuY2Ugb2YgYW55IGNhcm5hbCBwbGVhc3VyZS4="""
   val additionalText = "This is text that shouldn't be read."
 
   @Test def testBase64DecodeFromDelimitedStream1(): Unit = {
-    val data = "cGxlYXN1cmUu" // encoding of "pleasure."
+    val data = "c29sdXRpb25zLg" // encoding of "solutions."
     val terminator = "terminator"
     val afterTerminator = "afterTerminator"
     val is = IOUtils.toInputStream(data + terminator + afterTerminator,
@@ -81,14 +84,14 @@ ZSBzaG9ydCB2ZWhlbWVuY2Ugb2YgYW55IGNhcm5hbCBwbGVhc3VyZS4="""
       BoundaryMarkLimitingStream(is, terminator, iso8859, targetChunkSize = 4)
     val b64 = java.util.Base64.getMimeDecoder().wrap(delimitedStream)
     val actualData = IOUtils.toString(b64, iso8859)
-    assertEquals("pleasure.", actualData)
+    assertEquals("solutions.", actualData)
     // The input stream should have been advanced past the terminator
     val actualAfterData = IOUtils.toString(is, iso8859)
     assertEquals(afterTerminator, actualAfterData)
   }
 
   @Test def testBase64DecodeFromDelimitedStream2(): Unit = {
-    val data = "cGxlYXN1cmUu" // encoding of "pleasure."
+    val data = "c29sdXRpb25zLg" // encoding of "solutions."
     val terminator = ";;;"
     val afterTerminator = "afterTerminator"
     val is = IOUtils.toInputStream(data + terminator + afterTerminator, "ascii").asInstanceOf[ByteArrayInputStream]
@@ -96,7 +99,7 @@ ZSBzaG9ydCB2ZWhlbWVuY2Ugb2YgYW55IGNhcm5hbCBwbGVhc3VyZS4="""
       BoundaryMarkLimitingStream(is, terminator, iso8859, targetChunkSize = 1)
     val b64 = java.util.Base64.getMimeDecoder().wrap(delimitedStream)
     val actualData = IOUtils.toString(b64, iso8859)
-    assertEquals("pleasure.", actualData)
+    assertEquals("solutions.", actualData)
     val actualAfterData = IOUtils.toString(is, iso8859)
     assertEquals(afterTerminator, actualAfterData)
   }

--- a/daffodil-macro-lib/src/main/scala/org/apache/daffodil/processors/parsers/PointOfUncertaintyMacros.scala
+++ b/daffodil-macro-lib/src/main/scala/org/apache/daffodil/processors/parsers/PointOfUncertaintyMacros.scala
@@ -59,7 +59,7 @@ object PointOfUncertaintyMacros {
         // The "body" uses the "param" variable name, and scala doesn't like it
         // if we just create a new variable with this name, with a very unclear
         // error message. Instead, we need to create a "fresh" variable name to
-        // hold he new point of uncertainty, and then transform the body so
+        // hold the new point of uncertainty, and then transform the body so
         // that all instances of "param" are replaced with our new fresh name.
         val transformer = new Transformer {
           override def transform(tree: Tree): Tree = tree match {

--- a/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/processors/unparsers/SpecifiedLengthUnparsers.scala
+++ b/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/processors/unparsers/SpecifiedLengthUnparsers.scala
@@ -424,7 +424,7 @@ class SpecifiedLengthPrefixedUnparser(
       // suspension to resume and unparse the value
       val suspension = new PrefixLengthSuspendableOperation(erd, elem, plElem, lengthUnits, prefixedLengthAdjustmentInUnits)
 
-      // Run the suspension--we know he suspension will not be able to succeed
+      // Run the suspension--we know the suspension will not be able to succeed
       // since maybeLengthInBits is not defined, but this performs various
       // actions to suspend the operation and allow it to be run later
       suspension.run(state)

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/debugger/InteractiveDebugger.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/debugger/InteractiveDebugger.scala
@@ -529,8 +529,8 @@ class InteractiveDebugger(runner: InteractiveDebuggerRunner, eCompilers: Express
     }
 
     // This ensures that there are no naming conflicts (e.g. short form names
-    // conflict). This is really just a sanity check, and really only needs to
-    // be run whenever names change or new commands are added.
+    // conflict). This really only needs to be run whenever names change or new
+    // commands are added.
 
     // Uncomment this and the DebugCommandBase.checkNameConflicts line to do a
     // check when changes are made.

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/layers/GZipTransformer.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/layers/GZipTransformer.scala
@@ -115,7 +115,7 @@ class GZIPFixedOutputStream private (os: java.io.OutputStream) extends java.io.O
     if (bytePosition < 0) {
       // The bad byte has been fixed, pass all writes directly through to the
       // underlying OutputStream. This may be more efficient than the default
-      // OutputStream write() function, which writes the bytes from his array
+      // OutputStream write() function, which writes the bytes from this array
       // one at a time
       os.write(b, off, len)
     } else {

--- a/daffodil-schematron/src/test/scala/org/apache/daffodil/validation/schematron/TestBasicValidation.scala
+++ b/daffodil-schematron/src/test/scala/org/apache/daffodil/validation/schematron/TestBasicValidation.scala
@@ -30,7 +30,7 @@ import scala.io.Source
 
 /**
  * basic function tests adapted from the Camel Schematron implementation
- * https://github.com/apache/camel/blob/master/components/camel-schematron/src/test/java/org/apache/camel/component/schematron
+ * https://github.com/apache/camel/blob/main/components/camel-schematron/src/test/java/org/apache/camel/component/schematron
  */
 class TestBasicValidation {
 

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section07/discriminators/multipleDiscriminators.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section07/discriminators/multipleDiscriminators.tdml
@@ -94,7 +94,7 @@
     The first discriminator evaluates to false, causing immediate backtracking.
     The second discriminator is never evaluated.
     We speculatively parse innerBranch2, and it is successful.
-    Exactly he same behavior as multipleDiscriminators1.
+    Exactly the same behavior as multipleDiscriminators1.
     -->
   <tdml:parserTestCase name="multipleDiscriminators2" model="multipleDiscriminators" root="root">
     <tdml:document>fta</tdml:document>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section23/dfdl_functions/Functions.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section23/dfdl_functions/Functions.tdml
@@ -562,10 +562,10 @@
     <xs:element name="e_lowercase2" type="xs:string" dfdl:inputValueCalc="{ fn:lower-case('TeSt LoWeR') }" />
     <xs:element name="e_lowercase3" type="xs:string" dfdl:inputValueCalc="{ fn:lower-case('') }" />
 
-    <xs:element name="e_contains1" type="xs:boolean" dfdl:inputValueCalc="{ fn:contains('The quick brown fox.', 'quick') }" />
-    <xs:element name="e_contains2" type="xs:boolean" dfdl:inputValueCalc="{ fn:contains('The quick brown fox.', 'slow') }" />
-    <xs:element name="e_contains3" type="xs:boolean" dfdl:inputValueCalc="{ fn:contains('The quick brown fox.', '') }" />
-    <xs:element name="e_contains4" type="xs:boolean" dfdl:inputValueCalc="{ fn:contains('', 'test') }" />
+    <xs:element name="e_contains1" type="xs:boolean" dfdl:inputValueCalc="{ fn:contains('Four word test sentence.', 'word') }" />
+    <xs:element name="e_contains2" type="xs:boolean" dfdl:inputValueCalc="{ fn:contains('Four word test sentence.', 'missing') }" />
+    <xs:element name="e_contains3" type="xs:boolean" dfdl:inputValueCalc="{ fn:contains('Four word test sentence.', '') }" />
+    <xs:element name="e_contains4" type="xs:boolean" dfdl:inputValueCalc="{ fn:contains('', 'missing') }" />
     <xs:element name="e_contains5">
       <xs:complexType>
         <xs:sequence dfdl:separator=",">
@@ -577,10 +577,10 @@
     </xs:element>
     <xs:element name="e_contains6" type="xs:boolean" dfdl:inputValueCalc="{ fn:contains('test', 'est', 'collation') }" />
 
-    <xs:element name="e_startswith1" type="xs:boolean" dfdl:inputValueCalc="{ fn:starts-with('The quick brown fox.', 'The q') }" />
-    <xs:element name="e_startswith2" type="xs:boolean" dfdl:inputValueCalc="{ fn:starts-with('The quick brown fox.', 'he qu') }" />
-    <xs:element name="e_startswith3" type="xs:boolean" dfdl:inputValueCalc="{ fn:starts-with('The quick brown fox.', '') }" />
-    <xs:element name="e_startswith4" type="xs:boolean" dfdl:inputValueCalc="{ fn:starts-with('', 'The') }" />
+    <xs:element name="e_startswith1" type="xs:boolean" dfdl:inputValueCalc="{ fn:starts-with('Four word test sentence.', 'Four w') }" />
+    <xs:element name="e_startswith2" type="xs:boolean" dfdl:inputValueCalc="{ fn:starts-with('Four word test sentence.', 'our wo') }" />
+    <xs:element name="e_startswith3" type="xs:boolean" dfdl:inputValueCalc="{ fn:starts-with('Four word test sentence.', '') }" />
+    <xs:element name="e_startswith4" type="xs:boolean" dfdl:inputValueCalc="{ fn:starts-with('', 'Four') }" />
     <xs:element name="e_startswith5">
       <xs:complexType>
         <xs:sequence dfdl:separator=",">
@@ -592,10 +592,10 @@
     </xs:element>
     <xs:element name="e_startswith6" type="xs:boolean" dfdl:inputValueCalc="{ fn:starts-with('test', 'te', 'collation') }" />
 
-    <xs:element name="e_endswith1" type="xs:boolean" dfdl:inputValueCalc="{ fn:ends-with('The quick brown fox.', 'fox.') }" />
-    <xs:element name="e_endswith2" type="xs:boolean" dfdl:inputValueCalc="{ fn:ends-with('The quick brown fox.', 'The') }" />
-    <xs:element name="e_endswith3" type="xs:boolean" dfdl:inputValueCalc="{ fn:ends-with('The quick brown fox.', '') }" />
-    <xs:element name="e_endswith4" type="xs:boolean" dfdl:inputValueCalc="{ fn:ends-with('', 'fox') }" />
+    <xs:element name="e_endswith1" type="xs:boolean" dfdl:inputValueCalc="{ fn:ends-with('Four word test sentence.', 'sentence.') }" />
+    <xs:element name="e_endswith2" type="xs:boolean" dfdl:inputValueCalc="{ fn:ends-with('Four word test sentence.', 'Four') }" />
+    <xs:element name="e_endswith3" type="xs:boolean" dfdl:inputValueCalc="{ fn:ends-with('Four word test sentence.', '') }" />
+    <xs:element name="e_endswith4" type="xs:boolean" dfdl:inputValueCalc="{ fn:ends-with('', 'sentence') }" />
     <xs:element name="e_endswith5">
       <xs:complexType>
         <xs:sequence dfdl:separator=",">
@@ -607,9 +607,9 @@
     </xs:element>
     <xs:element name="e_endswith6" type="xs:boolean" dfdl:inputValueCalc="{ fn:ends-with('test', 'est', 'collation') }" />
 
-    <xs:element name="e_substringbefore1" type="xs:string" dfdl:inputValueCalc="{ fn:substring-before('The quick brown fox.', 'quick') }" />
+    <xs:element name="e_substringbefore1" type="xs:string" dfdl:inputValueCalc="{ fn:substring-before('Four word test sentence.', 'word') }" />
     <xs:element name="e_substringbefore2" type="xs:string" dfdl:inputValueCalc="{ fn:substring-before('', '') }" />
-    <xs:element name="e_substringbefore3" type="xs:string" dfdl:inputValueCalc="{ fn:substring-before('The quick brown fox.', '') }" />
+    <xs:element name="e_substringbefore3" type="xs:string" dfdl:inputValueCalc="{ fn:substring-before('Four word test sentence.', '') }" />
     <xs:element name="e_substringbefore4">
       <xs:complexType>
         <xs:sequence dfdl:separator=",">
@@ -622,9 +622,9 @@
     <xs:element name="e_substringbefore5" type="xs:string" dfdl:inputValueCalc="{ fn:substring-before('test', 's', 'collation') }" />
     <xs:element name="e_substringbefore6" type="xs:string" dfdl:inputValueCalc="{ fn:substring-before('test') }" />
 
-    <xs:element name="e_substringafter1" type="xs:string" dfdl:inputValueCalc="{ fn:substring-after('The quick brown fox.', 'brown') }" />
+    <xs:element name="e_substringafter1" type="xs:string" dfdl:inputValueCalc="{ fn:substring-after('Four word test sentence.', 'test') }" />
     <xs:element name="e_substringafter2" type="xs:string" dfdl:inputValueCalc="{ fn:substring-after('', '') }" />
-    <xs:element name="e_substringafter3" type="xs:string" dfdl:inputValueCalc="{ fn:substring-after('The quick brown fox.', '') }" />
+    <xs:element name="e_substringafter3" type="xs:string" dfdl:inputValueCalc="{ fn:substring-after('Four word test sentence.', '') }" />
     <xs:element name="e_substringafter4">
       <xs:complexType>
         <xs:sequence dfdl:separator=",">
@@ -1541,12 +1541,12 @@
   <tdml:parserTestCase name="contains_05" root="e_contains5"
     model="Functions.dfdl.xsd" description="Section 23 - Functions - fn:contains - DFDL-23-104R">
 
-    <tdml:document>The quick brown fox.,The quick brown fox.</tdml:document>
+    <tdml:document>Four word test sentence.,Four word test sentence.</tdml:document>
     <tdml:infoset>
       <tdml:dfdlInfoset>
         <e_contains5>
-          <one>The quick brown fox.</one>
-          <two>The quick brown fox.</two>
+          <one>Four word test sentence.</one>
+          <two>Four word test sentence.</two>
           <contains>true</contains>
         </e_contains5>
       </tdml:dfdlInfoset>
@@ -1563,12 +1563,12 @@
   <tdml:parserTestCase name="contains_06" root="e_contains5"
     model="Functions.dfdl.xsd" description="Section 23 - Functions - fn:contains - DFDL-23-104R">
 
-    <tdml:document>The quick brown fox.,The quick BROWN fox.</tdml:document>
+    <tdml:document>Four word test sentence.,Four WORD test sentence.</tdml:document>
     <tdml:infoset>
       <tdml:dfdlInfoset>
         <e_contains5>
-          <one>The quick brown fox.</one>
-          <two>The quick BROWN fox.</two>
+          <one>Four word test sentence.</one>
+          <two>Four WORD test sentence.</two>
           <contains>false</contains>
         </e_contains5>
       </tdml:dfdlInfoset>
@@ -1675,12 +1675,12 @@
   <tdml:parserTestCase name="startswith_05" root="e_startswith5"
     model="Functions.dfdl.xsd" description="Section 23 - Functions - fn:starts-with - DFDL-23-105R">
 
-    <tdml:document>The quick brown fox.,The quick brown fox.</tdml:document>
+    <tdml:document>Four word test sentence.,Four word test sentence.</tdml:document>
     <tdml:infoset>
       <tdml:dfdlInfoset>
         <e_startswith5>
-          <one>The quick brown fox.</one>
-          <two>The quick brown fox.</two>
+          <one>Four word test sentence.</one>
+          <two>Four word test sentence.</two>
           <starts>true</starts>
         </e_startswith5>
       </tdml:dfdlInfoset>
@@ -1697,11 +1697,11 @@
   <tdml:parserTestCase name="startswith_06" root="e_startswith5"
     model="Functions.dfdl.xsd" description="Section 23 - Functions - fn:starts-with - DFDL-23-105R">
 
-    <tdml:document>The quick brown fox.,the</tdml:document>
+    <tdml:document>Four word test sentence.,the</tdml:document>
     <tdml:infoset>
       <tdml:dfdlInfoset>
         <e_startswith5>
-          <one>The quick brown fox.</one>
+          <one>Four word test sentence.</one>
           <two>the</two>
           <starts>false</starts>
         </e_startswith5>
@@ -1809,12 +1809,12 @@
   <tdml:parserTestCase name="endswith_05" root="e_endswith5"
     model="Functions.dfdl.xsd" description="Section 23 - Functions - fn:ends-with - DFDL-23-106R">
 
-    <tdml:document>The quick brown fox.,The quick brown fox.</tdml:document>
+    <tdml:document>Four word test sentence.,Four word test sentence.</tdml:document>
     <tdml:infoset>
       <tdml:dfdlInfoset>
         <e_endswith5>
-          <one>The quick brown fox.</one>
-          <two>The quick brown fox.</two>
+          <one>Four word test sentence.</one>
+          <two>Four word test sentence.</two>
           <ends>true</ends>
         </e_endswith5>
       </tdml:dfdlInfoset>
@@ -1831,12 +1831,12 @@
   <tdml:parserTestCase name="endswith_06" root="e_endswith5"
     model="Functions.dfdl.xsd" description="Section 23 - Functions - fn:ends-with - DFDL-23-106R">
 
-    <tdml:document>The quick brown fox.,The quick BROWN fox.</tdml:document>
+    <tdml:document>Four word test sentence.,Four WORD test sentence.</tdml:document>
     <tdml:infoset>
       <tdml:dfdlInfoset>
         <e_endswith5>
-          <one>The quick brown fox.</one>
-          <two>The quick BROWN fox.</two>
+          <one>Four word test sentence.</one>
+          <two>Four WORD test sentence.</two>
           <ends>false</ends>
         </e_endswith5>
       </tdml:dfdlInfoset>
@@ -1874,7 +1874,7 @@
     <tdml:document/>
     <tdml:infoset>
       <tdml:dfdlInfoset>
-        <e_substringbefore1>The </e_substringbefore1>
+        <e_substringbefore1>Four </e_substringbefore1>
       </tdml:dfdlInfoset>
     </tdml:infoset>
   </tdml:parserTestCase>
@@ -2030,7 +2030,7 @@
     <tdml:document/>
     <tdml:infoset>
       <tdml:dfdlInfoset>
-        <e_substringafter1> fox.</e_substringafter1>
+        <e_substringafter1> sentence.</e_substringafter1>
       </tdml:dfdlInfoset>
     </tdml:infoset>
   </tdml:parserTestCase>
@@ -2066,7 +2066,7 @@
     <tdml:document/>
     <tdml:infoset>
       <tdml:dfdlInfoset>
-        <e_substringafter3>The quick brown fox.</e_substringafter3>
+        <e_substringafter3>Four word test sentence.</e_substringafter3>
       </tdml:dfdlInfoset>
     </tdml:infoset>
   </tdml:parserTestCase>

--- a/tutorials/src/main/resources/DFDLTutorialStylesheet.xsl
+++ b/tutorials/src/main/resources/DFDLTutorialStylesheet.xsl
@@ -259,7 +259,7 @@
         <script src="https://daffodil.apache.org/assets/themes/apache/jquery/jquery-2.1.1.min.js"></script>
         <script src="https://daffodil.apache.org/assets/themes/apache/bootstrap/js/bootstrap.min.js"></script>
       </body>
-      <script src="https://cdn.rawgit.com/google/code-prettify/master/loader/run_prettify.js"></script>
+      <script src="https://cdn.jsdelivr.net/gh/google/code-prettify@e006587b4a893f0281e9dc9a53001c7ed584d4e7/loader/run_prettify.js"></script>
     </html>
   </xsl:template>
 


### PR DESCRIPTION
- Change references to Daffodil "main" branch
- Fix test quotes/strings and typos to avoid false positives
- Links to 3rd party repos are changed to 'main' where possible, or to a
  commit hash or tag where not, again to minimize false positives

Findings that are not resolved:

- Dependency license text that contains "his or her"--we probably
  shouldn't modify text from other licenses
- False positive found in "Saxon-HE" dependency

DAFFODIL-2557