### PR TITLE
Use same version for both log4j-api and log4j-core

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -31,6 +31,7 @@ object Dependencies {
     "commons-io" % "commons-io" % "2.11.0",
     "com.typesafe" % "config" % "1.4.1",
     "org.apache.logging.log4j" %% "log4j-api-scala" % "12.0",
+    "org.apache.logging.log4j" % "log4j-api" % "2.14.1",
     "org.apache.logging.log4j" % "log4j-core" % "2.14.1" % "it,test",
   )
 


### PR DESCRIPTION
Daffodil's libs contain log4j-api-2.13.2 and log4j-core-2.14.1.  They
should contain the same version of both log4j-api and log4j-core.

project/Dependencies.scala: Add log4j-api as well.

DAFFODIL-2602