### PR TITLE
Daffodil 2643 tdml logs

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -104,6 +104,7 @@ lazy val sapi             = Project("daffodil-sapi", file("daffodil-sapi")).conf
 lazy val tdmlLib             = Project("daffodil-tdml-lib", file("daffodil-tdml-lib")).configs(IntegrationTest)
                               .dependsOn(macroLib % "compile-internal", lib, io, io % "test->test")
                               .settings(commonSettings)
+                              .settings(libraryDependencies ++= Dependencies.core)
 
 lazy val tdmlProc         = Project("daffodil-tdml-processor", file("daffodil-tdml-processor")).configs(IntegrationTest)
                               .dependsOn(tdmlLib, runtime2, core)

--- a/daffodil-lib/src/main/resources/org/apache/daffodil/xsd/tdml.xsd
+++ b/daffodil-lib/src/main/resources/org/apache/daffodil/xsd/tdml.xsd
@@ -232,6 +232,7 @@
   <element name="infoset" type="tns:infosetType"/>
   <element name="errors" type="tns:errorsType"/>
   <element name="warnings" type="tns:warningsType"/>
+  <element name="logs" type="tns:logsType"/>
   <element name="validationErrors" type="tns:validationErrorsType"/>
 
   <complexType name="documentType" mixed="true">
@@ -332,6 +333,14 @@
     <attributeGroup ref="tns:errorWarnAttribs"/>
   </complexType>
 
+  <complexType name="logsType">
+    <sequence>
+      <element ref="tns:log" maxOccurs="unbounded" minOccurs="0"/>
+                        <!-- use <warnings/> to indicate no warnings should occur. -->
+    </sequence>
+    <attributeGroup ref="tns:errorWarnAttribs"/>
+  </complexType>
+
   <complexType name="validationErrorsType">
     <sequence>
       <element ref="tns:error" maxOccurs="unbounded" minOccurs="0"/>
@@ -342,6 +351,7 @@
 
   <element name="error" type="xs:string"/>
   <element name="warning" type="xs:string"/>
+  <element name="log" type="xs:string"/>
 
   <xs:attributeGroup name="errorWarnAttribs">
     <xs:attribute name="match" use="optional" default="all">

--- a/daffodil-lib/src/main/resources/org/apache/daffodil/xsd/tdml.xsd
+++ b/daffodil-lib/src/main/resources/org/apache/daffodil/xsd/tdml.xsd
@@ -167,6 +167,7 @@
       <element ref="tns:infoset"/>
       <element ref="tns:errors"/>
       <element ref="tns:warnings" minOccurs='0'/>
+      <element ref="tns:logs" minOccurs='0'/>
       <element ref="tns:validationErrors" minOccurs="0"/>
     </choice>
     <attributeGroup ref="tns:testCaseAttribs"/>
@@ -336,7 +337,7 @@
   <complexType name="logsType">
     <sequence>
       <element ref="tns:log" maxOccurs="unbounded" minOccurs="0"/>
-                        <!-- use <warnings/> to indicate no warnings should occur. -->
+                        <!-- use <logs/> to indicate no logs should occur. -->
     </sequence>
     <attributeGroup ref="tns:errorWarnAttribs"/>
   </complexType>
@@ -373,6 +374,7 @@
       <element ref="tns:document"/> <!-- must have either document, or errors, or both -->
       <element ref="tns:errors"/>
       <element ref="tns:warnings"/>
+      <element ref="tns:logs"/>
     </choice>
     <attributeGroup ref="tns:testCaseAttribs"/>
   </complexType>

--- a/daffodil-tdml-lib/src/main/scala/org/apache/daffodil/tdml/RunnerFactory.scala
+++ b/daffodil-tdml-lib/src/main/scala/org/apache/daffodil/tdml/RunnerFactory.scala
@@ -91,6 +91,8 @@ object Runner {
    */
   def defaultShouldDoWarningComparisonOnCrossTests = false
 
+  def defaultShouldDoLogComparisonCrossTests = false
+
 }
 
 /**

--- a/daffodil-tdml-lib/src/main/scala/org/apache/daffodil/tdml/RunnerFactory.scala
+++ b/daffodil-tdml-lib/src/main/scala/org/apache/daffodil/tdml/RunnerFactory.scala
@@ -181,7 +181,8 @@ class Runner private (
         defaultValidationDefault,
         defaultImplementationsDefault,
         Runner.defaultShouldDoErrorComparisonOnCrossTests,
-        Runner.defaultShouldDoWarningComparisonOnCrossTests)
+        Runner.defaultShouldDoWarningComparisonOnCrossTests,
+        Runner.defaultShouldDoLogComparisonCrossTests)
     }
     ts
   }

--- a/daffodil-tdml-lib/src/main/scala/org/apache/daffodil/tdml/TDMLAppender.scala
+++ b/daffodil-tdml-lib/src/main/scala/org/apache/daffodil/tdml/TDMLAppender.scala
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.daffodil.tdml
+
+import org.apache.logging.log4j.core.appender.AbstractAppender
+import org.apache.logging.log4j.core.filter.ThresholdFilter
+import org.apache.logging.log4j.core.LogEvent
+import org.apache.logging.log4j.core.Filter.Result
+import org.apache.logging.log4j.Level
+import org.apache.daffodil.api.Diagnostic
+import org.apache.daffodil.util.Maybe
+import org.apache.daffodil.util.Maybe._
+import org.apache.logging.log4j.core.config.plugins.{Plugin, PluginFactory}
+
+@Plugin(
+    name="CustomAppender",
+    category="Core",
+    elementType="appender"
+)
+class TDMLAppender 
+ extends AbstractAppender ("org.apache.daffodil.tdml", ThresholdFilter.createFilter(Level.INFO, Result.ACCEPT, Result.DENY), null, false, null) {
+
+    import TDMLAppender._
+
+    override def append(event: LogEvent): Unit = {
+        diagnostics = new LogDiagnostic(event.getMessage.getFormattedMessage) +: diagnostics
+    }
+}
+
+object TDMLAppender{
+    var diagnostics: Seq[Diagnostic] = Nil
+    var diagnostics2: Seq[String] = Nil
+
+    @PluginFactory
+    def createAppender(): TDMLAppender = {
+            new TDMLAppender
+    }
+
+    def getDiagnostics(): Seq[Throwable] = {
+        diagnostics
+    }
+
+    def clearDiagnostics(): Unit = {
+        diagnostics = Nil
+    }
+}
+
+class LogDiagnostic(msg: String)
+  extends Diagnostic(Nope, Nope, Nope, Maybe(msg)) {
+  override def isError = false
+  override def modeName = "Log"
+}

--- a/daffodil-tdml-lib/src/main/scala/org/apache/daffodil/tdml/TDMLRunner.scala
+++ b/daffodil-tdml-lib/src/main/scala/org/apache/daffodil/tdml/TDMLRunner.scala
@@ -609,7 +609,7 @@ abstract class TestCase(testCaseXML: NodeSeq, val parent: DFDLTestSuite) {
   lazy val optExpectedLogs: Option[ExpectedLogs] = (testCaseXML \ "logs").headOption.map { node => ExpectedLogs(node, this) }
   lazy val optExpectedValidationErrors: Option[ExpectedValidationErrors] = (testCaseXML \ "validationErrors").headOption.map { node => ExpectedValidationErrors(node, this) }
 
-  if(LogManager.getRootLogger().asInstanceOf[log4jLogger].getAppenders().get("org.apache.tdml")==null){
+  if(LogManager.getRootLogger().asInstanceOf[log4jLogger].getAppenders().get("org.apache.tdml")==null && optExpectedLogs.isDefined){
     val tdmlAppender = TDMLAppender.createAppender
     val loggers = LogManager.getRootLogger().asInstanceOf[log4jLogger]
     loggers.addAppender(tdmlAppender)

--- a/daffodil-tdml-processor/src/test/resources/test/tdml/testLogs.tdml
+++ b/daffodil-tdml-processor/src/test/resources/test/tdml/testLogs.tdml
@@ -1,0 +1,195 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<tdml:testSuite suiteName="tdml logs"
+  xmlns:tdml="http://www.ibm.com/xmlns/dfdl/testData"
+  xmlns:dfdlx="http://www.ogf.org/dfdl/dfdl-1.0/extensions"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/"
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns:ex="http://example.com"
+  xmlns:fn="http://www.w3.org/2005/xpath-functions">
+  <tdml:defineSchema name="causesLogs" elementFormDefault="unqualified">
+    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+    <dfdl:format ref="ex:GeneralFormat" lengthKind="implicit"/>
+    <xs:element name="output">
+      <xs:complexType>
+        <xs:sequence>
+          <xs:sequence dfdl:hiddenGroupRef="hidden_message" />
+          <xs:element name="message" type="xs:string" dfdl:lengthKind="explicit" dfdl:length="5" dfdl:inputValueCalc="{
+					if (dfdlx:trace(../Hidden_Value eq '0', 'value')) then 'hello'
+					else fn:error('Unrecognized value')}" dfdl:terminator="" />
+        </xs:sequence>
+      </xs:complexType>
+    </xs:element>
+    <xs:group name="hidden_message">
+      <xs:sequence>
+        <xs:element name="Hidden_Value" type="xs:string" dfdl:length="1" dfdl:lengthKind="explicit" dfdl:outputValueCalc="{
+				if (dfdlx:trace(../message eq 'hello', 'value')) then '0'
+				else fn:error('Unrecognized value')}" />
+      </xs:sequence>
+    </xs:group>
+  </tdml:defineSchema>
+
+  <tdml:defineSchema name="causesLogs2" elementFormDefault="unqualified">
+    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+    <dfdl:format ref="ex:GeneralFormat" lengthKind="implicit"/>
+    <xs:element name="output">
+      <xs:complexType>
+        <xs:sequence>
+          <xs:sequence dfdl:hiddenGroupRef="hidden_message" />
+          <xs:element name="message" type="xs:string" dfdl:lengthKind="explicit" dfdl:length="5" dfdl:inputValueCalc="{
+					if (dfdlx:trace(../Hidden_Value eq '0', 'value')) then 'hello'
+					else fn:error('Unrecognized value')}" dfdl:terminator="" />
+        </xs:sequence>
+      </xs:complexType>
+    </xs:element>
+    <xs:group name="hidden_message">
+      <xs:sequence>
+        <xs:element name="Hidden_Value" type="xs:string" dfdl:length="1" dfdl:lengthKind="explicit" dfdl:outputValueCalc="{
+				if (dfdlx:trace(../message eq 'hello', 'value')) then '0'
+				else fn:error('Unrecognized value')}" />
+      </xs:sequence>
+    </xs:group>
+  </tdml:defineSchema>
+
+  <tdml:defineSchema name="causesWarningsAndLogs" elementFormDefault="unqualified">
+    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+    <dfdl:format ref="ex:GeneralFormat" lengthKind="explicit" occursCountKind="implicit"/>
+    <xs:element name="output" dfdl:lengthKind="implicit">
+      <xs:complexType>
+        <xs:sequence>
+          <xs:sequence dfdl:hiddenGroupRef="hidden_message" />
+          <xs:element name="message" type="xs:string" dfdl:lengthKind="explicit" dfdl:length="5" dfdl:inputValueCalc="{
+					if (dfdlx:trace(../Hidden_Value eq '0', 'value')) then 'hello'
+					else fn:error('Unrecognized value')}" dfdl:terminator="" />
+          <xs:element name="AmbgElt" type="xs:string" dfdl:length='1' />
+          <xs:element name="B" type="xs:string" dfdl:length="1" />
+          <xs:element name="AmbgElt" type="xs:string" dfdl:length="1" minOccurs="0"/>
+          <xs:sequence>
+          <xs:annotation>
+            <xs:appinfo source="http://www.ogf.org/dfdl/">
+              <dfdl:assert>{ ./AmbgElt eq '1' }</dfdl:assert>
+            </xs:appinfo>
+          </xs:annotation>
+        </xs:sequence>
+        </xs:sequence>
+      </xs:complexType>
+    </xs:element>
+    <xs:group name="hidden_message">
+      <xs:sequence>
+        <xs:element name="Hidden_Value" type="xs:string" dfdl:length="1" dfdl:lengthKind="explicit" dfdl:outputValueCalc="{
+				if (dfdlx:trace(../message eq 'hello', 'value')) then '0'
+				else fn:error('Unrecognized value')}" />
+      </xs:sequence>
+    </xs:group>
+  </tdml:defineSchema>
+
+  <tdml:parserTestCase name="logWhenExpectingSuccess" root="output" model="causesLogs">
+    <tdml:document><![CDATA[0]]></tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <ex:output>
+          <message>hello</message>
+        </ex:output>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+    <tdml:logs>
+      <tdml:log>dfdlx:trace</tdml:log>
+    </tdml:logs>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="logWhenExpectingError" root="output" model="causesLogs">
+    <tdml:document><![CDATA[00]]></tdml:document>
+    <tdml:errors>
+      <tdml:error>Left over data</tdml:error>
+    </tdml:errors>
+    <tdml:logs>
+      <tdml:log>dfdlx:trace</tdml:log>
+    </tdml:logs>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="logWhenExpectingWarning" root="output" model="causesWarningsAndLogs">
+    <tdml:document><![CDATA[013]]></tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <ex:output>
+          <message>hello</message>
+          <AmbgElt>1</AmbgElt>
+          <B>3</B>
+        </ex:output>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+    <tdml:warnings>
+      <tdml:warning>Schema definition warning</tdml:warning>
+    </tdml:warnings>
+    <tdml:logs>
+      <tdml:log>dfdlx:trace</tdml:log>
+    </tdml:logs>
+  </tdml:parserTestCase>
+
+  <tdml:unparserTestCase name="unparserLogWhenExpectingSuccess" root="output" model="causesLogs">
+    <tdml:document><![CDATA[0]]></tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <ex:output>
+          <message>hello</message>
+        </ex:output>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+    <tdml:logs>
+      <tdml:log>dfdlx:trace</tdml:log>
+    </tdml:logs>
+  </tdml:unparserTestCase>
+
+  <tdml:unparserTestCase name="unparserLogWhenExpectingError" root="output" model="causesLogs">
+    <tdml:document><![CDATA[00]]></tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <ex:output>
+          <message>hello</message>
+        </ex:output>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+    <tdml:errors>
+      <tdml:error>output data length</tdml:error>
+    </tdml:errors>
+    <tdml:logs>
+      <tdml:log>dfdlx:trace</tdml:log>
+    </tdml:logs>
+  </tdml:unparserTestCase>
+
+  <tdml:unparserTestCase name="unparserLogWhenExpectingWarning" root="output" model="causesWarningsAndLogs">
+    <tdml:document><![CDATA[013]]></tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <ex:output>
+          <message>hello</message>
+          <AmbgElt>1</AmbgElt>
+          <B>3</B>
+        </ex:output>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+    <tdml:warnings>
+      <tdml:warning>Schema definition warning</tdml:warning>
+    </tdml:warnings>
+    <tdml:logs>
+      <tdml:log>dfdlx:trace</tdml:log>
+    </tdml:logs>
+  </tdml:unparserTestCase>
+</tdml:testSuite>

--- a/daffodil-tdml-processor/src/test/scala/org/apache/daffodil/tdml/TestTDMLRunnerLogs.scala
+++ b/daffodil-tdml-processor/src/test/scala/org/apache/daffodil/tdml/TestTDMLRunnerLogs.scala
@@ -22,8 +22,6 @@ import org.junit.AfterClass
 import org.apache.daffodil.Implicits._
 import org.junit.Assert.fail
 
-import org.apache.logging.log4j.LogManager
-
 object TestTDMLRunnerLogs {
   val runner = Runner("/test/tdml/", "testLogs.tdml")
 

--- a/daffodil-tdml-processor/src/test/scala/org/apache/daffodil/tdml/TestTDMLRunnerLogs.scala
+++ b/daffodil-tdml-processor/src/test/scala/org/apache/daffodil/tdml/TestTDMLRunnerLogs.scala
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.daffodil.tdml
+
+import org.junit.Test
+import org.junit.AfterClass
+import org.apache.daffodil.Implicits._
+import org.junit.Assert.fail
+
+import org.apache.logging.log4j.LogManager
+
+object TestTDMLRunnerLogs {
+  val runner = Runner("/test/tdml/", "testLogs.tdml")
+
+  @AfterClass def shutDown(): Unit = {
+    runner.reset
+  }
+}
+
+class TestTDMLRunnerLogs {
+  import TestTDMLRunnerLogs._
+
+  @Test def test_logWhenExpectingSuccess() = { runner.runOneTest("logWhenExpectingSuccess") }
+  @Test def test_logWhenExpectingError() = { runner.runOneTest("logWhenExpectingError") }
+  @Test def test_logWhenExpectingWarning() = { runner.runOneTest("logWhenExpectingWarning") }
+  @Test def test_unparserLogWhenExpectingSuccess() = { runner.runOneTest("unparserLogWhenExpectingSuccess") }
+  @Test def test_unparserLogWhenExpectingError() = { runner.runOneTest("unparserLogWhenExpectingError") }
+  @Test def test_unparserLogWhenExpectingWarning() = { runner.runOneTest("unparserLogWhenExpectingWarning") }
+
+  /*
+   * These tests insure that the TDML runner is actually testing the logs.
+   * A TDML test could silently not even be checking the logs and pass with false positive.
+   * These tests cause the TDML runner test to fail to find logs, and check
+   * that we got the TDML runner to detect this.
+   */
+
+  @Test def testLogsCheckedParserExpectingSuccess() = {
+    val testSuite =
+      <tdml:testSuite suiteName="tdml logs" xmlns:tdml="http://www.ibm.com/xmlns/dfdl/testData" xmlns:dfdlx="http://www.ogf.org/dfdl/dfdl-1.0/extensions" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:ex="http://example.com" xmlns:fn="http://www.w3.org/2005/xpath-functions">
+        <tdml:defineSchema name="causesLogs" elementFormDefault="unqualified">
+          <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+          <dfdl:format ref="ex:GeneralFormat" lengthKind="implicit"/>
+	      <xs:element name="output">
+		    <xs:complexType>
+			  <xs:sequence>
+				<xs:sequence dfdl:hiddenGroupRef="hidden_message" />
+				<xs:element name="message" type="xs:string" dfdl:inputValueCalc="{
+					if (../Hidden_Value eq '0') then 'hello'
+					else fn:error('Unrecognized value')}" dfdl:terminator="" />
+			  </xs:sequence>
+		    </xs:complexType>
+	      </xs:element>
+	      <xs:group name="hidden_message"> 
+		    <xs:sequence>
+		      <xs:element name="Hidden_Value" type="xs:string" dfdl:length="1" dfdl:lengthKind="explicit" dfdl:outputValueCalc="{
+				if (../message eq 'hello') then '0'
+				else fn:error('Unrecognized value')}"
+		      />
+		    </xs:sequence>
+          </xs:group>
+        </tdml:defineSchema>
+        <tdml:parserTestCase name="warningWhenExpectingSuccess" root="output" model="causesLogs">
+          <tdml:document><![CDATA[0]]></tdml:document>
+          <tdml:infoset>
+            <tdml:dfdlInfoset>
+              <ex:output>
+                <message>hello</message>
+              </ex:output>
+            </tdml:dfdlInfoset>
+          </tdml:infoset>
+          <tdml:logs>
+            <tdml:log>This will not be found</tdml:log>
+          </tdml:logs>
+        </tdml:parserTestCase>
+      </tdml:testSuite>
+
+    val runner = new Runner(testSuite)
+    val e = intercept[Exception] {
+      runner.runOneTest("warningWhenExpectingSuccess")
+    }
+    runner.reset
+    val msg = e.getMessage()
+    if (!msg.contains("This will not be found")) {
+      fail("TDML Logs were not checked")
+    }
+  }
+ 
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -32,6 +32,7 @@ object Dependencies {
     "com.typesafe" % "config" % "1.4.2",
     "org.apache.logging.log4j" %% "log4j-api-scala" % "12.0",
     "org.apache.logging.log4j" % "log4j-api" % "2.17.2",
+    "org.apache.logging.log4j" % "log4j-core" % "2.17.2",
     "org.apache.logging.log4j" % "log4j-core" % "2.17.2" % "it,test",
   )
 


### PR DESCRIPTION
TDML unit tests can now capture and look for logs
Like they do for warnings and errors, logs completed through log4j are
captured and can be required in the tdml test cases. The root logger
level is by default warning and when a tdml test is run, that level is
changed to info in order to capture logs. Tests were added to
demonstrate the feature as well as how it works in conjunction with
warnings and errors. Library dependencies were updated to give tdml-lib
access to log4jcore libraries needed to make an abstractappender

DAFFODIL-2643