### PR TITLE
Support --infoset null for CLI unparsing

### DIFF
--- a/daffodil-cli/src/it/scala/org/apache/daffodil/performance/TestCLIPerformance.scala
+++ b/daffodil-cli/src/it/scala/org/apache/daffodil/performance/TestCLIPerformance.scala
@@ -175,6 +175,27 @@ class TestCLIPerformance {
     }
   }
 
+  @Test def test_XXX_CLI_Performance_Unparse_2_Threads_2_Times_null(): Unit = {
+    val schemaFile = Util.daffodilPath("daffodil-test/src/test/resources/org/apache/daffodil/section00/general/generalSchema.dfdl.xsd")
+    val inputFile = Util.daffodilPath("daffodil-cli/src/it/resources/org/apache/daffodil/CLI/input/input14.txt")
+    val (testSchemaFile, testInputFile) = if (Util.isWindows) (Util.cmdConvert(schemaFile), Util.cmdConvert(inputFile)) else (schemaFile, inputFile)
+
+    val shell = Util.start("")
+
+    try {
+      val cmd = String.format("%s performance --unparse -I null -N 2 -t 2 -s %s -r e3 %s", Util.binPath, testSchemaFile, testInputFile)
+      shell.sendLine(cmd)
+      shell.expect(contains("total unparse time (sec):"))
+      shell.expect(contains("avg rate (files/sec):"))
+
+      Util.expectExitCode(ExitCode.Success, shell)
+      shell.sendLine("exit")
+      shell.expect(eof())
+    } finally {
+      shell.close()
+    }
+  }
+
   @Test def test_3643_CLI_Performance_Unparse_3_Threads_20_Times(): Unit = {
     val schemaFile = Util.daffodilPath("daffodil-test/src/test/resources/org/apache/daffodil/section00/general/generalSchema.dfdl.xsd")
     val inputFile = Util.daffodilPath("daffodil-cli/src/it/resources/org/apache/daffodil/CLI/input/input14.txt")

--- a/daffodil-cli/src/it/scala/org/apache/daffodil/unparsing/TestCLIUnparsing.scala
+++ b/daffodil-cli/src/it/scala/org/apache/daffodil/unparsing/TestCLIUnparsing.scala
@@ -606,6 +606,28 @@ class TestCLIunparsing {
     }
   }
 
+  @Test def test_xxxx_CLI_Unparsing_SimpleUnparse_null(): Unit = {
+
+    val schemaFile = Util.daffodilPath("daffodil-test/src/test/resources/org/apache/daffodil/section00/general/generalSchema.dfdl.xsd")
+    val inputFile = Util.daffodilPath("daffodil-cli/src/it/resources/org/apache/daffodil/CLI/input/input18.txt")
+    val (testSchemaFile, testInputFile) = if (Util.isWindows) (Util.cmdConvert(schemaFile), Util.cmdConvert(inputFile)) else (schemaFile, inputFile)
+
+    val shell = Util.start("")
+
+    try {
+      val cmd = String.format("%s unparse -I null -s %s --root e1 %s", Util.binPath, testSchemaFile, testInputFile)
+      shell.sendLine(cmd)
+      shell.expect(contains("Hello"))
+
+      Util.expectExitCode(ExitCode.Success, shell)
+      shell.send("exit\n")
+      shell.expect(eof)
+      shell.close()
+    } finally {
+      shell.close()
+    }
+  }
+
   @Test def test_XXX_CLI_Unparsing_Stream_01(): Unit = {
     val schemaFile = Util.daffodilPath("daffodil-cli/src/it/resources/org/apache/daffodil/CLI/cli_schema_02.dfdl.xsd")
     val inputFile = Util.daffodilPath("daffodil-cli/src/it/resources/org/apache/daffodil/CLI/input/input19.txt")

--- a/daffodil-lib/src/main/scala/org/apache/daffodil/xml/XMLUtils.scala
+++ b/daffodil-lib/src/main/scala/org/apache/daffodil/xml/XMLUtils.scala
@@ -873,9 +873,14 @@ object XMLUtils {
   }
 
   /**
-   * Prepares an XML node for diff comparison
+   * Normalizes scala XML, performing the following tasks
+   *
+   * - Removes comments
+   * - Converts PCData to Text nodes
+   * - Combines adjacent Text nodes
+   * - Removes unnecessary whitespace
    */
-  private def prepareForDiffComparison(n: Node): Node = {
+  def normalize(n: Node): Node = {
     val noComments = removeComments(n)
     val noPCData = convertPCDataToText(noComments)
     val combinedText = coalesceAllAdjacentTextNodes(noPCData)
@@ -891,8 +896,8 @@ object XMLUtils {
     ignoreProcInstr: Boolean = true,
     checkPrefixes: Boolean = false,
     checkNamespaces: Boolean = false): Unit = {
-    val expectedMinimized = prepareForDiffComparison(expected)
-    val actualMinimized = prepareForDiffComparison(actual)
+    val expectedMinimized = normalize(expected)
+    val actualMinimized = normalize(actual)
     val diffs = XMLUtils.computeDiff(
       expectedMinimized,
       actualMinimized,

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/infoset/NullInfosetInputter.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/infoset/NullInfosetInputter.scala
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.daffodil.infoset
+
+import java.io.InputStream
+
+import scala.collection.mutable.ArrayBuffer
+
+import scala.xml.Elem
+import scala.xml.SAXParser
+import scala.xml.Text
+import scala.xml.XML
+
+import org.apache.daffodil.dpath.NodeInfo
+import org.apache.daffodil.infoset.InfosetInputterEventType._
+import org.apache.daffodil.util.MaybeBoolean
+import org.apache.daffodil.xml.DaffodilSAXParserFactory
+import org.apache.daffodil.xml.XMLUtils
+
+object NullInfosetInputter {
+
+  case class Event(
+    eventType: InfosetInputterEventType,
+    localName: String = null,
+    namespaceURI: String = null,
+    simpleText: String = null,
+    isNilled: MaybeBoolean = MaybeBoolean.Nope,
+  )
+
+  def toEvents(is: InputStream): Array[Event] = {
+    val elem = {
+      val parser: SAXParser = {
+        val f = DaffodilSAXParserFactory()
+        f.setNamespaceAware(false)
+        val p = f.newSAXParser()
+        p
+      }
+      val node = XML.withSAXParser(parser).load(is)
+      val normalized = XMLUtils.normalize(node)
+      normalized
+    }
+    val events = ArrayBuffer[Event]()
+    events += Event(StartDocument)
+    nodeToEvents(elem.asInstanceOf[Elem], events)
+    events += Event(EndDocument)
+    events.toArray
+  }
+
+  /**
+   * Recursively walk a Scala XML Node, converting each Elem to an Event and
+   * appends it to the events array. Note that this function expects elem to
+   * have been normalized with XMLUtils.normalize, such that each Elem either
+   * has no children, a single Text child, or one or more Elem children.
+   */
+  private def nodeToEvents(elem: Elem, events: ArrayBuffer[Event]): Unit = {
+    val isSimple = elem.child.length == 0 || elem.child(0).isInstanceOf[Text]
+    val localName = elem.label
+    val namespaceURI = elem.namespace
+    val (simpleText, isNilled) = if (isSimple) {
+      val text = XMLUtils.remapPUAToXMLIllegalCharacters(elem.text)
+      val isNilled = elem.attribute(XMLUtils.XSI_NAMESPACE, "nil").map { attrs =>
+        val str = attrs.head.toString
+        val value = str == "true" || str == "1"
+        MaybeBoolean(value)
+      }.getOrElse(MaybeBoolean.Nope)
+      (text, isNilled)
+    } else {
+      (null, MaybeBoolean.Nope)
+    }
+
+    events += Event(StartElement, localName, namespaceURI, simpleText, isNilled)
+    if (!isSimple) elem.child.foreach { c => nodeToEvents(c.asInstanceOf[Elem], events) }
+    events += Event(EndElement, localName, namespaceURI)
+  }
+}
+
+/**
+ * InfosetInputter that has the minimum possible amount of overhead during
+ * unparse operations, intended to be used for performance comparisons. The
+ * events array should be created by calling NullInfosetInputter.toEvents()
+ * prior to any performance testing and outside any critical sections, and
+ * passed into a new NullInfosetInputter for unparsing.
+ */
+class NullInfosetInputter(events: Array[NullInfosetInputter.Event]) extends InfosetInputter {
+
+  private var curIndex = 0
+  private var curEvent: NullInfosetInputter.Event = events(0)
+
+  val supportsNamespaces: Boolean = true
+
+  def getEventType(): InfosetInputterEventType = curEvent.eventType
+  def getLocalName(): String = curEvent.localName
+  def getNamespaceURI(): String = curEvent.namespaceURI
+  def getSimpleText(primType: NodeInfo.Kind, runtimeProperties: java.util.Map[String,String]): String = curEvent.simpleText
+  def isNilled(): MaybeBoolean = curEvent.isNilled
+
+  def hasNext(): Boolean = curIndex + 1 < events.length
+  def next(): Unit = {
+    curIndex += 1
+    curEvent = events(curIndex)
+  }
+
+  def fini(): Unit = {}
+}

--- a/daffodil-tdml-processor/src/main/scala/org/apache/daffodil/tdml/TDMLInfosetOutputter.scala
+++ b/daffodil-tdml-processor/src/main/scala/org/apache/daffodil/tdml/TDMLInfosetOutputter.scala
@@ -28,6 +28,7 @@ import org.apache.daffodil.infoset.JDOMInfosetInputter
 import org.apache.daffodil.infoset.JDOMInfosetOutputter
 import org.apache.daffodil.infoset.JsonInfosetInputter
 import org.apache.daffodil.infoset.JsonInfosetOutputter
+import org.apache.daffodil.infoset.NullInfosetInputter
 import org.apache.daffodil.infoset.ScalaXMLInfosetInputter
 import org.apache.daffodil.infoset.ScalaXMLInfosetOutputter
 import org.apache.daffodil.infoset.W3CDOMInfosetInputter
@@ -110,6 +111,10 @@ class TDMLInfosetOutputter() extends InfosetOutputter {
     val w3cdomIn = new W3CDOMInfosetInputter(w3cdomOut.getResult)
     val jsonIn = new JsonInfosetInputter(new ByteArrayInputStream(jsonStream.toByteArray))
     val xmlIn = new XMLTextInfosetInputter(new ByteArrayInputStream(xmlStream.toByteArray))
-    new TDMLInfosetInputter(scalaIn, Seq(jdomIn, w3cdomIn, jsonIn, xmlIn))
+    val nullIn = {
+      val events = NullInfosetInputter.toEvents(new ByteArrayInputStream(xmlStream.toByteArray))
+      new NullInfosetInputter(events)
+    }
+    new TDMLInfosetInputter(scalaIn, Seq(jdomIn, w3cdomIn, jsonIn, xmlIn, nullIn))
   }
 }


### PR DESCRIPTION
A "null" infoset inputter does not normally make sense in the context of
unparsing because there must always be an infoset to unparse--you can't
unparse null data. But in the context of performance, a "null" infoset
inputter could be considered one that has close to zero overhead
(similar to the null infoset outputter for parsing), which can help to
understand the raw speed of Daffodil unparsing operations and to compare
different infoset inputter overheads.

To support this, this allows "null" to be used for the --infoset option
when unparsing. This triggers the use of a new NullInfosetInputter,
which uses a pre-created array of infoset events that are exactly what
the Daffodil unparser expects. The events are created outside of
measured unparser code, so the only overhead that occurs inside measured
code is indexing into the event array and returning fields from the
indexed event, which should give good picture of raw unparse speed.

DAFFODIL-2619