### PR TITLE
Fix some code generation corner cases

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -13,4 +13,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Do not include KEYS in archived source releases
 /KEYS export-ignore 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -86,7 +86,7 @@ jobs:
         uses: actions/checkout@v2.4.0
         with:
           repository: michaelrsweet/mxml
-          ref: v3.2
+          ref: v3.3
           path: mxml
 
       - name: Install mxml library (Windows)
@@ -148,6 +148,9 @@ jobs:
 
       - name: Run Integration Tests
         run: $SBT coverage IntegrationTest/test
+
+      - name: Run Modified Example Files Check
+        run: git diff --color --exit-code
 
       - name: Generate Coverage Report
         run: $SBT coverageAggregate

--- a/BUILD.md
+++ b/BUILD.md
@@ -60,7 +60,7 @@ in its own repositories.  You'll have to install the latest [SBT]
 version following its website's instructions and you'll have to build
 the [Mini-XML] library from source:
 
-    git clone -b v3.2 https://github.com/michaelrsweet/mxml.git
+    git clone -b v3.3 https://github.com/michaelrsweet/mxml.git
     # ./configure fails if you use CC=clang
     unset CC AR
     cd mxml
@@ -71,7 +71,7 @@ the [Mini-XML] library from source:
 Now you can build Daffodil from source and the sbt and daffodil
 commands you type will be able to call the C compiler.
 
-## Fedora 34
+## Fedora 35
 
 You can use the `dnf` package manager to install most of the tools
 needed to build Daffodil:
@@ -131,7 +131,7 @@ environment variables `CC` and `AR` to the clang binaries' names:
 However, MSYS2 has no [libmxml-devel][Mini-XML] package so you'll have
 to build the [Mini-XML] library from source:
 
-    git clone -b v3.2 https://github.com/michaelrsweet/mxml.git
+    git clone -b v3.3 https://github.com/michaelrsweet/mxml.git
     # some daffodil tests fail if you build mxml with clang
     unset CC AR
     cd mxml

--- a/daffodil-runtime2/src/main/resources/org/apache/daffodil/runtime2/c/Makefile
+++ b/daffodil-runtime2/src/main/resources/org/apache/daffodil/runtime2/c/Makefile
@@ -66,4 +66,15 @@ unparse-check: $(PROGRAM)
 clean:
 	rm -f $(PROGRAM) $(TEST_DAT).tmp $(TEST_DAT_XML).tmp
 
-.PHONY: check parse-check unparse-check clean
+# Maintainer only: Format C source files or check includes.
+
+FMT = clang-format -i
+IWYU = iwyu -Xiwyu --max_line_length=999 -Xiwyu --update_comments
+
+format:
+	$(FMT) $(HEADERS) $(SOURCES)
+
+iwyu:
+	-for f in $(SOURCES); do $(IWYU) $(CFLAGS) $(INCLUDES) $$f; done
+
+.PHONY: check parse-check unparse-check clean format iwyu

--- a/daffodil-runtime2/src/main/resources/org/apache/daffodil/runtime2/c/libcli/cli_errors.c
+++ b/daffodil-runtime2/src/main/resources/org/apache/daffodil/runtime2/c/libcli/cli_errors.c
@@ -18,9 +18,8 @@
 // clang-format off
 #include "cli_errors.h"
 #include <assert.h>    // for assert
-#include <inttypes.h>  // for PRId64
+#include <inttypes.h>  // for PRId64, uint8_t
 #include <stddef.h>    // for NULL
-#include <stdint.h>    // for uint8_t
 // clang-format on
 
 // USAGE - second line to append to CLI usage messages
@@ -65,7 +64,7 @@ error_lookup(uint8_t code)
          "unexpected getopt code %" PRId64 "\n"
          "Check for program error\n",
          FIELD_D64},
-        {CLI_PROGRAM_VERSION, "%s\n", FIELD_S},
+        {CLI_PROGRAM_VERSION, "%s\n", FIELD_S_ON_STDOUT},
         {CLI_STACK_EMPTY, "stack empty, stopping program\n", FIELD_ZZZ},
         {CLI_STACK_OVERFLOW, "stack overflow, stopping program\n", FIELD_ZZZ},
         {CLI_STACK_UNDERFLOW, "stack underflow, stopping program\n", FIELD_ZZZ},

--- a/daffodil-runtime2/src/main/resources/org/apache/daffodil/runtime2/c/libcli/xml_writer.c
+++ b/daffodil-runtime2/src/main/resources/org/apache/daffodil/runtime2/c/libcli/xml_writer.c
@@ -18,9 +18,9 @@
 // clang-format off
 #include "xml_writer.h"
 #include <assert.h>      // for assert
-#include <mxml.h>        // for mxmlNewOpaquef, mxml_node_t, mxmlElementSetAttr, mxmlGetOpaque, mxmlNewElement, mxmlDelete, mxmlGetElement, mxmlNewXML, mxmlSaveFile, MXML_NO_CALLBACK
-#include <stdbool.h>     // for bool
-#include <stdint.h>      // for int16_t, int32_t, int64_t, int8_t, uint16_t, uint32_t, uint64_t, uint8_t
+#include <mxml.h>        // for mxmlNewOpaquef, mxml_node_t, mxmlElementSetAttr, mxmlGetOpaque, mxmlNewElement, mxmlDelete, mxmlGetElement, mxmlNewOpaque, mxmlNewXML, mxmlSaveFile, MXML_NO_CALLBACK
+#include <stdbool.h>     // for bool, false, true
+#include <stdint.h>      // for uint8_t, int16_t, int32_t, int64_t, int8_t, uint16_t, uint32_t, uint64_t
 #include <stdlib.h>      // for free, malloc
 #include <string.h>      // for strcmp
 #include "cli_errors.h"  // for CLI_XML_DECL, CLI_XML_ELEMENT, CLI_XML_WRITE, LIMIT_XML_NESTING

--- a/daffodil-runtime2/src/main/resources/org/apache/daffodil/runtime2/c/libruntime/infoset.c
+++ b/daffodil-runtime2/src/main/resources/org/apache/daffodil/runtime2/c/libruntime/infoset.c
@@ -28,10 +28,11 @@ const char *
 get_erd_name(const ERD *erd)
 {
     static char name[LIMIT_NAME_LENGTH];
-    char *      next = name;
-    char *      last = name + sizeof(name) - 1;
 
-    if (next && erd->namedQName.prefix)
+    char *next = name;
+    char *last = name + sizeof(name) - 1;
+
+    if (erd->namedQName.prefix)
     {
         next = memccpy(next, erd->namedQName.prefix, 0, last - next);
         if (next)
@@ -119,19 +120,14 @@ get_erd_ns(const ERD *erd)
 static const Error *
 walkInfosetNode(const VisitEventHandler *handler, const InfosetBase *infoNode)
 {
-    const Error *error = NULL;
-
-    // Start visiting the node
-    if (!error)
-    {
-        error = handler->visitStartComplex(handler, infoNode);
-    }
-
-    // Walk the node's children recursively
     const size_t      count = infoNode->erd->numChildren;
     const ERD **const childrenERDs = infoNode->erd->childrenERDs;
     const size_t *    offsets = infoNode->erd->offsets;
 
+    // Start visiting the node
+    const Error *error = handler->visitStartComplex(handler, infoNode);
+
+    // Walk the node's children recursively
     for (size_t i = 0; i < count && !error; i++)
     {
         const size_t offset = offsets[i];
@@ -182,12 +178,8 @@ walkInfosetNode(const VisitEventHandler *handler, const InfosetBase *infoNode)
 const Error *
 walkInfoset(const VisitEventHandler *handler, const InfosetBase *infoset)
 {
-    const Error *error = NULL;
+    const Error *error = handler->visitStartDocument(handler);
 
-    if (!error)
-    {
-        error = handler->visitStartDocument(handler);
-    }
     if (!error)
     {
         error = walkInfosetNode(handler, infoset);

--- a/daffodil-runtime2/src/main/resources/org/apache/daffodil/runtime2/c/libruntime/parsers.h
+++ b/daffodil-runtime2/src/main/resources/org/apache/daffodil/runtime2/c/libruntime/parsers.h
@@ -22,7 +22,7 @@
 #include <stdbool.h>  // for bool
 #include <stddef.h>   // for size_t
 #include <stdint.h>   // for int64_t, uint32_t, int16_t, int32_t, int8_t, uint16_t, uint64_t, uint8_t
-#include "infoset.h"  // for PState
+#include "infoset.h"  // for PState, HexBinary
 // clang-format on
 
 // Parse binary booleans, real numbers, and integers

--- a/daffodil-runtime2/src/main/resources/org/apache/daffodil/runtime2/c/libruntime/unparsers.h
+++ b/daffodil-runtime2/src/main/resources/org/apache/daffodil/runtime2/c/libruntime/unparsers.h
@@ -22,7 +22,7 @@
 #include <stdbool.h>  // for bool
 #include <stddef.h>   // for size_t
 #include <stdint.h>   // for uint32_t, int16_t, int32_t, int64_t, int8_t, uint16_t, uint64_t, uint8_t
-#include "infoset.h"  // for UState
+#include "infoset.h"  // for UState, HexBinary
 // clang-format on
 
 // Unparse binary booleans, real numbers, and integers

--- a/daffodil-runtime2/src/main/scala/org/apache/daffodil/runtime2/generators/ElementParseAndUnspecifiedLengthCodeGenerator.scala
+++ b/daffodil-runtime2/src/main/scala/org/apache/daffodil/runtime2/generators/ElementParseAndUnspecifiedLengthCodeGenerator.scala
@@ -38,7 +38,7 @@ trait ElementParseAndUnspecifiedLengthCodeGenerator {
     if (context.isSimpleType) {
       cgState.addSimpleTypeERD(context) // ERD static initializer
       Runtime2CodeGenerator.generateCode(elementContentGram, cgState) // initSelf, parseSelf, unparseSelf
-    } else {
+    } else if (cgState.elementNotSeenYet(context)) {
       cgState.pushComplexElement(context)
       cgState.addBeforeSwitchStatements(context) // switch statements for choices
       context.elementChildren.foreach { child =>

--- a/daffodil-runtime2/src/test/c/examples/NestedUnion/generated_code.c
+++ b/daffodil-runtime2/src/test/c/examples/NestedUnion/generated_code.c
@@ -1,10 +1,10 @@
 // clang-format off
 #include "generated_code.h"
 #include <math.h>       // for NAN
-#include <stdbool.h>    // for true, false, bool
+#include <stdbool.h>    // for false, bool, true
 #include <stddef.h>     // for NULL, size_t
 #include <string.h>     // for memset, memcmp
-#include "errors.h"     // for Error, PState, UState, ERR_CHOICE_KEY, UNUSED
+#include "errors.h"     // for Error, PState, UState, ERR_CHOICE_KEY, Error::(anonymous), UNUSED
 #include "parsers.h"    // for alloc_hexBinary, parse_hexBinary, parse_be_float, parse_be_int16, parse_validate_fixed, parse_be_bool32, parse_be_bool16, parse_be_int32, parse_be_uint16, parse_be_uint32, parse_le_bool32, parse_le_int64, parse_le_uint16, parse_le_uint8, parse_be_bool8, parse_be_double, parse_be_int64, parse_be_int8, parse_be_uint64, parse_be_uint8, parse_le_bool16, parse_le_bool8, parse_le_double, parse_le_float, parse_le_int16, parse_le_int32, parse_le_int8, parse_le_uint32, parse_le_uint64
 #include "unparsers.h"  // for unparse_hexBinary, unparse_be_float, unparse_be_int16, unparse_validate_fixed, unparse_be_bool32, unparse_be_bool16, unparse_be_int32, unparse_be_uint16, unparse_be_uint32, unparse_le_bool32, unparse_le_int64, unparse_le_uint16, unparse_le_uint8, unparse_be_bool8, unparse_be_double, unparse_be_int64, unparse_be_int8, unparse_be_uint64, unparse_be_uint8, unparse_le_bool16, unparse_le_bool8, unparse_le_double, unparse_le_float, unparse_le_int16, unparse_le_int32, unparse_le_int8, unparse_le_uint32, unparse_le_uint64
 // clang-format on

--- a/daffodil-runtime2/src/test/c/examples/NestedUnion/generated_code.h
+++ b/daffodil-runtime2/src/test/c/examples/NestedUnion/generated_code.h
@@ -2,10 +2,10 @@
 #define GENERATED_CODE_H
 
 // clang-format off
-#include "infoset.h"  // for HexBinary, InfosetBase
 #include <stdbool.h>  // for bool
 #include <stddef.h>   // for size_t
 #include <stdint.h>   // for uint8_t, int16_t, int32_t, int64_t, uint32_t, int8_t, uint16_t, uint64_t
+#include "infoset.h"  // for InfosetBase, HexBinary
 // clang-format on
 
 // Define infoset structures

--- a/daffodil-runtime2/src/test/c/examples/ex_nums/generated_code.c
+++ b/daffodil-runtime2/src/test/c/examples/ex_nums/generated_code.c
@@ -1,10 +1,10 @@
 // clang-format off
 #include "generated_code.h"
 #include <math.h>       // for NAN
-#include <stdbool.h>    // for true, false, bool
+#include <stdbool.h>    // for false, bool, true
 #include <stddef.h>     // for NULL, size_t
 #include <string.h>     // for memset, memcmp
-#include "errors.h"     // for Error, PState, UState, ERR_CHOICE_KEY, UNUSED
+#include "errors.h"     // for Error, PState, UState, ERR_CHOICE_KEY, Error::(anonymous), UNUSED
 #include "parsers.h"    // for alloc_hexBinary, parse_hexBinary, parse_be_float, parse_be_int16, parse_validate_fixed, parse_be_bool32, parse_be_bool16, parse_be_int32, parse_be_uint16, parse_be_uint32, parse_le_bool32, parse_le_int64, parse_le_uint16, parse_le_uint8, parse_be_bool8, parse_be_double, parse_be_int64, parse_be_int8, parse_be_uint64, parse_be_uint8, parse_le_bool16, parse_le_bool8, parse_le_double, parse_le_float, parse_le_int16, parse_le_int32, parse_le_int8, parse_le_uint32, parse_le_uint64
 #include "unparsers.h"  // for unparse_hexBinary, unparse_be_float, unparse_be_int16, unparse_validate_fixed, unparse_be_bool32, unparse_be_bool16, unparse_be_int32, unparse_be_uint16, unparse_be_uint32, unparse_le_bool32, unparse_le_int64, unparse_le_uint16, unparse_le_uint8, unparse_be_bool8, unparse_be_double, unparse_be_int64, unparse_be_int8, unparse_be_uint64, unparse_be_uint8, unparse_le_bool16, unparse_le_bool8, unparse_le_double, unparse_le_float, unparse_le_int16, unparse_le_int32, unparse_le_int8, unparse_le_uint32, unparse_le_uint64
 // clang-format on

--- a/daffodil-runtime2/src/test/c/examples/ex_nums/generated_code.h
+++ b/daffodil-runtime2/src/test/c/examples/ex_nums/generated_code.h
@@ -2,10 +2,10 @@
 #define GENERATED_CODE_H
 
 // clang-format off
-#include "infoset.h"  // for HexBinary, InfosetBase
 #include <stdbool.h>  // for bool
 #include <stddef.h>   // for size_t
 #include <stdint.h>   // for uint8_t, int16_t, int32_t, int64_t, uint32_t, int8_t, uint16_t, uint64_t
+#include "infoset.h"  // for InfosetBase, HexBinary
 // clang-format on
 
 // Define infoset structures

--- a/daffodil-runtime2/src/test/scala/org/apache/daffodil/runtime2/TestCodeGenerator.scala
+++ b/daffodil-runtime2/src/test/scala/org/apache/daffodil/runtime2/TestCodeGenerator.scala
@@ -39,8 +39,7 @@ import org.junit.Test
  */
 class TestCodeGenerator {
   // Ensure all tests remove tempDir after creating it
-  val tempDir: os.Path = os.temp.dir()
-
+  val tempDir: os.Path = os.temp.dir(dir = null, prefix = "daffodil-runtime2-")
   @After def after(): Unit = {
     os.remove.all(tempDir)
   }
@@ -86,9 +85,14 @@ class TestCodeGenerator {
 
     // Generate code from the test schema successfully
     val codeDir = cg.generateCode(None, tempDir.toString)
+    val daffodilMain = codeDir/"libcli"/"daffodil_main.c"
+    val generatedCodeHeader = codeDir/"libruntime"/"generated_code.h"
+    val generatedCodeFile = codeDir/"libruntime"/"generated_code.c"
     assert(!cg.isError, cg.getDiagnostics.map(_.getMessage()).mkString("\n"))
     assert(os.exists(codeDir))
-    assert(os.exists(codeDir/"libruntime"/"generated_code.c"))
+    assert(os.exists(daffodilMain))
+    assert(os.exists(generatedCodeHeader))
+    assert(os.exists(generatedCodeFile))
   }
 
   @Test def test_compileCode_success(): Unit = {
@@ -167,5 +171,13 @@ class TestCodeGenerator {
     val ur = dp.unparse(input, output)
     assert(ur.isError, "expected ur.isError to be true")
     assert(ur.getDiagnostics.nonEmpty, "expected ur.getDiagnostics to be non-empty")
+  }
+
+  // Test added for code coverage because "sbt coverage compile" doesn't include genExamples
+  @Test def test_CodeGenerator_main(): Unit = {
+    val rootDir = if (os.exists(os.pwd/"src")) os.pwd/os.up else os.pwd
+    val examplesDir = rootDir/"daffodil-runtime2"/"target"/"test_CodeGenerator_main"
+    val args = Array(examplesDir.toString)
+    CodeGenerator.main(args)
   }
 }

--- a/project/Rat.scala
+++ b/project/Rat.scala
@@ -36,7 +36,7 @@ object Rat {
     file("daffodil-cli/src/windows/dialog.bmp"),
 
     // generated_code.[ch] examples
-    file("daffodil-runtime2/src/test/resources/org/apache/daffodil/runtime2/examples"),
+    file("daffodil-runtime2/src/test/c/examples"),
 
     // test files that cannot include the Apache license without breaking tests
     file("daffodil-cli/src/it/resources/org/apache/daffodil/CLI/debugger/982"),


### PR DESCRIPTION
1. Elements used in multiple places within a schema were causing
   redundant code generation

2. Empty complex type elements without any child elements were causing
   compiler warnings

3. Certain choice dispatch key expressions were causing compiler
   errors

Also start keeping generated code examples up to date by automation.

main.yml - Bump mxml from 3.2 to 3.3.

BUILD.md - Bump mxml from 3.2 to 3.3 and Fedora from 34 to 35.

Makefile - Add "format" and "iwyu" targets for maintainers' use.

cli_errors.c - Print program version on stdout, not stderr.  Update includes.

xml_reader.c - Fix a lint warning.  Update includes.

xml_writer.c - Update includes.

infoset.c - Fix some lint warnings.

parsers.h - Update includes.

unparsers.h - Update includes.

CodeGeneratorState.scala - Fix code generation for some corner cases: 1)
elements used in multiple places within a schema causing redundant
code generation, 2) empty complex type elements without any child
elements causing compiler warnings, 3) certain choice dispatch key
expressions causing compiler errors.  Update includes.

ElementParseAndUnspecifiedLengthCodeGenerator.scala - Fix code
generation for one corner case (elements used in multiple places
within a schema causing redundant code generation).

NestedUnion/generated_code.[ch] - Update generated code example by
automation.

ex_nums/generated_code.[ch] - Update generated code example by
automation.

TestCodeGenerator.scala - Change tempDir from /tmp/NNN... to
/tmp/daffodil-runtime2-NNN... to make its purpose clearer.  Add new
test_updateGeneratedCodeExamples to keep our generated code examples
up to date by automation.

DAFFODIL-2585