### PR TITLE
Remove dfdlx:choiceDispatchKeyKind and dfdlx:choiceBranchKeyKind

### DIFF
--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/SchemaSet.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/SchemaSet.scala
@@ -679,7 +679,6 @@ class TransitiveClosureSchemaComponents private() extends TransitiveClosure[Sche
     }
     val misc: SSC = sc match {
       case eb: ElementBase => eb.optPrefixLengthElementDecl.toSeq
-      case ch: ChoiceTermBase => ch.optRepTypeElement.toSeq
       case _ => Seq()
     }
 

--- a/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/ChoiceTermRuntime1Mixin.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/ChoiceTermRuntime1Mixin.scala
@@ -35,8 +35,6 @@ import org.apache.daffodil.util.Delay
 
 trait ChoiceTermRuntime1Mixin { self: ChoiceTermBase =>
 
-  requiredEvaluationsIfActivated(optRepTypeElement.map{ _.elementRuntimeData.initialize })
-
   /**
    * The members of the choice group with special treatment given to some kinds of members.
    *

--- a/daffodil-propgen/src/main/resources/org/apache/daffodil/xsd/DFDL_part2_attributes.xsd
+++ b/daffodil-propgen/src/main/resources/org/apache/daffodil/xsd/DFDL_part2_attributes.xsd
@@ -448,8 +448,6 @@
     <xsd:attribute name="choiceLengthKind" type="dfdl:ChoiceLengthKindEnum" />
     <xsd:attribute name="choiceLength" type="dfdl:DFDLNonNegativeInteger" />
     <xsd:attribute name="choiceDispatchKey" type="dfdl:DFDLExpression" />
-    <xsd:attribute ref="dfdlx:choiceBranchKeyKind" />
-    <xsd:attribute ref="dfdlx:choiceDispatchKeyKind" />
   </xsd:attributeGroup>
 
   <!--16 Arrays and Optional Elements: Properties for Repeating and Variable-Occurrence 
@@ -966,8 +964,6 @@
       type="dfdl:DFDLNonNegativeInteger" />
     <xsd:attribute form="qualified" name="choiceDispatchKey"
       type="dfdl:DFDLExpression" />
-    <xsd:attribute ref="dfdlx:choiceBranchKeyKind" />
-    <xsd:attribute ref="dfdlx:choiceDispatchKeyKind" />
   </xsd:attributeGroup>
 
   <!--16 Arrays and Optional Elements: Properties for Repeating and Variable-Occurrence 

--- a/daffodil-propgen/src/main/resources/org/apache/daffodil/xsd/dafext.xsd
+++ b/daffodil-propgen/src/main/resources/org/apache/daffodil/xsd/dafext.xsd
@@ -436,22 +436,6 @@
             </xs:documentation>
           </xs:annotation>
         </xs:element>
-        <xs:element name="requireChoiceDispatchKeyKindProperty" type="xs:boolean" default="false" minOccurs="0">
-          <xs:annotation>
-            <xs:documentation>
-              If true, require that the dfdl:choiceDispatchKeyKind property is specified. If false, use a
-              default value if the property is not defined in the schema.
-            </xs:documentation>
-          </xs:annotation>
-        </xs:element>
-        <xs:element name="requireChoiceBranchKeyKindProperty" type="xs:boolean" default="false" minOccurs="0">
-          <xs:annotation>
-            <xs:documentation>
-              If true, require that the dfdl:choiceBranchKeyKind property is specified. If false, use a
-              default value if the property is not defined in the schema.
-            </xs:documentation>
-          </xs:annotation>
-        </xs:element>
         <xs:element name="requireEmptyElementParsePolicyProperty" type="xs:boolean" default="false" minOccurs="0">
           <xs:annotation>
             <xs:documentation>

--- a/daffodil-propgen/src/main/resources/org/apache/daffodil/xsd/dfdlx.xsd
+++ b/daffodil-propgen/src/main/resources/org/apache/daffodil/xsd/dfdlx.xsd
@@ -34,9 +34,7 @@
 
   <xs:simpleType name="PropertyNameType">
     <xs:restriction base="xs:string">
-      <xs:enumeration value="dfdlx:choiceBranchKeyKind" />
       <xs:enumeration value="dfdlx:choiceBranchKeyRanges" />
-      <xs:enumeration value="dfdlx:choiceDispatchKeyKind" />
       <xs:enumeration value="dfdlx:emptyElementParsePolicy"/>
       <xs:enumeration value="dfdlx:inputTypeCalc"/>
       <xs:enumeration value="dfdlx:objectKind"/>
@@ -72,17 +70,6 @@
     <xs:restriction base="xs:string">
       <xs:enumeration value="treatAsEmpty" />
       <xs:enumeration value="treatAsMissing" />
-    </xs:restriction>
-  </xs:simpleType>
-
-  <xs:attribute name="choiceBranchKeyKind" type="dfdlx:ChoiceKeyKindType"/>
-  <xs:attribute name="choiceDispatchKeyKind"  type="dfdlx:ChoiceKeyKindType"/>
-  <xs:simpleType name="ChoiceKeyKindType">
-    <xs:restriction base="xs:string">
-      <xs:enumeration value="byType"/>
-      <xs:enumeration value="explicit"/>
-      <xs:enumeration value="speculative"/>
-      <xs:enumeration value="implicit"/>
     </xs:restriction>
   </xs:simpleType>
   

--- a/daffodil-test/src/test/resources/org/apache/daffodil/extensions/type_calc/inputTypeCalc.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/extensions/type_calc/inputTypeCalc.tdml
@@ -104,80 +104,11 @@
       </xs:restriction>
     </xs:simpleType>
 
-    <xs:element name="choice_dispatchKeyByType_01">
-      <xs:complexType>
-        <xs:choice dfdlx:choiceBranchKeyKind="explicit" dfdlx:choiceDispatchKeyKind="byType" >
-          <xs:element name="unreachable" type="tns:unreachableRepTypeuint8" dfdl:choiceBranchKey="-1"/>
-          <xs:element name="one" type="tns:_1_to_string" dfdl:choiceBranchKey="1"/>
-          <xs:element name="two" type="tns:_2through100_to_string" dfdl:choiceBranchKey="2"/>
-          <xs:element name="three_four_five" type="tns:_2through100_to_string" dfdl:choiceBranchKey="3 4 5"/>
-          <xs:element name="_101_122" type="tns:complexSet_to_string" dfdl:choiceBranchKey="101 122"/>
-        </xs:choice>
-      </xs:complexType>
-    </xs:element>
-
-    <xs:element name="choice_dispatchKeyByType_02">
-      <xs:complexType>
-        <xs:sequence>
-          <xs:element name="byte" dfdl:occursCountKind="parsed" maxOccurs="unbounded">
-            <xs:complexType>
-              <xs:choice dfdlx:choiceBranchKeyKind="explicit" dfdlx:choiceDispatchKeyKind="byType" >
-                <xs:element name="unreachable" type="tns:unreachableRepTypeuint8" dfdl:choiceBranchKey="255"/>
-                <xs:element name="one" type="tns:_1_to_string" dfdl:choiceBranchKey="1"/>
-                <xs:element name="two" type="tns:_2through100_to_string" dfdl:choiceBranchKey="2"/>
-                <xs:element name="three_four_five" type="tns:_2through100_to_string" dfdl:choiceBranchKey="3 4 5"/>
-                <xs:element name="_101_122" type="tns:complexSet_to_string" dfdl:choiceBranchKey="101 122"/>
-              </xs:choice>
-            </xs:complexType>
-          </xs:element>
-        </xs:sequence>
-      </xs:complexType>
-    </xs:element>
-
-    <xs:element name="choice_branchKeyByType_01">
-      <xs:complexType>
-        <xs:sequence>
-          <xs:element name="byte" dfdl:occursCountKind="parsed" maxOccurs="unbounded">
-            <xs:complexType>
-              <xs:sequence>
-                <xs:element name="dispatchKey" type="tns:uint8">
-                  <xs:annotation>
-                    <xs:appinfo source="http://www.ogf.org/dfdl/">
-                      <dfdl:discriminator>{ fn:true() }</dfdl:discriminator>
-                    </xs:appinfo>
-                  </xs:annotation>
-                </xs:element>
-                <xs:choice dfdlx:choiceBranchKeyKind="byType" dfdlx:choiceDispatchKeyKind="explicit" dfdl:choiceDispatchKey="{ ex:dispatchKey }">
-                  <xs:element name="unreachable" type="tns:unreachableRepTypeuint8"/>
-                  <xs:element name="many" type="tns:_2through100_to_int"/>
-                  <xs:element name="one" type="tns:_1_to_string"/>
-                </xs:choice>
-              </xs:sequence>
-            </xs:complexType>
-          </xs:element>
-        </xs:sequence>
-      </xs:complexType>
-    </xs:element>
 
     <xs:element name="inputTypeCalc_unionOfKeysetValueCalcs_01">
       <xs:complexType>
         <xs:sequence>
           <xs:element name="byte" type="tns:_1through100_union_to_string" maxOccurs="unbounded" dfdl:occursCountKind="parsed"/>
-        </xs:sequence>
-      </xs:complexType>
-    </xs:element>
-
-    <xs:element name="inputTypeCalc_unionOfKeysetValueCalcs_02">
-      <xs:complexType>
-        <xs:sequence>
-          <xs:element name="byte" maxOccurs="unbounded" dfdl:occursCountKind="parsed">
-            <xs:complexType>
-              <xs:choice dfdlx:choiceBranchKeyKind="byType" dfdlx:choiceDispatchKeyKind="byType">
-                <xs:element name="a" type="tns:_1through100_union_to_string"/>
-                <xs:element name="b" type="tns:complexSet_to_string"/>
-              </xs:choice>
-            </xs:complexType>
-          </xs:element>
         </xs:sequence>
       </xs:complexType>
     </xs:element>
@@ -305,126 +236,6 @@
     </tdml:infoset>
   </tdml:unparserTestCase>
 
-  <tdml:parserTestCase name="InputTypeCalc_choiceDispatchByType_01"
-    root="choice_dispatchKeyByType_01" model="inputTypeCalc-Embedded.dfdl.xsd" description="Extensions - choiceDispatchByType with keysetValue types">
-
-    <tdml:document>
-    <tdml:documentPart type="byte">
-    01
-    </tdml:documentPart>
-    </tdml:document>
-    <tdml:infoset>
-      <tdml:dfdlInfoset xmlns:xs="http://www.w3.org/2001/XMLSchema"
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-        <choice_dispatchKeyByType_01>
-          <one>one</one>
-        </choice_dispatchKeyByType_01>
-      </tdml:dfdlInfoset>
-    </tdml:infoset>
-  </tdml:parserTestCase>
-
-  <tdml:parserTestCase name="InputTypeCalc_choiceDispatchByType_02"
-    root="choice_dispatchKeyByType_02" model="inputTypeCalc-Embedded.dfdl.xsd" description="Extensions - choiceDispatchByType with keysetValue types">
-
-    <tdml:document>
-    <tdml:documentPart type="byte">
-    01 02 03 04 05 65 7A
-    </tdml:documentPart>
-    </tdml:document>
-    <tdml:infoset>
-      <tdml:dfdlInfoset xmlns:xs="http://www.w3.org/2001/XMLSchema"
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-        <choice_dispatchKeyByType_02>
-          <byte><one>one</one></byte>
-          <byte><two>2-100</two></byte>
-          <byte><three_four_five>2-100</three_four_five></byte>
-          <byte><three_four_five>2-100</three_four_five></byte>
-          <byte><three_four_five>2-100</three_four_five></byte>
-          <byte><_101_122>101 103-110 115 120-125</_101_122></byte>
-          <byte><_101_122>101 103-110 115 120-125</_101_122></byte>
-        </choice_dispatchKeyByType_02>
-      </tdml:dfdlInfoset>
-    </tdml:infoset>
-  </tdml:parserTestCase>
-
-  <tdml:parserTestCase name="InputTypeCalc_choiceDispatchByType_03"
-    root="choice_dispatchKeyByType_01" model="inputTypeCalc-Embedded.dfdl.xsd" description="Extensions - choiceDispatchByType with keysetValue types - bad key">
-
-    <tdml:document>
-    <tdml:documentPart type="byte">
-    ff
-    </tdml:documentPart>
-    </tdml:document>
-    <tdml:errors>
-      <tdml:error>Parse Error</tdml:error>
-      <tdml:error>Failed to match any of the branch keys</tdml:error>
-    </tdml:errors>
-  </tdml:parserTestCase>
-
-  <tdml:unparserTestCase name="InputTypeCalc_unparse_choiceDispatchByType_01"
-    root="choice_dispatchKeyByType_01" model="inputTypeCalc-Embedded.dfdl.xsd" description="Extensions - choiceDispatchByType with keysetValue types">
-
-    <tdml:document>
-    <tdml:documentPart type="byte">
-    01
-    </tdml:documentPart>
-    </tdml:document>
-    <tdml:infoset>
-      <tdml:dfdlInfoset xmlns:xs="http://www.w3.org/2001/XMLSchema"
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-        <choice_dispatchKeyByType_01>
-          <one>one</one>
-        </choice_dispatchKeyByType_01>
-      </tdml:dfdlInfoset>
-    </tdml:infoset>
-  </tdml:unparserTestCase>
-
-  <tdml:unparserTestCase name="InputTypeCalc_unparse_choiceDispatchByType_02"
-    root="choice_dispatchKeyByType_02" model="inputTypeCalc-Embedded.dfdl.xsd" description="Extensions - choiceDispatchByType with keysetValue types">
-
-    <tdml:document>
-    <tdml:documentPart type="byte">
-    01 02 02 65
-    </tdml:documentPart>
-    </tdml:document>
-    <tdml:infoset>
-      <tdml:dfdlInfoset xmlns:xs="http://www.w3.org/2001/XMLSchema"
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-        <choice_dispatchKeyByType_02>
-          <byte><one>one</one></byte>
-          <byte><two>2-100</two></byte>
-
-          <!-- It is a bit unclear what the below should unparse to.
-               Since it's type is 2-100, it would normally unparse to 2 if it
-               were outside of the choice, so this test expects that here.
-          -->
-          <byte><three_four_five>2-100</three_four_five></byte>
-          <byte><_101_122>101 103-110 115 120-125</_101_122></byte>
-        </choice_dispatchKeyByType_02>
-      </tdml:dfdlInfoset>
-    </tdml:infoset>
-  </tdml:unparserTestCase>
-
-  <tdml:parserTestCase name="InputTypeCalc_choiceBranchKeyByType_01"
-    root="choice_branchKeyByType_01" model="inputTypeCalc-Embedded.dfdl.xsd" description="Extensions - choiceBranchKeyByType with keysetValue types">
-
-    <tdml:document>
-    <tdml:documentPart type="byte">
-    01 01 02 02 07 08
-    </tdml:documentPart>
-    </tdml:document>
-    <tdml:infoset>
-      <tdml:dfdlInfoset xmlns:xs="http://www.w3.org/2001/XMLSchema"
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-        <choice_branchKeyByType_01>
-          <byte><dispatchKey>1</dispatchKey><one>one</one></byte>
-          <byte><dispatchKey>2</dispatchKey><many>2</many></byte>
-          <byte><dispatchKey>7</dispatchKey><many>8</many></byte>
-        </choice_branchKeyByType_01>
-      </tdml:dfdlInfoset>
-    </tdml:infoset>
-  </tdml:parserTestCase>
-
   <tdml:parserTestCase name="InputTypeCalc_unionOfKeysetValueCalcs_01"
     root="inputTypeCalc_unionOfKeysetValueCalcs_01" model="inputTypeCalc-Embedded.dfdl.xsd" description="Extensions - repType with union of keysetValue types">
 
@@ -461,49 +272,6 @@
           <byte>one</byte>
           <byte>2-100</byte>
         </inputTypeCalc_unionOfKeysetValueCalcs_01>
-      </tdml:dfdlInfoset>
-    </tdml:infoset>
-  </tdml:unparserTestCase>
-
-  <tdml:parserTestCase name="InputTypeCalc_unionOfKeysetValueCalcs_02"
-    root="inputTypeCalc_unionOfKeysetValueCalcs_02" model="inputTypeCalc-Embedded.dfdl.xsd" description="Extensions - repType with union of keysetValue types">
-
-    <tdml:document>
-    <tdml:documentPart type="byte">
-    01 02 03 64 65 67
-    </tdml:documentPart>
-    </tdml:document>
-    <tdml:infoset>
-      <tdml:dfdlInfoset xmlns:xs="http://www.w3.org/2001/XMLSchema"
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-        <inputTypeCalc_unionOfKeysetValueCalcs_02>
-          <byte><a>one</a></byte>
-          <byte><a>2-100</a></byte>
-          <byte><a>2-100</a></byte>
-          <byte><a>2-100</a></byte>
-          <byte><b>101 103-110 115 120-125</b></byte>
-          <byte><b>101 103-110 115 120-125</b></byte>
-        </inputTypeCalc_unionOfKeysetValueCalcs_02>
-      </tdml:dfdlInfoset>
-    </tdml:infoset>
-  </tdml:parserTestCase>
-
-  <tdml:unparserTestCase name="InputTypeCalc_unparse_unionOfKeysetValueCalcs_02"
-    root="inputTypeCalc_unionOfKeysetValueCalcs_02" model="inputTypeCalc-Embedded.dfdl.xsd" description="Extensions - repType with union of keysetValue types">
-
-    <tdml:document>
-    <tdml:documentPart type="byte">
-    01 02 65
-    </tdml:documentPart>
-    </tdml:document>
-    <tdml:infoset>
-      <tdml:dfdlInfoset xmlns:xs="http://www.w3.org/2001/XMLSchema"
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-        <inputTypeCalc_unionOfKeysetValueCalcs_02>
-          <byte><a>one</a></byte>
-          <byte><a>2-100</a></byte>
-          <byte><b>101 103-110 115 120-125</b></byte>
-        </inputTypeCalc_unionOfKeysetValueCalcs_02>
       </tdml:dfdlInfoset>
     </tdml:infoset>
   </tdml:unparserTestCase>

--- a/daffodil-test/src/test/scala/org/apache/daffodil/extensions/TestInputTypeValueCalc.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/extensions/TestInputTypeValueCalc.scala
@@ -48,20 +48,8 @@ class TestInputTypeValueCalc {
   @Test def test_InputTypeCalc_unparse_keysetValue_01(): Unit = { runner.runOneTest("InputTypeCalc_unparse_keysetValue_01") }
   @Test def test_InputTypeCalc_unparse_keysetValue_02(): Unit = { runner.runOneTest("InputTypeCalc_unparse_keysetValue_02") }
 
-  @Test def test_InputTypeCalc_choiceDispatchByType_01(): Unit = { runner.runOneTest("InputTypeCalc_choiceDispatchByType_01") }
-  @Test def test_InputTypeCalc_choiceDispatchByType_02(): Unit = { runner.runOneTest("InputTypeCalc_choiceDispatchByType_02") }
-  @Test def test_InputTypeCalc_choiceDispatchByType_03(): Unit = { runner.runOneTest("InputTypeCalc_choiceDispatchByType_03") }
-
-  @Test def test_InputTypeCalc_unparse_choiceDispatchByType_01(): Unit = { runner.runOneTest("InputTypeCalc_unparse_choiceDispatchByType_01") }
-  @Test def test_InputTypeCalc_unparse_choiceDispatchByType_02(): Unit = { runner.runOneTest("InputTypeCalc_unparse_choiceDispatchByType_02") }
-
-  @Test def test_InputTypeCalc_choiceBranchKeyByType_01(): Unit = { runner.runOneTest("InputTypeCalc_choiceBranchKeyByType_01") }
-
   @Test def test_InputTypeCalc_unionOfKeysetValueCalcs_01(): Unit = { runner.runOneTest("InputTypeCalc_unionOfKeysetValueCalcs_01") }
   @Test def test_InputTypeCalc_unparse_unionOfKeysetValueCalcs_01(): Unit = { runner.runOneTest("InputTypeCalc_unparse_unionOfKeysetValueCalcs_01") }
-
-  @Test def test_InputTypeCalc_unionOfKeysetValueCalcs_02(): Unit = { runner.runOneTest("InputTypeCalc_unionOfKeysetValueCalcs_02") }
-  @Test def test_InputTypeCalc_unparse_unionOfKeysetValueCalcs_02(): Unit = { runner.runOneTest("InputTypeCalc_unparse_unionOfKeysetValueCalcs_02") }
 
   @Test def test_InputTypeCalc_expression_01(): Unit = { exprRunner.runOneTest("InputTypeCalc_expression_01") }
   @Test def test_OutputTypeCalc_expression_01(): Unit = { exprRunner.runOneTest("OutputTypeCalc_expression_01") }


### PR DESCRIPTION
Unused by any known DFDL schema.

Removing to simplify daffodil around the enumerations/table features.

DAFFODIL-2273