### PR TITLE
Use setVariable value expression to get referenced elements

### DIFF
--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/DFDLStatementMixin.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/DFDLStatementMixin.scala
@@ -52,11 +52,8 @@ trait ResolvesDFDLStatementMixin
     f: ContentValueReferencedElementInfoMixin => Set[DPathElementCompileInfo]) = {
     s match {
       case sv: DFDLSetVariable => {
-        val mdv = sv.defv.maybeDefaultValueExpr
-        if (mdv.isDefined)
-          f(mdv.get)
-        else
-          ReferencedElementInfos.None
+        val v = sv.gram(self).expr
+        f(v)
       }
       case nv: DFDLNewVariableInstance => {
         val mdv = nv.maybeDefaultValueExpr

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section07/variables/setVarWIthValueLength.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section07/variables/setVarWIthValueLength.tdml
@@ -96,7 +96,7 @@
     <infoset>
       <dfdlInfoset>
         <f:root>
-          <message>0</message>
+          <someElement>0</someElement>
         </f:root>
       </dfdlInfoset>
     </infoset>
@@ -111,7 +111,7 @@
     <infoset>
       <dfdlInfoset>
         <f:root2>
-          <message>0</message>
+          <someElement>0</someElement>
         </f:root2>
       </dfdlInfoset>
     </infoset>

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section07/variables/TestSetVarWithValueLength.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section07/variables/TestSetVarWithValueLength.scala
@@ -34,11 +34,10 @@ object TestSetVarWithValueLength {
 class TestSetVarWithValueLength {
 
   import TestSetVarWithValueLength._
-  @Test def dummyTest(): Unit = { val r = runner ; () } // prevents tools from auto-removing the imports
 
   // DAFFODIL-2629 Runtime SDE
-  // @Test def testSetVarWithValueLength1() = { runner.runOneTest("setVarWithValueLength1") }
-  // @Test def testSetVarWithValueLength2() = { runner.runOneTest("setVarWithValueLength2") }
+  @Test def testSetVarWithValueLength1() = { runner.runOneTest("setVarWithValueLength1") }
+  @Test def testSetVarWithValueLength2() = { runner.runOneTest("setVarWithValueLength2") }
 
 
 }


### PR DESCRIPTION
When trying to calculcate which elements are referenced via
dfdl:setVariable expressions, which is used for things like value and
content length, we incorectly used the default expression associated
with the dfdl:defineDariable instead of the actual value expression of
the dfdl:setVariable. This modifies the logic to use the correct
expression.

DAFFODIL-2629