### PR TITLE
Prepare for patch release 3.2.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -152,7 +152,7 @@ lazy val testStdLayout    = Project("daffodil-test-stdLayout", file("test-stdLay
 
 lazy val commonSettings = Seq(
   organization := "org.apache.daffodil",
-  version := "3.3.0-SNAPSHOT",
+  version := "3.2.1",
   scalaVersion := "2.12.15",
   crossScalaVersions := Seq("2.12.15"),
   scalacOptions ++= buildScalacOptions(scalaVersion.value),


### PR DESCRIPTION
Change version in build.sbt to 3.2.1

This is for a urgent patch release to fix 2 CVEs (log4J, JDOM)
and to incorporate the fix for unparsing layers with checksums
(DAFFODIL-2608) which
is a key feature of 3.2.0 found to be broken.

DAFFODIL-2609