### PR TITLE
Fix handling of %#x25; character entity

### DIFF
--- a/daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/Entities.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/Entities.tdml
@@ -1363,4 +1363,68 @@ is multiple bytes in UTF-8 encoding that is used"
     </tdml:infoset>
   </tdml:parserTestCase>
 
+  <tdml:defineSchema name="AllAsciiCodePointEntities">
+
+    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+    <dfdl:format ref="ex:GeneralFormat" lengthKind="delimited" encoding="ISO-8859-1" />
+
+    <xs:element name="hexEntities" type="xs:string" dfdl:initiator="%#x00;%#x01;%#x02;%#x03;%#x04;%#x05;%#x06;%#x07;%#x08;%#x09;%#x0A;%#x0B;%#x0C;%#x0D;%#x0E;%#x0F;%#x10;%#x11;%#x12;%#x13;%#x14;%#x15;%#x16;%#x17;%#x18;%#x19;%#x1A;%#x1B;%#x1C;%#x1D;%#x1E;%#x1F;%#x20;%#x21;%#x22;%#x23;%#x24;%#x25;%#x26;%#x27;%#x28;%#x29;%#x2A;%#x2B;%#x2C;%#x2D;%#x2E;%#x2F;%#x30;%#x31;%#x32;%#x33;%#x34;%#x35;%#x36;%#x37;%#x38;%#x39;%#x3A;%#x3B;%#x3C;%#x3D;%#x3E;%#x3F;%#x40;%#x41;%#x42;%#x43;%#x44;%#x45;%#x46;%#x47;%#x48;%#x49;%#x4A;%#x4B;%#x4C;%#x4D;%#x4E;%#x4F;%#x50;%#x51;%#x52;%#x53;%#x54;%#x55;%#x56;%#x57;%#x58;%#x59;%#x5A;%#x5B;%#x5C;%#x5D;%#x5E;%#x5F;%#x60;%#x61;%#x62;%#x63;%#x64;%#x65;%#x66;%#x67;%#x68;%#x69;%#x6A;%#x6B;%#x6C;%#x6D;%#x6E;%#x6F;%#x70;%#x71;%#x72;%#x73;%#x74;%#x75;%#x76;%#x77;%#x78;%#x79;%#x7A;%#x7B;%#x7C;%#x7D;%#x7E;%#x7F;%#x80;%#x81;%#x82;%#x83;%#x84;%#x85;%#x86;%#x87;%#x88;%#x89;%#x8A;%#x8B;%#x8C;%#x8D;%#x8E;%#x8F;%#x90;%#x91;%#x92;%#x93;%#x94;%#x95;%#x96;%#x97;%#x98;%#x99;%#x9A;%#x9B;%#x9C;%#x9D;%#x9E;%#x9F;%#xA0;%#xA1;%#xA2;%#xA3;%#xA4;%#xA5;%#xA6;%#xA7;%#xA8;%#xA9;%#xAA;%#xAB;%#xAC;%#xAD;%#xAE;%#xAF;%#xB0;%#xB1;%#xB2;%#xB3;%#xB4;%#xB5;%#xB6;%#xB7;%#xB8;%#xB9;%#xBA;%#xBB;%#xBC;%#xBD;%#xBE;%#xBF;%#xC0;%#xC1;%#xC2;%#xC3;%#xC4;%#xC5;%#xC6;%#xC7;%#xC8;%#xC9;%#xCA;%#xCB;%#xCC;%#xCD;%#xCE;%#xCF;%#xD0;%#xD1;%#xD2;%#xD3;%#xD4;%#xD5;%#xD6;%#xD7;%#xD8;%#xD9;%#xDA;%#xDB;%#xDC;%#xDD;%#xDE;%#xDF;%#xE0;%#xE1;%#xE2;%#xE3;%#xE4;%#xE5;%#xE6;%#xE7;%#xE8;%#xE9;%#xEA;%#xEB;%#xEC;%#xED;%#xEE;%#xEF;%#xF0;%#xF1;%#xF2;%#xF3;%#xF4;%#xF5;%#xF6;%#xF7;%#xF8;%#xF9;%#xFA;%#xFB;%#xFC;%#xFD;%#xFE;%#xFF;" />
+    <xs:element name="decEntities" type="xs:string" dfdl:initiator="%#0;%#1;%#2;%#3;%#4;%#5;%#6;%#7;%#8;%#9;%#10;%#11;%#12;%#13;%#14;%#15;%#16;%#17;%#18;%#19;%#20;%#21;%#22;%#23;%#24;%#25;%#26;%#27;%#28;%#29;%#30;%#31;%#32;%#33;%#34;%#35;%#36;%#37;%#38;%#39;%#40;%#41;%#42;%#43;%#44;%#45;%#46;%#47;%#48;%#49;%#50;%#51;%#52;%#53;%#54;%#55;%#56;%#57;%#58;%#59;%#60;%#61;%#62;%#63;%#64;%#65;%#66;%#67;%#68;%#69;%#70;%#71;%#72;%#73;%#74;%#75;%#76;%#77;%#78;%#79;%#80;%#81;%#82;%#83;%#84;%#85;%#86;%#87;%#88;%#89;%#90;%#91;%#92;%#93;%#94;%#95;%#96;%#97;%#98;%#99;%#100;%#101;%#102;%#103;%#104;%#105;%#106;%#107;%#108;%#109;%#110;%#111;%#112;%#113;%#114;%#115;%#116;%#117;%#118;%#119;%#120;%#121;%#122;%#123;%#124;%#125;%#126;%#127;%#128;%#129;%#130;%#131;%#132;%#133;%#134;%#135;%#136;%#137;%#138;%#139;%#140;%#141;%#142;%#143;%#144;%#145;%#146;%#147;%#148;%#149;%#150;%#151;%#152;%#153;%#154;%#155;%#156;%#157;%#158;%#159;%#160;%#161;%#162;%#163;%#164;%#165;%#166;%#167;%#168;%#169;%#170;%#171;%#172;%#173;%#174;%#175;%#176;%#177;%#178;%#179;%#180;%#181;%#182;%#183;%#184;%#185;%#186;%#187;%#188;%#189;%#190;%#191;%#192;%#193;%#194;%#195;%#196;%#197;%#198;%#199;%#200;%#201;%#202;%#203;%#204;%#205;%#206;%#207;%#208;%#209;%#210;%#211;%#212;%#213;%#214;%#215;%#216;%#217;%#218;%#219;%#220;%#221;%#222;%#223;%#224;%#225;%#226;%#227;%#228;%#229;%#230;%#231;%#232;%#233;%#234;%#235;%#236;%#237;%#238;%#239;%#240;%#241;%#242;%#243;%#244;%#245;%#246;%#247;%#248;%#249;%#250;%#251;%#252;%#253;%#254;%#255;" />
+
+  </tdml:defineSchema>
+
+  <tdml:parserTestCase name="allAsciiHexEntities" root="hexEntities" model="AllAsciiCodePointEntities">
+    <tdml:document>
+      <tdml:documentPart type="byte">00 01 02 03 04 05 06 07 08 09 0A 0B 0C 0D 0E 0F</tdml:documentPart>
+      <tdml:documentPart type="byte">10 11 12 13 14 15 16 17 18 19 1A 1B 1C 1D 1E 1F</tdml:documentPart>
+      <tdml:documentPart type="byte">20 21 22 23 24 25 26 27 28 29 2A 2B 2C 2D 2E 2F</tdml:documentPart>
+      <tdml:documentPart type="byte">30 31 32 33 34 35 36 37 38 39 3A 3B 3C 3D 3E 3F</tdml:documentPart>
+      <tdml:documentPart type="byte">40 41 42 43 44 45 46 47 48 49 4A 4B 4C 4D 4E 4F</tdml:documentPart>
+      <tdml:documentPart type="byte">50 51 52 53 54 55 56 57 58 59 5A 5B 5C 5D 5E 5F</tdml:documentPart>
+      <tdml:documentPart type="byte">60 61 62 63 64 65 66 67 68 69 6A 6B 6C 6D 6E 6F</tdml:documentPart>
+      <tdml:documentPart type="byte">70 71 72 73 74 75 76 77 78 79 7A 7B 7C 7D 7E 7F</tdml:documentPart>
+      <tdml:documentPart type="byte">80 81 82 83 84 85 86 87 88 89 8A 8B 8C 8D 8E 8F</tdml:documentPart>
+      <tdml:documentPart type="byte">90 91 92 93 94 95 96 97 98 99 9A 9B 9C 9D 9E 9F</tdml:documentPart>
+      <tdml:documentPart type="byte">A0 A1 A2 A3 A4 A5 A6 A7 A8 A9 AA AB AC AD AE AF</tdml:documentPart>
+      <tdml:documentPart type="byte">B0 B1 B2 B3 B4 B5 B6 B7 B8 B9 BA BB BC BD BE BF</tdml:documentPart>
+      <tdml:documentPart type="byte">C0 C1 C2 C3 C4 C5 C6 C7 C8 C9 CA CB CC CD CE CF</tdml:documentPart>
+      <tdml:documentPart type="byte">D0 D1 D2 D3 D4 D5 D6 D7 D8 D9 DA DB DC DD DE DF</tdml:documentPart>
+      <tdml:documentPart type="byte">E0 E1 E2 E3 E4 E5 E6 E7 E8 E9 EA EB EC ED EE EF</tdml:documentPart>
+      <tdml:documentPart type="byte">F0 F1 F2 F3 F4 F5 F6 F7 F8 F9 FA FB FC FD FE FF</tdml:documentPart>
+      <tdml:documentPart type="text">string</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <ex:hexEntities>string</ex:hexEntities>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="allAsciiDecEntities" root="decEntities" model="AllAsciiCodePointEntities">
+    <tdml:document>
+      <tdml:documentPart type="byte">00 01 02 03 04 05 06 07 08 09 0A 0B 0C 0D 0E 0F</tdml:documentPart>
+      <tdml:documentPart type="byte">10 11 12 13 14 15 16 17 18 19 1A 1B 1C 1D 1E 1F</tdml:documentPart>
+      <tdml:documentPart type="byte">20 21 22 23 24 25 26 27 28 29 2A 2B 2C 2D 2E 2F</tdml:documentPart>
+      <tdml:documentPart type="byte">30 31 32 33 34 35 36 37 38 39 3A 3B 3C 3D 3E 3F</tdml:documentPart>
+      <tdml:documentPart type="byte">40 41 42 43 44 45 46 47 48 49 4A 4B 4C 4D 4E 4F</tdml:documentPart>
+      <tdml:documentPart type="byte">50 51 52 53 54 55 56 57 58 59 5A 5B 5C 5D 5E 5F</tdml:documentPart>
+      <tdml:documentPart type="byte">60 61 62 63 64 65 66 67 68 69 6A 6B 6C 6D 6E 6F</tdml:documentPart>
+      <tdml:documentPart type="byte">70 71 72 73 74 75 76 77 78 79 7A 7B 7C 7D 7E 7F</tdml:documentPart>
+      <tdml:documentPart type="byte">80 81 82 83 84 85 86 87 88 89 8A 8B 8C 8D 8E 8F</tdml:documentPart>
+      <tdml:documentPart type="byte">90 91 92 93 94 95 96 97 98 99 9A 9B 9C 9D 9E 9F</tdml:documentPart>
+      <tdml:documentPart type="byte">A0 A1 A2 A3 A4 A5 A6 A7 A8 A9 AA AB AC AD AE AF</tdml:documentPart>
+      <tdml:documentPart type="byte">B0 B1 B2 B3 B4 B5 B6 B7 B8 B9 BA BB BC BD BE BF</tdml:documentPart>
+      <tdml:documentPart type="byte">C0 C1 C2 C3 C4 C5 C6 C7 C8 C9 CA CB CC CD CE CF</tdml:documentPart>
+      <tdml:documentPart type="byte">D0 D1 D2 D3 D4 D5 D6 D7 D8 D9 DA DB DC DD DE DF</tdml:documentPart>
+      <tdml:documentPart type="byte">E0 E1 E2 E3 E4 E5 E6 E7 E8 E9 EA EB EC ED EE EF</tdml:documentPart>
+      <tdml:documentPart type="byte">F0 F1 F2 F3 F4 F5 F6 F7 F8 F9 FA FB FC FD FE FF</tdml:documentPart>
+      <tdml:documentPart type="text">string</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <ex:decEntities>string</ex:decEntities>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
 </tdml:testSuite>

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section06/entities/TestEntities.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section06/entities/TestEntities.scala
@@ -119,4 +119,6 @@ class TestEntities {
   @Test def test_invalid_entity_06(): Unit = { runnerInvalid.runOneTest("text_invalid_entity_among_multiple_valid_combined") }
   @Test def test_invalid_entity_07(): Unit = { runnerInvalid.runOneTest("text_invalid_entity_escaped") }
 
+  @Test def test_allAsciiHexEntities(): Unit = { runner_01.runOneTest("allAsciiHexEntities") }
+  @Test def test_allAsciiDecEntities(): Unit = { runner_01.runOneTest("allAsciiDecEntities") }
 }


### PR DESCRIPTION
We sort of have a two-pass system for handling DFDL strings that contain
character entities related to delimiters. The first past converts
character entities to the character values, excluding things like
escaped percents and charater classes like NL, WSP, etc. The second pass
handles those excluded entities.

However, this first pass replaces the hex entity %#x25; (and
corresponding decimal entity) to a percent sign, which can then
interfere with the second pass, which should never see single percent
signs except for the exceptions mentioned above.

This modifies the first pass so that character entities that result in a
single percent are replaced with a double-percent. This will then be
converted to single precent used escaped-percent logic elsewhere.

This also has refactors related existing code to be more robust and
reduce duplication.

DAFFODIL-2479