### PR TITLE
Fix unique qname check in unordered sequences

### DIFF
--- a/daffodil-test/src/test/resources/org/apache/daffodil/section14/unordered_sequences/UnorderedSequences.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section14/unordered_sequences/UnorderedSequences.tdml
@@ -726,8 +726,8 @@
     root="SDE_01">
     <tdml:document><![CDATA[a1,bx20:y99:z,c55]]></tdml:document>
     <tdml:errors>
-      <tdml:error>Members of an unordered sequence</tdml:error>
-      <tdml:error>must be Element or ElementRef</tdml:error>
+      <tdml:error>unordered sequence</tdml:error>
+      <tdml:error>element declaration or element reference</tdml:error>
     </tdml:errors>
   </tdml:parserTestCase>
 
@@ -737,8 +737,9 @@
     root="SDE_02">
     <tdml:document><![CDATA[a1,bx20:y99:z,c55]]></tdml:document>
     <tdml:errors>
-      <tdml:error>Members of an unordered sequence</tdml:error>
-      <tdml:error>that are optional or array elements must have dfdl:occursCountKind='parsed'.</tdml:error>
+      <tdml:error>unordered sequence</tdml:error>
+      <tdml:error>optional or array</tdml:error>
+      <tdml:error>dfdl:occursCountKind='parsed'</tdml:error>
     </tdml:errors>
   </tdml:parserTestCase>
 
@@ -748,8 +749,8 @@
     root="SDE_03">
     <tdml:document><![CDATA[a1,bx20:y99:z,c55]]></tdml:document>
     <tdml:errors>
-      <tdml:error>Two or more members of the unordered sequence</tdml:error>
-      <tdml:error>have the same name and the same namespace.</tdml:error>
+      <tdml:error>unordered sequence</tdml:error>
+      <tdml:error>same name and the same namespace</tdml:error>
     </tdml:errors>
   </tdml:parserTestCase>
 
@@ -941,6 +942,19 @@
       <tdml:error>Assertion</tdml:error>
       <tdml:error>the expected message</tdml:error>
     </tdml:errors>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="test_unordered_namespaces_01"
+    model="unordered_namespaces_01.dfdl.xsd" root="root">
+    <tdml:document><![CDATA[-3.*4]]></tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <b02:root xmlns:a02="http://a02.com" xmlns:b02="http://b02.com">
+          <a02:inty>3</a02:inty>
+          <b02:inty>4</b02:inty>
+        </b02:root>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
   </tdml:parserTestCase>
 
 </tdml:testSuite>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section14/unordered_sequences/unordered_namespaces_01.dfdl.xsd
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section14/unordered_sequences/unordered_namespaces_01.dfdl.xsd
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/"
+  targetNamespace="http://b02.com" xmlns:a02="http://a02.com" xmlns:b02="http://b02.com">
+
+  <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+
+  <xs:annotation>
+    <xs:appinfo source="http://www.ogf.org/dfdl/">
+      <dfdl:format ref="b02:GeneralFormat" lengthKind="delimited" />
+    </xs:appinfo>
+  </xs:annotation>
+
+  <xs:include schemaLocation="unordered_namespaces_02.dfdl.xsd"/>
+  <xs:import namespace="http://a02.com" schemaLocation="unordered_namespaces_03.dfdl.xsd"/>
+
+  <xs:element name="root">
+    <xs:complexType>
+      <xs:sequence dfdl:sequenceKind="unordered" dfdl:separator=".">
+        <xs:element ref="a02:inty" dfdl:initiator="-"/>
+        <xs:element ref="b02:inty" dfdl:initiator="*"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+
+</xs:schema>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section14/unordered_sequences/unordered_namespaces_02.dfdl.xsd
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section14/unordered_sequences/unordered_namespaces_02.dfdl.xsd
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/">
+
+  <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+
+  <xs:annotation>
+    <xs:appinfo source="http://www.ogf.org/dfdl/">
+      <dfdl:format ref="GeneralFormat" />
+    </xs:appinfo>
+  </xs:annotation>
+
+  <xs:element name="inty" type="xs:int" dfdl:lengthKind="delimited"/>
+
+</xs:schema>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section14/unordered_sequences/unordered_namespaces_03.dfdl.xsd
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section14/unordered_sequences/unordered_namespaces_03.dfdl.xsd
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<xs:schema targetNamespace="http://a02.com" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/">
+
+  <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+
+  <xs:annotation>
+    <xs:appinfo source="http://www.ogf.org/dfdl/">
+      <dfdl:format ref="GeneralFormat" />
+    </xs:appinfo>
+  </xs:annotation>
+
+  <xs:element name="inty" type="xs:int" dfdl:lengthKind="delimited"/>
+
+</xs:schema>

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section14/unordered_sequences/TestUnorderedSequences.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section14/unordered_sequences/TestUnorderedSequences.scala
@@ -63,6 +63,8 @@ class TestUnorderedSequences {
   @Test def test_initiated_unordered2 = { runner.runOneTest("test_initiated_unordered2") }
   @Test def test_initiated_unordered3 = { runner.runOneTest("test_initiated_unordered3") }
 
+  @Test def test_unordered_namespaces_01 = { runner.runOneTest("test_unordered_namespaces_01") }
+
   @Test def test_BE000 = { runnerBE.runOneTest("BE000") }
   @Test def test_BE001 = { runnerBE.runOneTest("BE001") }
   @Test def test_BE002 = { runnerBE.runOneTest("BE002") }


### PR DESCRIPTION
- We incorrectly used the targetNamespace when determining if members of
  an unordered sequence had the same name/namespaces. The
  targetNamespace can be different from the actual namespace due when
  importing a schema. Instead, this groups by the namedQName of elements
  to determine if there are any duplicate non-unique elements. This uses
  the actually namespace after imported.
- Update other unordered sequence checks to SDE on the context of the
  group member rather than on the unordere sequences. It is likely the
  element that needs to be changed, so that context is more important.
- Remove the 'path' from the SDE. This generally isn't all that helpful
  and is more for debugging. The SDE context is more useful.

DAFFODIL-2460