### PR TITLE
WIP: Feature to provide a dfdlx:schema that wraps an XSD-based DFDL schema

### DIFF
--- a/daffodil-propgen/src/main/resources/org/apache/daffodil/xsd/dfdlx.xsd
+++ b/daffodil-propgen/src/main/resources/org/apache/daffodil/xsd/dfdlx.xsd
@@ -107,6 +107,29 @@
     <xs:attribute form="qualified" name="layerLengthUnits" type="dfdlx:LayerLengthUnitsEnum" />
     <xs:attribute form="qualified" name="layerBoundaryMark" type="dfdl:ListOfDFDLStringLiteral_Or_DFDLExpression" />
   </xs:attributeGroup>
+  
+  <!-- 
+    This lets you encapsulate an XSD schema with <dfdlx:schema>...</dfdlx:schema>
+    and then full GUI support for editing the DFDL schema can be provided 
+    by IDEs like eclipse. 
+    
+    This along with having to name the files with extension ".dfdl", not ".xsd", so
+    that the IDE will treat them as XML files, not XML Schema files.
+    
+    The IDE can then be setup to treat ".dfdl" files as XML files, and validation
+    and syntax support for XML editing will then work in the IDE.
+    
+    Daffodil will accept these ".dfdl" files with top level <dfdlx:schema> element
+    and ignore this wrapper, and treat them otherwise exactly like regular ".dfdl.xsd" 
+    DFDL schema files.
+     -->
+  <xs:element name="schema">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref="xs:schema"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
 
 
   <xs:simpleType name="LayerTransformType">

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section00/general/generalSchema.dfdl
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section00/general/generalSchema.dfdl
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<dfdlx:schema 
+  xmlns:dfdlx="http://www.ogf.org/dfdl/dfdl-1.0/extensions"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.ogf.org/dfdl/dfdl-1.0/extensions org/apache/daffodil/xsd/dfdlx.xsd">
+<schema xmlns="http://www.w3.org/2001/XMLSchema"
+  targetNamespace="http://example.com" xmlns:tns="http://example.com"
+  xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/" 
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns:fn="http://www.w3.org/2005/xpath-functions"
+  elementFormDefault="qualified">
+
+  <include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+
+  <annotation>
+    <appinfo source="http://www.ogf.org/dfdl/">
+      <dfdl:format ref="tns:GeneralFormat"/>
+    </appinfo>
+  </annotation>
+    
+  <element name="e1" dfdl:lengthKind="explicit" dfdl:length="5" type="xs:string" />
+  <element name="e2" dfdl:lengthKind="explicit" dfdl:length="1" type="xs:string" />
+      
+  <element name="e3" dfdl:lengthKind="implicit">
+    <complexType>
+      <sequence dfdl:initiator="[" dfdl:separator="," dfdl:terminator="]">
+        <element name="s1" type="xs:string" dfdl:lengthKind="delimited" />
+        <element name="s2" type="xs:string" dfdl:lengthKind="delimited" />
+      </sequence>
+    </complexType>
+  </element>
+  <xs:annotation></xs:annotation>
+
+</schema>
+</dfdlx:schema>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section00/general/tunables.xml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section00/general/tunables.xml
@@ -17,7 +17,9 @@
 -->
 
 <daf:dfdlConfig
-	xmlns:daf="urn:ogf:dfdl:2013:imp:daffodil.apache.org:2018:ext">
+	xmlns:daf="urn:ogf:dfdl:2013:imp:daffodil.apache.org:2018:ext"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="urn:ogf:dfdl:2013:imp:daffodil.apache.org:2018:ext org/apache/daffodil/xsd/dafext.xsd">
 	<daf:tunables >
 		<daf:unqualifiedPathStepPolicy>defaultNamespace</daf:unqualifiedPathStepPolicy>
 	</daf:tunables>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section07/external_variables/daffodil_config_cli_test.xml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section07/external_variables/daffodil_config_cli_test.xml
@@ -15,7 +15,6 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-
 <!--
   Note: Bug DAFFODIL-2339
 


### PR DESCRIPTION
This provides better support for writing DFDL schemas from ordinary XML
infrastructure in IDEs/Tools.

Fix incorrect URI

Removed dfdl-config-format.xsd

This was redundantly defining the dafext namespace. Unusable that way in
conjunction with the dafext.xsd file.

Nothing was including/importing this file anyway.

Moved the one definition in it, of dfdlConfig to dafext.xsd.

Provided xsi:schemaLocation in the XML files that contained dfdlConfig
elements.

Correct invalid tdml files that should be valid.

Mostly this is missing definitions for ex:, tns: and dfdlx:

DAFFODIL-1638

Provide dfdlx:schema element which allows for IDE support.

By creating dfdlx:schema in files with extension ".dfdl" (not
".dfdl.xsd") you can edit the schema in an IDE, and get full support
because the IDE's own XSD support doesn't get in the way.

You must setup the IDE so ".dfdl" files are treated as XML just as
you do with ".tdml" files. Then turn off XML Schema Validation, but
leave turned on XML validation.