### PR TITLE
Ensure quasi elements for type calc expressions have a parent

### DIFF
--- a/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/processors/unparsers/ExpressionEvaluatingUnparsers.scala
+++ b/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/processors/unparsers/ExpressionEvaluatingUnparsers.scala
@@ -156,6 +156,13 @@ class TypeValueCalcUnparser(typeCalculator: TypeCalculator, repTypeUnparser: Unp
     if (ustate.withinHiddenNest)
       tmpInfosetElement.setHidden()
 
+    // Although quasi elements aren't really part of the infoset, we still
+    // require that certain invariants hold. One of which is that all elements
+    // have a parent. This is necessary for things like running the
+    // InfosetWalker in the interactive debugger. To ensure this invariant
+    // holds, we set the parent of this quasi element to the same as that of
+    // the current infoset node.
+    tmpInfosetElement.setParent(currentSimple.parent)
 
     if (ustate.processorStatus == Success) {
 


### PR DESCRIPTION
These quasi elements aren't really part of the infoset so a parent
element isn't actually needed, except for in some rare cases such as
when walking the infoset in the interactive debugger. There may also be
other edge cases we are unaware of. So ensure that these quasi type calc
elements have a parent, making it the same as its related simple
element.

DAFFODIL-2627