### PR TITLE
Fix C compilation error on CentOS 7

### DIFF
--- a/daffodil-runtime2/src/main/resources/org/apache/daffodil/runtime2/c/libcli/xml_reader.c
+++ b/daffodil-runtime2/src/main/resources/org/apache/daffodil/runtime2/c/libcli/xml_reader.c
@@ -268,7 +268,8 @@ strtohexbinary(const char *text, HexBinary *hexBinary)
 
     // Store hexadecimal characters into byte array
     if (hexBinary->array) memset(hexBinary->array, 0, hexBinary->lengthInBytes);
-    for (size_t i = 0; i < numNibbles; i++)
+    size_t i;
+    for (i = 0; i < numNibbles; i++)
     {
         char    c = text[i];
         uint8_t value = 0;

--- a/daffodil-runtime2/src/main/resources/org/apache/daffodil/runtime2/c/libcli/xml_writer.c
+++ b/daffodil-runtime2/src/main/resources/org/apache/daffodil/runtime2/c/libcli/xml_writer.c
@@ -86,7 +86,8 @@ binaryToHex(HexBinary hexBinary, bool freeMemory)
 
     // Convert each binary byte to two hexadecimal characters
     char *nibble = text;
-    for (size_t i = 0; i < hexBinary.lengthInBytes; i++)
+    size_t i;
+    for (i = 0; i < hexBinary.lengthInBytes; i++)
     {
         static char hexDigit[] = "0123456789ABCDEF";
         *(nibble++) = hexDigit[hexBinary.array[i] / 16]; // high nibble


### PR DESCRIPTION
xml_reader.c, xml_writer.c - Define loop variable i before, not
inside, "for (" loop statement.

DAFFODIL-2566