### PR TITLE
Change layering to pass and use state.

### DIFF
--- a/.sonar-project.properties
+++ b/.sonar-project.properties
@@ -16,7 +16,7 @@
 sonar.organization=apache
 sonar.projectKey=apache-daffodil
 
-sonar.modules=daffodil-cli,daffodil-core,daffodil-io,daffodil-japi,daffodil-lib,daffodil-macro-lib,daffodil-propgen,daffodil-runtime1,daffodil-runtime1-unparser,daffodil-runtime2,daffodil-sapi,daffodil-tdml-lib,daffodil-tdml-processor,daffodil-test,daffodil-test-ibm1,daffodil-udf
+sonar.modules=daffodil-cli,daffodil-core,daffodil-io,daffodil-japi,daffodil-lib,daffodil-macro-lib,daffodil-propgen,daffodil-runtime1,daffodil-runtime1-layers,daffodil-runtime1-unparser,daffodil-runtime2,daffodil-sapi,daffodil-tdml-lib,daffodil-tdml-processor,daffodil-test,daffodil-test-ibm1,daffodil-udf
 sonar.sources=src/main
 sonar.tests=src/it,src/test
 sonar.c.file.suffixes=-

--- a/daffodil-core/src/main/scala/org/apache/daffodil/grammar/primitives/LayeredSequence.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/grammar/primitives/LayeredSequence.scala
@@ -20,7 +20,7 @@ package org.apache.daffodil.grammar.primitives
 import org.apache.daffodil.grammar.Terminal
 import org.apache.daffodil.dsom._
 import org.apache.daffodil.layers.LayerCompileInfo
-import org.apache.daffodil.layers.LayerSerializedInfo
+import org.apache.daffodil.layers.LayerRuntimeInfo
 import org.apache.daffodil.processors.parsers.{Parser => DaffodilParser}
 import org.apache.daffodil.processors.unparsers.{Unparser => DaffodilUnparser}
 import org.apache.daffodil.util.Misc
@@ -36,7 +36,7 @@ case class LayeredSequence(sq: SequenceGroupTermBase, bodyTerm: SequenceChild)
 
   val layerCompileInfo = new LayerCompileInfo(
     sq,
-    new LayerSerializedInfo(
+    new LayerRuntimeInfo(
       sq.sequenceRuntimeData,
       sq.maybeLayerCharsetEv,
       Maybe.toMaybe(sq.optionLayerLengthKind),
@@ -62,12 +62,12 @@ case class LayeredSequence(sq: SequenceGroupTermBase, bodyTerm: SequenceChild)
   lazy val bodyParser = bodyTerm.parser
   lazy val bodyUnparser = bodyTerm.unparser
 
-  lazy val layerSerializedInfo = layerCompileInfo.layerSerializedInfo
+  lazy val layerRuntimeInfo = layerCompileInfo.layerRuntimeInfo
 
   override lazy val parser: DaffodilParser =
-    new LayeredSequenceParser(srd, layerTransformerFactory,  layerSerializedInfo, bodyParser)
+    new LayeredSequenceParser(srd, layerTransformerFactory,  layerRuntimeInfo, bodyParser)
 
   override lazy val unparser: DaffodilUnparser = {
-    new LayeredSequenceUnparser(srd, layerTransformerFactory, layerSerializedInfo, bodyUnparser)
+    new LayeredSequenceUnparser(srd, layerTransformerFactory, layerRuntimeInfo, bodyUnparser)
   }
 }

--- a/daffodil-runtime1-layers/src/main/scala/org/apache/daffodil/layers/Base64Transformer.scala
+++ b/daffodil-runtime1-layers/src/main/scala/org/apache/daffodil/layers/Base64Transformer.scala
@@ -19,6 +19,7 @@ package org.apache.daffodil.layers
 
 import org.apache.daffodil.io.BoundaryMarkLimitingStream
 import org.apache.daffodil.io.LayerBoundaryMarkInsertingJavaOutputStream
+import org.apache.daffodil.processors.ParseOrUnparseState
 import org.apache.daffodil.schema.annotation.props.gen.LayerLengthKind
 
 final class Base64MIMELayerCompiler
@@ -67,9 +68,9 @@ final class Base64MIMETransformer(name: String, layerRuntimeInfo: LayerRuntimeIn
     b64
   }
 
-  override def wrapLimitingStream(jis: java.io.InputStream) = {
-    val javaCharset = layerRuntimeInfo.optLayerCharset.get
-    val layerBoundaryMark = layerRuntimeInfo.optLayerBoundaryMark.get
+  override def wrapLimitingStream(state: ParseOrUnparseState, jis: java.io.InputStream) = {
+    val javaCharset = layerRuntimeInfo.optLayerCharset(state).get
+    val layerBoundaryMark = layerRuntimeInfo.optLayerBoundaryMark(state).get
     val s = BoundaryMarkLimitingStream(jis, layerBoundaryMark, javaCharset)
     s
   }
@@ -79,9 +80,9 @@ final class Base64MIMETransformer(name: String, layerRuntimeInfo: LayerRuntimeIn
     b64
   }
 
-  override protected def wrapLimitingStream(jos: java.io.OutputStream) = {
-    val javaCharset = layerRuntimeInfo.optLayerCharset.get
-    val layerBoundaryMark = layerRuntimeInfo.optLayerBoundaryMark.get
+  override protected def wrapLimitingStream(state: ParseOrUnparseState, jos: java.io.OutputStream) = {
+    val javaCharset = layerRuntimeInfo.optLayerCharset(state).get
+    val layerBoundaryMark = layerRuntimeInfo.optLayerBoundaryMark(state).get
     val newJOS = new LayerBoundaryMarkInsertingJavaOutputStream(jos, layerBoundaryMark, javaCharset)
     newJOS
   }

--- a/daffodil-runtime1-layers/src/main/scala/org/apache/daffodil/layers/ByteSwapTransformer.scala
+++ b/daffodil-runtime1-layers/src/main/scala/org/apache/daffodil/layers/ByteSwapTransformer.scala
@@ -24,6 +24,7 @@ import java.util.Deque
 import org.apache.daffodil.exceptions.Assert
 import org.apache.daffodil.schema.annotation.props.gen.LayerLengthKind
 import org.apache.daffodil.io.ExplicitLengthLimitingStream
+import org.apache.daffodil.processors.ParseOrUnparseState
 
 final class FourByteSwapLayerCompiler
   extends LayerCompiler("fourbyteswap") {
@@ -189,8 +190,8 @@ class ByteSwapTransformer(wordsize: Int, name: String, layerRuntimeInfo: LayerRu
     s
   }
 
-  override def wrapLimitingStream(jis: java.io.InputStream) = {
-    val layerLengthInBytes = layerRuntimeInfo.optLayerLength.get
+  override def wrapLimitingStream(state: ParseOrUnparseState, jis: java.io.InputStream) = {
+    val layerLengthInBytes = layerRuntimeInfo.optLayerLength(state).get
 
     val s = new ExplicitLengthLimitingStream(jis, layerLengthInBytes)
     s
@@ -201,7 +202,7 @@ class ByteSwapTransformer(wordsize: Int, name: String, layerRuntimeInfo: LayerRu
     s
   }
 
-  override protected def wrapLimitingStream(jos: java.io.OutputStream) = {
+  override protected def wrapLimitingStream(state: ParseOrUnparseState, jos: java.io.OutputStream) = {
     jos // just return jos. The way the length will be used/stored is by way of
     // taking the content length of the enclosing element. That will measure the
     // length relative to the "ultimate" data output stream.

--- a/daffodil-runtime1-layers/src/main/scala/org/apache/daffodil/layers/GZipTransformer.scala
+++ b/daffodil-runtime1-layers/src/main/scala/org/apache/daffodil/layers/GZipTransformer.scala
@@ -19,6 +19,7 @@ package org.apache.daffodil.layers
 
 import org.apache.daffodil.schema.annotation.props.gen.LayerLengthKind
 import org.apache.daffodil.io.ExplicitLengthLimitingStream
+import org.apache.daffodil.processors.ParseOrUnparseState
 
 final class GZIPLayerCompiler
   extends LayerCompiler("gzip") {
@@ -53,8 +54,8 @@ class GZIPTransformer(name: String, layerRuntimeInfo: LayerRuntimeInfo)
     s
   }
 
-  override def wrapLimitingStream(jis: java.io.InputStream) = {
-    val layerLengthInBytes = layerRuntimeInfo.optLayerLength.get
+  override def wrapLimitingStream(state: ParseOrUnparseState, jis: java.io.InputStream) = {
+    val layerLengthInBytes = layerRuntimeInfo.optLayerLength(state).get
     val s = new ExplicitLengthLimitingStream(jis, layerLengthInBytes)
     s
   }
@@ -64,7 +65,7 @@ class GZIPTransformer(name: String, layerRuntimeInfo: LayerRuntimeInfo)
     s
   }
 
-  override protected def wrapLimitingStream(jis: java.io.OutputStream) = {
+  override protected def wrapLimitingStream(state: ParseOrUnparseState, jis: java.io.OutputStream) = {
     jis // just return jis. The way the length will be used/stored is by way of
     // taking the content length of the enclosing element. That will measure the
     // length relative to the "ultimate" data output stream.

--- a/daffodil-runtime1-layers/src/main/scala/org/apache/daffodil/layers/LineFoldedTransformer.scala
+++ b/daffodil-runtime1-layers/src/main/scala/org/apache/daffodil/layers/LineFoldedTransformer.scala
@@ -28,6 +28,7 @@ import java.io.InputStream
 import org.apache.daffodil.exceptions.ThrowsSDE
 import org.apache.daffodil.schema.annotation.props.Enum
 import org.apache.daffodil.io.RegexLimitingStream
+import org.apache.daffodil.processors.ParseOrUnparseState
 
 /*
  * This and related classes implement so called "line folding" from
@@ -140,14 +141,14 @@ object LineFoldMode extends Enum[LineFoldMode] {
 final class LineFoldedTransformerDelimited(mode: LineFoldMode, layerRuntimeInfo: LayerRuntimeInfo)
   extends LayerTransformer(mode.transformName, layerRuntimeInfo) {
 
-  override protected def wrapLimitingStream(jis: java.io.InputStream) = {
+  override protected def wrapLimitingStream(state: ParseOrUnparseState, jis: java.io.InputStream) = {
     // regex means CRLF not followed by space or tab.
     // NOTE: this regex cannot contain ANY capturing groups (per scaladoc on RegexLimitingStream)
     val s = new RegexLimitingStream(jis, "\\r\\n(?!(?:\\t|\\ ))", "\r\n", StandardCharsets.ISO_8859_1)
     s
   }
 
-  override protected def wrapLimitingStream(jos: java.io.OutputStream) = {
+  override protected def wrapLimitingStream(state: ParseOrUnparseState, jos: java.io.OutputStream) = {
     //
     // Q: How do we insert a CRLF "not followed by tab or space" when we don't
     // control what follows?
@@ -177,11 +178,11 @@ final class LineFoldedTransformerDelimited(mode: LineFoldMode, layerRuntimeInfo:
 class LineFoldedTransformerImplicit(mode: LineFoldMode, layerRuntimeInfo: LayerRuntimeInfo)
   extends LayerTransformer(mode.transformName, layerRuntimeInfo) {
 
-  override protected def wrapLimitingStream(jis: java.io.InputStream) = {
+  override protected def wrapLimitingStream(state: ParseOrUnparseState, jis: java.io.InputStream) = {
     jis // no limiting - just pull input until EOF.
   }
 
-  override protected def wrapLimitingStream(jos: java.io.OutputStream) = {
+  override protected def wrapLimitingStream(state: ParseOrUnparseState, jos: java.io.OutputStream) = {
     jos // no limiting - just write output until EOF.
   }
 

--- a/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/processors/unparsers/LayeredSequenceUnparser.scala
+++ b/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/processors/unparsers/LayeredSequenceUnparser.scala
@@ -17,27 +17,27 @@
 
 package org.apache.daffodil.processors.unparsers
 
-import org.apache.daffodil.layers.LayerSerializedInfo
+import org.apache.daffodil.layers.LayerRuntimeInfo
 import org.apache.daffodil.layers.LayerTransformerFactory
 import org.apache.daffodil.processors.SequenceRuntimeData
 
 class LayeredSequenceUnparser(ctxt: SequenceRuntimeData,
   layerTransformerFactory: LayerTransformerFactory,
-  layerSerializedInfo: LayerSerializedInfo,
+  layerRuntimeInfo: LayerRuntimeInfo,
   childUnparser: SequenceChildUnparser)
   extends OrderedUnseparatedSequenceUnparser(ctxt, Seq(childUnparser)) {
 
   override lazy val runtimeDependencies =
-    layerSerializedInfo.evaluatables.toVector
+    layerRuntimeInfo.evaluatables.toVector
 
   override def nom = "LayeredSequence"
 
   override def unparse(state: UState): Unit = {
-    val layerTransformer = layerTransformerFactory.newInstance(layerSerializedInfo.layerRuntimeInfo(state))
+    val layerTransformer = layerTransformerFactory.newInstance(layerRuntimeInfo)
 
     val originalDOS = state.dataOutputStream // layer will output to the original, then finish it upon closing.
 
-    val newDOS = originalDOS.addBuffered // newDOS is where unparsers after this one returns will unparse into.
+    val newDOS = originalDOS.addBuffered() // newDOS is where unparsers after this one returns will unparse into.
     //
     // New layerDOS is where the layer will unparse into. Ultimately anything written
     // to layerDOS ends up, post transform, in originalDOS.

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/LayeredSequenceParser.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/LayeredSequenceParser.scala
@@ -18,7 +18,7 @@
 package org.apache.daffodil.processors.parsers
 
 import org.apache.daffodil.layers.LayerNotEnoughDataException
-import org.apache.daffodil.layers.LayerSerializedInfo
+import org.apache.daffodil.layers.LayerRuntimeInfo
 import org.apache.daffodil.layers.LayerTransformerFactory
 import org.apache.daffodil.processors.SequenceRuntimeData
 import org.apache.daffodil.util.MaybeULong
@@ -26,17 +26,17 @@ import org.apache.daffodil.util.MaybeULong
 class LayeredSequenceParser(
   rd: SequenceRuntimeData,
   layerTransformerFactory: LayerTransformerFactory,
-  layerSerializedInfo: LayerSerializedInfo,
+  layerRuntimeInfo: LayerRuntimeInfo,
   bodyParser: SequenceChildParser)
   extends OrderedUnseparatedSequenceParser(rd, Vector(bodyParser)) {
   override def nom = "LayeredSequence"
 
   override lazy val runtimeDependencies =
-    layerSerializedInfo.evaluatables.toVector
+    layerRuntimeInfo.evaluatables.toVector
 
   override def parse(state: PState): Unit = {
 
-    val layerTransformer = layerTransformerFactory.newInstance(layerSerializedInfo.layerRuntimeInfo(state))
+    val layerTransformer = layerTransformerFactory.newInstance(layerRuntimeInfo)
     val savedDIS = state.dataInputStream
 
     val isAligned = savedDIS.align(layerTransformer.mandatoryLayerAlignmentInBits, state)

--- a/daffodil-test/src/test/scala/org/apache/daffodil/layers/AISTransformer.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/layers/AISTransformer.scala
@@ -31,6 +31,7 @@ import org.apache.daffodil.io.BoundaryMarkLimitingStream
 import org.apache.daffodil.io.LayerBoundaryMarkInsertingJavaOutputStream
 import org.apache.daffodil.io.InputSourceDataInputStream
 import org.apache.daffodil.io.FormatInfo
+import org.apache.daffodil.processors.ParseOrUnparseState
 import org.apache.daffodil.schema.annotation.props.gen.BinaryFloatRep
 import org.apache.daffodil.schema.annotation.props.gen.BitOrder
 import org.apache.daffodil.schema.annotation.props.gen.ByteOrder
@@ -97,7 +98,7 @@ class AISPayloadArmoringTransformer(name: String, layerRuntimeInfo: LayerRuntime
     new AISPayloadArmoringInputStream(jis)
   }
 
-  override def wrapLimitingStream(jis: java.io.InputStream) = {
+  override def wrapLimitingStream(state: ParseOrUnparseState, jis: java.io.InputStream) = {
     val layerBoundaryMark = ","
     val s = BoundaryMarkLimitingStream(jis, layerBoundaryMark, iso8859)
     s
@@ -107,7 +108,7 @@ class AISPayloadArmoringTransformer(name: String, layerRuntimeInfo: LayerRuntime
     new AISPayloadArmoringOutputStream(jos)
   }
 
-  override protected def wrapLimitingStream(jos: java.io.OutputStream) = {
+  override protected def wrapLimitingStream(state: ParseOrUnparseState, jos: java.io.OutputStream) = {
     val layerBoundaryMark = ","
     val newJOS = new LayerBoundaryMarkInsertingJavaOutputStream(jos, layerBoundaryMark, iso8859)
     newJOS

--- a/daffodil-test/src/test/scala/org/apache/daffodil/layers/CheckDigit.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/layers/CheckDigit.scala
@@ -17,6 +17,8 @@
 
 package org.apache.daffodil.layers
 
+import org.apache.daffodil.processors.ParseOrUnparseState
+import org.apache.daffodil.processors.VariableRuntimeData
 import org.apache.daffodil.util.Logger
 
 import java.nio.ByteBuffer
@@ -25,8 +27,8 @@ import java.nio.ByteBuffer
 final class CheckDigitExplicit(
   name: String,
   layerRuntimeInfo: LayerRuntimeInfo,
-  outputVar: VariableHandle,
-  inputVars: Seq[VariableHandle])
+  outputVar: VariableRuntimeData,
+  inputVars: Seq[VariableRuntimeData])
 extends ByteBufferExplicitLengthLayerTransform[Int](
   layerRuntimeInfo,
   name,
@@ -61,9 +63,9 @@ extends ByteBufferExplicitLengthLayerTransform[Int](
    *
    * The checkDigit is the total of all digits, viewed as a string, the last digit of that total.
    */
-  protected def compute(isUnparse: Boolean, inputs: Seq[Any], byteBuffer: ByteBuffer) = {
+  protected def compute(state: ParseOrUnparseState, isUnparse: Boolean, inputs: Seq[Any], byteBuffer: ByteBuffer) = {
     assert(inputs.length == 1)
-    val charset = layerRuntimeInfo.optLayerCharset.get
+    val charset = layerRuntimeInfo.optLayerCharset(state).get
     assert(charset.newDecoder().maxCharsPerByte() == 1) // is a SBCS charset
     val isVerbose = parseParams(inputs(0).asInstanceOf[String]).isVerbose
     val s = new String(byteBuffer.array(), charset)

--- a/daffodil-test/src/test/scala/org/apache/daffodil/layers/CheckDigitLayerCompiler.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/layers/CheckDigitLayerCompiler.scala
@@ -18,6 +18,7 @@
 package org.apache.daffodil.layers
 
 import org.apache.daffodil.dpath.NodeInfo.PrimType
+import org.apache.daffodil.processors.VariableRuntimeData
 import org.apache.daffodil.schema.annotation.props.gen.LayerLengthKind
 import org.apache.daffodil.schema.annotation.props.gen.LayerLengthUnits
 
@@ -32,7 +33,7 @@ extends LayerCompiler("checkDigit") {
 
   override def compileLayer(layerCompileInfo: LayerCompileInfo) = {
     val outputVar =
-      layerCompileInfo.getVariableHandle(
+      layerCompileInfo.getVariableRuntimeData(
         variablesPreferredNamespacePrefix,
         variablesNamespace,
         localNameOfVariableToWrite,
@@ -40,7 +41,7 @@ extends LayerCompiler("checkDigit") {
 
     val inputVRDs = localNamesAndTypesOfVariablesToRead.map {
       case (local, primType) =>
-        layerCompileInfo.getVariableHandle(variablesPreferredNamespacePrefix, variablesNamespace, local, primType)
+        layerCompileInfo.getVariableRuntimeData(variablesPreferredNamespacePrefix, variablesNamespace, local, primType)
     }
     layerCompileInfo.optLayerLengthKind match {
       case Some(LayerLengthKind.Explicit) => // ok
@@ -63,7 +64,7 @@ extends LayerCompiler("checkDigit") {
   }
 }
 
-class CheckDigitLayerTransformerFactory(name: String, inputVars: Seq[VariableHandle], outputVar: VariableHandle)
+class CheckDigitLayerTransformerFactory(name: String, inputVars: Seq[VariableRuntimeData], outputVar: VariableRuntimeData)
   extends LayerTransformerFactory("checkDigit") {
 
   override def newInstance(layerRuntimeInfo: LayerRuntimeInfo)= {

--- a/daffodil-test/src/test/scala/org/apache/daffodil/layers/IPv4Checksum.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/layers/IPv4Checksum.scala
@@ -18,6 +18,8 @@
 package org.apache.daffodil.layers
 
 import org.apache.daffodil.exceptions.Assert
+import org.apache.daffodil.processors.ParseOrUnparseState
+import org.apache.daffodil.processors.VariableRuntimeData
 import passera.unsigned.UShort
 
 import java.nio.ByteBuffer
@@ -31,12 +33,12 @@ import java.nio.ByteBuffer
 final class IPv4Checksum(
   name: String,
   layerRuntimeInfo: LayerRuntimeInfo,
-  outputVar: VariableHandle)
+  outputVar: VariableRuntimeData)
 extends ByteBufferExplicitLengthLayerTransform[Int](
   layerRuntimeInfo,
   name,
   inputVars = Seq(),
-  outputVar: VariableHandle) {
+  outputVar: VariableRuntimeData) {
 
   /**
    * This layer is always exactly 20 bytes long.
@@ -45,7 +47,7 @@ extends ByteBufferExplicitLengthLayerTransform[Int](
 
   private def chksumShortIndex = 5
 
-  override protected def compute(isUnparse: Boolean, inputs: Seq[Any], byteBuffer: ByteBuffer) = {
+  override protected def compute(state: ParseOrUnparseState, isUnparse: Boolean, inputs: Seq[Any], byteBuffer: ByteBuffer) = {
     val shortBuf = byteBuffer.asShortBuffer()
 
     var i = 0

--- a/daffodil-test/src/test/scala/org/apache/daffodil/layers/IPv4ChecksumLayerCompiler.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/layers/IPv4ChecksumLayerCompiler.scala
@@ -18,6 +18,7 @@
 package org.apache.daffodil.layers
 
 import org.apache.daffodil.dpath.NodeInfo.PrimType
+import org.apache.daffodil.processors.VariableRuntimeData
 import org.apache.daffodil.schema.annotation.props.gen.LayerLengthKind
 import org.apache.daffodil.schema.annotation.props.gen.LayerLengthUnits
 
@@ -32,7 +33,7 @@ final class IPv4ChecksumLayerCompiler
 
   override def compileLayer(layerCompileInfo: LayerCompileInfo) = {
 
-    val outputVar = layerCompileInfo.getVariableHandle(
+    val outputVar = layerCompileInfo.getVariableRuntimeData(
       variablesPreferredNamespacePrefix,
       variablesNamespace,
       localNameOfVariableToWrite,
@@ -57,7 +58,7 @@ final class IPv4ChecksumLayerCompiler
   }
 }
 
-class IPv4ChecksumLayerTransformerFactory(name: String, outputVar: VariableHandle)
+class IPv4ChecksumLayerTransformerFactory(name: String, outputVar: VariableRuntimeData)
     extends LayerTransformerFactory(name) {
 
   override def newInstance(layerRuntimeInfo: LayerRuntimeInfo)= {

--- a/daffodil-test/src/test/scala/org/apache/daffodil/layers/TestIPv4.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/layers/TestIPv4.scala
@@ -38,7 +38,7 @@ class TestIPv4 {
   @Test def test_IPv4_1(): Unit = { runner.runOneTest("IPv4_1") }
 
   // DAFFODIL-2608
-  // @Test def test_IPv4_array(): Unit = { runner.runOneTest("IPv4_array") }
+  @Test def test_IPv4_array(): Unit = { runner.runOneTest("IPv4_array") }
 
   @Test def test_IPv4_1e(): Unit = { runner.runOneTest("IPv4_1e") }
 


### PR DESCRIPTION
Removed state from LayerRuntimeInfo

This fixes layer unparsing as the passed state can be the one created for use
by suspensions.

Eliminated LayerSerializedInfo, as it is the same as LayerRuntimeInfo now.

Eliminated VariableHandle (just use VariableRuntimeData)

Tested with PCAP and EthernetIP, both of which now work.

DAFFODIL-2608