### PR TITLE
Refresh sub-NOTICEs in bin.NOTICE

### DIFF
--- a/daffodil-cli/bin.LICENSE
+++ b/daffodil-cli/bin.LICENSE
@@ -208,8 +208,8 @@ The Apache Daffodil project contains subcomponents with separate copyright
 notices and license terms. Your use of the source code for these subcomponents
 is subject to the terms and conditions of the following licenses.
 
-  This product bundles 'ICU4J', including the following files:
-    - lib/com.ibm.icu.icu4j-<VERSION>.jar
+- lib/com.ibm.icu.icu4j-<VERSION>.jar
+  This product bundles 'ICU4J' with the above files.
   These files are available under the Unicode License. For details, see
   https://github.com/unicode-org/icu/blob/release-<VERSION>/icu4c/LICENSE
 
@@ -628,8 +628,8 @@ is subject to the terms and conditions of the following licenses.
     (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
     OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-  This product bundles 'JDOM2', including the following files:
-    - lib/org.jdom.jdom2-<VERSION>.jar
+- lib/org.jdom.jdom2-<VERSION>.jar
+  This product bundles 'JDOM2' with the above files.
   These files are available under an Apache style License:
 
     Redistribution and use in source and binary forms, with or without
@@ -681,8 +681,8 @@ is subject to the terms and conditions of the following licenses.
     Brett McLaughlin <brett_AT_jdom_DOT_org>.  For more information
     on the JDOM Project, please see <http://www.jdom.org/>. 
 
-  This product bundles 'JLine', including the following files:
-    - lib/org.jline.jline-<VERSION>.jar
+- lib/org.jline.jline-<VERSION>.jar
+  This product bundles 'JLine' with the above files.
   These files are available under a BSD-3-Clause license. For details, see
   https://github.com/jline/jline3/blob/HEAD/LICENSE.txt
 
@@ -721,8 +721,8 @@ is subject to the terms and conditions of the following licenses.
     IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
     OF THE POSSIBILITY OF SUCH DAMAGE.
 
-  This product bundles 'Passera' compiled source, including the following files:
-    - passera/ directory in lib/org.apache.daffodil.daffodil-lib-<VERSION>.jar
+- passera/ directory in lib/org.apache.daffodil.daffodil-lib-<VERSION>.jar
+  This product bundles 'Passera' compiled source with the above files.
   These files are available under the BSD-2-Clause license:
 
     Copyright (c) 2011-2013, Nate Nystrom
@@ -749,8 +749,8 @@ is subject to the terms and conditions of the following licenses.
     OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
     OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-  This product bundles 'Saxon-HE (Home Edition)', including the following files:
-    - lib/net.sf.saxon.Saxon-HE-<VERSION>.jar
+- lib/net.sf.saxon.Saxon-HE-<VERSION>.jar
+  This product bundles 'Saxon-HE (Home Edition)' with the above files.
   These files are available under the MPL 2.0 license:
 
     Most of the open source code in the Saxon product is governed by the Mozilla Public
@@ -1170,8 +1170,8 @@ is subject to the terms and conditions of the following licenses.
       from James Clark.
 
 
-  This product bundles 'Scallop', including the following files:
-    - lib/org.rogach.scallop_<VERSION>.jar
+- lib/org.rogach.scallop_<VERSION>.jar
+  This product bundles 'Scallop' with the above files.
   These files are available under under an MIT License. For details, see
   https://github.com/scallop/scallop/blob/develop/license.txt
 
@@ -1195,9 +1195,9 @@ is subject to the terms and conditions of the following licenses.
     OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
     SOFTWARE.
 
-  This product bundles 'Schematron' converter content, including the following files:
-    - iso-schematron-xslt2/ExtractSchFromXSD-2.xsl in lib/org.apache.daffodil.daffodil-schematron-<VERSION>.jar
-  The content is available under the MIT License:
+- iso-schematron-xslt2/ExtractSchFromXSD-2.xsl in lib/org.apache.daffodil.daffodil-schematron-<VERSION>.jar
+  This product bundles 'Schematron' converter content with the above files.
+  These files are available under the MIT License:
 
     Copyright (c) 2002-2010 Rick Jelliffe and Topologi Pty. Ltd.
 
@@ -1219,14 +1219,14 @@ is subject to the terms and conditions of the following licenses.
     OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
     THE SOFTWARE.
 
-  This product bundles 'Schematron' skeleton XSLT implementation, including the following files:
-    - iso-schematron-xslt2/iso_abstract_expand.xsl in lib/org.apache.daffodil.daffodil-schematron-<VERSION>.jar
-    - iso-schematron-xslt2/iso_dsdl_include.xsl in lib/org.apache.daffodil.daffodil-schematron-<VERSION>.jar
-    - iso-schematron-xslt2/iso_schematron_message_xslt2.xsl in lib/org.apache.daffodil.daffodil-schematron-<VERSION>.jar
-    - iso-schematron-xslt2/iso_schematron_skeleton_for_saxon.xsl in lib/org.apache.daffodil.daffodil-schematron-<VERSION>.jar
-    - iso-schematron-xslt2/iso_svrl_for_xslt2.xsl in lib/org.apache.daffodil.daffodil-schematron-<VERSION>.jar
-    - iso-schematron-xslt2/sch-messages-en.xhtml in lib/org.apache.daffodil.daffodil-schematron-<VERSION>.jar
-  The content is available under the MIT License:
+- iso-schematron-xslt2/iso_abstract_expand.xsl in lib/org.apache.daffodil.daffodil-schematron-<VERSION>.jar
+- iso-schematron-xslt2/iso_dsdl_include.xsl in lib/org.apache.daffodil.daffodil-schematron-<VERSION>.jar
+- iso-schematron-xslt2/iso_schematron_message_xslt2.xsl in lib/org.apache.daffodil.daffodil-schematron-<VERSION>.jar
+- iso-schematron-xslt2/iso_schematron_skeleton_for_saxon.xsl in lib/org.apache.daffodil.daffodil-schematron-<VERSION>.jar
+- iso-schematron-xslt2/iso_svrl_for_xslt2.xsl in lib/org.apache.daffodil.daffodil-schematron-<VERSION>.jar
+- iso-schematron-xslt2/sch-messages-en.xhtml in lib/org.apache.daffodil.daffodil-schematron-<VERSION>.jar
+  This product bundles 'Schematron' skeleton XSLT implementation with the above files.
+  These files are available under the MIT License:
 
     Copyright (c) 2004-2010 Rick Jellife and Academia Sinica Computing Centre, Taiwan
 
@@ -1248,8 +1248,8 @@ is subject to the terms and conditions of the following licenses.
     OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
     SOFTWARE.
 
-  This product bundles 'Stax 2 API', including the following files:
-    - lib/org.codehaus.woodstox.stax2-api-<VERSION>.jar
+- lib/org.codehaus.woodstox.stax2-api-<VERSION>.jar
+  This product bundles 'Stax 2 API' with the above files.
   These files are available under the BSD-2-Clause license:
 
     Copyright 2010- FasterXML.com
@@ -1275,12 +1275,13 @@ is subject to the terms and conditions of the following licenses.
     OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
     OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-  This product bundles 'W3C' copied or derived material, including the following files:
-    - org/apache/daffodil/xsd/XMLSchema.dtd (https://www.w3.org/2001/XMLSchema.dtd) in lib/org.apache.daffodil.daffodil-lib-<VERSION>.jar
-    - org/apache/daffodil/xsd/XMLSchema.xsd (https://www.w3.org/2001/XMLSchema.xsd) in lib/org.apache.daffodil.daffodil-lib-<VERSION>.jar
-    - org/apache/daffodil/xsd/XMLSchema_for_DFDL.xsd (https://www.w3.org/2001/XMLSchema.dtd) in lib/org.apache.daffodil.daffodil-lib-<VERSION>.jar
-    - org/apache/daffodil/xsd/datatypes.dtd (https://www.w3.org/2001/datatypes.dtd) in lib/org.apache.daffodil.daffodil-lib-<VERSION>.jar
-    - org/apache/daffodil/xsd/xml.xsd (https://www.w3.org/2001/xml.xsd) in lib/org.apache.daffodil.daffodil-lib-<VERSION>.jar
+- org/apache/daffodil/xsd/XMLSchema.dtd (https://www.w3.org/2001/XMLSchema.dtd) in lib/org.apache.daffodil.daffodil-lib-<VERSION>.jar
+- org/apache/daffodil/xsd/XMLSchema.xsd (https://www.w3.org/2001/XMLSchema.xsd) in lib/org.apache.daffodil.daffodil-lib-<VERSION>.jar
+- org/apache/daffodil/xsd/XMLSchema_for_DFDL.xsd (https://www.w3.org/2001/XMLSchema.dtd) in lib/org.apache.daffodil.daffodil-lib-<VERSION>.jar
+- org/apache/daffodil/xsd/datatypes.dtd (https://www.w3.org/2001/datatypes.dtd) in lib/org.apache.daffodil.daffodil-lib-<VERSION>.jar
+- org/apache/daffodil/xsd/xml.xsd (https://www.w3.org/2001/xml.xsd) in lib/org.apache.daffodil.daffodil-lib-<VERSION>.jar
+- W3C schemas and documents in lib/org.xmlresolver.xmlresolver-<VERSION>-data.jar
+  This product bundles 'W3C' copied or derived material with the above files.
   These files are available under the W3C Software and Document License:
 
     By obtaining and/or copying this work, you (the licensee) agree that you have
@@ -1319,9 +1320,9 @@ is subject to the terms and conditions of the following licenses.
     permission. Title to copyright in this work will at all times remain with
     copyright holders.
 
-  This product bundles 'os-lib', including the following files:
-    - lib/com.lihaoyi.geny_<VERSION>.jar
-    - lib/com.lihaoyi.os-lib_<VERSION>.jar
+- lib/com.lihaoyi.geny_<VERSION>.jar
+- lib/com.lihaoyi.os-lib_<VERSION>.jar
+  This product bundles 'os-lib' with the above files.
   These files are available under the MIT license:
 
     License

--- a/daffodil-cli/bin.NOTICE
+++ b/daffodil-cli/bin.NOTICE
@@ -11,95 +11,7 @@ Based on source code originally developed by
 
 The following NOTICE information applies to binary components distributed with this project:
 
-Apache Commons IO (lib/commons-io.commons-io-<VERSION>.jar)
-  Apache Commons IO
-  Copyright 2002-2021 The Apache Software Foundation
-
-  This product includes software developed at
-  The Apache Software Foundation (https://www.apache.org/).
-
-Apache Log4j (lib/org.apache.logging.log4j.log4j-api-<VERSION>.jar, org.apache.logging.log4j.log4j-core-<VERSION>.jar)
-  Apache Log4j
-  Copyright 1999-2019 Apache Software Foundation
-
-  This product includes software developed at
-  The Apache Software Foundation (http://www.apache.org/).
-
-  ResolverUtil.java
-  Copyright 2005-2006 Tim Fennell
-
-  Dumbster SMTP test server
-  Copyright 2004 Jason Paul Kitchen
-
-  TypeUtil.java
-  Copyright 2002-2012 Ramnivas Laddad, Juergen Hoeller, Chris Beams
-
-  picocli (http://picocli.info)
-  Copyright 2017 Remko Popma
-
-Apache Log4j Scala API (lib/org.apache.logging.log4j.log4j-api-scala_<VERSION>.jar)
-  Copyright 2016-2018 Apache Software Foundation
-
-  This product includes software developed at
-  The Apache Software Foundation (http://www.apache.org/).
-
-  AsciidocPlugin.scala
-  Copyright (c) 2008, 2009, 2010, 2011 Josh Suereth, Steven Blundy, Josh Cough,
-  Mark Harrah, Stuart Roebuck, Tony Sloane, Vesa Vilhonen, Jason Zaugg
-
-Apache Xerces Java (lib/xerces.xercesImpl-<VERSION>.jar)
-  Apache Xerces Java
-  Copyright 1999-2022 The Apache Software Foundation
-
-  This product includes software developed at
-  The Apache Software Foundation (http://www.apache.org/).
-
-  Portions of this software were originally based on the following:
-    - software copyright (c) 1999, IBM Corporation., http://www.ibm.com.
-    - software copyright (c) 1999, Sun Microsystems., http://www.sun.com.
-    - voluntary contributions made by Paul Eng on behalf of the 
-      Apache Software Foundation that were originally developed at iClick, Inc.,
-      software copyright (c) 1999.
-
-Apache XML Commons Resolver (lib/xml-resolver.xml-resolver-<VERSION>.jar)
-  Apache XML Commons Resolver
-  Copyright 2006 The Apache Software Foundation.
-
-  This product includes software developed at
-  The Apache Software Foundation http://www.apache.org/
-
-  Portions of this code are derived from classes placed in the
-  public domain by Arbortext on 10 Apr 2000. See:
-  http://www.arbortext.com/customer_support/updates_and_technical_notes/catalogs/docs/README.htm
-
-Apache XML Commons XML APIs (lib/xml-apis.xml-apis-<VERSION>.jar)
-  Apache XML Commons XML APIs
-  Copyright 1999-2009 The Apache Software Foundation.
-
-  This product includes software developed at
-  The Apache Software Foundation (http://www.apache.org/).
-
-  Portions of this software were originally based on the following:
-    - software copyright (c) 1999, IBM Corporation., http://www.ibm.com.
-    - software copyright (c) 1999, Sun Microsystems., http://www.sun.com.
-    - software copyright (c) 2000 World Wide Web Consortium, http://www.w3.org
-
-JDOM2 (lib/org.jdom.jdom2-<VERSION>.jar)
-  Copyright (C) 2000-2012 Jason Hunter & Brett McLaughlin.
-
-  All rights reserved.
-
-  This product includes software developed by the
-  JDOM Project (http://www.jdom.org/).
-
-Jansi (lib/org.fusesource.jansi.jansi-<VERSION>.jar)
-  Copyright (C) 2009, Progress Software Corporation and/or its
-  subsidiaries or affiliates.  All rights reserved.
-
-Jackson JSON processor (lib/com.fasterxml.jackson.core.jackson-core-<VERSION>.jar)
-  Copyright (c) 2007- Tatu Saloranta, tatu.saloranta@iki.fi
-  Copyright (c) 2008-2020 FasterXML. All rights reserved.
-
+- lib/com.fasterxml.jackson.core.jackson-core-<VERSION>.jar
   # Jackson JSON processor
 
   Jackson is a high-performance, Free/Open Source JSON processing library.
@@ -118,11 +30,87 @@ Jackson JSON processor (lib/com.fasterxml.jackson.core.jackson-core-<VERSION>.ja
   in some artifacts (usually source distributions); but is always available
   from the source code management (SCM) system project uses.
 
-Scala (lib/org.scala-lang.scala-library-<VERSION>.jar)
-      (org/apache/daffodil/util/UniquenessCache.class in lib/org.apache.daffodil.daffodil-lib-<VERSION>.jar)
+- lib/commons-codec.commons-codec-<VERSION>.jar
+  Apache Commons Codec
+  Copyright 2002-2017 The Apache Software Foundation
+
+  src/test/org/apache/commons/codec/language/DoubleMetaphoneTest.java
+  contains test data from http://aspell.net/test/orig/batch0.tab.
+  Copyright (C) 2002 Kevin Atkinson (kevina@gnu.org)
+
+  ===============================================================================
+
+  The content of package org.apache.commons.codec.language.bm has been translated
+  from the original php source code available at http://stevemorse.org/phoneticinfo.htm
+  with permission from the original authors.
+  Original source copyright:
+  Copyright (c) 2008 Alexander Beider & Stephen P. Morse.
+
+- lib/commons-io.commons-io-<VERSION>.jar
+  Apache Commons IO
+  Copyright 2002-2021 The Apache Software Foundation
+
+- lib/commons-logging.commons-logging-<VERSION>.jar
+  Apache Commons Logging
+  Copyright 2003-2014 The Apache Software Foundation
+
+- lib/org.apache.httpcomponents.httpclient-<VERSION>.jar
+  Apache HttpClient
+  Copyright 1999-2020 The Apache Software Foundation
+
+- lib/org.apache.httpcomponents.httpcore-<VERSION>.jar
+  Apache HttpCore
+  Copyright 2005-2020 The Apache Software Foundation
+
+- lib/org.apache.logging.log4j.log4j-api-<VERSION>.jar
+  Apache Log4j API
+  Copyright 1999-2022 The Apache Software Foundation
+
+- lib/org.apache.logging.log4j.log4j-api-scala_<VERSION>.jar
+  Apache Log4j Scala API
+  Copyright 2016-2022 Apache Software Foundation
+
+  AsciidocPlugin.scala
+  Copyright (c) 2008, 2009, 2010, 2011 Josh Suereth, Steven Blundy, Josh Cough,
+  Mark Harrah, Stuart Roebuck, Tony Sloane, Vesa Vilhonen, Jason Zaugg
+
+- lib/org.apache.logging.log4j.log4j-core-<VERSION>.jar
+  Apache Log4j Core
+  Copyright 1999-2012 Apache Software Foundation
+
+  ResolverUtil.java
+  Copyright 2005-2006 Tim Fennell
+
+- lib/org.jdom.jdom2-<VERSION>.jar
+  Copyright (C) 2000-2012 Jason Hunter & Brett McLaughlin.
+  All rights reserved.
+
+  This product includes software developed by the
+  JDOM Project (http://www.jdom.org/).
+
+- lib/org.scala-lang.modules.scala-parser-combinators_<VERSION>.jar
+  Scala parser combinators
+  Copyright (c) 2002-2022 EPFL
+  Copyright (c) 2011-2022 Lightbend, Inc.
+
+  Scala includes software developed at
+  LAMP/EPFL (https://lamp.epfl.ch/) and
+  Lightbend, Inc. (https://www.lightbend.com/).
+
+- lib/org.scala-lang.modules.scala-xml_<VERSION>.jar
+  scala-xml
+  Copyright (c) 2002-2022 EPFL
+  Copyright (c) 2011-2022 Lightbend, Inc.
+
+  scala-xml includes software developed at
+  LAMP/EPFL (https://lamp.epfl.ch/) and
+  Lightbend, Inc. (https://www.lightbend.com/).
+
+- lib/org.scala-lang.scala-library-<VERSION>.jar
+- org/apache/daffodil/util/UniquenessCache.class in lib/org.apache.daffodil.daffodil-lib-<VERSION>.jar
   Scala
-  Copyright (c) 2002-2020 EPFL
-  Copyright (c) 2011-2020 Lightbend, Inc.
+  Copyright (c) 2002-2021 EPFL
+  Copyright (c) 2011-2021 Lightbend, Inc.
 
   Scala includes software developed at
   LAMP/EPFL (https://lamp.epfl.ch/) and
@@ -133,8 +121,8 @@ Scala (lib/org.scala-lang.scala-library-<VERSION>.jar)
   and can be found in:
     daffodil-lib/src/main/scala/org/apache/daffodil/util/UniquenessCache.scala
 
-Scala Parser Combinators (lib/org.scala-lang.modules.scala-parser-combinators_<VERSION>.jar)
-  Scala parser combinators
+- lib/org.scala-lang.scala-reflect-<REFLECT>.jar
+  Scala
   Copyright (c) 2002-2021 EPFL
   Copyright (c) 2011-2021 Lightbend, Inc.
 
@@ -142,20 +130,30 @@ Scala Parser Combinators (lib/org.scala-lang.modules.scala-parser-combinators_<V
   LAMP/EPFL (https://lamp.epfl.ch/) and
   Lightbend, Inc. (https://www.lightbend.com/).
 
-Scala XML (lib/org.scala-lang.modules.scala-xml_<VERSION>.jar)
-  scala-xml
-  Copyright (c) 2002-2020 EPFL
-  Copyright (c) 2011-2020 Lightbend, Inc.
+- lib/xerces.xercesImpl-<VERSION>.jar
+  Apache Xerces Java
+  Copyright 1999-2022 The Apache Software Foundation
 
-  scala-xml includes software developed at
-  LAMP/EPFL (https://lamp.epfl.ch/) and
-  Lightbend, Inc. (https://www.lightbend.com/).
+  Portions of this software were originally based on the following:
+    - software copyright (c) 1999, IBM Corporation., http://www.ibm.com.
+    - software copyright (c) 1999, Sun Microsystems., http://www.sun.com.
+    - voluntary contributions made by Paul Eng on behalf of the 
+      Apache Software Foundation that were originally developed at iClick, Inc.,
+      software copyright (c) 1999.
 
-XML Resolver (lib/org.xmlresolver.xmlresolver-<VERSION>-data.jar, lib/org.xmlresolver.xmlresolver-<VERSION>.jar)
-  xmlresolver
-  Copyright 2015 Norman Walsh and contributors.
-  <http://nwalsh.com/>
+- lib/xml-apis.xml-apis-<VERSION>.jar
+  Apache XML Commons XML APIs
+  Copyright 1999-2009 The Apache Software Foundation.
 
-  xmlresolver includes software developed by the
-  XML Resolver Project (https://github.com/xmlresolver
-  and https://xmlresolver.org/).
+  Portions of this software were originally based on the following:
+    - software copyright (c) 1999, IBM Corporation., http://www.ibm.com.
+    - software copyright (c) 1999, Sun Microsystems., http://www.sun.com.
+    - software copyright (c) 2000 World Wide Web Consortium, http://www.w3.org
+
+- lib/xml-resolver.xml-resolver-<VERSION>.jar
+  Apache XML Commons Resolver
+  Copyright 2006 The Apache Software Foundation.
+
+  Portions of this code are derived from classes placed in the
+  public domain by Arbortext on 10 Apr 2000. See:
+  http://www.arbortext.com/customer_support/updates_and_technical_notes/catalogs/docs/README.htm


### PR DESCRIPTION
Add sub-NOTICEs for these new transitive dependencies which
xmlresolver (Saxon-HE's new transitive dependency) depends on:

  commons-codec.commons-codec-1.11.jar
  commons-logging.commons-logging-1.2.jar
  org.apache.httpcomponents.httpclient-4.5.13.jar
  org.apache.httpcomponents.httpcore-4.4.13.jar

Also update some other sub-NOTICEs that had gotten out of date and
remove the line "This product includes software developed at The
Apache Software Foundation (https://www.apache.org/)" from sub-NOTICEs
since Apache instructions say it's redundant in sub-NOTICEs.  While
we're at it, include even jars which have no sub-NOTICEs and reorder
all sub-NOTICEs by their jar name so we can compare the list in
bin.NOTICE to a listing of the lib directory to find new additions and
deletions more easily in the future.

DAFFODIL-2680