### PR TITLE
layering extension to support CRC, checksum, parity

### DIFF
--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/RuntimePropertyMixins.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/RuntimePropertyMixins.scala
@@ -67,7 +67,7 @@ import org.apache.daffodil.schema.annotation.props.gen.TextPadKind
 import org.apache.daffodil.schema.annotation.props.gen.YesNo
 import org.apache.daffodil.processors.LayerTransformEv
 import org.apache.daffodil.processors.LayerEncodingEv
-import org.apache.daffodil.processors.LayerLengthInBytesEv
+import org.apache.daffodil.processors.LayerLengthEv
 import org.apache.daffodil.processors.LayerBoundaryMarkEv
 import org.apache.daffodil.processors.LayerCharsetEv
 import org.apache.daffodil.schema.annotation.props.TextStandardExponentRepMixin
@@ -778,10 +778,10 @@ trait LayeringRuntimeValuedPropertiesMixin
     ExpressionCompilers.JLong.compileProperty(qn, NodeInfo.Long, layerLengthRaw, decl, dpathCompileInfo)
   }
 
-  final lazy val maybeLayerLengthInBytesEv = {
+  final lazy val maybeLayerLengthEv = {
     if (optionLayerLengthRaw.isDefined) {
       layerLengthUnits
-      val ev = new LayerLengthInBytesEv(layerLengthExpr, tci)
+      val ev = new LayerLengthEv(layerLengthExpr, tci)
       ev.compile(tunable)
       One(ev)
     } else {

--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/SequenceGroup.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/SequenceGroup.scala
@@ -229,10 +229,10 @@ abstract class SequenceGroupTermBase(
         maybeLayerTransformEv.get,
         maybeLayerCharsetEv,
         Maybe.toMaybe(optionLayerLengthKind),
-        maybeLayerLengthInBytesEv,
+        maybeLayerLengthEv,
         Maybe.toMaybe(optionLayerLengthUnits),
         maybeLayerBoundaryMarkEv,
-        dpathCompileInfo)
+        sequenceRuntimeData)
       lt.compile(tunable)
       Maybe.One(lt)
     }

--- a/daffodil-io/src/main/scala/org/apache/daffodil/io/DirectOrBufferedDataOutputStream.scala
+++ b/daffodil-io/src/main/scala/org/apache/daffodil/io/DirectOrBufferedDataOutputStream.scala
@@ -36,7 +36,10 @@ import org.apache.daffodil.util.Misc
  * This simple extension just gives us a public method for access to the underlying byte array.
  * That way we don't have to make a copy just to access the bytes.
  */
-private[io] class ByteArrayOutputStreamWithGetBuf() extends java.io.ByteArrayOutputStream {
+class ByteArrayOutputStreamWithGetBuf() extends java.io.ByteArrayOutputStream {
+  def setBuf(bufArg: Array[Byte]) : Unit = {
+    buf = bufArg
+  }
   def getBuf = buf
 }
 

--- a/daffodil-io/src/main/scala/org/apache/daffodil/io/InputSourceDataInputStream.scala
+++ b/daffodil-io/src/main/scala/org/apache/daffodil/io/InputSourceDataInputStream.scala
@@ -189,7 +189,8 @@ final class InputSourceDataInputStream private(val inputSource: InputSource)
 
   def getByteArray(bitLengthFrom1: Int, finfo: FormatInfo, array: Array[Byte]): Unit = {
     // threadCheck()
-    if (!isDefinedForLength(bitLengthFrom1)) throw DataInputStream.NotEnoughDataException(bitLengthFrom1)
+    if (!isDefinedForLength(bitLengthFrom1))
+      throw DataInputStream.NotEnoughDataException(bitLengthFrom1)
 
     val bytesNeeded = (bitLengthFrom1 + 7) / 8
     Assert.usage(array.size >= bytesNeeded)

--- a/daffodil-lib/src/main/scala/org/apache/daffodil/util/ByteBufferOutputStream.scala
+++ b/daffodil-lib/src/main/scala/org/apache/daffodil/util/ByteBufferOutputStream.scala
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.daffodil.util
+
+import java.io.OutputStream
+import java.nio.ByteBuffer
+
+/**
+ * Provides OutputStream API, buf fills in a finite-sized ByteBuffer.
+ *
+ * Overflowing the capacity of the byte buffer throws an exception.
+ *
+ * @param bb The ByteBuffer to be filled in.
+ */
+class ByteBufferOutputStream(val byteBuffer: ByteBuffer)
+ extends OutputStream {
+
+  byteBuffer.limit(byteBuffer.capacity())
+
+  def write(b: Int) = byteBuffer.put(b.toByte)
+
+  def size() = byteBuffer.position()
+}

--- a/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/processors/unparsers/LayeredSequenceUnparser.scala
+++ b/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/processors/unparsers/LayeredSequenceUnparser.scala
@@ -18,7 +18,6 @@
 package org.apache.daffodil.processors.unparsers
 
 import org.apache.daffodil.processors.LayerTransformerEv
-import org.apache.daffodil.io.DirectOrBufferedDataOutputStream
 import org.apache.daffodil.processors.SequenceRuntimeData
 
 class LayeredSequenceUnparser(ctxt: SequenceRuntimeData,
@@ -36,18 +35,16 @@ class LayeredSequenceUnparser(ctxt: SequenceRuntimeData,
     val originalDOS = state.dataOutputStream // layer will output to the original, then finish it upon closing.
 
     val newDOS = originalDOS.addBuffered // newDOS is where unparsers after this one returns will unparse into.
-
-    //
-    // FIXME: Cast should not be necessary
     //
     // New layerDOS is where the layer will unparse into. Ultimately anything written
     // to layerDOS ends up, post transform, in originalDOS.
     //
-    val layerDOS = layerTransformer.addLayer(originalDOS, state).asInstanceOf[DirectOrBufferedDataOutputStream]
+    val layerDOS = layerTransformer.addLayer(originalDOS, state)
 
     // unparse the layer body into layerDOS
     state.dataOutputStream = layerDOS
     super.unparse(state)
+    layerTransformer.endLayerForUnparse(state)
 
     // now we're done with the layer, so finalize the layer
     layerDOS.lastInChain.setFinished(state)

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/layers/AISTransformer.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/layers/AISTransformer.scala
@@ -22,12 +22,13 @@ import org.apache.daffodil.schema.annotation.props.gen.LayerLengthKind
 import org.apache.daffodil.schema.annotation.props.gen.LayerLengthUnits
 import org.apache.daffodil.util.Maybe
 import org.apache.daffodil.util.MaybeInt
-import org.apache.daffodil.processors.LayerLengthInBytesEv
+import org.apache.daffodil.processors.LayerLengthEv
 import org.apache.daffodil.processors.LayerBoundaryMarkEv
 import org.apache.daffodil.processors.LayerCharsetEv
 import org.apache.daffodil.processors.parsers.PState
 import org.apache.daffodil.processors.unparsers.UState
 import org.apache.daffodil.processors.charset.BitsCharsetAISPayloadArmoring
+
 import java.nio._
 import java.nio.charset._
 import java.io._
@@ -44,7 +45,7 @@ import org.apache.daffodil.schema.annotation.props.gen.EncodingErrorPolicy
 import org.apache.daffodil.schema.annotation.props.gen.UTF16Width
 import org.apache.daffodil.processors.charset.BitsCharsetDecoder
 import org.apache.daffodil.processors.charset.BitsCharsetEncoder
-import org.apache.daffodil.dsom.DPathCompileInfo
+import org.apache.daffodil.processors.SequenceRuntimeData
 
 object AISPayloadArmoringTransformer {
   val iso8859 = StandardCharsets.ISO_8859_1
@@ -164,10 +165,10 @@ object AISPayloadArmoringTransformerFactory
   override def newInstance(
     maybeLayerCharsetEv: Maybe[LayerCharsetEv],
     maybeLayerLengthKind: Maybe[LayerLengthKind],
-    maybeLayerLengthInBytesEv: Maybe[LayerLengthInBytesEv],
+    maybeLayerLengthEv: Maybe[LayerLengthEv],
     maybeLayerLengthUnits: Maybe[LayerLengthUnits],
     maybeLayerBoundaryMarkEv: Maybe[LayerBoundaryMarkEv],
-    tci: DPathCompileInfo): LayerTransformer = {
+    srd: SequenceRuntimeData) = {
 
     val xformer = new AISPayloadArmoringTransformer()
     xformer

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/layers/Base64Transformer.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/layers/Base64Transformer.scala
@@ -20,18 +20,19 @@ package org.apache.daffodil.layers
 import org.apache.daffodil.schema.annotation.props.gen.LayerLengthKind
 import org.apache.daffodil.schema.annotation.props.gen.LayerLengthUnits
 import org.apache.daffodil.util.Maybe
-import org.apache.daffodil.processors.LayerLengthInBytesEv
+import org.apache.daffodil.processors.LayerLengthEv
 import org.apache.daffodil.processors.LayerBoundaryMarkEv
 import org.apache.daffodil.processors.LayerCharsetEv
 import org.apache.daffodil.io.BoundaryMarkLimitingStream
 import org.apache.daffodil.processors.parsers.PState
 import org.apache.daffodil.processors.charset.BitsCharsetJava
+
 import java.nio.charset.Charset
 import org.apache.daffodil.processors.charset.BitsCharset
 import org.apache.daffodil.exceptions.Assert
 import org.apache.daffodil.processors.unparsers.UState
 import org.apache.daffodil.io.LayerBoundaryMarkInsertingJavaOutputStream
-import org.apache.daffodil.dsom.DPathCompileInfo
+import org.apache.daffodil.processors.SequenceRuntimeData
 
 class Base64MIMETransformer(layerCharsetEv: LayerCharsetEv, layerBoundaryMarkEv: LayerBoundaryMarkEv)
   extends LayerTransformer() {
@@ -67,6 +68,7 @@ class Base64MIMETransformer(layerCharsetEv: LayerCharsetEv, layerBoundaryMarkEv:
     val newJOS = new LayerBoundaryMarkInsertingJavaOutputStream(jos, layerBoundaryMark, javaCharset)
     newJOS
   }
+
 }
 
 object Base64MIMETransformerFactory
@@ -75,25 +77,25 @@ object Base64MIMETransformerFactory
   override def newInstance(
     maybeLayerCharsetEv: Maybe[LayerCharsetEv],
     maybeLayerLengthKind: Maybe[LayerLengthKind],
-    maybeLayerLengthInBytesEv: Maybe[LayerLengthInBytesEv],
+    maybeLayerLengthEv: Maybe[LayerLengthEv],
     maybeLayerLengthUnits: Maybe[LayerLengthUnits],
     maybeLayerBoundaryMarkEv: Maybe[LayerBoundaryMarkEv],
-    tci: DPathCompileInfo): LayerTransformer = {
+    srd: SequenceRuntimeData) = {
 
-    tci.schemaDefinitionUnless(
+    srd.schemaDefinitionUnless(
       scala.util.Properties.isJavaAtLeast("1.8"),
       "Base64 layer support requires Java 8 (aka Java 1.8).")
 
-    tci.schemaDefinitionUnless(
+    srd.schemaDefinitionUnless(
       maybeLayerBoundaryMarkEv.isDefined,
       "Property dfdlx:layerBoundaryMark was not defined.")
-    tci.schemaDefinitionUnless(
+    srd.schemaDefinitionUnless(
       maybeLayerLengthKind.isEmpty ||
         (maybeLayerLengthKind.get eq LayerLengthKind.BoundaryMark),
       "Only dfdlx:layerLengthKind 'boundaryMark' is supported, but '%s' was specified",
       maybeLayerLengthKind.get.toString)
 
-    tci.schemaDefinitionUnless(
+    srd.schemaDefinitionUnless(
       maybeLayerCharsetEv.isDefined,
       "Property dfdlx:layerEncoding must be defined.")
 

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/layers/GZipTransformer.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/layers/GZipTransformer.scala
@@ -20,15 +20,15 @@ package org.apache.daffodil.layers
 import org.apache.daffodil.schema.annotation.props.gen.LayerLengthKind
 import org.apache.daffodil.schema.annotation.props.gen.LayerLengthUnits
 import org.apache.daffodil.util.Maybe
-import org.apache.daffodil.processors.LayerLengthInBytesEv
+import org.apache.daffodil.processors.LayerLengthEv
 import org.apache.daffodil.processors.LayerBoundaryMarkEv
 import org.apache.daffodil.processors.LayerCharsetEv
 import org.apache.daffodil.processors.parsers.PState
 import org.apache.daffodil.io.ExplicitLengthLimitingStream
 import org.apache.daffodil.processors.unparsers.UState
-import org.apache.daffodil.dsom.DPathCompileInfo
+import org.apache.daffodil.processors.SequenceRuntimeData
 
-class GZIPTransformer(layerLengthInBytesEv: LayerLengthInBytesEv)
+class GZIPTransformer(layerLengthEv: LayerLengthEv)
   extends LayerTransformer() {
 
   override def wrapLayerDecoder(jis: java.io.InputStream) = {
@@ -37,7 +37,7 @@ class GZIPTransformer(layerLengthInBytesEv: LayerLengthInBytesEv)
   }
 
   override def wrapLimitingStream(jis: java.io.InputStream, state: PState) = {
-    val layerLengthInBytes: Int = layerLengthInBytesEv.evaluate(state).toInt
+    val layerLengthInBytes: Int = layerLengthEv.evaluate(state).toInt
     val s = new ExplicitLengthLimitingStream(jis, layerLengthInBytes)
     s
   }
@@ -60,12 +60,12 @@ object GZIPTransformerFactory
   override def newInstance(
     maybeLayerCharsetEv: Maybe[LayerCharsetEv],
     maybeLayerLengthKind: Maybe[LayerLengthKind],
-    maybeLayerLengthInBytesEv: Maybe[LayerLengthInBytesEv],
+    maybeLayerLengthEv: Maybe[LayerLengthEv],
     maybeLayerLengthUnits: Maybe[LayerLengthUnits],
     maybeLayerBoundaryMarkEv: Maybe[LayerBoundaryMarkEv],
-    tci: DPathCompileInfo): LayerTransformer = {
+    srd: SequenceRuntimeData) = {
 
-    val xformer = new GZIPTransformer(maybeLayerLengthInBytesEv.get)
+    val xformer = new GZIPTransformer(maybeLayerLengthEv.get)
     xformer
   }
 }

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/layers/LineFoldedTransformer.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/layers/LineFoldedTransformer.scala
@@ -20,20 +20,22 @@ package org.apache.daffodil.layers
 import org.apache.daffodil.schema.annotation.props.gen.LayerLengthKind
 import org.apache.daffodil.schema.annotation.props.gen.LayerLengthUnits
 import org.apache.daffodil.util.Maybe
-import org.apache.daffodil.processors.LayerLengthInBytesEv
+import org.apache.daffodil.processors.LayerLengthEv
 import org.apache.daffodil.processors.LayerBoundaryMarkEv
 import org.apache.daffodil.processors.LayerCharsetEv
 import org.apache.daffodil.processors.parsers.PState
+
 import java.nio.charset.StandardCharsets
 import org.apache.daffodil.exceptions.Assert
 import org.apache.daffodil.processors.unparsers.UState
 import org.apache.daffodil.io.LayerBoundaryMarkInsertingJavaOutputStream
+
 import java.io.OutputStream
 import java.io.InputStream
 import org.apache.daffodil.exceptions.ThrowsSDE
 import org.apache.daffodil.schema.annotation.props.Enum
 import org.apache.daffodil.io.RegexLimitingStream
-import org.apache.daffodil.dsom.DPathCompileInfo
+import org.apache.daffodil.processors.SequenceRuntimeData
 
 /*
  * This and related classes implement so called "line folding" from
@@ -158,12 +160,12 @@ sealed abstract class LineFoldedTransformerFactory(mode: LineFoldMode, name: Str
   override def newInstance(
     maybeLayerCharsetEv: Maybe[LayerCharsetEv],
     maybeLayerLengthKind: Maybe[LayerLengthKind],
-    maybeLayerLengthInBytesEv: Maybe[LayerLengthInBytesEv],
+    maybeLayerLengthEv: Maybe[LayerLengthEv],
     maybeLayerLengthUnits: Maybe[LayerLengthUnits],
     maybeLayerBoundaryMarkEv: Maybe[LayerBoundaryMarkEv],
-    tci: DPathCompileInfo): LayerTransformer = {
+    srd: SequenceRuntimeData) = {
 
-    tci.schemaDefinitionUnless(
+    srd.schemaDefinitionUnless(
       maybeLayerLengthKind.isDefined,
       "The property dfdlx:layerLengthKind must be defined.")
 
@@ -176,7 +178,7 @@ sealed abstract class LineFoldedTransformerFactory(mode: LineFoldMode, name: Str
           new LineFoldedTransformerImplicit(mode)
         }
         case x =>
-          tci.SDE(
+          srd.SDE(
             "Property dfdlx:layerLengthKind can only be 'implicit' or 'boundaryMark', but was '%s'",
             x.toString)
       }

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/EvLayering.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/EvLayering.scala
@@ -42,7 +42,7 @@ final class LayerEncodingEv(override val expr: CompiledExpression[String], tci: 
 final class LayerCharsetEv(layerEncodingEv: LayerEncodingEv, override val ci: DPathCompileInfo)
   extends CharsetEvBase(layerEncodingEv, ci)
 
-final class LayerLengthInBytesEv(override val expr: CompiledExpression[JLong], override val ci: DPathCompileInfo)
+final class LayerLengthEv(override val expr: CompiledExpression[JLong], override val ci: DPathCompileInfo)
   extends EvaluatableExpression[JLong](
     expr,
     ci)
@@ -70,16 +70,16 @@ final class LayerTransformerEv(
   layerTransformEv: LayerTransformEv,
   maybeLayerCharsetEv: Maybe[LayerCharsetEv],
   maybeLayerLengthKind: Maybe[LayerLengthKind],
-  maybeLayerLengthInBytesEv: Maybe[LayerLengthInBytesEv],
+  maybeLayerLengthEv: Maybe[LayerLengthEv],
   maybeLayerLengthUnits: Maybe[LayerLengthUnits],
   maybeLayerBoundaryMarkEv: Maybe[LayerBoundaryMarkEv],
-  ci: DPathCompileInfo)
-  extends Evaluatable[LayerTransformer](ci)
+  srd: SequenceRuntimeData)
+  extends Evaluatable[LayerTransformer](srd.dpathCompileInfo)
   with NoCacheEvaluatable[LayerTransformer] {
 
   override lazy val runtimeDependencies = layerTransformEv +:
     (maybeLayerCharsetEv.toList ++
-      maybeLayerLengthInBytesEv.toList ++
+      maybeLayerLengthEv.toList ++
       maybeLayerBoundaryMarkEv.toList)
 
   /**
@@ -92,10 +92,10 @@ final class LayerTransformerEv(
     val xformer = factory.newInstance(
       maybeLayerCharsetEv,
       maybeLayerLengthKind,
-      maybeLayerLengthInBytesEv,
+      maybeLayerLengthEv,
       maybeLayerLengthUnits,
       maybeLayerBoundaryMarkEv,
-      ci)
+      srd)
     xformer
   }
 }

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/VariableMap1.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/VariableMap1.scala
@@ -197,7 +197,7 @@ class VariableCircularDefinition(qname: NamedQName, context: VariableRuntimeData
  * Needed so that when unparsing multiple clones of a UState can share
  * and modify, the same VMap.
  *
- * This is a new mechanism, which allows for less rel-allocation of VariableMaps.
+ * This is a new mechanism, which allows for less re-allocation of VariableMaps.
  * There's a box that the variable map lives in, called vbox for convention.
  * by having two UState items point to the same vbox they can share the
  * variables. This is fine for unparsing, because all shared uses are not

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/PState.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/PState.scala
@@ -63,6 +63,7 @@ import org.apache.daffodil.util.Poolable
 import org.apache.daffodil.infoset.DIComplexState
 import org.apache.daffodil.infoset.DISimpleState
 import org.apache.daffodil.exceptions.Abort
+import org.apache.daffodil.exceptions.ThrowsSDE
 import org.apache.daffodil.infoset.DataValue.DataValuePrimitive
 import org.apache.daffodil.xml.GlobalQName
 
@@ -327,9 +328,14 @@ final class PState private (
     this.infoset = newParent
   }
 
-  def setVariable(vrd: VariableRuntimeData, newValue: DataValuePrimitive, referringContext: VariableRuntimeData): Unit = {
+  def setVariable(vrd: VariableRuntimeData, newValue: DataValuePrimitive, referringContext: ThrowsSDE): Unit = {
     variableMap.setVariable(vrd, newValue, referringContext, this)
     changedVariablesStack.top += vrd.globalQName
+  }
+
+  def getVariable(vrd: VariableRuntimeData, referringContext: ThrowsSDE): DataValuePrimitive = {
+    val res = variableMap.readVariable(vrd, referringContext, this)
+    res
   }
 
   /**

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/unparsers/UState.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/unparsers/UState.scala
@@ -33,6 +33,7 @@ import org.apache.daffodil.infoset.DIArray
 import org.apache.daffodil.infoset.DIDocument
 import org.apache.daffodil.infoset.DIElement
 import org.apache.daffodil.infoset.DINode
+import org.apache.daffodil.infoset.DataValue.DataValuePrimitive
 import org.apache.daffodil.infoset.InfosetAccessor
 import org.apache.daffodil.infoset.InfosetInputter
 import org.apache.daffodil.io.DirectOrBufferedDataOutputStream
@@ -50,6 +51,7 @@ import org.apache.daffodil.processors.TermRuntimeData
 import org.apache.daffodil.processors.UnparseResult
 import org.apache.daffodil.processors.VariableBox
 import org.apache.daffodil.processors.VariableMap
+import org.apache.daffodil.processors.VariableRuntimeData
 import org.apache.daffodil.processors.charset.BitsCharset
 import org.apache.daffodil.processors.charset.BitsCharsetDecoder
 import org.apache.daffodil.processors.charset.BitsCharsetEncoder
@@ -73,6 +75,21 @@ abstract class UState(
   areDebugging: Boolean)
   extends ParseOrUnparseState(vbox, diagnosticsArg, dataProcArg, tunable)
   with Cursor[InfosetAccessor] with ThrowsSDE with SavesErrorsAndWarnings {
+
+  final def setVariable(vrd: VariableRuntimeData, newValue: DataValuePrimitive, referringContext: ThrowsSDE) =
+    vbox.vmap.setVariable(vrd, newValue, referringContext, this)
+
+  /**
+   * For unparsing, this throws a RetryableException in the case where the variable cannot (yet) be read.
+   *
+   * @param vrd Identifies the variable to read.
+   * @param referringContext Where to place blame if there is an error.
+   * @return The data value of the variable, or throws exceptions if there is no value.
+   */
+  final def getVariable(vrd: VariableRuntimeData, referringContext: ThrowsSDE): DataValuePrimitive =
+    vbox.vmap.readVariable(vrd, referringContext, this)
+
+
 
   /**
    * Push onto the dynamic TRD context stack

--- a/daffodil-test/src/test/resources/org/apache/daffodil/layers/IPv4.dfdl.xsd
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/layers/IPv4.dfdl.xsd
@@ -1,0 +1,155 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/"
+           xmlns:dfdlx="http://www.ogf.org/dfdl/dfdl-1.0/extensions"
+           xmlns:fn="http://www.w3.org/2005/xpath-functions"
+           xmlns:daf="urn:ogf:dfdl:2013:imp:daffodil.apache.org:2018:ext"
+           xmlns:chksum="urn:org.apache.daffodil.layers.IPv4Checksum"
+           xmlns:tns="urn:org.apache.daffodil.layers.IPv4"
+           targetNamespace="urn:org.apache.daffodil.layers.IPv4" >
+
+  <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+
+  <xs:import namespace="urn:org.apache.daffodil.layers.IPv4Checksum"
+             schemaLocation="org/apache/daffodil/layers/xsd/IPv4ChecksumLayer.dfdl.xsd"/>
+
+  <xs:annotation>
+    <xs:appinfo source="http://www.ogf.org/dfdl/">
+      <dfdl:defineFormat name="basicBigEndianBinary">
+        <dfdl:format
+          ref="tns:GeneralFormat"
+          representation="binary"
+          binaryNumberRep="binary"
+          byteOrder="bigEndian"
+          bitOrder="mostSignificantBitFirst"
+          alignmentUnits="bits"
+          alignment="1"
+          occursCountKind="implicit"
+          lengthUnits="bits"/>
+      </dfdl:defineFormat>
+      <dfdl:format ref="tns:basicBigEndianBinary"/>
+    </xs:appinfo>
+  </xs:annotation>
+
+  <xs:element name="IPv4Header" type="tns:IPv4Header"/>
+
+  <xs:complexType name="IPv4Header">
+    <!--
+    Modified with proposed checksum computation via layer transform
+    -->
+    <xs:sequence>
+      <xs:annotation>
+        <xs:appinfo source="http://www.ogf.org/dfdl/">
+          <!--
+          The checksum field in an IPv4 actually lives in the middle of the
+          data that it is a checksum of.
+
+          That is, some of the 16-bit words going into the checksum are before
+          the checksum itself, others are after.
+
+          At parse time we must check that this computed checksum value, and the
+          actual value of the element in the infoset are equal.
+
+          We have an option to place the computed checksum in another element
+          and then have a schematron validation rule or just a DFDL assert (recoverable)
+          check that the checksum element and computed checksum are equal.
+
+          Below, that element is called "ComputedChecksum".
+
+          When unparsing, the infoset contains a checksum, which remains in the infoset, but
+          it is overwritten (in the layer transform) by the recomputed checksum available for comparison purposes in
+          the ComputedChecksum variable.
+          -->
+          <dfdl:newVariableInstance ref="chksum:IPv4Checksum"/>
+        </xs:appinfo>
+      </xs:annotation>
+
+      <xs:sequence dfdl:ref="chksum:IPv4ChecksumLayer">
+        <xs:sequence>
+        <xs:element name="Version" type="tns:bit" dfdl:length="4"/>
+        <xs:element name="IHL" type="tns:bit" dfdl:length="4"/>
+        <xs:element name="DSCP" type="tns:bit" dfdl:length="6"/>
+        <xs:element name="ECN" type="tns:bit" dfdl:length="2"/>
+        <xs:element name="Length" type="tns:bit" dfdl:length="16"
+          dfdl:outputValueCalc='{ ../FakeData }'/>
+        <xs:element name="Identification" type="tns:bit" dfdl:length="16"/>
+        <xs:element name="Flags" type="tns:bit" dfdl:length="3"/>
+        <xs:element name="FragmentOffset" type="tns:bit" dfdl:length="13"/>
+        <xs:element name="TTL" type="tns:bit" dfdl:length="8"/>
+        <xs:element name="Protocol" type="tns:bit" dfdl:length="8"/>
+        <xs:element name="Checksum" type="chksum:IPv4Checksum"/>
+        <xs:element name="IPSrc" type="tns:hexByte" dfdl:length="4"/>
+        <xs:element name="IPDest" type="tns:hexByte" dfdl:length="4"/>
+      </xs:sequence>
+      </xs:sequence>
+      <!--
+      This exists purely to make unparsing of the header suspend when trying to unparse
+      the Length element.
+
+      We just want the tests to rule out deadlock in this case.
+      -->
+      <xs:element name="FakeData" type="tns:bit"
+                  dfdl:inputValueCalc='{ ../Length }'/>
+      <!--
+      We want the schema author to have all options on what to do if the
+      checksum is incorrect when parsing. Hence, we just put the computed value
+      into this element.
+      -->
+      <xs:element name="ComputedChecksum" type="chksum:IPv4Checksum"
+                  dfdl:inputValueCalc='{ $chksum:IPv4Checksum }'/>
+      <!--
+      One recommendation is to treat incorrect checksum values as a validation
+      error. This preserves the ability to use the schema forensically to examine
+      data with incorrect checksums.
+
+      This uses a DFDL recoverable error assertion to report that the
+      checksum is incorrect. A recoverable error assert is not technically
+      a validation error, but behaves similarly in that it does not prevent the
+      parse from completing. It is essentially a warning about the data.
+
+      A schematron check would accomplish much the same thing, with the
+      advantage that the error would be reported as an "official" validation error.
+      -->
+      <xs:sequence>
+        <xs:annotation>
+          <xs:appinfo source="http://www.ogf.org/dfdl/">
+            <dfdl:assert
+              failureType="recoverableError"
+              message="Incorrect checksum."
+              test='{ Checksum eq ComputedChecksum }'
+            />
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:sequence>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:simpleType name="bit"
+                 dfdl:lengthKind="explicit"
+                 dfdl:lengthUnits="bits">
+    <xs:restriction base="xs:unsignedInt"/>
+  </xs:simpleType>
+
+  <xs:simpleType name="hexByte" dfdl:lengthKind="explicit" dfdl:lengthUnits="bytes">
+    <xs:restriction base="xs:hexBinary"/>
+  </xs:simpleType>
+
+
+</xs:schema>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/layers/IPv4.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/layers/IPv4.tdml
@@ -1,0 +1,209 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<tdml:testSuite
+  xmlns:tdml="http://www.ibm.com/xmlns/dfdl/testData"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/"
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns:fn="http://www.w3.org/2005/xpath-functions"
+  xmlns:dfdlx="http://www.ogf.org/dfdl/dfdl-1.0/extensions"
+  xmlns:ipv4="urn:org.apache.daffodil.layers.IPv4"
+  xmlns:chksum="urn:org.apache.daffodil.layers.IPv4Checksum"
+  xmlns:ex="http://example.com"
+  xmlns:tns="http://example.com"
+  defaultRoundTrip="none">
+
+
+  <tdml:parserTestCase name="IPv4_1" root="IPv4Header" model="org/apache/daffodil/layers/IPv4.dfdl.xsd"
+    roundTrip="none">
+    <tdml:document>
+      <!--
+      see https://en.wikipedia.org/wiki/IPv4_header_checksum
+      for working through the details of this IPv4 Header
+
+      The first line of 5 words is the part 1 of the header
+      The second line is the checksum
+      The third line of 4 words is the part 2 of the header (src, dest addresses)
+      -->
+      <tdml:documentPart type="byte"><![CDATA[
+4500 0073 0000 4000 4011
+b861
+c0a8 0001 c0a8 00c7
+       ]]></tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <ipv4:IPv4Header>
+          <Version>4</Version>
+          <IHL>5</IHL>
+          <DSCP>0</DSCP>
+          <ECN>0</ECN>
+          <Length>115</Length>
+          <Identification>0</Identification>
+          <Flags>2</Flags>
+          <FragmentOffset>0</FragmentOffset>
+          <TTL>64</TTL>
+          <Protocol>17</Protocol>
+          <Checksum>47201</Checksum>
+          <IPSrc>C0A80001</IPSrc>
+          <IPDest>C0A800C7</IPDest>
+          <FakeData>115</FakeData>
+          <ComputedChecksum>47201</ComputedChecksum>
+        </ipv4:IPv4Header>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="IPv4_1e" root="IPv4Header"  model="org/apache/daffodil/layers/IPv4.dfdl.xsd"
+                       roundTrip="none">
+    <tdml:document>
+      <!-- Will get not enough data error from the layer -->
+      <tdml:documentPart type="byte"><![CDATA[
+4500
+       ]]></tdml:documentPart>
+    </tdml:document>
+    <tdml:errors>
+      <tdml:error>Parse Error</tdml:error>
+      <tdml:error>Insufficient bits</tdml:error>
+      <tdml:error>160</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="IPv4_2" root="IPv4Header" model="org/apache/daffodil/layers/IPv4.dfdl.xsd"
+                       roundTrip="none">
+    <tdml:document>
+      <!--
+      similar, but the data has a 1 in the indentification which
+      makes the stored checksum in the middle of the data incorrect.
+      -->
+      <tdml:documentPart type="byte"><![CDATA[
+4500 0073 0001 4000 4011
+b861
+c0a8 0001 c0a8 00c7
+       ]]></tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <ipv4:IPv4Header>
+          <Version>4</Version>
+          <IHL>5</IHL>
+          <DSCP>0</DSCP>
+          <ECN>0</ECN>
+          <Length>115</Length>
+          <Identification>1</Identification>
+          <Flags>2</Flags>
+          <FragmentOffset>0</FragmentOffset>
+          <TTL>64</TTL>
+          <Protocol>17</Protocol>
+          <Checksum>47201</Checksum>
+          <IPSrc>C0A80001</IPSrc>
+          <IPDest>C0A800C7</IPDest>
+          <FakeData>115</FakeData>
+          <ComputedChecksum>47200</ComputedChecksum>
+        </ipv4:IPv4Header>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+    <tdml:warnings>
+      <tdml:warning>Assertion Incorrect checksum</tdml:warning>
+    </tdml:warnings>
+  </tdml:parserTestCase>
+
+
+  <tdml:unparserTestCase name="IPv4_1u" root="IPv4Header" model="org/apache/daffodil/layers/IPv4.dfdl.xsd"
+                       roundTrip="none">
+    <tdml:document>
+      <!--
+      see https://en.wikipedia.org/wiki/IPv4_header_checksum
+      for working through the details of this IPv4 Header
+
+      The first line of 5 words is the part 1 of the header
+      The second line is the checksum
+      The third line of 4 words is the part 2 of the header (src, dest addresses)
+      -->
+      <tdml:documentPart type="byte"><![CDATA[
+4500 0073 0000 4000 4011
+b861
+c0a8 0001 c0a8 00c7
+       ]]></tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <ipv4:IPv4Header>
+          <Version>4</Version>
+          <IHL>5</IHL>
+          <DSCP>0</DSCP>
+          <ECN>0</ECN>
+          <Length>115</Length>
+          <Identification>0</Identification>
+          <Flags>2</Flags>
+          <FragmentOffset>0</FragmentOffset>
+          <TTL>64</TTL>
+          <Protocol>17</Protocol>
+          <Checksum>47201</Checksum>
+          <IPSrc>C0A80001</IPSrc>
+          <IPDest>C0A800C7</IPDest>
+          <FakeData>115</FakeData>
+          <ComputedChecksum>0</ComputedChecksum> <!-- ignored when unparsing -->
+        </ipv4:IPv4Header>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:unparserTestCase>
+
+  <tdml:unparserTestCase name="IPv4_2u" root="IPv4Header" model="org/apache/daffodil/layers/IPv4.dfdl.xsd"
+                         roundTrip="none">
+    <tdml:document>
+      <!--
+      see https://en.wikipedia.org/wiki/IPv4_header_checksum
+      for working through the details of this IPv4 Header
+
+      The first line of 5 words is the part 1 of the header
+      The second line is the checksum
+      The third line of 4 words is the part 2 of the header (src, dest addresses)
+      -->
+      <tdml:documentPart type="byte"><![CDATA[
+4500 0073 0001 4000 4011
+b860
+c0a8 0001 c0a8 00c7
+       ]]></tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <ipv4:IPv4Header>
+          <Version>4</Version>
+          <IHL>5</IHL>
+          <DSCP>0</DSCP>
+          <ECN>0</ECN>
+          <Length>115</Length>
+          <Identification>1</Identification><!-- changed to 1 -->
+          <Flags>2</Flags>
+          <FragmentOffset>0</FragmentOffset>
+          <TTL>64</TTL>
+          <Protocol>17</Protocol>
+          <Checksum>0</Checksum><!-- will be recomputed on unparse -->
+          <IPSrc>C0A80001</IPSrc>
+          <IPDest>C0A800C7</IPDest>
+          <FakeData>115</FakeData>
+          <ComputedChecksum>0</ComputedChecksum><!-- ignored unparsing -->
+        </ipv4:IPv4Header>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:unparserTestCase>
+
+
+
+</tdml:testSuite>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/layers/TestCheckDigit.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/layers/TestCheckDigit.tdml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<testSuite
+  xmlns="http://www.ibm.com/xmlns/dfdl/testData"
+  xmlns:tdml="http://www.ibm.com/xmlns/dfdl/testData"
+  suiteName="checkDigit" description="checkDigit layer tests"
+  xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/"
+  xmlns:fn="http://www.w3.org/2005/xpath-functions" 
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:ex="http://example.com"
+  xmlns:cd="urn:org.apache.daffodil.layers.checkDigit"
+  defaultRoundTrip="onePass">
+
+  <!--
+  The check digit is the result of taking all digits 0-9 of the layer data, adding them together, and taking only the least-significant digit of the resulting sum.
+
+  Example: for 10:22:18.234 The sum is 23, so the check-digit is 3.
+  -->
+
+  <parserTestCase name="test_checkDigit_01" root="r" model="checkDigit.dfdl.xsd">
+    <document>2021-09-25:1</document>
+    <infoset><dfdlInfoset>
+      <ex:r xmlns="">
+       <value>2021-09-25</value>
+       <checkDigit>1</checkDigit>
+       <computedCheckDigit>1</computedCheckDigit>
+      </ex:r>
+    </dfdlInfoset></infoset>
+  </parserTestCase>
+
+  <parserTestCase name="test_checkDigit_01e" root="r" model="checkDigit.dfdl.xsd">
+    <document>2021-09-2</document>
+    <errors>
+      <error>Parse Error</error>
+      <error>insufficient</error>
+      <error>80</error>
+    </errors>
+  </parserTestCase>
+
+  <parserTestCase name="test_checkDigit_02" root="r" model="checkDigit.dfdl.xsd"
+    roundTrip="none">
+    <document>2021-09-25:7</document>
+    <infoset><dfdlInfoset>
+      <ex:r xmlns="">
+        <value>2021-09-25</value>
+        <checkDigit>7</checkDigit>
+        <computedCheckDigit>1</computedCheckDigit>
+      </ex:r>
+    </dfdlInfoset></infoset>
+    <warnings>
+      <warning>Incorrect check digit</warning>
+      <warning>7</warning>
+    </warnings>
+  </parserTestCase>
+
+  <unparserTestCase name="test_checkDigit_01u" root="r" model="checkDigit.dfdl.xsd"
+    roundTrip="none">
+    <document>2021-09-25:1</document>
+    <infoset><dfdlInfoset>
+      <ex:r xmlns="">
+        <value>2021-09-25</value>
+        <checkDigit>0</checkDigit><!-- value is ignored. Notice 1 came out in the data. -->
+        <computedCheckDigit>1</computedCheckDigit>
+      </ex:r>
+    </dfdlInfoset></infoset>
+  </unparserTestCase>
+
+</testSuite>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/layers/ais.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/layers/ais.tdml
@@ -38,7 +38,11 @@ required to pad the data payload to a 6-bit boundary. So it is 0 to 5.
 The *5C is a NMEA 0183 data integrity checksum, preceded by "*" - computed on 
 the whole message including the AIVDM, but excluding the "!"
 
-Seems another role for layers is computing checksums.
+According to the wikipedia article on NMEA 0183, this checksum is just an XOR of the
+specific message bytes.
+
+Another role for layers is computing checksums. This schema could be enhanced to do that
+(DAFFODIL-2563)
 
 Example Multifragment sentence:
 !AIVDM,2,1,3,B,55P5TL01VIaAL@7WKO@mBplU@<PDhh000000001S;AJ::4A80?4i@E53,0*3E
@@ -95,6 +99,7 @@ Example Multifragment sentence:
             </xs:sequence>
             <xs:element name="bitsPad" type="xs:unsignedInt" dfdl:ref="ex:aisText" dfdl:lengthKind="explicit" dfdl:length="1" />
               <!--  must be 0 to 5 -->
+            <!-- DAFFODIL-2563 - recompute this checksum, with another layer transform -->
             <xs:element name="checksum" type="xs:string" dfdl:ref="ex:aisText" dfdl:initiator="*" />
           </xs:sequence>
         </xs:sequence>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/layers/checkDigit.dfdl.xsd
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/layers/checkDigit.dfdl.xsd
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+
+<schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns="http://www.w3.org/2001/XMLSchema"
+           xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/"
+           xmlns:dfdlx="http://www.ogf.org/dfdl/dfdl-1.0/extensions"
+           xmlns:fn="http://www.w3.org/2005/xpath-functions"
+           xmlns:daf="urn:ogf:dfdl:2013:imp:daffodil.apache.org:2018:ext"
+           xmlns:cd="urn:org.apache.daffodil.layers.checkDigit"
+           xmlns:ex="http://example.com"
+           xmlns:tns="http://example.com"
+           targetNamespace="http://example.com">
+
+  <include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd" />
+
+  <import
+    namespace="urn:org.apache.daffodil.layers.checkDigit"
+    schemaLocation="org/apache/daffodil/layers/xsd/checkDigitLayer.dfdl.xsd"/>
+
+  <annotation>
+    <appinfo source="http://www.ogf.org/dfdl/">
+      <dfdl:format ref="tns:GeneralFormat" encoding="ascii" />
+    </appinfo>
+  </annotation>
+
+  <element name="r">
+    <complexType>
+      <sequence>
+        <annotation>
+          <appinfo source="http://www.ogf.org/dfdl/">
+            <dfdl:newVariableInstance ref="cd:checkDigit"/>
+            <dfdl:newVariableInstance ref="cd:checkDigitParams" defaultValue="verbose"/>
+          </appinfo>
+        </annotation>
+        <sequence>
+          <sequence dfdl:ref="cd:checkDigitExplicit" dfdlx:layerLength="10">
+            <element name="value" type="tns:dateType"/>
+          </sequence>
+          <element name="checkDigit" type="cd:checkDigitType" dfdl:initiator=":"
+                   dfdl:outputValueCalc='{ $cd:checkDigit }'/>
+          <element name="computedCheckDigit" type="cd:checkDigitType"
+                   dfdl:inputValueCalc='{ $cd:checkDigit }'/>
+          <sequence>
+            <annotation>
+              <appinfo source="http://www.ogf.org/dfdl/">
+                <dfdl:assert
+                  failureType="recoverableError"
+                  test='{ checkDigit eq $cd:checkDigit }'
+                  message='{ fn:concat("Incorrect check digit: ", checkDigit, ". Should be: ", $cd:checkDigit, ".") }' />
+              </appinfo>
+            </annotation>
+          </sequence>
+        </sequence>
+      </sequence>
+    </complexType>
+  </element>
+
+  <simpleType name="dateType"
+              dfdl:lengthKind="explicit"
+              dfdl:length="10"
+              dfdl:calendarPatternKind="explicit"
+              dfdl:calendarPattern="yyyy-MM-dd">
+    <restriction base="xs:date"/>
+  </simpleType>
+
+
+</schema>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/layers/xsd/IPv4ChecksumLayer.dfdl.xsd
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/layers/xsd/IPv4ChecksumLayer.dfdl.xsd
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/"
+           xmlns:dfdlx="http://www.ogf.org/dfdl/dfdl-1.0/extensions"
+           xmlns:fn="http://www.w3.org/2005/xpath-functions"
+           xmlns:daf="urn:ogf:dfdl:2013:imp:daffodil.apache.org:2018:ext"
+           xmlns:tns="urn:org.apache.daffodil.layers.IPv4Checksum"
+           targetNamespace="urn:org.apache.daffodil.layers.IPv4Checksum">
+
+  <xs:annotation>
+    <xs:documentation>
+      Variable for the layer transform used for IPv4 checksum calculation.
+
+      Per the checksum algorithm described in IETF RFC791.
+
+      The data has a well-known fixed layer length. Hence, layerLengthKind is 'implicit'.
+
+      If the data doesn't match this expected fixed length, issue PE/UE.
+
+      This checksum is written into the result variable.
+    </xs:documentation>
+    <xs:appinfo source="http://www.ogf.org/dfdl/">
+      <dfdl:defineVariable name="IPv4Checksum" type="xs:unsignedShort"/>
+      <dfdl:defineFormat name="IPv4ChecksumLayer">
+        <dfdl:format dfdlx:layerTransform='{ "IPv4Checksum" }' dfdlx:layerLengthKind="implicit"/>
+      </dfdl:defineFormat>
+    </xs:appinfo>
+  </xs:annotation>
+
+  <xs:simpleType name="IPv4Checksum"
+    dfdl:lengthKind="explicit" dfdl:length="16" dfdl:lengthUnits="bits">
+    <xs:restriction base="xs:unsignedShort"/>
+  </xs:simpleType>
+
+</xs:schema>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/layers/xsd/checkDigitLayer.dfdl.xsd
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/layers/xsd/checkDigitLayer.dfdl.xsd
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<schema
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns="http://www.w3.org/2001/XMLSchema"
+  xmlns:fn="http://www.w3.org/2005/xpath-functions"
+  xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/"
+  xmlns:dfdlx="http://www.ogf.org/dfdl/dfdl-1.0/extensions"
+  xmlns:cd="urn:org.apache.daffodil.layers.checkDigit"
+  xmlns:tns="urn:org.apache.daffodil.layers.checkDigit"
+  targetNamespace="urn:org.apache.daffodil.layers.checkDigit"
+  elementFormDefault="unqualified">
+
+  <include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd" />
+
+  <annotation>
+    <appinfo source="http://www.ogf.org/dfdl/">
+
+      <dfdl:format ref="cd:GeneralFormat" />
+
+      <dfdl:defineVariable name="checkDigit" type="xs:int"/>
+      <dfdl:defineVariable name="checkDigitParams" type="xs:string" defaultValue=""/>
+
+      <dfdl:defineFormat name="checkDigitExplicit">
+        <!-- up to an explicit length limit, only digits are totaled. Other characters
+             are ignored --> 
+        <dfdl:format dfdlx:layerTransform='{ "checkDigit" }' dfdlx:layerLengthKind="explicit" dfdlx:layerLengthUnits="bytes"/>
+      </dfdl:defineFormat>
+
+      <dfdl:defineFormat name="checkDigitImplicit">
+        <!-- up to but not including the first non-digit character --> 
+        <dfdl:format dfdlx:layerTransform='{ "checkDigit" }' dfdlx:layerLengthKind="implicit"/>
+      </dfdl:defineFormat>
+     
+    </appinfo>
+  </annotation>
+
+  <simpleType name="checkDigitType" dfdl:length="1" dfdl:lengthKind="explicit">
+    <restriction base="xs:int">
+      <xs:minInclusive value="0"/>
+      <xs:maxInclusive value="9"/>
+    </restriction>
+  </simpleType>
+
+</schema>

--- a/daffodil-test/src/test/scala/org/apache/daffodil/layers/CheckDigit.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/layers/CheckDigit.scala
@@ -1,0 +1,242 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.daffodil.layers
+
+import org.apache.commons.io.IOUtils
+import org.apache.daffodil.schema.annotation.props.gen.LayerLengthKind
+import org.apache.daffodil.schema.annotation.props.gen.LayerLengthUnits
+import org.apache.daffodil.util.Maybe
+import org.apache.daffodil.processors.LayerLengthEv
+import org.apache.daffodil.processors.LayerBoundaryMarkEv
+import org.apache.daffodil.processors.LayerCharsetEv
+import org.apache.daffodil.processors.parsers.PState
+import org.apache.daffodil.processors.unparsers.UState
+
+import java.io._
+import org.apache.daffodil.dpath.NodeInfo.PrimType
+import org.apache.daffodil.exceptions.Assert
+import org.apache.daffodil.processors.CharsetEvBase
+import org.apache.daffodil.processors.SequenceRuntimeData
+import org.apache.daffodil.processors.SuspendableOperation
+import org.apache.daffodil.processors.charset.BitsCharsetJava
+import org.apache.daffodil.util.ByteBufferOutputStream
+import org.apache.daffodil.util.Logger
+import org.apache.daffodil.xml.NS
+import org.apache.daffodil.xml.RefQName
+
+import java.nio.ByteBuffer
+import java.nio.charset.Charset
+
+
+final class CheckDigitExplicit(
+  srd: SequenceRuntimeData,
+  charset: Charset,
+  layerLengthEv: LayerLengthEv)
+extends LayerTransformer() {
+  Assert.invariant(charset.newDecoder().maxCharsPerByte() == 1) // is a SBCS charset
+
+  private val checkDigitVRD = {
+    val varNamespace = NS("urn:org.apache.daffodil.layers.checkDigit")
+    val varQName = RefQName(Some("cd"), "checkDigit", varNamespace).toGlobalQName
+    val vrd = srd.variableMap.getVariableRuntimeData(varQName).getOrElse {
+      srd.SDE("Variable '%s' is not defined.", varQName.toExtendedSyntax)
+    }
+    srd.schemaDefinitionUnless(vrd.primType == PrimType.Int,
+      "Variable '%s' is not of type 'xs:int'.", varQName.toExtendedSyntax)
+    vrd
+  }
+
+  private val checkDigitParamsVRD = {
+    val varNamespace = NS("urn:org.apache.daffodil.layers.checkDigit")
+    val varQName = RefQName(Some("cd"), "checkDigitParams", varNamespace).toGlobalQName
+    val vrd = srd.variableMap.getVariableRuntimeData(varQName).getOrElse {
+      srd.SDE("Variable '%s' is not defined.", varQName.toExtendedSyntax)
+    }
+    srd.schemaDefinitionUnless(vrd.primType == PrimType.String,
+      "Variable '%s' is not of type 'xs:string'.", varQName.toExtendedSyntax)
+    vrd
+  }
+
+  private var limitingOutputStream : ByteBufferOutputStream = _
+  private var originalOutputStream: OutputStream = _
+
+  //
+  // Our example here takes a parameter which is a flag indicating if it is to
+  // issue warning messages to help with debugging.
+  //
+  // But really this is just to show that a layer transform can read variables
+  // as well as write them.
+  //
+  case class Params(isVerbose: Boolean)
+
+  private def parseParams(paramString: String) = {
+    if (paramString.toLowerCase.contains("verbose")) Params(isVerbose = true)
+    else Params(isVerbose = false)
+  }
+
+  protected def wrapLayerDecoder(jis: InputStream) = jis
+
+  override def wrapLimitingStream(jis: java.io.InputStream, state: PState) = {
+    val layerLengthInBytes: Int = layerLengthEv.evaluate(state).toInt
+    val ba = new Array[Byte](layerLengthInBytes)
+    try
+      IOUtils.readFully(jis, ba)
+    catch {
+      case eof: EOFException =>
+        throw LayerNotEnoughDataException(srd, state, eof, ba.length)
+    }
+    // this stream will be used by the parse when it parses the
+    // schema contents of the layer. We have already consumed the bytes
+    // from the original input stream, and saved those in the byte array
+    // to enable the computation of the checkDigit.
+    val layerStream = new ByteArrayInputStream(ba)
+    val str = new String(ba, charset) // always does replacement on decode errors.
+    val params = state.getVariable(checkDigitParamsVRD, srd).getString
+    val isVerbose = parseParams(params).isVerbose
+    if (isVerbose)
+      Logger.log.info(s"CheckDigit layer: computing check digit for '$str.")
+
+    val checkDigit = computeCheckDigit(str)
+    state.setVariable(checkDigitVRD, checkDigit, srd) // assign to result variable
+    layerStream
+  }
+
+  protected def wrapLayerEncoder(jos: OutputStream) = jos
+
+  protected def wrapLimitingStream(jos: OutputStream, state: UState) = {
+    originalOutputStream = jos
+    val layerLengthInBytes: Int = layerLengthEv.evaluate(state).toInt
+    val ba = new Array[Byte](layerLengthInBytes)
+    val byteBuf = ByteBuffer.wrap(ba) // we don't need byteOrder in this example, but FYI: bigEndian byte order by default
+    limitingOutputStream = new ByteBufferOutputStream(byteBuf)
+    limitingOutputStream
+  }
+
+  /**
+   * Shared by both parsing and unparsing.
+   *
+   * Ignores any non-digit character in the argument.
+   *
+   * The checkDigit is the total of all digits, viewed as a string, the last digit of that total.
+   *
+   * Returns a long, because the type of the variable this gets assigned to, is unsignedInt, which
+   * uses a Long as its representation.
+   */
+  private def computeCheckDigit(s: String): Int = {
+    val digits: Seq[Int] = s.filter{ _.isDigit }.map{ _.asDigit }
+    val num = digits.sum
+    val checkDigit = num.toString.last.asDigit
+    checkDigit
+  }
+
+  final class SuspendableCheckDigitLayerOperation()
+    extends SuspendableOperation {
+    override def rd = srd
+
+    /**
+     * Test succeeds if all the data required has been written to the layer
+     */
+    protected def test(ustate: UState) = {
+      //
+      // Note that there is no such thing when unparsing as "not enough data". Rather, the unparser
+      // will just deadlock because this test will never be satisfied.
+      //
+      limitingOutputStream.size() == limitingOutputStream.byteBuffer.capacity()
+    }
+
+    /**
+     * Computes checkdigit, assigns the output variable, then writes the layer data out,
+     */
+    protected def continuation(ustate: UState): Unit = {
+      val ba = limitingOutputStream.byteBuffer.array()
+      val str = new String(ba, charset)
+      val checkDigit = computeCheckDigit(str)
+      ustate.setVariable(checkDigitVRD, checkDigit, srd) // assign to the result variable.
+      //
+      // write out the layer data
+      originalOutputStream.write(ba)
+      originalOutputStream.close()
+    }
+  }
+
+  private lazy val suspendableOperation = new SuspendableCheckDigitLayerOperation()
+
+  override def endLayerForUnparse(s: UState): Unit = {
+    suspendableOperation.run(s)
+  }
+
+}
+
+object CheckDigit
+  extends LayerTransformerFactory("checkDigit") {
+
+  override def newInstance(
+    maybeLayerCharsetEv: Maybe[LayerCharsetEv], // if not supplied, taken from the srd.
+    maybeLayerLengthKind: Maybe[LayerLengthKind], // explicit or implicit
+    maybeLayerLengthEv: Maybe[LayerLengthEv], // ignored (with warning ideally)
+    maybeLayerLengthUnits: Maybe[LayerLengthUnits], // ignored (with warning ideally)
+    maybeLayerBoundaryMarkEv: Maybe[LayerBoundaryMarkEv], // ignored (for now, this is a future possibility)
+    srd: SequenceRuntimeData) = {
+
+
+    val layerLengthKind = {
+      if (maybeLayerLengthKind.isEmpty) {
+        srd.SDE("The 'dfdlx:layerLengthKind' property must be defined.")
+      } else {
+        val llk = maybeLayerLengthKind.get
+        llk match {
+          case LayerLengthKind.Explicit => {
+            srd.schemaDefinitionUnless(maybeLayerLengthEv.isDefined, "Property dfdlx:layerLength must be defined.")
+            maybeLayerLengthUnits.toScalaOption match {
+              case Some(LayerLengthUnits.Bytes) => // ok
+              case None => // ok
+              case _ => srd.SDE("Property dfdlx:layerLengthUnits must be 'bytes'.")
+            }
+          }
+          case other => srd.SDE("The dfdlx:layerLengthKind '%s' is not supported.", other)
+        }
+        llk
+      }
+    }
+
+    // To simplify, insist the charset is a constant, 8-bit aligned, SBCS encoding, e.g., ascii or 8859-1.
+
+    val layerCharsetEv: CharsetEvBase =
+      if (maybeLayerCharsetEv.isDefined) maybeLayerCharsetEv.get
+      else srd.encodingInfo.charsetEv
+
+    val bitsCharset = layerCharsetEv.optConstant.getOrElse{
+      srd.SDE("Must have a character set encoding defined.")
+    }
+    val javaCharset: Charset = bitsCharset match {
+      case jbc: BitsCharsetJava if jbc.bitWidthOfACodeUnit == 8 => jbc.javaCharset
+      case _ => srd.SDE(
+        "Charset encoding must be for a byte-aligned single-byte character set, but was encoding '%s', which has width %s bits, and alignment %s bits.",
+        bitsCharset.name, bitsCharset.bitWidthOfACodeUnit, bitsCharset.mandatoryBitAlignment)
+    }
+
+    //
+    // ToDo: We can't issue SDW because we don't have a context object
+    // for that sort of compilation time warning. We *should* have that.
+    // That requires a layer factory method called at schema compile time with the
+    // Sequence term (not just term runtime data) as an argument.
+    //
+    val xformer = new CheckDigitExplicit(srd, javaCharset, maybeLayerLengthEv.get)
+    xformer
+  }
+}

--- a/daffodil-test/src/test/scala/org/apache/daffodil/layers/IPv4Checksum.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/layers/IPv4Checksum.scala
@@ -1,0 +1,241 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.daffodil.layers
+
+import org.apache.commons.io.IOUtils
+import org.apache.daffodil.schema.annotation.props.gen.LayerLengthKind
+import org.apache.daffodil.schema.annotation.props.gen.LayerLengthUnits
+import org.apache.daffodil.util.Maybe
+import org.apache.daffodil.processors.LayerLengthEv
+import org.apache.daffodil.processors.LayerBoundaryMarkEv
+import org.apache.daffodil.processors.LayerCharsetEv
+import org.apache.daffodil.processors.parsers.PState
+import org.apache.daffodil.processors.unparsers.UState
+
+import java.io._
+import org.apache.daffodil.dpath.NodeInfo.PrimType
+import org.apache.daffodil.exceptions.Assert
+import org.apache.daffodil.processors.SequenceRuntimeData
+import org.apache.daffodil.processors.SuspendableOperation
+import org.apache.daffodil.util.ByteBufferOutputStream
+import org.apache.daffodil.util.Maybe.One
+import org.apache.daffodil.xml.NS
+import org.apache.daffodil.xml.RefQName
+import passera.unsigned.UShort
+
+import java.nio.ByteBuffer
+import java.nio.ShortBuffer
+
+/**
+ *  The layer transform computes the checksum of the header data.
+ *  per IETF RFC 791.
+ *
+ *  The data has a well-known fixed length, so layerLengthKind is always 'implicit'.
+ */
+final class IPv4Checksum(srd: SequenceRuntimeData)
+extends LayerTransformer() {
+
+  private def hdrLengthInBytes = 20
+
+  private def chksumShortIndex = 5
+
+  private val finalChecksumVRD = {
+    val varNamespace = NS("urn:org.apache.daffodil.layers.IPv4Checksum")
+    val finalChecksumVarQName = RefQName(Some("chksum"), "IPv4Checksum", varNamespace).toGlobalQName
+    val vrd = srd.variableMap.getVariableRuntimeData(finalChecksumVarQName).getOrElse {
+      srd.SDE("Variable '%s' is not defined.", finalChecksumVarQName.toExtendedSyntax)
+    }
+    srd.schemaDefinitionUnless(vrd.primType == PrimType.UnsignedShort,
+      "Variable '%s' is not of type 'xs:unsignedShort'.", finalChecksumVarQName.toExtendedSyntax)
+    vrd
+  }
+
+  /**
+   * The header data will be captured here. All the limiting streams and
+   * the byte/short buffers are all aliases into this same object.
+   */
+  private val hdrByteArr = new Array[Byte](hdrLengthInBytes)
+
+  /**
+   * Stream from which the header will be parsed.
+   */
+  private val limitingInputStream = new ByteArrayInputStream(hdrByteArr)
+
+
+  /**
+   * ByteBuffer view of the header bytes.
+   */
+  private val byteBuf = ByteBuffer.wrap(hdrByteArr) // bigEndian byte order by default
+  private val shortBuf = byteBuf.asShortBuffer()
+
+  /**
+   * Stream to which the header will be unparsed.
+   */
+  private val limitingOutputStream = new ByteBufferOutputStream(byteBuf)
+
+  /**
+   * Assigned by wrapLimitingStream for parsing to capture the original source
+   * of the header bytes for parsing.
+   */
+  private var optOriginalInputStream: Maybe[InputStream] = Maybe.Nope
+
+  /**
+   * Assigned by wrapLimitingStream for unparsing to capture the original
+   * output stream to which the bytes are ultimately written.
+   */
+  private var optOriginalOutputStream: Maybe[OutputStream] = Maybe.Nope
+
+  protected def wrapLayerDecoder(jis: InputStream) = jis
+
+  protected def wrapLimitingStream(jis: InputStream, state: PState) = {
+    optOriginalInputStream = One(jis)
+    limitingInputStream
+  }
+
+  protected def wrapLayerEncoder(jos: OutputStream) = jos
+
+  protected def wrapLimitingStream(jos: OutputStream, state: UState) = {
+    optOriginalOutputStream = One(jos)
+    limitingOutputStream
+  }
+
+  /**
+   * Shared by both parsing and unparsing. Contains the checksum algorithm.
+   */
+  private def computeChecksum(shortBuf: ShortBuffer): Int = {
+    var i = 0
+    var chksum: Int = 0
+    val nShorts = hdrLengthInBytes / 2
+    while (i < nShorts) {
+      if (i == chksumShortIndex) {
+        // for the checksum calculation treat the incoming checksum field of the data as 0
+        // so we just don't do an addition here.
+      } else {
+        chksum += UShort(shortBuf.get(i)).toInt
+      }
+      Assert.invariant(chksum >= 0)
+      i += 1
+    }
+    //
+    // now combine the carry bits in the most significant 16 bits into the lower 16 bits.
+    //
+    val checksumLow = chksum & 0xFFFF
+    val checksumHigh = chksum >>> 16
+    val checksumTotal: Int = checksumLow + checksumHigh
+    Assert.invariant(checksumTotal <= 0xFFFF && checksumTotal >= 0)
+    val checksumTotalShort = UShort(checksumTotal.toShort)
+    val checksum = checksumTotalShort.toInt
+    //
+    // take ones complement to get the final checksum
+    //
+    val finalChecksum: Int = (~checksum) & 0xFFFF
+    finalChecksum
+  }
+
+  override def startLayerForParse(s: PState): Unit = {
+    //
+    // For parsing, all the hard work happens here, allowing the layered input stream to
+    // just deliver the bytes
+    //
+    Assert.invariant(s.bitPos0b % 8 == 0) // we are byte aligned.
+    Assert.invariant(optOriginalInputStream.isDefined)
+
+    try
+      IOUtils.readFully(optOriginalInputStream.get, hdrByteArr)
+    catch {
+      case eof: EOFException =>
+        throw new LayerNotEnoughDataException(srd, s, eof, hdrLengthInBytes)
+    }
+    val checksumInDataStream = shortBuf.get()
+    val checksum = computeChecksum(shortBuf)
+    s.setVariable(finalChecksumVRD, checksum, srd) // assign to result variable.
+  }
+
+  final class SuspendableChecksumLayerOperation()
+    extends SuspendableOperation {
+    override def rd = srd
+
+    /**
+     * Test succeeds if all the data required has been written to the layer
+     */
+    protected def test(ustate: UState) = {
+      //
+      // Note: there is no unparse equivalent of not-enough-data error, because the unparser
+      // will just deadlock here waiting for more data.
+      //
+      limitingOutputStream.size() == hdrLengthInBytes
+    }
+
+    /**
+     * Computes checksum and overwrites that part of the layer data
+     * with the new checksum, writes the layer data out,
+     * and assigns the output variable.
+     */
+    protected def continuation(ustate: UState): Unit = {
+      Assert.invariant(optOriginalOutputStream.isDefined)
+      val finalChecksum = computeChecksum(shortBuf)
+      ustate.setVariable(finalChecksumVRD, finalChecksum, srd) // assign to the result variable.
+      //
+      // clobber the byte buffer bytes corresponding to the checksum with
+      // the recomputed value
+      //
+      shortBuf.put(chksumShortIndex, finalChecksum.toShort)
+      //
+      // write out the layer data (which has recomputed checksum in it.
+      optOriginalOutputStream.get.write(hdrByteArr)
+      optOriginalOutputStream.get.close()
+    }
+  }
+
+  private lazy val suspendableOperation = new SuspendableChecksumLayerOperation()
+
+  override def endLayerForUnparse(s: UState): Unit = {
+    suspendableOperation.run(s)
+  }
+
+}
+
+  object IPv4Checksum
+    extends LayerTransformerFactory("IPv4Checksum") {
+
+    override def newInstance(
+      maybeLayerCharsetEv: Maybe[LayerCharsetEv],
+      maybeLayerLengthKind: Maybe[LayerLengthKind],
+      maybeLayerLengthEv: Maybe[LayerLengthEv],
+      maybeLayerLengthUnits: Maybe[LayerLengthUnits],
+      maybeLayerBoundaryMarkEv: Maybe[LayerBoundaryMarkEv],
+      srd: SequenceRuntimeData) = {
+      srd.schemaDefinitionUnless(maybeLayerLengthKind.isEmpty ||
+        maybeLayerLengthKind.get == LayerLengthKind.Implicit,
+        "Must have dfdlx:layerLengthKind undefined or 'implicit', but was '%s'.",
+        maybeLayerLengthKind.get.toString)
+      //
+      // ToDo: We can't issue SDW because we don't have a context object
+      // for that sort of compilation time warning. We *should* have that.
+      // That requires a layer factory method called at schema compile time with the
+      // Sequence term (not just term runtime data) as an argument.
+      //
+      // We would like to warn if maybeLayerLengthUnits is defined here and is not bytes
+      // We would like to warn if maybeLayerBoundaryMarkEv is defined (since it is unused by this layer)
+      // We would like to warn if maybeLayerCharsetEv is defined (since it is unused by this layer)
+      // We would like to warn if maybeLayerLengthEv is defined (since it is unused by this layer)
+      //
+      val xformer = new IPv4Checksum(srd)
+      xformer
+    }
+  }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/layers/TestCheckDigit.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/layers/TestCheckDigit.scala
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.daffodil.layers
+
+import org.junit.AfterClass
+import org.junit.Test
+import org.apache.daffodil.tdml.Runner
+
+object TestCheckDigit {
+
+  LayerTransformerFactory.register(CheckDigit)
+
+  lazy val runner = Runner("/org/apache/daffodil/layers", "TestCheckDigit.tdml")
+
+  @AfterClass def shutDown(): Unit = {
+    runner.reset
+  }
+}
+
+class TestCheckDigit {
+
+  import TestCheckDigit._
+
+  @Test def test_checkDigit_01(): Unit = { runner.runOneTest("test_checkDigit_01") }
+  @Test def test_checkDigit_01e(): Unit = { runner.runOneTest("test_checkDigit_01e") }
+
+  @Test def test_checkDigit_02(): Unit = { runner.runOneTest("test_checkDigit_02") }
+
+  @Test def test_checkDigit_01u(): Unit = { runner.runOneTest("test_checkDigit_01u") }
+
+}

--- a/daffodil-test/src/test/scala/org/apache/daffodil/layers/TestIPv4.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/layers/TestIPv4.scala
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.daffodil.layers
+
+import org.junit.Test
+import org.apache.daffodil.tdml.Runner
+import org.junit.AfterClass
+
+object TestIPv4 {
+
+  LayerTransformerFactory.register(IPv4Checksum)
+
+  val testDir = "/org/apache/daffodil/layers/"
+  val runner = Runner(testDir, "IPv4.tdml")
+
+  @AfterClass def shutDown(): Unit = {
+    runner.reset
+  }
+}
+
+class TestIPv4 {
+
+  import TestIPv4._
+
+  @Test def test_IPv4_1(): Unit = { runner.runOneTest("IPv4_1") }
+  @Test def test_IPv4_1e(): Unit = { runner.runOneTest("IPv4_1e") }
+
+  @Test def test_IPv4_2(): Unit = { runner.runOneTest("IPv4_2") }
+
+  @Test def test_IPv4_1u(): Unit = { runner.runOneTest("IPv4_1u") }
+  @Test def test_IPv4_2u(): Unit = { runner.runOneTest("IPv4_2u") }
+
+
+}


### PR DESCRIPTION
Layering feature evolved slightly to support CRC, checksum, parity feature.

Test is based on ipv4 with a layer transform.

This PR starts with 2 commits. First commit is just removing deprecated layering properties that were in the dfdl namespace, and accepted with no prefix like DFDL official properties. Now we are enforcing that one must write dfdlx:layerTransform with the proper extension prefix. 

DAFFODIL-2221