### PR TITLE
Add a "daffodil" alias to the RPM

### DIFF
--- a/daffodil-cli/build.sbt
+++ b/daffodil-cli/build.sbt
@@ -49,6 +49,9 @@ maintainer := "Apache Daffodil <dev@daffodil.apache.org>"
 //
 rpmVendor := "Apache Daffodil"
 
+// Add an alias so users can install either "apache-daffodil" or "daffodil" with dnf
+rpmProvides := Seq("daffodil = %{version}-%{release}")
+
 Rpm / packageArchitecture := "noarch"
 
 Rpm / packageSummary := "Open-source implementation of the Data Format Description Language (DFDL)"


### PR DESCRIPTION
The official name of the Daffodil RPM is "apache-daffodil", which means
this intuitive command to install the RPM with dnf does not work:

    dnf install daffodil

Instead you need to install using the full name:

    dnf install apache-daffodil

To support both commands, adds a "Provides: daffodil" tag to the RPM
build configuration, which essentially adds an alias so that users can
dnf install either "daffodil" or "apache-daffodil".

DAFFODIL-2613