### PR TITLE
Use conistent logic between SAXInfosetOutputter and XMLTextInfosetOutputter

### DIFF
--- a/daffodil-lib/src/main/scala/org/apache/daffodil/xml/XMLUtils.scala
+++ b/daffodil-lib/src/main/scala/org/apache/daffodil/xml/XMLUtils.scala
@@ -931,6 +931,8 @@ Differences were (path, expected, actual):
     computeDiffOne(
       a,
       b,
+      TopScope,
+      TopScope,
       None,
       Nil,
       ignoreProcInstr,
@@ -952,6 +954,8 @@ Differences were (path, expected, actual):
   def computeDiffOne(
     an: Node,
     bn: Node,
+    aParentScope: NamespaceBinding,
+    bParentScope: NamespaceBinding,
     maybeIndex: Option[Int],
     parentPathSteps: Seq[String],
     ignoreProcInstr: Boolean,
@@ -968,16 +972,18 @@ Differences were (path, expected, actual):
         val maybeType: Option[String] = Option(typeA.getOrElse(typeB.getOrElse(null)))
         val nilledA = a.attribute(XSI_NAMESPACE.toString, "nil")
         val nilledB = b.attribute(XSI_NAMESPACE.toString, "nil")
+        val mappingsA = if (checkNamespaces) nsbA.buildString(aParentScope).trim else ""
+        val mappingsB = if (checkNamespaces) nsbB.buildString(bParentScope).trim else ""
 
         if (labelA != labelB) {
           // different label
           List((zPath, labelA, labelB))
         } else if (checkPrefixes && prefixA != prefixB) {
           // different prefix
-          List((zPath, prefixA, prefixB))
-        } else if (checkNamespaces && nsbA != nsbB ) {
+          List((zPath + "/" + labelA + "@prefix", prefixA, prefixB))
+        } else if (checkNamespaces && mappingsA != mappingsB) {
           // different namespace bindings
-          List((zPath, nsbA.toString(), nsbB.toString()))
+          List((zPath + "/" + labelA + "@xmlns", mappingsA, mappingsB))
         } else if (nilledA != nilledB) {
           // different xsi:nil
           List((zPath + "/" + labelA + "@xsi:nil",
@@ -1018,6 +1024,8 @@ Differences were (path, expected, actual):
             computeDiffOne(
               ca,
               cb,
+              nsbA,
+              nsbB,
               maybeChildIndex,
               thisPathStep,
               ignoreProcInstr,

--- a/daffodil-lib/src/test/scala/org/apache/daffodil/xml/test/unit/TestXMLUtils.scala
+++ b/daffodil-lib/src/test/scala/org/apache/daffodil/xml/test/unit/TestXMLUtils.scala
@@ -91,6 +91,29 @@ class TestXMLUtils {
     assertEquals("", d2attribs)
   }
 
+  @Test def testPrefixDiff(): Unit = {
+    // different prefix should error, even though the namespace is the same
+    val d1 = <ns1:a xmlns:ns1="someprefix">a</ns1:a>
+    val d2 = <ns2:a xmlns:ns1="someprefix">a</ns2:a>
+    val diffs = XMLUtils.computeDiff(d1, d2, checkPrefixes = true)
+    val Seq((path, a, b)) = diffs
+    assertEquals("/a@prefix", path)
+    assertEquals("ns1", a)
+    assertEquals("ns2", b)
+  }
+
+  @Test def testNamespaceDiff(): Unit = {
+    // different namespace mappings should error
+    val d1 = <ns1:a xmlns:ns1="someprefixA">a</ns1:a>
+    val d2 = <ns1:a xmlns:ns1="someprefixB">a</ns1:a>
+    val diffs = XMLUtils.computeDiff(d1, d2, checkNamespaces = true)
+    val Seq((path, a, b)) = diffs
+    assertEquals("/a@xmlns", path)
+    assertEquals("xmlns:ns1=\"someprefixA\"", a)
+    assertEquals("xmlns:ns1=\"someprefixB\"", b)
+  }
+
+
   @Test def testIsNil(): Unit = {
     val d1 = JDOMUtils.elem2Element(<a xmlns:xsi={ XMLUtils.XSI_NAMESPACE } xsi:nil="true"/>)
     val d2 = JDOMUtils.elem2Element(<a xmlns:xsi={ XMLUtils.XSI_NAMESPACE }>foo</a>)

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section06/namespaces/multiFile.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section06/namespaces/multiFile.tdml
@@ -77,5 +77,68 @@
       </tdml:dfdlInfoset>
     </tdml:infoset>
   </tdml:parserTestCase>
+
+  <!--
+    This complex schema caused an issue where the "value" element would get a
+    redundant xmlns:tns="nsB" prefix mapping when using SAX. Although the
+    infoset is still technically valid with the extra mapping (it's redundant
+    and nothing uses the prefix), The TDML Runner ensures SAX and non-SAX
+    infosets are exactly the same, so this would lead to a failure. This test
+    ensures we do not have any regressions with the complex schema and SAX
+    namespace issues.
+  -->
+  <tdml:parserTestCase name="complexIncludesNamespaces_01" root="root"
+    model="test05sch1.dfdl.xsd">
+    <tdml:document>
+      <tdml:documentPart type="text">1ab</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <tns:root xmlns:nsB="nsB" xmlns:tns="nsA">
+          <elem>1</elem>
+          <tns:elem1 xmlns:tns="nsB">
+            <tns:elem1_fields>
+              <field_a>
+                <value>a</value>
+              </field_a>
+              <field_b>b</field_b>
+            </tns:elem1_fields>
+          </tns:elem1>
+        </tns:root>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <!--
+    This complex schema caused an issue where the "value" element would get a
+    redundant xmlns:tns="nsB" prefix mapping when using SAX. Although the
+    infoset is still technically valid with the extra mapping (it's redundant
+    and nothing uses the prefix), The TDML Runner ensures SAX and non-SAX
+    infosets are exactly the same, so this would lead to a failure. This test
+    ensures we do not have any regressions with the complex schema and SAX
+    namespace issues.
+  -->
+  <tdml:parserTestCase name="complexIncludesNamespaces_02" root="root"
+    model="test05sch1.dfdl.xsd">
+    <tdml:document>
+      <tdml:documentPart type="text">2cd</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <tns:root xmlns:nsB="nsB" xmlns:tns="nsA">
+          <elem>2</elem>
+          <tns:elem2 xmlns:tns="nsB">
+            <tns:elem2_fields>
+              <field_c>
+                <value>c</value>
+              </field_c>
+              <field_d>d</field_d>
+            </tns:elem2_fields>
+          </tns:elem2>
+        </tns:root>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
   
 </tdml:testSuite>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section06/namespaces/test05sch1.dfdl.xsd
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section06/namespaces/test05sch1.dfdl.xsd
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<xs:schema
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/"
+  xmlns:nsB="nsB"
+  xmlns:tns="nsA"
+  targetNamespace="nsA"
+  elementFormDefault="unqualified">
+
+  <xs:import namespace="nsB" schemaLocation="test05sch2.dfdl.xsd" />
+
+  <xs:annotation>
+    <xs:appinfo source="http://www.ogf.org/dfdl/">
+      <dfdl:format ref="nsB:commonFormat" />
+    </xs:appinfo>
+  </xs:annotation>
+
+  <xs:complexType name="rootType">
+    <xs:sequence>
+      <xs:element name="elem" type="xs:int" dfdl:lengthKind="explicit" dfdl:length="1" />
+      <xs:choice dfdl:choiceDispatchKey="{ xs:string(./elem) }">
+        <xs:element dfdl:choiceBranchKey="1" ref="nsB:elem1"/>
+        <xs:element dfdl:choiceBranchKey="2" ref="nsB:elem2"/>
+      </xs:choice>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:element name="root" type="tns:rootType"/>
+
+</xs:schema>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section06/namespaces/test05sch2.dfdl.xsd
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section06/namespaces/test05sch2.dfdl.xsd
@@ -1,0 +1,40 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<xs:schema
+  elementFormDefault="unqualified"
+  targetNamespace="nsB"
+  xmlns:nsD="nsD"
+  xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/"
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns:tns="nsB">
+
+  <xs:import namespace="nsD" schemaLocation="test05sch6.dfdl.xsd"/>
+
+  <xs:annotation>
+    <xs:appinfo source="http://www.ogf.org/dfdl/">
+      <dfdl:defineFormat name="commonFormat">
+        <dfdl:format ref="nsD:commonFormat"/>
+      </dfdl:defineFormat>
+    </xs:appinfo>
+  </xs:annotation>
+
+  <xs:include schemaLocation="test05sch3.dfdl.xsd"/>
+  <xs:include schemaLocation="test05sch4.dfdl.xsd"/>
+
+</xs:schema>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section06/namespaces/test05sch3.dfdl.xsd
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section06/namespaces/test05sch3.dfdl.xsd
@@ -1,0 +1,53 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<xs:schema
+  elementFormDefault="unqualified"
+  targetNamespace="nsB"
+  xmlns:nsC="nsC"
+  xmlns:nsD="nsD"
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/"
+  xmlns:tns="nsB">
+
+  <xs:import namespace="nsC" schemaLocation="test05sch5.dfdl.xsd" />
+
+  <xs:annotation>
+    <xs:appinfo source="http://www.ogf.org/dfdl/">
+      <dfdl:format ref="nsD:commonFormat" />
+    </xs:appinfo>
+  </xs:annotation>
+
+  <xs:element name="elem1_fields">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="field_a" type="nsC:shared_type"/>
+        <xs:element name="field_b" type="xs:string" dfdl:length="1" dfdl:lengthKind="explicit" />
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="elem1">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref="tns:elem1_fields"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+
+</xs:schema>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section06/namespaces/test05sch4.dfdl.xsd
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section06/namespaces/test05sch4.dfdl.xsd
@@ -1,0 +1,53 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<xs:schema
+  elementFormDefault="unqualified"
+  targetNamespace="nsB"
+  xmlns:nsC="nsC"
+  xmlns:nsD="nsD"
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/"
+  xmlns:tns="nsB">
+
+  <xs:import namespace="nsC" schemaLocation="test05sch5.dfdl.xsd" />
+
+  <xs:annotation>
+    <xs:appinfo source="http://www.ogf.org/dfdl/">
+      <dfdl:format ref="nsD:commonFormat" />
+    </xs:appinfo>
+  </xs:annotation>
+
+  <xs:element name="elem2_fields">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="field_c" type="nsC:shared_type"/>
+        <xs:element name="field_d" type="xs:string" dfdl:length="1" dfdl:lengthKind="explicit" />
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="elem2">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref="tns:elem2_fields"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+
+</xs:schema>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section06/namespaces/test05sch5.dfdl.xsd
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section06/namespaces/test05sch5.dfdl.xsd
@@ -1,0 +1,45 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<xs:schema
+  elementFormDefault="unqualified"
+  targetNamespace="nsC"
+  xmlns:tns="nsC"
+  xmlns:nsD="nsD"
+  xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/"
+  xmlns:xs="http://www.w3.org/2001/XMLSchema">
+
+  <xs:import namespace="nsD" schemaLocation="test05sch6.dfdl.xsd"/>
+
+  <xs:annotation>
+    <xs:appinfo source="http://www.ogf.org/dfdl/">
+      <dfdl:format ref="nsD:commonFormat" />
+    </xs:appinfo>
+  </xs:annotation>
+
+  <xs:complexType name="shared_type">
+    <xs:group ref="tns:shared_type_group"/>
+  </xs:complexType>
+
+  <xs:group name="shared_type_group">
+    <xs:sequence>
+      <xs:element name="value" type="xs:string" dfdl:lengthKind="explicit" dfdl:length="1" />
+    </xs:sequence>
+  </xs:group>
+
+</xs:schema>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section06/namespaces/test05sch6.dfdl.xsd
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section06/namespaces/test05sch6.dfdl.xsd
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<xs:schema
+  targetNamespace="nsD"
+  xmlns:tns="nsD"
+  xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/"
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  elementFormDefault="unqualified">
+  
+  <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+
+  <xs:annotation>
+    <xs:appinfo source="http://www.ogf.org/dfdl/">
+
+      <dfdl:defineFormat name="commonFormat">
+        <dfdl:format ref="tns:GeneralFormat" />
+      </dfdl:defineFormat>
+
+      <dfdl:format ref="tns:commonFormat" />
+
+    </xs:appinfo>
+  </xs:annotation>
+
+</xs:schema>

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section06/namespaces/TestNamespaces.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section06/namespaces/TestNamespaces.scala
@@ -186,4 +186,7 @@ class TestNamespaces {
   @Test def test_toplevel_annotation_invalid_02(): Unit = { runner.runOneTest("toplevel_annotation_invalid_02") }
 
   @Test def test_incorrectAppinfoSource(): Unit = { runner.runOneTest("incorrectAppinfoSource") }
+
+  @Test def test_complexIncludesNamespaces_01(): Unit = { runner2.runOneTest("complexIncludesNamespaces_01") }
+  @Test def test_complexIncludesNamespaces_02(): Unit = { runner2.runOneTest("complexIncludesNamespaces_02") }
 }


### PR DESCRIPTION
The SAXInfosetOutputter and XMLTextInfosetOutputter used slightly
different logic to figure out namespace mappings to add to an element.
In complex cases with lots of includes, shared references, and
overlapping namespace bindings, this could cause inconsistent namespace
mappings, which causes failures in the TDMLRunner, which mandates
consistency between SAX and non-SAX. The SAX logic should be fine, but
our broken minimizedScope (DAFODIL-2282) leads to issues. By mimicking
the XMLTextInosetOututter logic (i.e. value equality check +
shadowRedefined), we avoid those issues.

Also, fix XML diff reporting of different prefixes and namespace
mappings. The changes are:
- Add the label to the path, otherwise we just output the elements
  parent element and it isn't clear where the issue is
- Add @prefix or @xmlns to indicate the problem is related to
  different prefixes or different namespace mappings
- For namespace reporting, only compare/report the mappings on the
  particular element rather than the entire namespace binding. The
  easiest way to do this is to keep track of the parent scope, use
  NamespaceBinding.buildString(...) to create a string, and compare
  that string.

DAFFODIL-2568