### PR TITLE
Fix NVI so defaultValue expr has access to properties of term.

### DIFF
--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/DFDLDefineVariable.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/DFDLDefineVariable.scala
@@ -142,11 +142,11 @@ final class DFDLNewVariableInstance(node: Node, decl: AnnotatedSchemaComponent)
   }
 
   final def gram(term: Term) = LV('gram) {
-    NewVariableInstanceStart(decl, this)
+    NewVariableInstanceStart(decl, this, term)
   }.value
 
   final def endGram(term: Term) = LV('endGram) {
-    NewVariableInstanceEnd(decl, this)
+    NewVariableInstanceEnd(decl, this, term)
   }.value
 }
 
@@ -164,6 +164,6 @@ final class DFDLSetVariable(node: Node, decl: AnnotatedSchemaComponent)
   }
 
   final def gram(term: Term) = LV('gram) {
-    SetVariable(this)
+    SetVariable(this, term)
   }.value
 }

--- a/daffodil-core/src/main/scala/org/apache/daffodil/grammar/primitives/PrimitivesExpressions.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/grammar/primitives/PrimitivesExpressions.scala
@@ -171,7 +171,7 @@ case class InitiatedContent(
   override def unparser = hasNoUnparser
 }
 
-case class SetVariable(stmt: DFDLSetVariable)
+case class SetVariable(stmt: DFDLSetVariable, override val term: Term)
   extends ExpressionEvaluatorBase(stmt.annotatedSC) {
 
   val baseName = "SetVariable[" + stmt.varQName.local + "]"
@@ -186,7 +186,7 @@ case class SetVariable(stmt: DFDLSetVariable)
     if (stmt.defv.runtimeData.direction == VariableDirection.UnparseOnly)
       new NadaParser(stmt.defv.runtimeData)
     else
-      new SetVariableParser(expr, stmt.defv.runtimeData)
+      new SetVariableParser(expr, stmt.defv.runtimeData, term.termRuntimeData)
   }
 
   override lazy val unparser: DaffodilUnparser = {
@@ -201,39 +201,39 @@ abstract class NewVariableInstanceBase(decl: AnnotatedSchemaComponent, stmt: DFD
   extends Terminal(decl, true) {
 }
 
-case class NewVariableInstanceStart(decl: AnnotatedSchemaComponent, stmt: DFDLNewVariableInstance)
+case class NewVariableInstanceStart(decl: AnnotatedSchemaComponent, stmt: DFDLNewVariableInstance, override val term: Term)
   extends NewVariableInstanceBase(decl, stmt) {
 
   lazy val parser: DaffodilParser = {
     if (stmt.defv.runtimeData.direction == VariableDirection.UnparseOnly)
       new NadaParser(stmt.variableRuntimeData)
     else
-      new NewVariableInstanceStartParser(stmt.variableRuntimeData)
+      new NewVariableInstanceStartParser(stmt.variableRuntimeData, term.termRuntimeData)
   }
 
   override lazy val unparser: DaffodilUnparser = {
     if (stmt.defv.runtimeData.direction == VariableDirection.ParseOnly)
       new NadaUnparser(stmt.variableRuntimeData)
     else
-      new NewVariableInstanceStartUnparser(stmt.variableRuntimeData)
+      new NewVariableInstanceStartUnparser(stmt.variableRuntimeData, term.termRuntimeData)
   }
 }
 
-case class NewVariableInstanceEnd(decl: AnnotatedSchemaComponent, stmt: DFDLNewVariableInstance)
+case class NewVariableInstanceEnd(decl: AnnotatedSchemaComponent, stmt: DFDLNewVariableInstance, override val term: Term)
   extends NewVariableInstanceBase(decl, stmt) {
 
   lazy val parser: DaffodilParser = {
     if (stmt.defv.runtimeData.direction == VariableDirection.UnparseOnly)
       new NadaParser(stmt.variableRuntimeData)
     else
-      new NewVariableInstanceEndParser(stmt.variableRuntimeData)
+      new NewVariableInstanceEndParser(stmt.variableRuntimeData, term.termRuntimeData)
   }
 
   override lazy val unparser: DaffodilUnparser = {
     if (stmt.defv.runtimeData.direction == VariableDirection.ParseOnly)
       new NadaUnparser(stmt.variableRuntimeData)
     else
-      new NewVariableInstanceEndUnparser(stmt.variableRuntimeData)
+      new NewVariableInstanceEndUnparser(stmt.variableRuntimeData, term.termRuntimeData)
   }
 }
 

--- a/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/processors/unparsers/ExpressionEvaluatingUnparsers.scala
+++ b/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/processors/unparsers/ExpressionEvaluatingUnparsers.scala
@@ -28,6 +28,7 @@ import org.apache.daffodil.processors.ElementRuntimeData
 import org.apache.daffodil.processors.Evaluatable
 import org.apache.daffodil.processors.NonTermRuntimeData
 import org.apache.daffodil.processors.Success
+import org.apache.daffodil.processors.TermRuntimeData
 import org.apache.daffodil.processors.TypeCalculator
 import org.apache.daffodil.processors.VariableRuntimeData
 import org.apache.daffodil.processors.VariableInProcess
@@ -93,20 +94,21 @@ final class NewVariableInstanceDefaultValueSuspendableExpression(
 
 // When implemented this almost certainly wants to be a combinator
 // Not two separate unparsers.
-class NewVariableInstanceStartUnparser(override val context: VariableRuntimeData)
+class NewVariableInstanceStartUnparser(vrd: VariableRuntimeData, trd: TermRuntimeData)
   extends PrimUnparserNoData {
 
+  override def context = trd
   override lazy val runtimeDependencies = Vector()
 
   override lazy val childProcessors = Vector()
 
   override def unparse(state: UState) = {
-    val nvi = state.newVariableInstance(context)
+    val nvi = state.newVariableInstance(vrd)
 
-    if (context.maybeDefaultValueExpr.isDefined) {
-      val dve = context.maybeDefaultValueExpr.get
+    if (vrd.maybeDefaultValueExpr.isDefined) {
+      val dve = vrd.maybeDefaultValueExpr.get
       nvi.setState(VariableInProcess)
-      val suspendableExpression = new NewVariableInstanceDefaultValueSuspendableExpression(dve, context, nvi)
+      val suspendableExpression = new NewVariableInstanceDefaultValueSuspendableExpression(dve, vrd, nvi)
       suspendableExpression.run(state)
     } else if (nvi.firstInstanceInitialValue.isDefined) {
       // The NVI will inherit the default value of the original variable instance
@@ -116,14 +118,15 @@ class NewVariableInstanceStartUnparser(override val context: VariableRuntimeData
   }
 }
 
-class NewVariableInstanceEndUnparser(override val context: VariableRuntimeData)
+class NewVariableInstanceEndUnparser(vrd: VariableRuntimeData, trd: TermRuntimeData)
   extends PrimUnparserNoData {
 
+  override def context = trd
   override lazy val runtimeDependencies = Vector()
 
   override lazy val childProcessors = Vector()
 
-  override def unparse(state: UState) = state.removeVariableInstance(context)
+  override def unparse(state: UState) = state.removeVariableInstance(vrd)
 }
 
 class TypeValueCalcUnparser(typeCalculator: TypeCalculator, repTypeUnparser: Unparser, e: ElementRuntimeData, repTypeRuntimeData: ElementRuntimeData)

--- a/daffodil-test/src/test/resources/org/apache/daffodil/extensions/lookAhead/lookAhead.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/extensions/lookAhead/lookAhead.tdml
@@ -31,6 +31,9 @@
       dfdlx:emptyElementParsePolicy="treatAsEmpty"
       />
 
+    <dfdl:defineVariable name="myVar1" type="xs:integer" />
+    <dfdl:defineVariable name="myVar2" type="xs:integer" />
+
    <xs:element name="lookAhead_01">
      <xs:complexType>
        <xs:sequence>
@@ -134,6 +137,35 @@
        <xs:sequence>
          <xs:element type="xs:int" name="zero" dfdl:inputValueCalc=" { dfdlx:lookAhead(0, 0) }" />
          <xs:element type="xs:hexBinary" name="data" dfdl:length="8" dfdl:lengthKind="explicit" />
+       </xs:sequence>
+     </xs:complexType>
+   </xs:element>
+
+   <xs:element name="lookAhead_newVariableInstance_01" >
+     <xs:complexType>
+       <xs:sequence>
+         <xs:annotation>
+           <xs:appinfo source="http://www.ogf.org/dfdl/">
+             <dfdl:newVariableInstance ref="ex:myVar1"
+               defaultValue="{ dfdlx:lookAhead(0, 63) }" />
+           </xs:appinfo>
+         </xs:annotation>
+         <xs:element type="xs:hexBinary" name="data" dfdl:length="64" dfdl:lengthKind="explicit" />
+         <xs:element type="xs:integer" name="varValue" dfdl:inputValueCalc="{ $ex:myVar1 }" />
+       </xs:sequence>
+     </xs:complexType>
+   </xs:element>
+
+   <xs:element name="lookAhead_setVariable_01" >
+     <xs:complexType>
+       <xs:sequence>
+         <xs:annotation>
+           <xs:appinfo source="http://www.ogf.org/dfdl/">
+             <dfdl:setVariable ref="ex:myVar2">{ dfdlx:lookAhead(0, 63) }</dfdl:setVariable>
+           </xs:appinfo>
+         </xs:annotation>
+         <xs:element type="xs:hexBinary" name="data" dfdl:length="64" dfdl:lengthKind="explicit" />
+         <xs:element type="xs:integer" name="varValue" dfdl:inputValueCalc="{ $ex:myVar2 }" />
        </xs:sequence>
      </xs:complexType>
    </xs:element>
@@ -389,5 +421,42 @@
       </tdml:dfdlInfoset>
     </tdml:infoset>
   </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="lookAhead_newVariableInstance_01"
+    root="lookAhead_newVariableInstance_01" model="lookAhead-Embedded.dfdl.xsd" description="Extensions - lookAhead">
+
+    <tdml:document>
+    <tdml:documentPart type="byte">
+    FF ff FF ff FF ff FF FF
+    </tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <lookAhead_newVariableInstance_01>
+          <data>FFFFFFFFFFFFFFFF</data>
+          <varValue>9223372036854775807</varValue>
+        </lookAhead_newVariableInstance_01>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="lookAhead_setVariable_01"
+    root="lookAhead_setVariable_01" model="lookAhead-Embedded.dfdl.xsd" description="Extensions - lookAhead">
+
+    <tdml:document>
+    <tdml:documentPart type="byte">
+    FF ff FF ff FF ff FF FF
+    </tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <lookAhead_setVariable_01>
+          <data>FFFFFFFFFFFFFFFF</data>
+          <varValue>9223372036854775807</varValue>
+        </lookAhead_setVariable_01>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
 
 </tdml:testSuite>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section23/dfdl_expressions/expressions3.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section23/dfdl_expressions/expressions3.tdml
@@ -529,4 +529,55 @@
       <tdml:error>42</tdml:error>
     </tdml:errors>
   </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="setVariable_neg_01"
+                       root="setVariable_neg_01" model="setVar.dfdl.xsd"
+                       description="setVariable negative runtime error test.">
+
+    <tdml:document/>
+    <tdml:errors>
+      <tdml:error>Parse Error</tdml:error>
+      <tdml:error>/ by zero</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="setVariable_neg_line_info_01"
+                       root="setVariable_neg_01" model="setVar.dfdl.xsd"
+                       description="setVariable negative runtime error reports useful line number of setVar statement.">
+
+    <tdml:document/>
+    <tdml:errors>
+      <tdml:error>Parse Error</tdml:error>
+      <tdml:error>/ by zero</tdml:error>
+      <tdml:error>Location line 49</tdml:error><!-- need proper line number -->
+      <tdml:error>dfdl:setVariable</tdml:error><!-- should mention the kind of DFDL statement -->
+      <tdml:error>setVar.dfdl.xsd</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="newVariableInstance_neg_01"
+                       root="newVariableInstance_neg_01" model="setVar.dfdl.xsd"
+                       description="newVariableInstance negative runtime error test.">
+
+    <tdml:document/>
+    <tdml:errors>
+      <tdml:error>Parse Error</tdml:error>
+      <tdml:error>/ by zero</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="newVariableInstance_neg_line_info_01"
+                       root="newVariableInstance_neg_01" model="setVar.dfdl.xsd"
+                       description="newVariableInstance negative runtime error reports useful line number of newVariableInstance statement.">
+
+    <tdml:document/>
+    <tdml:errors>
+      <tdml:error>Parse Error</tdml:error>
+      <tdml:error>/ by zero</tdml:error>
+      <tdml:error>Location line 69</tdml:error> <!-- need proper line number -->
+      <tdml:error>dfdl:newVariableInstance</tdml:error> <!-- should mention the kind of DFDL statement -->
+      <tdml:error>setVar.dfdl.xsd</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
 </tdml:testSuite>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section23/dfdl_expressions/setVar.dfdl.xsd
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section23/dfdl_expressions/setVar.dfdl.xsd
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<xs:schema
+  xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/"
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns:ex="http://example.com"
+  targetNamespace="http://example.com"
+  elementFormDefault="unqualified">
+
+  <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+
+  <xs:annotation>
+    <xs:appinfo source="http://www.ogf.org/dfdl/">
+
+      <dfdl:format ref="ex:GeneralFormat"/>
+
+      <dfdl:defineVariable name="myVar" type="xs:int"/>
+
+    </xs:appinfo>
+  </xs:annotation>
+
+  <!-- for testing the diagnostic message when a setVariable gets an error at runtime. -->
+  <xs:element name="setVariable_neg_01">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element type="xs:int" name="value" dfdl:inputValueCalc='{ 0 }'/>
+        <xs:sequence>
+          <xs:annotation>
+            <xs:appinfo source="http://www.ogf.org/dfdl/">
+              <!--
+                 The diagnostic message should identify the line below as the location of the div by zero error
+                 -->
+              <dfdl:setVariable ref="ex:myVar">{ xs:int(1 div ./value) }</dfdl:setVariable>
+            </xs:appinfo>
+          </xs:annotation>
+          <xs:element type="xs:int" name="varValue" dfdl:inputValueCalc="{ $ex:myVar }"/>
+        </xs:sequence>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+
+  <!-- for testing the diagnostic message when a newVariableInstance gets an error at runtime. -->
+  <xs:element name="newVariableInstance_neg_01">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element type="xs:int" name="value" dfdl:inputValueCalc='{ 0 }'/>
+        <xs:sequence>
+          <xs:annotation>
+            <xs:appinfo source="http://www.ogf.org/dfdl/">
+              <!--
+                 The diagnostic message should identify the line below as the location of the div by zero error
+                 -->
+              <dfdl:newVariableInstance ref="ex:myVar" defaultValue='{ xs:int(1 div ./value) }'/>
+            </xs:appinfo>
+          </xs:annotation>
+          <xs:element type="xs:int" name="varValue" dfdl:inputValueCalc="{ $ex:myVar }"/>
+        </xs:sequence>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+
+</xs:schema>

--- a/daffodil-test/src/test/scala/org/apache/daffodil/extensions/TestLookAhead.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/extensions/TestLookAhead.scala
@@ -46,4 +46,6 @@ class TestLookAhead {
   @Test def test_lookAhead_negativeOffset_01(): Unit = { runner.runOneTest("lookAhead_negativeOffset_01") }
   @Test def test_lookAhead_negativeBitsize_01(): Unit = { runner.runOneTest("lookAhead_negativeBitsize_01") }
   @Test def test_lookAhead_zeroBitsize_01(): Unit = { runner.runOneTest("lookAhead_zeroBitsize_01") }
+  @Test def test_lookAhead_newVariableInstance_01(): Unit = { runner.runOneTest("lookAhead_newVariableInstance_01") }
+  @Test def test_lookAhead_setVariable_01(): Unit = { runner.runOneTest("lookAhead_setVariable_01") }
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section23/dfdl_expressions/TestDFDLExpressions3.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section23/dfdl_expressions/TestDFDLExpressions3.scala
@@ -49,4 +49,13 @@ class TestDFDLExpressions3 {
   // @Test def test_array_self_expr1() { runner.runOneTest("test_array_self_expr1") }
   @Test def test_array_self_expr2(): Unit = { runner.runOneTest("test_array_self_expr2") }
 
+  @Test def test_setVariable_neg_01(): Unit = { runner.runOneTest("setVariable_neg_01") }
+
+  // DAFFODIL-2594
+  // @Test def test_setVariable_neg_line_info_01(): Unit = { runner.runOneTest("setVariable_neg_line_info_01") }
+
+  @Test def test_newVariableInstance_neg_01(): Unit = { runner.runOneTest("newVariableInstance_neg_01") }
+
+  // DAFFODIL-2594
+  // @Test def test_newVariableInstance_neg_line_info_01(): Unit = { runner.runOneTest("newVariableInstance_neg_line_info_01") }
 }


### PR DESCRIPTION
@jadams-tresys You can pull this and add any other changes. 

This is, I believe, part of the fix for DAFFODIL-2587.

Doesn't have a test showing that this fixes lookAhead when called from the default value of a newVariableInstance.

But it does pass the Term object so that the TermRuntimeData is available from the NewVariableInstanceStartParser/Unparser, and is used as the context when the expression is evaluated. So this *should* fix it. 

Note that I did not make the corresponding change for SetVariable - which presumably also needs the Term so it can get access to the TermRuntimeData, so that bitOrder and other physical properties are available for functions like lookAhead. 

DAFFODIL-2587