### PR TITLE
Fix output of info parser / info unparser in debug

### DIFF
--- a/daffodil-cli/src/it/scala/org/apache/daffodil/debugger/TestCLIDebugger.scala
+++ b/daffodil-cli/src/it/scala/org/apache/daffodil/debugger/TestCLIDebugger.scala
@@ -1440,5 +1440,56 @@ class TestCLIdebugger {
     }
   }
 
+  @Test def test_CLI_Debugger_parse_unparser_not_available(): Unit = {
+    val schemaFile = Util.daffodilPath("daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/charClassEntities.dfdl.xsd")
+    val inputFile = Util.daffodilPath("daffodil-cli/src/it/resources/org/apache/daffodil/CLI/input/input3.txt")
+    val (testSchemaFile, testInputFile) = if (Util.isWindows) (Util.cmdConvert(schemaFile), Util.cmdConvert(inputFile)) else (schemaFile, inputFile)
+
+    val shell = if (Util.isWindows) Util.start("", envp = DAFFODIL_JAVA_OPTS) else Util.start("")
+
+    try {
+      val cmd = String.format("%s -d parse -s %s %s", Util.binPath, testSchemaFile, testInputFile)
+      shell.sendLine(cmd)
+      shell.expect(contains("(debug)"))
+
+      shell.sendLine("info parser")
+      shell.expect(contains("parser: <Element name='matrix'><DelimiterStackParser>...</DelimiterStackParser></Element>"))
+
+      shell.sendLine("info unparser")
+      shell.expect(contains("unparser: not available"))
+
+      shell.sendLine("continue")
+
+      Util.expectExitCode(ExitCode.Success, shell)
+    } finally {
+      shell.close()
+    }
+  }
+
+  @Test def test_CLI_Debugger_unparse_parser_not_available(): Unit = {
+    val schemaFile = Util.daffodilPath("daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/charClassEntities.dfdl.xsd")
+    val inputFile = Util.daffodilPath("daffodil-cli/src/it/resources/org/apache/daffodil/CLI/input/input1.txt.xml")
+    val (testSchemaFile, testInputFile) = if (Util.isWindows) (Util.cmdConvert(schemaFile), Util.cmdConvert(inputFile)) else (schemaFile, inputFile)
+
+    val shell = if (Util.isWindows) Util.start("", envp = DAFFODIL_JAVA_OPTS) else Util.start("")
+
+    try {
+      val cmd = String.format("%s -d unparse -s %s %s", Util.binPath, testSchemaFile, testInputFile)
+      shell.sendLine(cmd)
+      shell.expect(contains("(debug)"))
+
+      shell.sendLine("info unparser")
+      shell.expect(contains("unparser: <ConvertTextNumberUnparser/>"))
+
+      shell.sendLine("info parser")
+      shell.expect(contains("parser: not available"))
+
+      shell.sendLine("continue")
+
+      Util.expectExitCode(ExitCode.Success, shell)
+    } finally {
+      shell.close()
+    }
+  }
 
 }

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/debugger/InteractiveDebugger.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/debugger/InteractiveDebugger.scala
@@ -1595,7 +1595,22 @@ class InteractiveDebugger(runner: InteractiveDebuggerRunner, eCompilers: Express
         val desc = "display the current Daffodil " + name
         val longDesc = desc
         def act(args: Seq[String], state: ParseOrUnparseState, processor: Processor): DebugState.Type = {
-          debugPrintln("%s: %s".format(name, processor.toBriefXML(2))) // only 2 levels of output, please!
+          state match {
+            case pstate: PState => {
+              if (name == "parser") {
+                debugPrintln("%s: %s".format(name, processor.toBriefXML(2)))
+              } else {
+                debugPrintln("unparser: not available")
+              }
+            }
+            case ustate: UState => {
+              if (name == "unparser") {
+                debugPrintln("%s: %s".format(name, processor.toBriefXML(2)))
+              } else {
+                debugPrintln("parser: not available")
+              }
+            }
+          }
           DebugState.Pause
         }
       }


### PR DESCRIPTION
When the user is in debug mode with the subcommand parse, the ouput for
info unparser will now display correctly.
When the user is in debug mode with the subcommand unparse, the output
for info parser will now display correctly.

When the user is in debug mode while calling the parse or unparse
subcommand, we want to make sure that the info printed to the screen for
parser and unparser are accurate. This is done by comparing the
subcommand and the info argument. The "info parser" command prints the
parser information only when the parser subcommand is utilized. The "info
unparser" command prints the unparser information only when the unparse
subcommand is utilitzed.

DAFFODIL-2488