### PR TITLE
Choose TDML implementation to run TDML tests

### DIFF
--- a/daffodil-cli/src/it/resources/org/apache/daffodil/CLI/testNonCompatibleImplementation.tdml
+++ b/daffodil-cli/src/it/resources/org/apache/daffodil/CLI/testNonCompatibleImplementation.tdml
@@ -27,10 +27,20 @@
   <tdml:defineSchema name="s1">
     <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
     <dfdl:format ref="ex:GeneralFormat" />
-
     <xs:element name="e1" dfdl:lengthKind="explicit"
       dfdl:length="2" type="xs:int" />
+  </tdml:defineSchema>
 
+  <tdml:defineSchema name="s2">
+    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+    <dfdl:format ref="ex:GeneralFormat" representation="binary" />
+    <xs:element name="e1">
+      <xs:complexType>
+        <xs:sequence>
+          <xs:element name="e2" type="xs:int"/>
+        </xs:sequence>
+      </xs:complexType>
+    </xs:element>
   </tdml:defineSchema>
 
   <tdml:parserTestCase name="testNotCompatibleImplementation1" root="e1"
@@ -40,6 +50,21 @@
     <tdml:infoset>
       <tdml:dfdlInfoset>
         <e1>42</e1>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="testDaffodilCImplementation1" root="e1"
+    model="s2" description="this test specifies daffodilC as implementation."
+    implementations="daffodilC">
+    <tdml:document>
+      <tdml:documentPart type="byte">0000002a</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <e1>
+          <e2>42</e2>
+        </e1>
       </tdml:dfdlInfoset>
     </tdml:infoset>
   </tdml:parserTestCase>

--- a/daffodil-cli/src/it/scala/org/apache/daffodil/CLI/Util.scala
+++ b/daffodil-cli/src/it/scala/org/apache/daffodil/CLI/Util.scala
@@ -26,7 +26,6 @@ import org.apache.daffodil.Main.ExitCode
 
 import java.nio.file.Paths
 import java.io.{File, PrintWriter}
-import scala.collection.JavaConverters._
 import java.util.concurrent.TimeUnit
 import org.apache.daffodil.xml.XMLUtils
 import org.junit.Assert.fail
@@ -39,7 +38,7 @@ object Util {
 
   val isWindows = System.getProperty("os.name").toLowerCase().startsWith("windows")
 
-  val dafRoot = sys.env.get("DAFFODIL_HOME").getOrElse(".")
+  val dafRoot = sys.env.getOrElse("DAFFODIL_HOME", ".")
 
   def daffodilPath(dafRelativePath: String): String = {
     XMLUtils.slashify(dafRoot) + dafRelativePath
@@ -82,7 +81,7 @@ object Util {
   // The inputStream will be at index 0
   // The errorStream will be at index 1
   def getShell(cmd: String, spawnCmd: String, envp: Map[String, String] = Map.empty[String, String], timeout: Long): Expect = {
-    val newEnv = System.getenv().asScala ++ envp
+    val newEnv = sys.env ++ envp
 
     val envAsArray = newEnv.toArray.map { case (k, v) => k + "=" + v }
     val process = Runtime.getRuntime().exec(spawnCmd, envAsArray)

--- a/daffodil-cli/src/it/scala/org/apache/daffodil/executing/TestCLIexecuting.scala
+++ b/daffodil-cli/src/it/scala/org/apache/daffodil/executing/TestCLIexecuting.scala
@@ -194,7 +194,47 @@ class TestCLIexecuting {
       val cmd = String.format("%s test %s testNotCompatibleImplementation1", Util.binPath, testTdmlFile)
       println(cmd)
       shell.sendLine(cmd)
-      shell.expect(contains("[Skipped] testNotCompatibleImplementation1 (Not compatible implementation.)"))
+      shell.expect(contains("[Skipped] testNotCompatibleImplementation1 (not compatible"))
+
+      Util.expectExitCode(ExitCode.Success, shell)
+      shell.sendLine("exit")
+    } finally {
+      shell.close()
+    }
+  }
+
+  @Test def test_CLI_catch_TestBadArguments(): Unit = {
+    val tdmlFile = Util.daffodilPath("daffodil-cli/src/it/resources/org/apache/daffodil/CLI/testNonCompatibleImplementation.tdml")
+
+    val testTdmlFile = if (Util.isWindows) Util.cmdConvert(tdmlFile) else tdmlFile
+
+    val shell = Util.start("")
+
+    try {
+      val cmd = String.format("%s test -I notDaffodilC %s", Util.binPath, testTdmlFile)
+      println(cmd)
+      shell.sendLine(cmd)
+      shell.expectIn(1, contains("[error] Bad arguments for option 'implementation'"))
+
+      Util.expectExitCode(ExitCode.Usage, shell)
+      shell.sendLine("exit")
+    } finally {
+      shell.close()
+    }
+  }
+
+  @Test def test_CLI_Executing_implementation(): Unit = {
+    val tdmlFile = Util.daffodilPath("daffodil-cli/src/it/resources/org/apache/daffodil/CLI/testNonCompatibleImplementation.tdml")
+
+    val testTdmlFile = if (Util.isWindows) Util.cmdConvert(tdmlFile) else tdmlFile
+
+    val shell = Util.start("")
+
+    try {
+      val cmd = String.format("%s test -I daffodilC %s testDaffodilCImplementation1", Util.binPath, testTdmlFile)
+      println(cmd)
+      shell.sendLine(cmd)
+      shell.expect(contains("[Pass] testDaffodilCImplementation1"))
 
       Util.expectExitCode(ExitCode.Success, shell)
       shell.sendLine("exit")

--- a/daffodil-lib/src/main/resources/org/apache/daffodil/xsd/tdml.xsd
+++ b/daffodil-lib/src/main/resources/org/apache/daffodil/xsd/tdml.xsd
@@ -101,7 +101,7 @@
   <simpleType name="implementationItem">
     <restriction base="xs:token">
       <enumeration value="daffodil"/>
-      <enumeration value="daffodil-runtime2"/>
+      <enumeration value="daffodilC"/>
       <enumeration value="ibm"/>
     </restriction>
   </simpleType>

--- a/daffodil-propgen/src/main/resources/org/apache/daffodil/xsd/dafext.xsd
+++ b/daffodil-propgen/src/main/resources/org/apache/daffodil/xsd/dafext.xsd
@@ -45,7 +45,7 @@
   </xs:complexType>
 
   <xs:simpleType name="PropertyNameType">
-    <xs:restriction base="xs:string">
+    <xs:restriction base="xs:token">
       <xs:enumeration value="parseUnparsePolicy"/>
     </xs:restriction>
   </xs:simpleType>
@@ -502,14 +502,6 @@
             </xs:documentation>
           </xs:annotation>
         </xs:element>
-        <xs:element name="tdmlImplementation" type="xs:string" default="daffodil" minOccurs="0">
-          <xs:annotation>
-            <xs:documentation>
-              TDMLDFDLProcessorFactory implementation to use when running TDML tests.
-              Allowed values are "daffodil" (default), "daffodil-runtime2", and "ibm".
-            </xs:documentation>
-          </xs:annotation>
-        </xs:element>
         <xs:element name="tempFilePath" type="xs:string" default="This string is ignored. Default value is taken from java.io.tmpdir property"  minOccurs="0">
           <xs:annotation>
             <xs:documentation>
@@ -587,15 +579,27 @@
         <xs:restriction base="dfdlx:ParseUnparsePolicyEnum" />
       </xs:simpleType>
       <xs:simpleType>
-        <xs:restriction base="xs:string">
+        <xs:restriction base="xs:token">
           <xs:enumeration value="fromRoot" />
         </xs:restriction>
       </xs:simpleType>
     </xs:union>
   </xs:simpleType>
 
+  <!--
+    TDML implementation to use when running TDML tests. Currently daffodil and ibm use the
+    same classname, so you still need different classpaths to call ibm as a cross tester.
+  -->
+  <xs:simpleType name="TunableTDMLImplementation">
+    <xs:restriction base="xs:token">
+      <xs:enumeration value="daffodil" />
+      <xs:enumeration value="daffodilC" />
+      <xs:enumeration value="ibm" />
+    </xs:restriction>
+  </xs:simpleType>
+
   <xs:simpleType name="TunableUnqualifiedPathStepPolicy">
-    <xs:restriction base="xs:string">
+    <xs:restriction base="xs:token">
       <xs:enumeration value="defaultNamespace" />
       <xs:enumeration value="noNamespace" />
       <xs:enumeration value="preferDefaultNamespace" />

--- a/daffodil-runtime2/src/main/resources/org/apache/daffodil/runtime2/c/libruntime/parsers.c
+++ b/daffodil-runtime2/src/main/resources/org/apache/daffodil/runtime2/c/libruntime/parsers.c
@@ -507,26 +507,25 @@ parse_le_uint8(uint8_t *number, size_t num_bits, PState *pstate)
     *number = (uint8_t)integer;
 }
 
-// Skip fill bytes until end bitPos0b is reached
+// Parse fill bits until end bitPos0b is reached
 
 void
-parse_fill_bytes(size_t end_bitPos0b, PState *pstate)
+parse_fill_bits(size_t end_bitPos0b, PState *pstate)
 {
-    union
-    {
-        uint8_t bytes[1];
-    } buffer;
+    assert(pstate->bitPos0b <= end_bitPos0b);
 
-    // Update our last successful parse position only if this loop
-    // finishes without any errors
-    size_t current_bitPos0b = pstate->bitPos0b;
-    while (current_bitPos0b < end_bitPos0b)
+    size_t fill_bits = end_bitPos0b - pstate->bitPos0b;
+    uint8_t bytes[1];
+    while (fill_bits)
     {
-        read_bits(buffer.bytes, BYTE_WIDTH, pstate);
+        size_t num_bits = (fill_bits >= BYTE_WIDTH) ? BYTE_WIDTH : fill_bits;
+        read_bits(bytes, num_bits, pstate);
         if (pstate->error) return;
-        current_bitPos0b += BYTE_WIDTH;
+        fill_bits -= num_bits;
     }
-    pstate->bitPos0b = current_bitPos0b;
+    
+    // If we got all the way here, update our last successful parse position
+    pstate->bitPos0b = end_bitPos0b;
 }
 
 // Allocate memory for hexBinary array

--- a/daffodil-runtime2/src/main/resources/org/apache/daffodil/runtime2/c/libruntime/parsers.h
+++ b/daffodil-runtime2/src/main/resources/org/apache/daffodil/runtime2/c/libruntime/parsers.h
@@ -57,9 +57,9 @@ extern void parse_le_uint32(uint32_t *number, size_t num_bits, PState *pstate);
 extern void parse_le_uint64(uint64_t *number, size_t num_bits, PState *pstate);
 extern void parse_le_uint8(uint8_t *number, size_t num_bits, PState *pstate);
 
-// Parse fill bytes until end bytePos0b is reached
+// Parse fill bits until end bitPos0b is reached
 
-extern void parse_fill_bytes(size_t end_bytePos0b, PState *pstate);
+extern void parse_fill_bits(size_t end_bitPos0b, PState *pstate);
 
 // Allocate memory for hexBinary array
 

--- a/daffodil-runtime2/src/main/resources/org/apache/daffodil/runtime2/c/libruntime/unparsers.h
+++ b/daffodil-runtime2/src/main/resources/org/apache/daffodil/runtime2/c/libruntime/unparsers.h
@@ -57,9 +57,9 @@ extern void unparse_le_uint32(uint32_t number, size_t num_bits, UState *ustate);
 extern void unparse_le_uint64(uint64_t number, size_t num_bits, UState *ustate);
 extern void unparse_le_uint8(uint8_t number, size_t num_bits, UState *ustate);
 
-// Unparse fill bytes until end bytePos0b is reached
+// Unparse fill bits until end bitPos0b is reached
 
-extern void unparse_fill_bytes(size_t end_bytePos0b, const uint8_t fill_byte, UState *ustate);
+extern void unparse_fill_bits(size_t end_bitPos0b, const uint8_t fill_byte, UState *ustate);
 
 // Unparse opaque bytes from hexBinary field
 

--- a/daffodil-runtime2/src/main/scala/org/apache/daffodil/runtime2/CodeGenerator.scala
+++ b/daffodil-runtime2/src/main/scala/org/apache/daffodil/runtime2/CodeGenerator.scala
@@ -161,9 +161,9 @@ class CodeGenerator(root: Root) extends DFDL.CodeGenerator {
    * sequence if no compiler could be found in the user's PATH.
    */
   lazy val pickCompiler: Seq[String] = {
-    val ccEnv = System.getenv("CC")
+    val ccEnv = sys.env.getOrElse("CC", "zig cc")
     val compilers = Seq(ccEnv, "zig cc", "cc", "clang", "gcc")
-    val path = System.getenv("PATH").split(File.pathSeparatorChar)
+    val path = sys.env.getOrElse("PATH", ".").split(File.pathSeparatorChar)
     def inPath(compiler: String): Boolean = {
       (compiler != null) && {
         val exec = compiler.takeWhile(_ != ' ')

--- a/daffodil-runtime2/src/main/scala/org/apache/daffodil/runtime2/generators/CodeGeneratorState.scala
+++ b/daffodil-runtime2/src/main/scala/org/apache/daffodil/runtime2/generators/CodeGeneratorState.scala
@@ -331,10 +331,10 @@ class CodeGeneratorState(private val root: ElementBase) {
     if (context.maybeFixedLengthInBits.isDefined && context.maybeFixedLengthInBits.get > 0) {
       val octalFillByte = context.fillByteEv.constValue.toByte.toOctalString
       val parseStatement =
-        s"""    parse_fill_bytes(end_bitPos0b, pstate);
+        s"""    parse_fill_bits(end_bitPos0b, pstate);
            |    if (pstate->error) return;""".stripMargin
       val unparseStatement =
-        s"""    unparse_fill_bytes(end_bitPos0b, '\\$octalFillByte', ustate);
+        s"""    unparse_fill_bits(end_bitPos0b, '\\$octalFillByte', ustate);
            |    if (ustate->error) return;""".stripMargin
 
       structs.top.parserStatements += parseStatement

--- a/daffodil-runtime2/src/test/resources/org/apache/daffodil/runtime2/ex_nums.tdml
+++ b/daffodil-runtime2/src/test/resources/org/apache/daffodil/runtime2/ex_nums.tdml
@@ -17,52 +17,22 @@
 -->
 
 <tdml:testSuite
-  defaultImplementations="daffodil daffodil-runtime2"
-  defaultRoundTrip="onePass"
+  defaultRoundTrip="none"
   description="TDML tests for ex_nums.dfdl.xsd"
   xmlns:daf="urn:ogf:dfdl:2013:imp:daffodil.apache.org:2018:ext"
   xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/"
   xmlns:tdml="http://www.ibm.com/xmlns/dfdl/testData">
 
   <!--
-      Can run all tests in this file with:
+      Run all tests:
 
-      daffodil test -i ex_nums.tdml
-  -->
+      daffodil test -i -I daffodil ex_nums.tdml
+      daffodil test -i -I daffodilC ex_nums.tdml
 
-  <tdml:defineConfig name="config-runtime1">
-    <daf:tunables>
-      <daf:tdmlImplementation>daffodil</daf:tdmlImplementation>
-    </daf:tunables>
-  </tdml:defineConfig>
-
-  <tdml:defineConfig name="config-runtime2">
-    <daf:tunables>
-      <daf:tdmlImplementation>daffodil-runtime2</daf:tdmlImplementation>
-    </daf:tunables>
-  </tdml:defineConfig>
-
-  <!--
-      Can run individual daffodil commands for easier debugging:
+      Or you can debug specific steps in isolation:
 
       daffodil parse -s ex_nums.dfdl.xsd -o ex_nums.dat.xml ex_nums.dat
       daffodil unparse -s ex_nums.dfdl.xsd -o ex_nums.dat ex_nums.dat.xml
-  -->
-
-  <tdml:parserTestCase
-    config="config-runtime1"
-    model="ex_nums.dfdl.xsd"
-    name="ex_nums_runtime1">
-    <tdml:document>
-      <tdml:documentPart type="file">ex_nums.dat</tdml:documentPart>
-    </tdml:document>
-    <tdml:infoset>
-      <tdml:dfdlInfoset type="file">ex_nums.dat.xml</tdml:dfdlInfoset>
-    </tdml:infoset>
-  </tdml:parserTestCase>
-
-  <!--
-      Can run individual daffodil commands for easier debugging:
 
       daffodil generate c -s ex_nums.dfdl.xsd && cd c && make
       c/daffodil parse -o ex_nums.dat.xml ex_nums.dat
@@ -70,9 +40,9 @@
   -->
 
   <tdml:parserTestCase
-    config="config-runtime2"
     model="ex_nums.dfdl.xsd"
-    name="ex_nums_runtime2">
+    name="ex_nums"
+    roundTrip="onePass">
     <tdml:document>
       <tdml:documentPart type="file">ex_nums.dat</tdml:documentPart>
     </tdml:document>
@@ -82,15 +52,20 @@
   </tdml:parserTestCase>
 
   <!--
-      validation="limited" will report no validation errors, while
-      validation="on" will report errors which cannot be captured
+      In runtime1, parse with validation="off" or "limited" reads
+      non-fixed values with no validation diagnostics, while parse
+      with validation="on" reads non-fixed values with validation
+      diagnostics
+
+      daffodil parse -s ex_nums.dfdl.xsd -o /dev/null -V off ex_nums.error.dat
+      daffodil parse -s ex_nums.dfdl.xsd -o /dev/null -V limited ex_nums.error.dat
+      daffodil parse -s ex_nums.dfdl.xsd -o /dev/null -V on ex_nums.error.dat
   -->
 
   <tdml:parserTestCase
-    config="config-runtime1"
+    implementations="daffodil"
     model="ex_nums.dfdl.xsd"
-    name="ex_nums_runtime1_error"
-    roundTrip="none"
+    name="runtime1_error_limited"
     validation="limited">
     <tdml:document>
       <tdml:documentPart type="file">ex_nums.error.dat</tdml:documentPart>
@@ -100,19 +75,57 @@
     </tdml:infoset>
   </tdml:parserTestCase>
 
+  <tdml:parserTestCase
+    model="ex_nums.dfdl.xsd"
+    name="runtime1_error_on"
+    validation="on">
+    <tdml:document>
+      <tdml:documentPart type="file">ex_nums.error.dat</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset type="file">ex_nums.error.dat.xml</tdml:dfdlInfoset>
+    </tdml:infoset>
+    <tdml:validationErrors>
+      <tdml:error>value</tdml:error>
+      <tdml:error>boolean_false</tdml:error>
+      <tdml:error>does not match</tdml:error>
+    </tdml:validationErrors>
+  </tdml:parserTestCase>
+
   <!--
-      Note that when unparsing (needs a separate test case since
-      roundtripping is turned off), runtime2 should write fixed values
-      instead of writing error values with validation diagnostics
-      (change still to be done)
+      In runtime1, unparse writes non-fixed values with no error or
+      validation diagnostics regardless of validation setting
+
+      daffodil unparse -s ex_nums.dfdl.xsd -o /dev/null -V off ex_nums.error.dat.xml
+      daffodil unparse -s ex_nums.dfdl.xsd -o /dev/null -V limited ex_nums.error.dat.xml
+      daffodil unparse -s ex_nums.dfdl.xsd -o /dev/null -V on ex_nums.error.dat.xml
+  -->
+
+  <tdml:unparserTestCase
+    implementations="daffodil"
+    model="ex_nums.dfdl.xsd"
+    name="runtime1_error_unparse">
+    <tdml:infoset>
+      <tdml:dfdlInfoset type="file">ex_nums.error.dat.xml</tdml:dfdlInfoset>
+    </tdml:infoset>
+    <tdml:document>
+      <tdml:documentPart type="file">ex_nums.error.dat</tdml:documentPart>
+    </tdml:document>
+  </tdml:unparserTestCase>
+
+  <!--
+      In runtime2, parse always reads non-fixed values with validation
+      diagnostics (parse doesn't even have a validation option, but
+      test must pass validation="on" so TDMLRunner can expect errors)
+
+      c/daffodil parse -o c/ex_nums.error.dat.xml ex_nums.error.dat
   -->
 
   <tdml:parserTestCase
-    config="config-runtime2"
+    implementations="daffodilC"
     model="ex_nums.dfdl.xsd"
-    name="ex_nums_runtime2_error"
-    roundTrip="none"
-    validation="limited">
+    name="runtime2_error_parse"
+    validation="on">
     <tdml:document>
       <tdml:documentPart type="file">ex_nums.error.dat</tdml:documentPart>
     </tdml:document>
@@ -157,5 +170,29 @@
       <tdml:error>attribute</tdml:error>
     </tdml:validationErrors>
   </tdml:parserTestCase>
+
+  <!--
+      In runtime2, unparse always writes non-fixed values with error
+      diagnostics (unparse doesn't even have a validation option)
+
+      c/daffodil unparse -o c/ex_nums.error.dat ex_nums.error.dat.xml
+  -->
+
+  <tdml:unparserTestCase
+    implementations="daffodilC"
+    model="ex_nums.dfdl.xsd"
+    name="runtime2_error_unparse">
+    <tdml:infoset>
+      <tdml:dfdlInfoset type="file">ex_nums.error.dat.xml</tdml:dfdlInfoset>
+    </tdml:infoset>
+    <tdml:document>
+      <tdml:documentPart type="file">ex_nums.error.dat</tdml:documentPart>
+    </tdml:document>
+    <tdml:errors>
+      <tdml:error>value</tdml:error>
+      <tdml:error>boolean_false</tdml:error>
+      <tdml:error>does not match</tdml:error>
+    </tdml:errors>
+  </tdml:unparserTestCase>
 
 </tdml:testSuite>

--- a/daffodil-runtime2/src/test/resources/org/apache/daffodil/runtime2/nested.tdml
+++ b/daffodil-runtime2/src/test/resources/org/apache/daffodil/runtime2/nested.tdml
@@ -17,25 +17,18 @@
 -->
 
 <tdml:testSuite
-  defaultConfig="config-runtime2"
-  defaultImplementations="daffodil daffodil-runtime2"
   defaultRoundTrip="onePass"
   description="TDML tests for nested.dfdl.xsd"
   xmlns:daf="urn:ogf:dfdl:2013:imp:daffodil.apache.org:2018:ext"
   xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/"
   xmlns:tdml="http://www.ibm.com/xmlns/dfdl/testData">
 
-  <tdml:defineConfig name="config-runtime1">
-    <daf:tunables>
-      <daf:tdmlImplementation>daffodil</daf:tdmlImplementation>
-    </daf:tunables>
-  </tdml:defineConfig>
+  <!--
+      Run all tests:
 
-  <tdml:defineConfig name="config-runtime2">
-    <daf:tunables>
-      <daf:tdmlImplementation>daffodil-runtime2</daf:tdmlImplementation>
-    </daf:tunables>
-  </tdml:defineConfig>
+      daffodil test -i -I daffodil nested.tdml
+      daffodil test -i -I daffodilC nested.tdml
+  -->
 
   <tdml:parserTestCase model="nested.dfdl.xsd" name="nested_struct">
     <tdml:document>

--- a/daffodil-tdml-processor/src/main/scala/org/apache/daffodil/tdml/processor/Runtime2TDMLDFDLProcessor.scala
+++ b/daffodil-tdml-processor/src/main/scala/org/apache/daffodil/tdml/processor/Runtime2TDMLDFDLProcessor.scala
@@ -38,7 +38,7 @@ final class Runtime2TDMLDFDLProcessorFactory private(
 
   override type R = Runtime2TDMLDFDLProcessorFactory
 
-  override def implementationName = "daffodil-runtime2"
+  override def implementationName = TDMLImplementation.DaffodilC.toString
 
   def this() = this(compiler = Compiler(validateDFDLSchemas = true),
     checkAllTopLevel = false,

--- a/daffodil-tdml-processor/src/test/java/org/apache/daffodil/tdml/TestRunnerFactory.java
+++ b/daffodil-tdml-processor/src/test/java/org/apache/daffodil/tdml/TestRunnerFactory.java
@@ -24,6 +24,7 @@ import org.apache.daffodil.util.Misc;
 import org.junit.Test;
 import org.xml.sax.InputSource;
 
+import scala.Option;
 import scala.collection.JavaConverters;
 import scala.xml.Elem;
 import scala.xml.XML;
@@ -39,6 +40,7 @@ public class TestRunnerFactory {
     Right<scala.xml.Elem, String> rightURI = new Right<>(tdmlUri.toString());
     Runner runner = new Runner(
       rightURI,
+      Option.apply(null),
       true,
       true,
       false,

--- a/daffodil-test/src/test/resources/org/apache/daffodil/runtime2/ISRM_green_to_orange_60000.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/runtime2/ISRM_green_to_orange_60000.tdml
@@ -17,8 +17,6 @@
 -->
 
 <tdml:testSuite
-  defaultConfig="config-runtime2"
-  defaultImplementations="daffodil daffodil-runtime2"
   defaultRoundTrip="onePass"
   defaultValidation="on"
   description="TDML tests for ISRM_green_to_orange_60000.dfdl.xsd"
@@ -26,17 +24,12 @@
   xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/"
   xmlns:tdml="http://www.ibm.com/xmlns/dfdl/testData">
 
-  <tdml:defineConfig name="config-runtime1">
-    <daf:tunables>
-      <daf:tdmlImplementation>daffodil</daf:tdmlImplementation>
-    </daf:tunables>
-  </tdml:defineConfig>
+  <!--
+      Run all tests:
 
-  <tdml:defineConfig name="config-runtime2">
-    <daf:tunables>
-      <daf:tdmlImplementation>daffodil-runtime2</daf:tdmlImplementation>
-    </daf:tunables>
-  </tdml:defineConfig>
+      daffodil test -i -I daffodil ISRM_green_to_orange_60000.tdml
+      daffodil test -i -I daffodilC ISRM_green_to_orange_60000.tdml
+  -->
 
   <tdml:parserTestCase model="ISRM_green_to_orange_60000.dfdl.xsd" name="ISRM_green_to_orange_60000_0">
     <tdml:document>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/runtime2/ISRM_orange_to_green_60002.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/runtime2/ISRM_orange_to_green_60002.tdml
@@ -17,8 +17,6 @@
 -->
 
 <tdml:testSuite
-  defaultConfig="config-runtime2"
-  defaultImplementations="daffodil daffodil-runtime2"
   defaultRoundTrip="onePass"
   defaultValidation="on"
   description="TDML tests for ISRM_orange_to_green_60002.dfdl.xsd"
@@ -26,17 +24,12 @@
   xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/"
   xmlns:tdml="http://www.ibm.com/xmlns/dfdl/testData">
 
-  <tdml:defineConfig name="config-runtime1">
-    <daf:tunables>
-      <daf:tdmlImplementation>daffodil</daf:tdmlImplementation>
-    </daf:tunables>
-  </tdml:defineConfig>
+  <!--
+      Run all tests:
 
-  <tdml:defineConfig name="config-runtime2">
-    <daf:tunables>
-      <daf:tdmlImplementation>daffodil-runtime2</daf:tdmlImplementation>
-    </daf:tunables>
-  </tdml:defineConfig>
+      daffodil test -i -I daffodil ISRM_orange_to_green_60002.tdml
+      daffodil test -i -I daffodilC ISRM_orange_to_green_60002.tdml
+  -->
 
   <tdml:parserTestCase model="ISRM_orange_to_green_60002.dfdl.xsd" name="ISRM_orange_to_green_60002">
     <tdml:document>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/runtime2/MPU_green_to_orange_60004.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/runtime2/MPU_green_to_orange_60004.tdml
@@ -17,8 +17,6 @@
 -->
 
 <tdml:testSuite
-  defaultConfig="config-runtime2"
-  defaultImplementations="daffodil daffodil-runtime2"
   defaultRoundTrip="onePass"
   defaultValidation="on"
   description="TDML tests for MPU_green_to_orange_60004.dfdl.xsd"
@@ -26,17 +24,12 @@
   xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/"
   xmlns:tdml="http://www.ibm.com/xmlns/dfdl/testData">
 
-  <tdml:defineConfig name="config-runtime1">
-    <daf:tunables>
-      <daf:tdmlImplementation>daffodil</daf:tdmlImplementation>
-    </daf:tunables>
-  </tdml:defineConfig>
+  <!--
+      Run all tests:
 
-  <tdml:defineConfig name="config-runtime2">
-    <daf:tunables>
-      <daf:tdmlImplementation>daffodil-runtime2</daf:tdmlImplementation>
-    </daf:tunables>
-  </tdml:defineConfig>
+      daffodil test -i -I daffodil MPU_green_to_orange_60004.tdml
+      daffodil test -i -I daffodilC MPU_green_to_orange_60004.tdml
+  -->
 
   <tdml:parserTestCase model="MPU_green_to_orange_60004.dfdl.xsd" name="MPU_green_to_orange_60004">
     <tdml:document>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/runtime2/MPU_orange_to_green_60006.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/runtime2/MPU_orange_to_green_60006.tdml
@@ -17,8 +17,6 @@
 -->
 
 <tdml:testSuite
-  defaultConfig="config-runtime2"
-  defaultImplementations="daffodil daffodil-runtime2"
   defaultRoundTrip="onePass"
   defaultValidation="on"
   description="TDML tests for MPU_orange_to_green_60006.dfdl.xsd"
@@ -26,17 +24,12 @@
   xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/"
   xmlns:tdml="http://www.ibm.com/xmlns/dfdl/testData">
 
-  <tdml:defineConfig name="config-runtime1">
-    <daf:tunables>
-      <daf:tdmlImplementation>daffodil</daf:tdmlImplementation>
-    </daf:tunables>
-  </tdml:defineConfig>
+  <!--
+      Run all tests:
 
-  <tdml:defineConfig name="config-runtime2">
-    <daf:tunables>
-      <daf:tdmlImplementation>daffodil-runtime2</daf:tdmlImplementation>
-    </daf:tunables>
-  </tdml:defineConfig>
+      daffodil test -i -I daffodil MPU_orange_to_green_60006.tdml
+      daffodil test -i -I daffodilC MPU_orange_to_green_60006.tdml
+  -->
 
   <tdml:parserTestCase model="MPU_orange_to_green_60006.dfdl.xsd" name="MPU_orange_to_green_60006_0">
     <tdml:document>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/runtime2/collisions.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/runtime2/collisions.tdml
@@ -17,23 +17,16 @@
 -->
 
 <tdml:testSuite
-  defaultConfig="config-runtime2"
-  defaultImplementations="daffodil daffodil-runtime2"
   defaultRoundTrip="true"
   xmlns:daf="urn:ogf:dfdl:2013:imp:daffodil.apache.org:2018:ext"
   xmlns:tdml="http://www.ibm.com/xmlns/dfdl/testData">
 
-  <tdml:defineConfig name="config-runtime1">
-    <daf:tunables>
-      <daf:tdmlImplementation>daffodil</daf:tdmlImplementation>
-    </daf:tunables>
-  </tdml:defineConfig>
+  <!--
+      Run all tests:
 
-  <tdml:defineConfig name="config-runtime2">
-    <daf:tunables>
-      <daf:tdmlImplementation>daffodil-runtime2</daf:tdmlImplementation>
-    </daf:tunables>
-  </tdml:defineConfig>
+      daffodil test -i -I daffodil collisions.tdml
+      daffodil test -i -I daffodilC collisions.tdml
+  -->
 
   <tdml:parserTestCase name="collisions" root="collisions" model="collisions.dfdl.xsd">
     <tdml:document>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/runtime2/egress_xdcc_bw.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/runtime2/egress_xdcc_bw.tdml
@@ -17,25 +17,19 @@
 -->
 
 <tdml:testSuite
-  defaultConfig="config-runtime2"
-  defaultImplementations="daffodil daffodil-runtime2"
   defaultRoundTrip="onePass"
+  defaultValidation="on"
   description="TDML tests for egress_xdcc_bw.dfdl.xsd"
   xmlns:daf="urn:ogf:dfdl:2013:imp:daffodil.apache.org:2018:ext"
   xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/"
   xmlns:tdml="http://www.ibm.com/xmlns/dfdl/testData">
 
-  <tdml:defineConfig name="config-runtime1">
-    <daf:tunables>
-      <daf:tdmlImplementation>daffodil</daf:tdmlImplementation>
-    </daf:tunables>
-  </tdml:defineConfig>
+  <!--
+      Run all tests:
 
-  <tdml:defineConfig name="config-runtime2">
-    <daf:tunables>
-      <daf:tdmlImplementation>daffodil-runtime2</daf:tdmlImplementation>
-    </daf:tunables>
-  </tdml:defineConfig>
+      daffodil test -i -I daffodil egress_xdcc_bw.tdml
+      daffodil test -i -I daffodilC egress_xdcc_bw.tdml
+  -->
 
   <tdml:parserTestCase model="egress_xdcc_bw.dfdl.xsd" name="egress_xdcc_bw_11">
     <tdml:document>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/runtime2/ingress_xdcc_bw.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/runtime2/ingress_xdcc_bw.tdml
@@ -17,25 +17,19 @@
 -->
 
 <tdml:testSuite
-  defaultConfig="config-runtime2"
-  defaultImplementations="daffodil daffodil-runtime2"
   defaultRoundTrip="onePass"
+  defaultValidation="on"
   description="TDML tests for ingress_xdcc_bw.dfdl.xsd"
   xmlns:daf="urn:ogf:dfdl:2013:imp:daffodil.apache.org:2018:ext"
   xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/"
   xmlns:tdml="http://www.ibm.com/xmlns/dfdl/testData">
 
-  <tdml:defineConfig name="config-runtime1">
-    <daf:tunables>
-      <daf:tdmlImplementation>daffodil</daf:tdmlImplementation>
-    </daf:tunables>
-  </tdml:defineConfig>
+  <!--
+      Run all tests:
 
-  <tdml:defineConfig name="config-runtime2">
-    <daf:tunables>
-      <daf:tdmlImplementation>daffodil-runtime2</daf:tdmlImplementation>
-    </daf:tunables>
-  </tdml:defineConfig>
+      daffodil test -i -I daffodil ingress_xdcc_bw.tdml
+      daffodil test -i -I daffodilC ingress_xdcc_bw.tdml
+  -->
 
   <tdml:parserTestCase model="ingress_xdcc_bw.dfdl.xsd" name="ingress_xdcc_bw_111">
     <tdml:document>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/runtime2/orion.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/runtime2/orion.tdml
@@ -17,8 +17,6 @@
 -->
 
 <tdml:testSuite
-  defaultConfig="config-runtime2"
-  defaultImplementations="daffodil daffodil-runtime2"
   defaultRoundTrip="onePass"
   defaultValidation="on"
   description="TDML tests for orion.dfdl.xsd"
@@ -26,17 +24,12 @@
   xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/"
   xmlns:tdml="http://www.ibm.com/xmlns/dfdl/testData">
 
-  <tdml:defineConfig name="config-runtime1">
-    <daf:tunables>
-      <daf:tdmlImplementation>daffodil</daf:tdmlImplementation>
-    </daf:tunables>
-  </tdml:defineConfig>
+  <!--
+      Run all tests:
 
-  <tdml:defineConfig name="config-runtime2">
-    <daf:tunables>
-      <daf:tdmlImplementation>daffodil-runtime2</daf:tdmlImplementation>
-    </daf:tunables>
-  </tdml:defineConfig>
+      daffodil test -i -I daffodil orion.tdml
+      daffodil test -i -I daffodilC orion.tdml
+  -->
 
   <tdml:parserTestCase model="orion.dfdl.xsd" name="orion_aptina">
     <tdml:document>

--- a/daffodil-test/src/test/scala/org/apache/daffodil/runtime2/TestCollisions.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/runtime2/TestCollisions.scala
@@ -17,13 +17,14 @@
 
 package org.apache.daffodil.runtime2
 
-import org.junit.Test
+import org.apache.daffodil.api.TDMLImplementation
 import org.apache.daffodil.tdml.Runner
 import org.junit.AfterClass
+import org.junit.Test
 
 object TestCollisions {
   val testDir = "/org/apache/daffodil/runtime2/"
-  val runner = Runner(testDir, "collisions.tdml")
+  val runner = Runner(testDir, "collisions.tdml", TDMLImplementation.DaffodilC)
 
   @AfterClass def shutDown(): Unit = { runner.reset }
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/runtime2/TestEgressXdccBw.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/runtime2/TestEgressXdccBw.scala
@@ -17,13 +17,14 @@
 
 package org.apache.daffodil.runtime2
 
+import org.apache.daffodil.api.TDMLImplementation
 import org.apache.daffodil.tdml.Runner
 import org.junit.AfterClass
 import org.junit.Test
 
 object TestEgressXdccBw {
   val testDir = "/org/apache/daffodil/runtime2/"
-  val runner = Runner(testDir, "egress_xdcc_bw.tdml")
+  val runner = Runner(testDir, "egress_xdcc_bw.tdml", TDMLImplementation.DaffodilC)
 
   @AfterClass def shutDown(): Unit = { runner.reset }
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/runtime2/TestExNums.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/runtime2/TestExNums.scala
@@ -17,22 +17,31 @@
 
 package org.apache.daffodil.runtime2
 
-import org.junit.Test
+import org.apache.daffodil.api.TDMLImplementation
 import org.apache.daffodil.tdml.Runner
 import org.junit.AfterClass
+import org.junit.Test
 
 object TestExNums {
   val testDir = "/org/apache/daffodil/runtime2/"
-  val runner = Runner(testDir, "ex_nums.tdml")
+  val runner1 = Runner(testDir, "ex_nums.tdml", TDMLImplementation.Daffodil)
+  val runner2 = Runner(testDir, "ex_nums.tdml", TDMLImplementation.DaffodilC)
 
-  @AfterClass def shutDown(): Unit = { runner.reset }
+  @AfterClass def shutDown(): Unit = {
+    runner1.reset
+    runner2.reset
+  }
 }
 
 class TestExNums {
   import TestExNums._
 
-  @Test def test_ex_nums_runtime1(): Unit = { runner.runOneTest("ex_nums_runtime1") }
-  @Test def test_ex_nums_runtime1_error(): Unit = { runner.runOneTest("ex_nums_runtime1_error") }
-  @Test def test_ex_nums_runtime2(): Unit = { runner.runOneTest("ex_nums_runtime2") }
-  @Test def test_ex_nums_runtime2_error(): Unit = { runner.runOneTest("ex_nums_runtime2_error") }
+  @Test def runtime1_ex_nums(): Unit = { runner1.runOneTest("ex_nums") }
+  @Test def runtime1_error_limited(): Unit = { runner1.runOneTest("runtime1_error_limited") }
+  @Test def runtime1_error_on(): Unit = { runner1.runOneTest("runtime1_error_on") }
+  @Test def runtime1_error_unparse(): Unit = { runner1.runOneTest("runtime1_error_unparse") }
+
+  @Test def runtime2_ex_nums(): Unit = { runner2.runOneTest("ex_nums") }
+  @Test def runtime2_error_parse(): Unit = { runner2.runOneTest("runtime2_error_parse") }
+  @Test def runtime2_error_unparse(): Unit = { runner2.runOneTest("runtime2_error_unparse") }
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/runtime2/TestIngressXdccBw.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/runtime2/TestIngressXdccBw.scala
@@ -17,13 +17,14 @@
 
 package org.apache.daffodil.runtime2
 
+import org.apache.daffodil.api.TDMLImplementation
 import org.apache.daffodil.tdml.Runner
 import org.junit.AfterClass
 import org.junit.Test
 
 object TestIngressXdccBw {
   val testDir = "/org/apache/daffodil/runtime2/"
-  val runner = Runner(testDir, "ingress_xdcc_bw.tdml")
+  val runner = Runner(testDir, "ingress_xdcc_bw.tdml", TDMLImplementation.DaffodilC)
 
   @AfterClass def shutDown(): Unit = { runner.reset }
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/runtime2/TestIsrmGreenToOrange60000.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/runtime2/TestIsrmGreenToOrange60000.scala
@@ -17,13 +17,14 @@
 
 package org.apache.daffodil.runtime2
 
+import org.apache.daffodil.api.TDMLImplementation
 import org.apache.daffodil.tdml.Runner
 import org.junit.AfterClass
 import org.junit.Test
 
 object TestIsrmGreenToOrange60000 {
   val testDir = "/org/apache/daffodil/runtime2/"
-  val runner = Runner(testDir, "ISRM_green_to_orange_60000.tdml")
+  val runner = Runner(testDir, "ISRM_green_to_orange_60000.tdml", TDMLImplementation.DaffodilC)
 
   @AfterClass def shutDown(): Unit = { runner.reset }
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/runtime2/TestIsrmOrangeToGreen60002.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/runtime2/TestIsrmOrangeToGreen60002.scala
@@ -17,13 +17,14 @@
 
 package org.apache.daffodil.runtime2
 
+import org.apache.daffodil.api.TDMLImplementation
 import org.apache.daffodil.tdml.Runner
 import org.junit.AfterClass
 import org.junit.Test
 
 object TestIsrmOrangeToGreen60002 {
   val testDir = "/org/apache/daffodil/runtime2/"
-  val runner = Runner(testDir, "ISRM_orange_to_green_60002.tdml")
+  val runner = Runner(testDir, "ISRM_orange_to_green_60002.tdml", TDMLImplementation.DaffodilC)
 
   @AfterClass def shutDown(): Unit = { runner.reset }
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/runtime2/TestMpuGreenToOrange60004.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/runtime2/TestMpuGreenToOrange60004.scala
@@ -17,13 +17,14 @@
 
 package org.apache.daffodil.runtime2
 
+import org.apache.daffodil.api.TDMLImplementation
 import org.apache.daffodil.tdml.Runner
 import org.junit.AfterClass
 import org.junit.Test
 
 object TestMpuGreenToOrange60004 {
   val testDir = "/org/apache/daffodil/runtime2/"
-  val runner = Runner(testDir, "MPU_green_to_orange_60004.tdml")
+  val runner = Runner(testDir, "MPU_green_to_orange_60004.tdml", TDMLImplementation.DaffodilC)
 
   @AfterClass def shutDown(): Unit = { runner.reset }
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/runtime2/TestMpuOrangeToGreen60006.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/runtime2/TestMpuOrangeToGreen60006.scala
@@ -17,13 +17,14 @@
 
 package org.apache.daffodil.runtime2
 
+import org.apache.daffodil.api.TDMLImplementation
 import org.apache.daffodil.tdml.Runner
 import org.junit.AfterClass
 import org.junit.Test
 
 object TestMpuOrangeToGreen60006 {
   val testDir = "/org/apache/daffodil/runtime2/"
-  val runner = Runner(testDir, "MPU_orange_to_green_60006.tdml")
+  val runner = Runner(testDir, "MPU_orange_to_green_60006.tdml", TDMLImplementation.DaffodilC)
 
   @AfterClass def shutDown(): Unit = { runner.reset }
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/runtime2/TestNested.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/runtime2/TestNested.scala
@@ -17,13 +17,14 @@
 
 package org.apache.daffodil.runtime2
 
+import org.apache.daffodil.api.TDMLImplementation
 import org.apache.daffodil.tdml.Runner
 import org.junit.AfterClass
 import org.junit.Test
 
 object TestNested {
   val testDir = "/org/apache/daffodil/runtime2/"
-  val runner: Runner = Runner(testDir, "nested.tdml")
+  val runner: Runner = Runner(testDir, "nested.tdml", TDMLImplementation.DaffodilC)
 
   @AfterClass def shutDown(): Unit = { runner.reset }
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/runtime2/TestOrion.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/runtime2/TestOrion.scala
@@ -17,13 +17,14 @@
 
 package org.apache.daffodil.runtime2
 
-import org.junit.Test
+import org.apache.daffodil.api.TDMLImplementation
 import org.apache.daffodil.tdml.Runner
 import org.junit.AfterClass
+import org.junit.Test
 
 object TestOrion {
   val testDir = "/org/apache/daffodil/runtime2/"
-  val runner = Runner(testDir, "orion.tdml")
+  val runner = Runner(testDir, "orion.tdml", TDMLImplementation.DaffodilC)
 
   @AfterClass def shutDown(): Unit = { runner.reset }
 }


### PR DESCRIPTION
Add TDML implementation option to Daffodil's CLI test subcommand and
extend Runner API with TDMLImplementation parameter (defined by
dafext.xsd) to allow running the same TDML file with any specified
TDMLImplementation without having to change the TDML file.  Run
runtime2 TDML and Scala tests with TDMLImplementation specified
through Runner API, not tunable.

Also fix some inconsistencies with fill bits overlooked by a previous
pull request which extended runtime2 to read and write N-bit numbers.
See more detailed changelog below.

DAFFODIL-2697

Util.scala: Use standard Scala idioms for getting DAFFODIL_HOME
environment variable and composing environment variables.

Main.scala: Import TDMLImplementation (newly defined in dafext.xsd) to
tell user which TDML implementations Daffodil supports.  Add TDML
implementation option to CLI test subcommand.  Allow default TDML
implementation to be overriden by setting TDML_IMPLEMENTATION
environment variable as well as by passing implementation option.
Pass TDML implementation to Runner for TDML file's tests.

tdml.xsd: Update names of TDML implementations to match names of TDML
implementations in dafext.xsd.  Change runtime2 implementation name
from "daffodil-runtime2" to "daffodilC" because a TDML implementation
name must be a valid identifier in both XML and Scala and you can't
embed a dash within a Scala identifier.

dafext.xsd: Change tdmlImplementation tunable's type from xs:string to
daf:TunableTDMLImplementation (we keep tunable because it's still
useful for writing TDML tests that target only one specific
implementation anyway).  Add TunableTDMLImplementation simple type
with enumerations listing every TDML implementation Daffodil supports,
which also creates a TDMLImplementation enumerated type we can import
into Scala files.  Change all enumerated simple types to use standard
xs:token idiom instead of xs:string.

PropertyGenerator.scala: Add TunableTDMLImplementation to
excludedTypes to generate it properly as an enumerated type.

parsers.c: Rename parse_fill_bytes to parse_fill_bits and make it read
exactly N fill bits (no more, no less).

parsers.h: Rename parse_fill_bytes to parse_fill_bits and rename its
first parameter to correct name end_bitPos0b (not end_bytePos0b).

unparsers.c: Rename unparse_fill_bytes to unparse_fill_bits and make
it write exactly N fill bits (no more, no less).

unparsers.h: Rename unparse_fill_bytes to unparse_fill_bits and rename
its first parameter to correct name end_bitPos0b (not end_bytePos0b).

CodeGenerator.scala: Use standard Scala idiom for getting CC and PATH
environment variables.

CodeGeneratorState.scala: Rename calls of (un)parse_fill_bytes to
(un)parse_fill_bits in generated C code.

ex_nums.tdml: Make comments show how to run CLI test subcommand with
different TDML implementations.  Update tdmlImplementation configs to
use correct TDML implementation names.  Add one-implementation-only
error tests to demonstrate how runtime1 and runtime2 handle non-fixed
values in elements with fixed attributes slightly differently
depending on validation levels.

nested.tdml: Replace tdmlImplementation configs with comments showing
how to run CLI test subcommand with different TDML implementations.

RunnerFactory.scala: Import TDMLImplementation to know which TDML
implementations Daffodil supports.  Extend Runner API with
useTDMLImplementation parameter in first apply method, additional
two-argument apply method, and base constructor to allow Scala/Java
code to specify TDML implementation when constructing a Runner (only
nif they choose to).  Make defaultImplementationsDefaultDefault
contain all TDML implementations Daffodil supports so TDML tests can
remove defaultImplementations attribute unless they really need to be
specific to one or two TDML implementations.

TDMLRunner.scala: Import TDMLImplementation to know which TDML
implementations Daffodil supports.  Extend DFDLTestSuite constructor
with useTDMLImplementation parameter to allow Runner API to pass TDML
implementation.  Modify tdmlDFDLProcessorFactory method to get TDML
implementation from either parent.useTDMLImplementation or
tunableObj.tdmlImplementation and match on TDMLImplementation
enumerations instead of literal strings.

Runtime2TDMLDFDLProcessor.scala: Don't set implementationName to
"daffodil-runtime2" literal string, set it to
TDMLImplementation.DaffodilC.toString to get the correct name defined
in dafext.xsd instead.

TestRunnerFactory.java: Pass TDMLImplementation argument to Runner
constructor in test case.

ISRM_green_to_orange_60000.tdml: Replace tdmlImplementation configs
with comments showing how to run CLI test subcommand with different
TDML implementations.

ISRM_orange_to_green_60002.tdml: Replace tdmlImplementation configs
with comments showing how to run CLI test subcommand with different
TDML implementations.

MPU_green_to_orange_60004.tdml: Replace tdmlImplementation configs
with comments showing how to run CLI test subcommand with different
TDML implementations.

MPU_orange_to_green_60006.tdml: Replace tdmlImplementation configs
with comments showing how to run CLI test subcommand with different
TDML implementations.

collisions.tdml: Replace tdmlImplementation configs with comments
showing how to run CLI test subcommand with different TDML
implementations.

egress_xdcc_bw.tdml: Replace tdmlImplementation configs with comments
showing how to run CLI test subcommand with different TDML
implementations.

ingress_xdcc_bw.tdml: Replace tdmlImplementation configs with comments
showing how to run CLI test subcommand with different TDML
implementations.

orion.tdml: Replace tdmlImplementation configs with comments showing
how to run CLI test subcommand with different TDML implementations.

TestCollisions.scala: Pass TDMLImplementation.DaffodilC to Runner.

TestEgressXdccBw.scala: Pass TDMLImplementation.DaffodilC to Runner.

TestExNums.scala: Pass TDMLImplementation.Daffodil and
TDMLImplementation.DaffodilC to two Runners to run both runtime1 and
runtime2 tests side by side.

TestIngressXdccBw.scala: Pass TDMLImplementation.DaffodilC to Runner.

TestIsrmGreenToOrange60000.scala: Pass TDMLImplementation.DaffodilC to
Runner.

TestIsrmOrangeToGreen60002.scala: Pass TDMLImplementation.DaffodilC to
Runner.

TestMpuGreenToOrange60004.scala: Pass TDMLImplementation.DaffodilC to
Runner.

TestMpuOrangeToGreen60006.scala: Pass TDMLImplementation.DaffodilC to
Runner.

TestNested.scala: Pass TDMLImplementation.DaffodilC to Runner.

TestOrion.scala: Pass TDMLImplementation.DaffodilC to Runner.