### PR TITLE
Improve validation and diagnostics when reloading saved parsers

### DIFF
--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/DataProcessor.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/DataProcessor.scala
@@ -357,7 +357,14 @@ class DataProcessor private (
 
   def save(output: DFDL.Output): Unit = {
 
-    val oos = new ObjectOutputStream(new GZIPOutputStream(Channels.newOutputStream(output)))
+    val os = Channels.newOutputStream(output)
+
+    // write a null-terminated UTF-8 string as a simple version identifier
+    val headerString = "DAFFODIL " + Misc.getDaffodilVersion + "\u0000"
+    os.write(headerString.getBytes("utf-8"))
+
+    // serialize and compress the data processor to the outputstream
+    val oos = new ObjectOutputStream(new GZIPOutputStream(os))
 
     //
     // Make a copy of this object, so that our state mods below don't side-effect the user's object.


### PR DESCRIPTION
When saving a parser, write a NUL-terminated ASCII string of the form
`DAFFODIL <VERSION>` directly to the output stream prior to DataProcessor
serialization.

A benefit to writing directly to the head of the OutputStream is that
this avoids the gzip compression and Java serialization in the header,
making it simple to read and validate for compatibility. This also
allows a user to run `head -1z` on a saved parser to quickly determine
what version of Daffodil a saved parser is compatible with.

When reloading a saved parser, we check that the file starts with the
string `DAFFODIL `, and the following data up to a NUL-terminator
matches the current version of Daffodil. If they are the same, we assume
we are reloading with the same version of Daffodil used to save the
parser, and so they should be compatible.

However, we can't really control if a user swaps out incompatible
dependencies between save/reload, and we also don't really know which
versions of libraries are compatible. So this also improves detection
and diagnostics when a reload error occurs that most likely due to
dependency incompatibility. So if there are reload errors, it should
make the cause and resolution more clear.

DAFFODIL-2266