### PR TITLE
Fix broken tests related to property scoping

### DIFF
--- a/daffodil-test/src/test/resources/org/apache/daffodil/section08/property_scoping/PropertyScoping.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section08/property_scoping/PropertyScoping.tdml
@@ -579,16 +579,16 @@
 
   <tdml:parserTestCase name="localAnnotation_05"
     description="DFDL Property Scoping Rules - DFDL-8-010R"
-    model="localAnnotationSchema" root="e5">
+    model="localAnnotationSchema" root="e5" roundTrip="twoPass">
     <tdml:document>
       <tdml:documentPart type="text">C:catastrophe,B:bologna,A:applesauce</tdml:documentPart>
     </tdml:document>
     <tdml:infoset>
       <tdml:dfdlInfoset>
         <e5>
-          <C>catastrophe</C>
-          <B>bologna</B>
           <A>applesauce</A>
+          <B>bologna</B>
+          <C>catastrophe</C>
         </e5>
       </tdml:dfdlInfoset>
     </tdml:infoset>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section08/property_scoping/PropertyScoping_01.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section08/property_scoping/PropertyScoping_01.tdml
@@ -57,40 +57,6 @@
     </xs:element>
   </tdml:defineSchema>
 
-  <tdml:defineSchema name="s1-u">
-    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
-    <dfdl:defineFormat name="def">
-      <dfdl:format ref="tns:def1" encoding="ascii"
-        lengthKind="explicit" lengthUnits="characters" length="5"
-        textNumberRep="zoned" />
-    </dfdl:defineFormat>
-
-    <dfdl:defineFormat name="def2">
-      <dfdl:format ref="tns:def3" lengthKind="explicit"
-        lengthUnits="characters" length="4" representation="text"
-        textNumberRep="standard" />
-    </dfdl:defineFormat>
-
-    <dfdl:defineFormat name="def3">
-      <dfdl:format ref="tns:GeneralFormat" representation="binary" />
-    </dfdl:defineFormat>
-
-    <dfdl:defineFormat name="def1">
-      <dfdl:format ref="tns:def2" />
-    </dfdl:defineFormat>
-
-    <dfdl:format ref="tns:GeneralFormat" lengthKind="explicit"
-      lengthUnits="characters" length="3" />
-
-    <xs:element name="easy" type="xs:int" dfdl:textNumberRep="standard">
-      <xs:annotation>
-        <xs:appinfo source="http://www.ogf.org/dfdl/">
-          <dfdl:element ref="tns:def"/>
-        </xs:appinfo>
-      </xs:annotation>
-    </xs:element>
-  </tdml:defineSchema>
-
   <tdml:defineSchema name="s1-u2">
     <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
     <dfdl:defineFormat name="def">
@@ -378,7 +344,7 @@
   </tdml:parserTestCase>
 
   <tdml:unparserTestCase name="unparse_property_scoping_02"
-    root="easy" model="s1-u"
+    root="easy" model="s1"
     description="Section 8 Combining DFDL Representation Properties from a dfdl:defineFormat - DFDL-8-018R">
     <tdml:infoset>
       <tdml:dfdlInfoset>

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section08/property_scoping/TestPropertyScoping.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section08/property_scoping/TestPropertyScoping.scala
@@ -45,9 +45,7 @@ class TestPropertyScoping {
   @Test def test_localAnnotation_02(): Unit = { runner.runOneTest("localAnnotation_02") }
   @Test def test_localAnnotation_03(): Unit = { runner.runOneTest("localAnnotation_03") }
   @Test def test_localAnnotation_04(): Unit = { runner.runOneTest("localAnnotation_04") }
-
-  //DFDL-1036 (was fixed) now DFDL-1159
-  //@Test def test_localAnnotation_05() { runner.runOneTest("localAnnotation_05") }
+  @Test def test_localAnnotation_05(): Unit = { runner.runOneTest("localAnnotation_05") }
 
   @Test def test_property_scoping_01(): Unit = { runner.runOneTest("property_scoping_01") }
   @Test def test_unparse_property_scoping_01(): Unit = { runner.runOneTest("unparse_property_scoping_01") }
@@ -61,10 +59,9 @@ class TestPropertyScoping {
   @Test def test_format_nesting_01(): Unit = { runner.runOneTest("format_nesting_01") }
 
   @Test def test_property_scoping_02(): Unit = { runner_01.runOneTest("property_scoping_02") }
-  // DAFFODIL-2103
-  // @Test def test_unparse_property_scoping_02() { runner_01.runOneTest("unparse_property_scoping_02") }
-  @Test def test_property_scoping_03() = { runner_01.runOneTest("property_scoping_03") }
-  @Test def test_unparse_property_scoping_03() = { runner_01.runOneTest("unparse_property_scoping_03") }
+  @Test def test_unparse_property_scoping_02(): Unit = { runner_01.runOneTest("unparse_property_scoping_02") }
+  @Test def test_property_scoping_03(): Unit = { runner_01.runOneTest("property_scoping_03") }
+  @Test def test_unparse_property_scoping_03(): Unit = { runner_01.runOneTest("unparse_property_scoping_03") }
   @Test def test_property_scoping_04(): Unit = { runner_01.runOneTest("property_scoping_04") }
   @Test def test_property_scoping_05(): Unit = { runner_01.runOneTest("property_scoping_05") }
   @Test def test_unparse_property_scoping_04(): Unit = { runner_01.runOneTest("unparse_property_scoping_04") }
@@ -82,6 +79,6 @@ class TestPropertyScoping {
   @Test def test_unparse_property_scoping_12(): Unit = { runner_01.runOneTest("unparse_property_scoping_12") }
   @Test def test_NearestEnclosingSequenceElementRef(): Unit = { runner_01.runOneTest("NearestEnclosingSequenceElementRef") }
 
-  @Test def test_property_refElementFormFail() = { runner_01.runOneTest("refElementFormFail") }
+  @Test def test_property_refElementFormFail(): Unit = { runner_01.runOneTest("refElementFormFail") }
 
 }


### PR DESCRIPTION
The unparse_property_scoping_02 test was added to show that property
scoping with nested define formats works as expected. But it was added
before unparsing was fully implemented, and had a small issue that meant
it never actually worked.

The issue is that the "s1-u" schema does not define the textNumberPattern
property so it inherits the value from DFDLGeneralFormat.dfdl.xsd,
which is a pattern that includes commas. This means the value `-1009`
unparses to `-1,009`, which is one character too long for the explicit
length of 5 and leads to a truncation error.

The solution is to just specify a textNumberPattern of "#####" so there
are no commas and it unparses to the expected length. But this makes the
schema exactly the same as the "s1" schema. So this just removes the
"s1-u" model, and changes the test to use the "s1" model. The test
passes, confirming that nested defineFormat references work as expected.

This also fixes the test_localAnnotation_05 commented out test in the
same file. This test is broken because the expected infoset isn't
ordered to match the schema order of an unordered sequence. The fix is
to just arrange the expected infoset to schema order and change it
two-pass.

Also adds missing `: Unit = ` return types on tests in this same file.

DAFFODIL-2103