### PR TITLE
Remove deprecated layering properties in dfdl: namespace.

### DIFF
--- a/daffodil-lib/src/main/resources/org/apache/daffodil/xsd/XMLSchema_for_DFDL.xsd
+++ b/daffodil-lib/src/main/resources/org/apache/daffodil/xsd/XMLSchema_for_DFDL.xsd
@@ -993,7 +993,6 @@ this to validate when we load a DFDL Schema.
         <!-- DFDL -->
         <xsd:attributeGroup ref="dfdl:SequenceAGQualified" />
         <xsd:attributeGroup ref="dfdl:SeparatorAGQualified" />
-        <xsd:attributeGroup ref="dfdl:LayeringAGQualified" />
       </xsd:extension>
     </xsd:complexContent>
   </xsd:complexType>

--- a/daffodil-propgen/src/main/resources/org/apache/daffodil/xsd/DFDL_part2_attributes.xsd
+++ b/daffodil-propgen/src/main/resources/org/apache/daffodil/xsd/DFDL_part2_attributes.xsd
@@ -418,30 +418,6 @@
     <xsd:attribute name="sequenceKind" type="dfdl:SequenceKindEnum" />
     <xsd:attribute name="hiddenGroupRef" type="xsd:QName" />
   </xsd:attributeGroup>
-  
-  <xsd:attribute name="layerTransform"
-    type="dfdl:LayerTransformType_Or_DFDLExpression" />
-  <xsd:attribute name="layerEncoding"
-    type="dfdl:EncodingEnum_Or_DFDLExpression" />
-  <xsd:attribute name="layerLengthKind" type="dfdl:LayerLengthKindEnum" />
-  <xsd:attribute name="layerLength"
-    type="dfdl:DFDLNonNegativeInteger_Or_DFDLExpression" />
-  <xsd:attribute name="layerLengthUnits" type="dfdl:LayerLengthUnitsEnum" />
-  <xsd:attribute name="layerBoundaryMark"
-    type="dfdl:ListOfDFDLStringLiteral_Or_DFDLExpression" />
-      
-  <xsd:attributeGroup name="LayeringAG">
-    <xsd:attribute name="layerTransform"
-      type="dfdl:LayerTransformType_Or_DFDLExpression" />
-    <xsd:attribute name="layerEncoding"
-      type="dfdl:EncodingEnum_Or_DFDLExpression" />
-    <xsd:attribute name="layerLengthKind" type="dfdl:LayerLengthKindEnum" />
-    <xsd:attribute name="layerLength"
-      type="dfdl:DFDLNonNegativeInteger_Or_DFDLExpression" />
-    <xsd:attribute name="layerLengthUnits" type="dfdl:LayerLengthUnitsEnum" />
-    <xsd:attribute name="layerBoundaryMark"
-      type="dfdl:ListOfDFDLStringLiteral_Or_DFDLExpression" />
-  </xsd:attributeGroup>
 
   <!-- 14.2 Sequence Groups with Delimiters -->
   <xsd:attribute name="separator"
@@ -629,13 +605,6 @@
 
       <xsd:enumeration value="sequenceKind" />
       <xsd:enumeration value="hiddenGroupRef" />
-      
-      <xsd:enumeration value="layerTransform"/>
-      <xsd:enumeration value="layerEncoding" />
-      <xsd:enumeration value="layerLengthKind" />
-      <xsd:enumeration value="layerLength" />
-      <xsd:enumeration value="layerLengthUnits" />
-      <xsd:enumeration value="layerBoundaryMark" />
       
       <xsd:enumeration value="initiatedContent" />
 
@@ -1043,7 +1012,6 @@
   <xsd:attributeGroup name="GroupAGQualified">
     <xsd:attributeGroup ref="dfdl:GroupCommonAGQualified" />
     <xsd:attributeGroup ref="dfdl:SequenceAGQualified" />
-    <xsd:attributeGroup ref="dfdl:LayeringAGQualified" /> <!-- backwards compatibility -->
     <xsd:attributeGroup ref="dfdlx:ExtLayeringAGQualified" />
     <xsd:attributeGroup ref="dfdl:ChoiceAGQualified" />
     <xsd:attributeGroup ref="dfdl:SeparatorAGQualified" />
@@ -1068,19 +1036,6 @@
     <xsd:attributeGroup ref="dfdl:BooleanBinaryAGQualified" />
     <xsd:attributeGroup ref="dfdlx:SimpleTypeValueCalcAGQualified" />
     <xsd:attributeGroup ref="dfdlx:ObjectKindAGQualified" />
-  </xsd:attributeGroup>
-
-  <xsd:attributeGroup name="LayeringAGQualified">
-    <xsd:attribute form="qualified" name="layerTransform"
-      type="dfdl:LayerTransformType_Or_DFDLExpression" />
-    <xsd:attribute form="qualified" name="layerEncoding"
-      type="dfdl:EncodingEnum_Or_DFDLExpression" />
-    <xsd:attribute form="qualified" name="layerLengthKind" type="dfdl:LayerLengthKindEnum" />
-    <xsd:attribute form="qualified" name="layerLength"
-      type="dfdl:DFDLNonNegativeInteger_Or_DFDLExpression" />
-    <xsd:attribute form="qualified" name="layerLengthUnits" type="dfdl:LayerLengthUnitsEnum" />
-    <xsd:attribute form="qualified" name="layerBoundaryMark"
-      type="dfdl:ListOfDFDLStringLiteral_Or_DFDLExpression" />
   </xsd:attributeGroup>
   
 </xsd:schema>

--- a/daffodil-propgen/src/main/resources/org/apache/daffodil/xsd/DFDL_part3_model.xsd
+++ b/daffodil-propgen/src/main/resources/org/apache/daffodil/xsd/DFDL_part3_model.xsd
@@ -273,7 +273,6 @@
         <xsd:sequence />
         <xsd:attributeGroup ref="dfdl:GroupCommonAG" />
         <xsd:attributeGroup ref="dfdl:SequenceAG" />
-        <xsd:attributeGroup ref="dfdl:LayeringAG" /> <!-- backwards compatibility -->
         <xsd:attributeGroup ref="dfdlx:ExtLayeringAG" />
         <xsd:attributeGroup ref="dfdl:SeparatorAG" />
       </xsd:extension>
@@ -340,7 +339,6 @@
   <xsd:attributeGroup name="GroupAG">
     <xsd:attributeGroup ref="dfdl:GroupCommonAG" />
     <xsd:attributeGroup ref="dfdl:SequenceAG" />
-    <xsd:attributeGroup ref="dfdl:LayeringAG" /> <!-- backwards compatibility -->
     <xsd:attributeGroup ref="dfdlx:ExtLayeringAG" />
     <xsd:attributeGroup ref="dfdl:ChoiceAG" />
     <xsd:attributeGroup ref="dfdl:SeparatorAG" />

--- a/daffodil-propgen/src/main/scala/org/apache/daffodil/propGen/PropertyGenerator.scala
+++ b/daffodil-propgen/src/main/scala/org/apache/daffodil/propGen/PropertyGenerator.scala
@@ -41,8 +41,6 @@ class PropertyGenerator(arg: Node) {
     "BinaryBooleanFalseRepType",
     "BinaryBooleanTrueRepType",
     "EmptyElementParsePolicy",
-    "ExtLayeringAG",
-    "ExtLayeringAGQualified",
     "FillByteType",
     "Property",
     "PropertyNameType",

--- a/daffodil-test/src/test/resources/org/apache/daffodil/layers/layers.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/layers/layers.tdml
@@ -216,50 +216,6 @@
     </tdml:infoset>
   </tdml:parserTestCase>
 
-  <tdml:defineSchema name="s3_deprecated" elementFormDefault="unqualified">
-    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
-    <dfdl:defineFormat name="general">
-      <dfdl:format ref="ex:GeneralFormat" lengthKind="delimited" outputNewLine="%CR;%LF;" />
-    </dfdl:defineFormat>
-    <dfdl:defineFormat name="folded">
-      <dfdl:format ref="ex:general" layerTransform="lineFolded_IMF" layerLengthKind="implicit" layerLengthUnits="bytes"
-        layerEncoding="iso-8859-1" />
-    </dfdl:defineFormat>
-    <dfdl:format ref="ex:general" />
-
-
-    <xs:element name="root" dfdl:lengthKind="implicit">
-      <xs:complexType>
-        <xs:sequence dfdl:ref="folded" xmlns:foo="urn:Foo" foo:bar="shouldBeIgnored">
-          <xs:sequence>
-            <xs:element name="marker" dfdl:initiator="boundary=" type="xs:string" dfdl:terminator="%CR;%LF;" />
-            <xs:element name="nothing" type="xs:string" dfdl:initiator="xxx" />
-          </xs:sequence>
-        </xs:sequence>
-      </xs:complexType>
-    </xs:element>
-
-  </tdml:defineSchema>
-
-  <tdml:parserTestCase name="layers3_deprecated" root="root" model="s3_deprecated" roundTrip="true">
-    <tdml:document>
-      <tdml:documentPart type="text" replaceDFDLEntities="true"><![CDATA[boundary=frontier%CR;%LF;xxx]]></tdml:documentPart>
-    </tdml:document>
-    <tdml:warnings>
-      <tdml:warning>layerTransform is deprecated</tdml:warning>
-      <tdml:warning>layerLengthUnits is deprecated</tdml:warning>
-      <tdml:warning>layerEncoding is deprecated</tdml:warning>
-      <tdml:warning>layerLengthKind is deprecated</tdml:warning>
-    </tdml:warnings>
-    <tdml:infoset>
-      <tdml:dfdlInfoset>
-        <ex:root>
-          <marker>frontier</marker>
-          <nothing />
-        </ex:root>
-      </tdml:dfdlInfoset>
-    </tdml:infoset>
-  </tdml:parserTestCase>
   
   <tdml:defineSchema name="err1" elementFormDefault="unqualified">
     <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>

--- a/daffodil-test/src/test/scala/org/apache/daffodil/layers/TestLayers.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/layers/TestLayers.scala
@@ -41,7 +41,6 @@ class TestLayers {
   @Test def test_layers1(): Unit = { runner.runOneTest("layers1") }
   @Test def test_layers2(): Unit = { runner.runOneTest("layers2") }
   @Test def test_layers3(): Unit = { runner.runOneTest("layers3") }
-  @Test def test_layers3_deprecated(): Unit = { runner.runOneTest("layers3_deprecated") }
   @Test def test_layersErr1(): Unit = { runner.runOneTest("layersErr1") }
   @Test def test_layers4(): Unit = { runner.runOneTest("layers4") }
 


### PR DESCRIPTION
Broke this change out of other PR since this is really a separate issue.

Removed support for non-dfdlx prefixed layerTransform properties. 

Also removed tests of these.

Only dfdlx:layerTransform and other layering properties are recognized now.

DAFFODIL-2564