### PR TITLE
Update GitHub Actions workflow to test against Java 17

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,7 +34,7 @@ jobs:
       fail-fast: false
       matrix:
         distribution: [ temurin ]
-        java_version: [ 8, 11, 16 ]
+        java_version: [ 8, 11, 17 ]
         scala_version: [ 2.12.15 ]
         os: [ ubuntu-20.04, windows-2019 ]
         include:


### PR DESCRIPTION
Java 17 was recently released and Java 16 is no longer supported.

DAFFODIL-2558