### PR TITLE
Update daffodil-cli link syntax

### DIFF
--- a/daffodil-cli/README.md
+++ b/daffodil-cli/README.md
@@ -81,6 +81,6 @@ users@daffodil.apache.org mailing lists. Bugs can be reported via the
 
 Daffodil is licensed under the [Apache License, v2.0](https://www.apache.org/licenses/LICENSE-2.0)
 
-This product includes The Saxon XSLT and XQuery Processor from
-Saxonica Limited (<http://www.saxonica.com/>), which is licensed under
+This product includes [The Saxon XSLT and XQuery Processor from
+Saxonica Limited](https://www.saxonica.com/), which is licensed under
 the Mozilla Public License version 2.0.


### PR DESCRIPTION
This is a simple change to 
- make the URL appears as a hyperlink to be more consistent with other links 
- update the link to HTTPS

