### PR TITLE
Work around issue resetting predefined vars

### DIFF
--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/VariableMap1.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/VariableMap1.scala
@@ -155,6 +155,7 @@ class VariableInstance private (val rd: VariableRuntimeData)
         this.setState(this.priorState)
         this.setValue(this.priorValue)
       }
+      case (VariableDefined, _, _) => // This should only occur for pre-defined variables
       case (_, _, _) => Assert.impossible("Should have SDE before reaching this")
     }
   }


### PR DESCRIPTION
This is a quick fix for this bug where a predefined variable is being reset beyond its original definition.  This was occurring in the EDIFACT and NACHA schemas.

Definitely feels a little hacky and I was trying to add a test case to reproduce the issue by having a choice branch backtrack after reading a predefined variable but was unsuccessful.  I'm not sure what is triggering this double reset in the EDIFACT/NACHA schemas, so this "fix" may be more of a bandaid instead of fixing a deeper issue.  Since this bug is holding up the release of 3.2.0, I figured it would be worth creating this pull request and open up the forum for discussion on how to fix this issue.

DAFFODIL-2580