### PR TITLE
Append needed WiX options to default lightOptions rather than overriding

### DIFF
--- a/daffodil-cli/build.sbt
+++ b/daffodil-cli/build.sbt
@@ -138,11 +138,9 @@ wixProductUpgradeId := "4C966AFF-585E-4E17-8CC2-059FD70FEC77"
 // re-installation of the same version. Despite the presence of
 // specific XML to enable this, the WiX compiler and linker
 // complain about it unless you specifically suppress the warning.
-lightOptions := Seq(
+lightOptions ++= Seq(
   "-sval", // validation does not currently work under Wine, this disables that
   "-sice:ICE61",
-  "-ext", "WixUIExtension",
-  "-cultures:en-us",
   "-loc", ((Windows / sourceDirectory).value / "Product_en-us.wxl").toString
 )
 

--- a/daffodil-cli/src/templates/bat-template
+++ b/daffodil-cli/src/templates/bat-template
@@ -35,6 +35,8 @@ REM DAFFODIL_JAVA_OPTS environment variable. If not specified, the JAVA_OPTS
 REM environment variable will be used. If that is not specified, reasonable
 REM defaults for Daffodil will be defined.
 
+setlocal
+
 set MAINCLASS=org.apache.daffodil.Main
 set BINDIR=%~dp0
 set LIBDIR=%BINDIR%..\lib
@@ -42,13 +44,13 @@ set CONFDIR=%BINDIR%..\conf
 set CLASSPATH=%LIBDIR%\*
 
 if defined DAFFODIL_JAVA_OPTS (
-	set JOPTS=%DAFFODIL_JAVA_OPTS%
+	set "JOPTS=%DAFFODIL_JAVA_OPTS%"
 ) else if defined JAVA_OPTS (
-	set JOPTS=%JAVA_OPTS%
+	set "JOPTS=%JAVA_OPTS%"
 )
 
 if defined DAFFODIL_CLASSPATH (
-	set CLASSPATH=%CLASSPATH%;%DAFFODIL_CLASSPATH%
+	set "CLASSPATH=%CLASSPATH%;%DAFFODIL_CLASSPATH%"
 )
 
 REM Prepend additional java options that must be provided. By prepending, a user


### PR DESCRIPTION
The lightOptions key in the sbt-native-packager plugin defaults to this:

    lightOptions := Seq(
      "-ext", "WixUIExtension",
      "-ext", "WixUtilExtension",
      "-cultures:en-us",
    )

We override the lightOptions setting with these same values plus some
additional ones for things like localization and disabling validation.
But we accidentally didn't include the WixUtilExtesnsion option. At some
point an update required this extension, and without it MSI builds
started to fail.

We could add the missing WixUtilExtension value to our overridden
lightOptions setting, but to ensure we pick up any defaults that the
sbt-native-packager plugin might add and require in the future, this
instead just appends our custom options to the existing setting by using
++=. This gives us back the WixUtilExtenion that we need for builds to
succeed.

Additionally, minor fixs are made to the bat script:
- Enable setlocal so variables used in the bat file do not pollute
  variable scope outside the bat file
- Quote variables inside if-statements. Otherwise, variables with
  parenthesis in them (which is common in Windows (x86) path) cause
  bat-file errors.

DAFFODIL-2584