### PR TITLE
Add a global TDML CompileResult cache

### DIFF
--- a/daffodil-tdml-lib/src/main/scala/org/apache/daffodil/tdml/processor/TDMLDFDLProcessor.scala
+++ b/daffodil-tdml-lib/src/main/scala/org/apache/daffodil/tdml/processor/TDMLDFDLProcessor.scala
@@ -119,13 +119,7 @@ trait TDMLDFDLProcessor {
 
   def unparse(parseResult: TDMLParseResult, outStream: java.io.OutputStream): TDMLUnparseResult
 
-  /**
-   * The TDMLRunner may cache the TDMLDFDLProcessor so that it can be reused
-   * among multiple parse/unparse calls without needing to rebuild the
-   * processor. This function is called once the TDMLRunner is done with the
-   * TMLDFDLProcessor. This allows state such as temporary files to be cleaned
-   * up. Actually does nothing unless overridden by an implementation.
-   */
+  @deprecated("Function no longer called, cleanup must be handled in individual TDMLResults.", "3.3.0")
   def cleanUp(): Unit = { /* Do nothing */ }
 }
 

--- a/daffodil-tdml-processor/src/main/scala/org/apache/daffodil/tdml/processor/Runtime2TDMLDFDLProcessor.scala
+++ b/daffodil-tdml-processor/src/main/scala/org/apache/daffodil/tdml/processor/Runtime2TDMLDFDLProcessor.scala
@@ -113,6 +113,11 @@ final class Runtime2TDMLDFDLProcessorFactory private(
       // Compile the generated code into an executable
       val executable = generator.compileCode(codeDir)
 
+      // There is is no way to clean up TDMLDFDLProcessors, they are just garbage
+      // collected when no longer needed. So recursively mark all generated
+      // files as deleteOnExit so we at least clean them up when the JVM exits
+      os.walk.stream(tempDir).foreach { _.toIO.deleteOnExit() }
+
       // Summarize the result of compiling the schema for the test
       val compileResult = if (generator.isError) {
         Left(generator.getDiagnostics) // C code compilation diagnostics
@@ -193,11 +198,6 @@ class Runtime2TDMLDFDLProcessor(tempDir: os.Path, executable: os.Path)
   def unparse(parseResult: TDMLParseResult, outStream: java.io.OutputStream): TDMLUnparseResult = {
     unparse(parseResult.getResult, outStream)
   }
-
-  /**
-   * Remove the generated executable
-   */
-  override def cleanUp(): Unit = os.remove.all(tempDir)
 }
 
 final class Runtime2TDMLParseResult(pr: ParseResult) extends TDMLParseResult {


### PR DESCRIPTION
We previosly only cache CompileResults on individual DFDLTestSuites.
This meant that we could compiled schemas within a single test suite,
but not between tests suites. This could lead to lots of duplicate
schema compilation if multiple .tdml files referenced the same schema

To avoid this, CompileResults are now stored in a global WeakHashMap
instead of the DFDLTestSuite. And DFDLTestSuites are changed to maintain
strong references to the keys of the CompileResult they use. This
ensures that as long as a DFDLTestSuite exists, so will all of its
CompileResults, so tests within a DFDLTestSuite can share them. And
after the DFDLTestSuite is garbage collected, as long as those weak
references aren't also garbage collected, other DFDLTestSuites will be
able to use them, and help to minimize compilation same schemas used in
different TDML files.

DAFFODIL-2627