### PR TITLE
Add tests verifying correct textNumberRoundingIncrement behavior

### DIFF
--- a/daffodil-test/src/test/resources/org/apache/daffodil/section13/text_number_props/TextNumberProps.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section13/text_number_props/TextNumberProps.tdml
@@ -300,6 +300,18 @@
       dfdl:textStandardGroupingSeparator="." dfdl:textStandardDecimalSeparator=","
       dfdl:textNumberRoundingIncrement="0.1" dfdl:textNumberRoundingMode="roundHalfEven" />
 
+    <xs:element name="tnp97" type="xs:decimal" dfdl:textNumberPattern="#,##0.02#"
+      dfdl:textNumberRounding="explicit" dfdl:textNumberRoundingIncrement="0.02" />
+
+    <xs:element name="tnp98" type="xs:decimal" dfdl:textNumberPattern="#,##0.020"
+      dfdl:textNumberRounding="explicit" dfdl:textNumberRoundingIncrement="0.02" />
+
+    <xs:element name="tnp99" type="xs:decimal" dfdl:textNumberPattern="0.0#E+000"
+      dfdl:textNumberRounding="explicit" dfdl:textNumberRoundingIncrement="1" />
+
+    <xs:element name="tnp100" type="xs:decimal" dfdl:textNumberPattern="##00"
+      dfdl:textNumberRounding="explicit" dfdl:textNumberRoundingIncrement="1" />
+
   </tdml:defineSchema>
   
   <tdml:defineSchema name="textNumberPattern2"  elementFormDefault="qualified">
@@ -4308,6 +4320,70 @@
       </tdml:dfdlInfoset>
     </tdml:infoset>
 
+  </tdml:unparserTestCase>
+
+  <!--
+     Test Name: textNumberRoundingIncrement1
+        Schema: textNumberPattern
+          Root: tnp97
+  -->
+  <tdml:unparserTestCase name="textNumberRoundingIncrement1" root="tnp97" model="textNumberPattern" roundTrip="none">
+    <tdml:document>
+      <tdml:documentPart type="text">0.12</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <tnp97>0.128</tnp97>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:unparserTestCase>
+
+  <!--
+     Test Name: textNumberRoundingIncrement2
+        Schema: textNumberPattern
+          Root: tnp98
+  -->
+  <tdml:unparserTestCase name="textNumberRoundingIncrement2" root="tnp98" model="textNumberPattern" roundTrip="none">
+    <tdml:document>
+      <tdml:documentPart type="text">0.120</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <tnp98>0.128</tnp98>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:unparserTestCase>
+
+  <!--
+     Test Name: textNumberRoundingIncrement3
+        Schema: textNumberPattern
+          Root: tnp99
+  -->
+  <tdml:unparserTestCase name="textNumberRoundingIncrement3" root="tnp99" model="textNumberPattern" roundTrip="none">
+    <tdml:document>
+      <tdml:documentPart type="text">9.0E-200</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <tnp99>8.6E-200</tnp99>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:unparserTestCase>
+
+  <!--
+     Test Name: textNumberRoundingIncrement4
+        Schema: textNumberPattern
+          Root: tnp100
+  -->
+  <tdml:unparserTestCase name="textNumberRoundingIncrement4" root="tnp100" model="textNumberPattern" roundTrip="none">
+    <tdml:document>
+      <tdml:documentPart type="text">1236</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <tnp100>1235.5</tnp100>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
   </tdml:unparserTestCase>
 
 </tdml:testSuite>

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section13/text_number_props/TestTextNumberProps.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section13/text_number_props/TestTextNumberProps.scala
@@ -240,4 +240,9 @@ class TestTextNumberProps {
 
   @Test def test_textStandardFloatPatternNoSeparators1(): Unit = { runner.runOneTest("textStandardFloatPatternNoSeparators1") }
   @Test def test_textStandardFloatPatternNoSeparators2(): Unit = { runner.runOneTest("textStandardFloatPatternNoSeparators2") }
+
+  @Test def test_textStandardRoundingIncrement1(): Unit = { runner.runOneTest("textNumberRoundingIncrement1") }
+  @Test def test_textStandardRoundingIncrement2(): Unit = { runner.runOneTest("textNumberRoundingIncrement2") }
+  @Test def test_textStandardRoundingIncrement3(): Unit = { runner.runOneTest("textNumberRoundingIncrement3") }
+  @Test def test_textStandardRoundingIncrement4(): Unit = { runner.runOneTest("textNumberRoundingIncrement4") }
 }


### PR DESCRIPTION
Tests added based on comments at https://unicode-org.atlassian.net/browse/ICU-20425

All tests pass with fixes made as part of ICU 70.1, some tests fail with
older versions.

DAFFODIL-2534