### PR TITLE
Improve diagnostic for no forward progress

### DIFF
--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/SequenceChildBases.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/SequenceChildBases.scala
@@ -197,7 +197,7 @@ abstract class SequenceChildParser(
   val childParser: Parser,
   val srd: SequenceRuntimeData,
   val trd: TermRuntimeData)
-  extends CombinatorParser(srd) {
+  extends CombinatorParser(trd) {
 
   override def childProcessors: Vector[Processor] = Vector(childParser)
 

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/SequenceParserBases.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/SequenceParserBases.scala
@@ -57,12 +57,13 @@ abstract class SequenceParserBase(
 
   final protected def checkForwardProgress(
     pstate: PState,
+    parser: RepeatingChildParser,
     currentPos: Long,
     priorPos: Long,
     ais: ArrayIndexStatus): ArrayIndexStatus = {
     Assert.invariant(currentPos >= priorPos)
     if (currentPos == priorPos && pstate.groupPos > 1) {
-      PE(pstate, "No forward progress.")
+      parser.PE(pstate, "Array element parsed succesfully, but consumed no data and is stuck in an infinite loop as it is unbounded.")
       Done
     } else {
       ais
@@ -173,7 +174,7 @@ abstract class SequenceParserBase(
                 // result of try could also be absent if we just ended a group
                 // by not finding a separator
                 //
-                ais = checkForwardProgress(pstate, currentPos, priorPos, ais)
+                ais = checkForwardProgress(pstate, parser, currentPos, priorPos, ais)
               }
               //
               // advance array position.

--- a/test-stdLayout/src/test/resources/org1/testStdLayout.tdml
+++ b/test-stdLayout/src/test/resources/org1/testStdLayout.tdml
@@ -34,7 +34,9 @@
       <tdml:documentPart type="file">org1/test-outer-data1.txt</tdml:documentPart>
     </tdml:document>
     <tdml:errors>
-      <tdml:error>No forward progress</tdml:error>
+      <tdml:error>consumed no data</tdml:error>
+      <tdml:error>infinite loop</tdml:error>
+      <tdml:error>inner:Inner</tdml:error>
     </tdml:errors>
   </tdml:parserTestCase>
   


### PR DESCRIPTION
Improved diagnostic message now contains reference to the array and
describes how it is stuck in an infinite loop.

DAFFODIL-2576