### PR TITLE
Fix fn:exists when unparsing non-blocking expressions

### DIFF
--- a/daffodil-test/src/test/resources/org/apache/daffodil/section23/dfdl_functions/Functions.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section23/dfdl_functions/Functions.tdml
@@ -4748,6 +4748,17 @@
       </xs:complexType>
     </xs:element>
 
+    <xs:element name="exists09">
+      <xs:complexType>
+        <xs:sequence>
+          <xs:element name="int" type="xs:int" minOccurs="0" dfdl:lengthKind="explicit" dfdl:length="1" />
+          <xs:element name="term" type="xs:string"
+            dfdl:lengthKind="explicit" dfdl:length="0"
+            dfdl:terminator="{ if (fn:exists(../ex:int)) then 'x' else 'y' }" />
+        </xs:sequence>
+      </xs:complexType>
+    </xs:element>
+
     <xs:element name="exactly-one01">
       <xs:complexType>
         <xs:sequence dfdl:separator="|">
@@ -4922,6 +4933,17 @@
             </xs:complexType>
           </xs:element>
           <xs:element name="numints" type="xs:int" dfdl:inputValueCalc="{ fn:count(/ex:count05b/ex:ints/ex:int, /ex:count05b/ex:ints/ex:int) }"/>
+        </xs:sequence>
+      </xs:complexType>
+    </xs:element>
+
+    <xs:element name="count06">
+      <xs:complexType>
+        <xs:sequence>
+          <xs:element name="int" type="xs:int" minOccurs="0" maxOccurs="2" dfdl:lengthKind="explicit" dfdl:length="1" />
+          <xs:element name="term" type="xs:string"
+            dfdl:lengthKind="explicit" dfdl:length="0"
+            dfdl:terminator="{ if (fn:count(../ex:int) gt 1) then 'x' else 'y' }" />
         </xs:sequence>
       </xs:complexType>
     </xs:element>
@@ -10531,6 +10553,51 @@
   </tdml:parserTestCase>
 
 <!--
+    Test Name: exists_13
+       Schema: XPathFunctions
+         Root: exists09
+         Purpose: This test demonstrates the exists() function works as expected
+                  when unparsing in something other than an output value calc expression
+-->
+
+  <tdml:unparserTestCase name="exists_13" root="exists09"
+    model="XPathFunctions" description="Section 23 - Functions - fn:exists - DFDL-23-122R">
+    <tdml:document>
+      <tdml:documentPart type="text">1x</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <exists09 xmlns="http://example.com">
+          <int>1</int>
+          <term></term>
+        </exists09>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:unparserTestCase>
+
+<!--
+    Test Name: exists_14
+       Schema: XPathFunctions
+         Root: exists09
+         Purpose: This test demonstrates the exists() function works as expected
+                  when unparsing in something other than an output value calc expression
+-->
+
+  <tdml:unparserTestCase name="exists_14" root="exists09"
+    model="XPathFunctions" description="Section 23 - Functions - fn:exists - DFDL-23-122R">
+    <tdml:document>
+      <tdml:documentPart type="text">y</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <exists09 xmlns="http://example.com">
+          <term></term>
+        </exists09>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:unparserTestCase>
+
+<!--
     Test Name: exactly_one_01
        Schema: XPathFunctions
          Root: exactly-one01
@@ -11047,6 +11114,75 @@
       <tdml:error>argument</tdml:error>
     </tdml:errors>
   </tdml:parserTestCase>
+
+<!--
+    Test Name: count_09
+       Schema: XPathFunctions
+         Root: count06
+         Purpose: This test demonstrates the count() function works as expected
+                  when unparsing in something other than an output value calc expression
+-->
+
+  <tdml:unparserTestCase name="count_09" root="count06"
+    model="XPathFunctions" description="Section 23 - Functions - fn:count - DFDL-23-122R">
+    <tdml:document>
+      <tdml:documentPart type="text">y</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <count06 xmlns="http://example.com">
+          <term></term>
+        </count06>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:unparserTestCase>
+
+<!--
+    Test Name: count_10
+       Schema: XPathFunctions
+         Root: count06
+         Purpose: This test demonstrates the count() function works as expected
+                  when unparsing in something other than an output value calc expression
+-->
+
+  <tdml:unparserTestCase name="count_10" root="count06"
+    model="XPathFunctions" description="Section 23 - Functions - fn:count - DFDL-23-122R">
+    <tdml:document>
+      <tdml:documentPart type="text">1y</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <count06 xmlns="http://example.com">
+          <int>1</int>
+          <term></term>
+        </count06>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:unparserTestCase>
+
+<!--
+    Test Name: count_11
+       Schema: XPathFunctions
+         Root: count06
+         Purpose: This test demonstrates the count() function works as expected
+                  when unparsing in something other than an output value calc expression
+-->
+
+  <tdml:unparserTestCase name="count_11" root="count06"
+    model="XPathFunctions" description="Section 23 - Functions - fn:count - DFDL-23-122R">
+    <tdml:document>
+      <tdml:documentPart type="text">12x</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <count06 xmlns="http://example.com">
+          <int>1</int>
+          <int>2</int>
+          <term></term>
+        </count06>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:unparserTestCase>
 
 <!--
     Test Name: local_name_01

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section23/dfdl_expressions/TestDFDLExpressions.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section23/dfdl_expressions/TestDFDLExpressions.scala
@@ -478,11 +478,11 @@ class TestDFDLExpressions {
   @Test def test_exists_05(): Unit = { runner2.runOneTest("exists_05") }
   @Test def test_exists_08(): Unit = { runner2.runOneTest("exists_08") }
   @Test def test_exists_09(): Unit = { runner2.runOneTest("exists_09") }
-
   @Test def test_exists_10(): Unit = { runner2.runOneTest("exists_10") }
-
   @Test def test_exists_11(): Unit = { runner2.runOneTest("exists_11") }
   @Test def test_exists_12(): Unit = { runner2.runOneTest("exists_12") }
+  @Test def test_exists_13(): Unit = { runner2.runOneTest("exists_13") }
+  @Test def test_exists_14(): Unit = { runner2.runOneTest("exists_14") }
 
   //DFDL-1189
   //@Test def test_exactly_one_01() { runner2.runOneTest("exactly_one_01") }
@@ -497,14 +497,16 @@ class TestDFDLExpressions {
   @Test def test_count_03(): Unit = { runner2.runOneTest("count_03") }
   @Test def test_count_03b(): Unit = { runner2.runOneTest("count_03b") }
   @Test def test_count_04(): Unit = { runner2.runOneTest("count_04") }
+  @Test def test_count_05(): Unit = { runner2.runOneTest("count_05") }
   @Test def test_count_05c(): Unit = { runner2.runOneTest("count_05c") }
+  @Test def test_count_06(): Unit = { runner2.runOneTest("count_06") }
   @Test def test_count_06b(): Unit = { runner2.runOneTest("count_06b") }
   @Test def test_count_07(): Unit = { runner2.runOneTest("count_07") }
-  @Test def test_count_08b(): Unit = { runner2.runOneTest("count_08b") }
-
-  @Test def test_count_05(): Unit = { runner2.runOneTest("count_05") }
-  @Test def test_count_06(): Unit = { runner2.runOneTest("count_06") }
   @Test def test_count_08(): Unit = { runner2.runOneTest("count_08") }
+  @Test def test_count_08b(): Unit = { runner2.runOneTest("count_08b") }
+  @Test def test_count_09(): Unit = { runner2.runOneTest("count_09") }
+  @Test def test_count_10(): Unit = { runner2.runOneTest("count_10") }
+  @Test def test_count_11(): Unit = { runner2.runOneTest("count_11") }
 
   @Test def test_local_name_01(): Unit = { runner2.runOneTest("local_name_01") }
   @Test def test_local_name_02(): Unit = { runner2.runOneTest("local_name_02") }


### PR DESCRIPTION
Unparsing non-blocking expressions represent expression that are only
backwards referencing and will not require a suspension. This means that
the associated node must be final, and so we can immediately respond
that the element exists or not. Rethrowing the associated exception not
correct in this case. That is only correct when suspensions will be
involve, in which case that exception triggers the suspension logic.

DAFFODIL-2648