### PR TITLE
Improve how we capture and restore variable maps in points of uncertainty

### DIFF
--- a/daffodil-test/src/test/resources/org/apache/daffodil/section07/variables/variables.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section07/variables/variables.tdml
@@ -2590,4 +2590,122 @@
     </tdml:document>
   </tdml:unparserTestCase>
 
+  <tdml:defineSchema name="escapeCharVars">
+
+    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd" />
+
+    <dfdl:defineVariable defaultValue="\" name="EscapeChar" type="xs:string"/>
+
+    <dfdl:format ref="GeneralFormat"
+      escapeSchemeRef="escapeScheme" />
+
+    <dfdl:defineEscapeScheme name="escapeScheme">
+      <dfdl:escapeScheme
+        escapeKind="escapeCharacter"
+        escapeCharacter="{ $EscapeChar }"
+        escapeEscapeCharacter="{ $EscapeChar }"
+        extraEscapedCharacters=""/>
+    </dfdl:defineEscapeScheme>
+
+    <xs:element name="root">
+      <xs:complexType>
+        <xs:sequence>
+          <xs:element name="delims" dfdl:initiator="[" dfdl:terminator="]" dfdl:length="1" dfdl:lengthKind="explicit" minOccurs="0">
+            <xs:complexType>
+              <xs:sequence>
+                <xs:element name="escapeChar" type="xs:string" dfdl:lengthKind="explicit" dfdl:length="1" dfdl:escapeSchemeRef="">
+                  <xs:annotation>
+                    <xs:appinfo source="http://www.ogf.org/dfdl/">
+                      <dfdl:setVariable ref="EscapeChar" value="{ . }" />
+                    </xs:appinfo>
+                  </xs:annotation>
+                </xs:element>
+              </xs:sequence>
+            </xs:complexType>
+          </xs:element>
+          <xs:sequence dfdl:separator=",">
+            <xs:element name="field" type="xs:string" dfdl:lengthKind="delimited" maxOccurs="unbounded" />
+          </xs:sequence>
+        </xs:sequence>
+      </xs:complexType>
+    </xs:element>
+
+  </tdml:defineSchema>
+
+  <tdml:parserTestCase name="escapeCharVars_01" root="root" model="escapeCharVars">
+    <tdml:document>[=]fieldOne,field=,Two,fieldThree</tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <root xmlns="http://example.com">
+          <delims>
+            <escapeChar>=</escapeChar>
+          </delims>
+          <field>fieldOne</field>
+          <field>field,Two</field>
+          <field>fieldThree</field>
+        </root>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="escapeCharVars_02" root="root" model="escapeCharVars">
+    <tdml:document>fieldOne,field\,Two,fieldThree</tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <root xmlns="http://example.com">
+          <field>fieldOne</field>
+          <field>field,Two</field>
+          <field>fieldThree</field>
+        </root>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+
+  <tdml:defineSchema name="multipleVarReadInPoU">
+
+    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd" />
+
+    <dfdl:defineVariable defaultValue="x" name="var1" type="xs:string"/>
+
+    <dfdl:format ref="GeneralFormat" />
+
+    <xs:element name="root">
+      <xs:complexType>
+        <xs:sequence>
+          <xs:element name="opt" minOccurs="0">
+            <xs:complexType>
+              <xs:sequence>
+                <xs:sequence>
+                  <xs:annotation>
+                    <xs:appinfo source="http://www.ogf.org/dfdl/">
+                      <dfdl:assert test="{ $var1 eq 'x' }" />
+                    </xs:appinfo>
+                  </xs:annotation>
+                </xs:sequence>
+                <xs:sequence>
+                  <xs:annotation>
+                    <xs:appinfo source="http://www.ogf.org/dfdl/">
+                      <dfdl:assert test="{ $var1 eq 'y' }" />
+                    </xs:appinfo>
+                  </xs:annotation>
+                </xs:sequence>
+              </xs:sequence>
+            </xs:complexType>
+          </xs:element>
+        </xs:sequence>
+      </xs:complexType>
+    </xs:element>
+
+  </tdml:defineSchema>
+
+  <tdml:parserTestCase name="multipleVarReadInPoU_01" root="root" model="multipleVarReadInPoU">
+    <tdml:document></tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <root xmlns="http://example.com"></root>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
 </tdml:testSuite>

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section07/variables/TestVariables.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section07/variables/TestVariables.scala
@@ -132,6 +132,12 @@ class TestVariables {
   @Test def test_setVar1_d_parse(): Unit = { runner_01.runOneTest("setVar1_d_parse") }
   @Test def test_setVar1_d_unparse(): Unit = { runner_01.runOneTest("setVar1_d_unparse") }
 
+  @Test def test_escapeCharVars_01(): Unit = { runner.runOneTest("escapeCharVars_01") }
+  @Test def test_escapeCharVars_02(): Unit = { runner.runOneTest("escapeCharVars_02") }
+
+  @Test def test_multipleVarReadInPoU_01(): Unit = { runner.runOneTest("multipleVarReadInPoU_01") }
+
+
 /*****************************************************************/
   val tdmlVal = XMLUtils.TDML_NAMESPACE
   val dfdl = XMLUtils.DFDL_NAMESPACE


### PR DESCRIPTION
Currently variable instances maintain their own prior state with special
"prior" variables. When resetting back to a PoU, we would use this prior
value to figure out what state to reset to. But this is fragile, and
really only keeps track of one level of change. This mean multiple
changes to variables within a single point of uncertainly can lead to
unexpected behavior or assertion failures.

This changes how we keep track of variable state. Rather than attempting
to roll back individual state changes, when needed to simply create a
deep copy of the entire variable map. But to avoid extra overhead, we
only make a copy right before state is about to change, essentially
implementing copy-on-write. This greatly simplifies the code while still
maintain good performance.

DAFFODIL-2580

See PR #674 for discussions that led to this change.