### PR TITLE
Remove duplicate prefix mapping check in SAX infosets

### DIFF
--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/DaffodilParseOutputStreamContentHandler.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/DaffodilParseOutputStreamContentHandler.scala
@@ -214,13 +214,7 @@ class DaffodilParseOutputStreamContentHandler(out: OutputStream, pretty: Boolean
     while (currentElementPrefixMapping != null) {
       val prefix = currentElementPrefixMapping.prefix
       val uri = currentElementPrefixMapping.uri
-
-      // check to see if the prefix is already mapped to the same URI. If it
-      // is, ignore this mapping since it adds nothing new
-      val maybeUri = XMLUtils.maybeURI(activePrefixMapping, prefix)
-      if (maybeUri.isEmpty || maybeUri.get != uri) {
-        activePrefixMapping = NamespaceBinding(prefix, uri, activePrefixMapping)
-      }
+      activePrefixMapping = NamespaceBinding(prefix, uri, activePrefixMapping)
       currentElementPrefixMapping = currentElementPrefixMapping.parent
     }
 


### PR DESCRIPTION
When converting SAX events to text using our built-in ContentHandler, we
intentionally do not output namespace prefix mappings if a prefix has
already been mapped to the same namespace. This differs from the
XMLTextInfosetOutputter behavior, which does not do this duplicate
removal. So for example, the XMLTextInfosetOutputter might output an
infoset like this with duplicate namespace mappings:

    <ns:a xmlns:ns="foo">
      <ns:b xmlns:ns="foo">test</ns:b>
    </ns:a>

But when using SAX we would output this, with the duplicate mapping
removed:

    <ns:a xmlns:ns="foo">
      <ns:b>test</ns:b>
    </ns:a>

Although these two infosets are functionally the same, our TDMLRunner
requires that they be exactly the same, including the namespace prefix
mappings on every element. Otherwise the TDMLRunner throws an exception
and the test fails.

Ideally, these two infoset outputters would always have the same output.
Also, one could argue that our SAX ContentHandler should more closely
match the SAX events, so if we get events with duplicate mappings, the
ContentHandler should output duplicate mappings. So this modifies the
ContentHandler so that it does not remove duplicate mappings, and it
matches the XMLTextInfosetOutputter behavior/output, allowing tests to
pass.

DAFFODIL-2568