### PR TITLE
Disable capture value length parsers for all delimited simple types

### DIFF
--- a/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/ElementBaseRuntime1Mixin.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/ElementBaseRuntime1Mixin.scala
@@ -79,18 +79,23 @@ trait ElementBaseRuntime1Mixin { self: ElementBase =>
         setElems.contains(this.dpathElementCompileInfo)
       }
 
-    // For simple elements with text representation, valueLength is captured in
-    // individual parsers since they handle removing delimiters and padding.
+    // For simple elements with text representation, value length is captured
+    // directly by the value parsers, since those parsers also handle removing
+    // delimiters and padding (which must be excluded from value length).
+    // Related, simple types that aren't text (e.g. hex binary, packed decimal)
+    // but are delimited also use the same simple text value parsers that
+    // capture value length.
     //
-    // For complex elements with specified length, valueLength is captured in
+    // For complex elements with specified length, value length is captured in
     // the specified length parsers, since they handle skipping unused
     // element regions. For complex elements, this means lengthKind is not
     // implicit or delimited.
     //
-    // So for these cases we do not want to capture value length, since
-    // they are handled by the parsers as necessary
+    // So for these cases we do not want to capture value length with the
+    // Capture{Start,End}OfValueLengthParsers, since those lengths are captured
+    // by the value parsers
     val capturedByParsers =
-      (isSimpleType && impliedRepresentation == Representation.Text) ||
+      (isSimpleType && (impliedRepresentation == Representation.Text || lengthKind == LengthKind.Delimited)) ||
         (isComplexType && (lengthKind != LengthKind.Implicit && lengthKind != LengthKind.Delimited))
 
     !capturedByParsers && isReferenced

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section23/dfdl_expressions/valueLength.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section23/dfdl_expressions/valueLength.tdml
@@ -170,6 +170,54 @@
       </xs:complexType>
     </xs:element>
 
+    <xs:element name="e9">
+      <xs:complexType>
+        <xs:sequence>
+          <xs:element name="pad" type="xs:int" />
+          <xs:element name="hex" type="xs:hexBinary" dfdl:lengthKind="delimited" dfdl:encoding="ISO-8859-1" />
+          <xs:element name="vl" type="xs:int" dfdl:inputValueCalc="{ dfdl:valueLength(../hex, 'bytes') } "/>
+        </xs:sequence>
+      </xs:complexType>
+    </xs:element>
+
+  </tdml:defineSchema>
+
+  <tdml:defineSchema name="cl2" elementFormDefault="unqualified">
+    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+
+    <dfdl:format ref="GeneralFormat" representation="binary" />
+
+    <dfdl:defineVariable name="headerSize" type="xs:unsignedInt" external="false" defaultValue="4" />
+
+    <xs:element name="root1">
+      <xs:complexType>
+        <xs:sequence>
+          <xs:element name="header">
+            <xs:complexType>
+              <xs:sequence>
+                <xs:element name="message_size" type="xs:unsignedInt" dfdl:lengthKind="explicit" dfdl:length="4"
+                  dfdl:outputValueCalc="{ dfdl:valueLength(../../message/content, 'bytes') + $headerSize }"/>
+              </xs:sequence>
+            </xs:complexType>
+          </xs:element>
+          <xs:element name="message" dfdl:lengthKind="explicit" dfdl:length="{ ../header/message_size - $headerSize}">
+            <xs:complexType>
+              <xs:sequence>
+                <xs:element name="content" type="xs:hexBinary" dfdl:lengthKind="delimited" dfdl:encoding="ISO-8859-1" />
+                <xs:sequence>
+                  <xs:annotation>
+                    <xs:appinfo source="http://www.ogf.org/dfdl/">
+                      <dfdl:assert test="{ dfdl:valueLength(content, 'bytes') eq (../header/message_size - $headerSize) }" />
+                    </xs:appinfo>
+                  </xs:annotation>
+                </xs:sequence>
+              </xs:sequence>
+            </xs:complexType>
+          </xs:element>
+        </xs:sequence>
+      </xs:complexType>
+    </xs:element>
+
   </tdml:defineSchema>
 
   <tdml:unparserTestCase name="valueLengthPair1" root="e1"
@@ -319,6 +367,78 @@
         </ex:e8>
       </tdml:dfdlInfoset>
     </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="valueLengthDelimitedHexBinary1" root="e9"
+    model="cl1" description="dfdl:valueLength of delimied hex binary">
+    <tdml:document>
+      <tdml:documentPart type="byte">00 00 00 01 AA BB CC DD</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <ex:e9>
+          <ex:pad>1</ex:pad>
+          <ex:hex>AABBCCDD</ex:hex>
+          <ex:vl>4</ex:vl>
+        </ex:e9>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="valueLengthDelimitedHexBinary2" root="root1"
+    model="cl2" description="dfdl:valueLength of delimied hex binary">
+    <tdml:document>
+      <tdml:documentPart type="byte">
+        00 00 00 07
+        62 01 00
+      </tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <root1>
+          <header>
+            <message_size>7</message_size>
+          </header>
+          <message>
+             <content>620100</content>
+          </message>
+        </root1>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="valueLengthDelimitedHexBinary3" root="root1"
+    model="cl2" description="dfdl:valueLength of delimied hex binary">
+    <tdml:document>
+      <tdml:documentPart type="byte">
+        00 00 00 04
+      </tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <root1>
+          <header>
+            <message_size>4</message_size>
+          </header>
+          <message>
+             <content></content>
+          </message>
+        </root1>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="valueLengthDelimitedHexBinary4" root="root1"
+    model="cl2" description="dfdl:valueLength of delimied hex binary">
+    <tdml:document>
+      <tdml:documentPart type="byte">
+        00 00 00 04
+        62 01 00
+      </tdml:documentPart>
+    </tdml:document>
+    <tdml:errors>
+      <tdml:error>Left over data</tdml:error>
+    </tdml:errors>
   </tdml:parserTestCase>
 
 </tdml:testSuite>

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section23/dfdl_expressions/TestDFDLExpressions2.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section23/dfdl_expressions/TestDFDLExpressions2.scala
@@ -68,6 +68,12 @@ class TestDFDLExpressions2 {
   @Test def test_valueLengthDfdlOccursCount(): Unit = { runner6.runOneTest("valueLengthDfdlOccursCount") }
   @Test def test_valueLengthDfdlEncoding(): Unit = { runner6.runOneTest("valueLengthDfdlEncoding") }
 
+  // DAFFODIL-2635
+  @Test def test_valueLengthDelimitedHexBinary1(): Unit = { runner6.runOneTest("valueLengthDelimitedHexBinary1") }
+  @Test def test_valueLengthDelimitedHexBinary2(): Unit = { runner6.runOneTest("valueLengthDelimitedHexBinary2") }
+  @Test def test_valueLengthDelimitedHexBinary3(): Unit = { runner6.runOneTest("valueLengthDelimitedHexBinary3") }
+  @Test def test_valueLengthDelimitedHexBinary4(): Unit = { runner6.runOneTest("valueLengthDelimitedHexBinary4") }
+
   //DFDL-1691
   @Test def test_div01(): Unit = { runner.runOneTest("div01") }
   @Test def test_div02(): Unit = { runner.runOneTest("div02") }


### PR DESCRIPTION
We already disable capture value length parsers for simple types with
representation="text" because the parsers for those text simple types
capture the value length themselve. This is needed because these parsers
have special logic for calculating the value length.

But simple types that aren't text (e.g. hex binary, packed decimal) but
are delimited use the same text parsers that capture value length. So
also disable capture length for delimited simple types. This ensures we
do not have multiple capture length logic executed for the same element
that may conflict.

DAFFODIL-2635