### PR TITLE
Allow <![CDATA[]]> to preserve whitespace in XML text content

### DIFF
--- a/daffodil-japi/src/main/java/org/apache/daffodil/japi/infoset/XMLTextEscapeStyle.java
+++ b/daffodil-japi/src/main/java/org/apache/daffodil/japi/infoset/XMLTextEscapeStyle.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.daffodil.japi.infoset;
+
+/**
+ * XMLTextEscapeStyles for determining whether to wrap info in CDATA tags
+ */
+public enum XMLTextEscapeStyle {
+  /**
+   * Special characters (quotation mark, ampersand, less-than, greater-than) in the
+   * text of xs:string elements are escaped, while non-special characters are written
+   * as is.
+   */
+  Standard,
+
+  /**
+   * The text of xs:string elements are wrapped in CDATA tags if the string contains
+   * special characters (quotation mark, ampersand, less-than, greater-than) or
+   * whitespace
+   */
+  CDATA,
+}

--- a/daffodil-japi/src/main/scala/org/apache/daffodil/japi/infoset/Infoset.scala
+++ b/daffodil-japi/src/main/scala/org/apache/daffodil/japi/infoset/Infoset.scala
@@ -40,6 +40,8 @@ import org.apache.daffodil.infoset.DIComplex
 import org.apache.daffodil.infoset.DIArray
 import org.apache.daffodil.dpath.NodeInfo
 
+import org.apache.daffodil.japi.packageprivate._
+
 /**
  * Abstract class used to determine how the infoset representation should be
  * input from a call to DataProcessor#unparse. This uses a Cursor API, such
@@ -52,7 +54,7 @@ abstract class InfosetInputter extends SInfosetInputter {
   /**
    * Return the current infoset inputter event type
    */
-  def getEventType(): InfosetInputterEventType 
+  def getEventType(): InfosetInputterEventType
 
   /**
    * Get the local name of the current event. This will only be called when the
@@ -211,7 +213,7 @@ abstract class InfosetOutputter extends SInfosetOutputter {
  * classes, we can document these classes and have a small and clean javadoc.
  */
 
- 
+
 /**
  * [[InfosetOutputter]] to build an infoset represented as a scala.xml.Node
  *
@@ -244,7 +246,23 @@ class XMLTextInfosetOutputter private (outputter: SXMLTextInfosetOutputter)
    *               insert indentation and newlines where it will not affect the
    *               content of the XML.
    */
-  def this(os: java.io.OutputStream, pretty: Boolean) = this(new SXMLTextInfosetOutputter(os, pretty))
+  def this(os: java.io.OutputStream, pretty: Boolean) = this(new SXMLTextInfosetOutputter(os,
+    pretty, XMLTextEscapeStyleConversions.styleToScala(XMLTextEscapeStyle.Standard)))
+
+  /**
+   * Output the infoset as XML Text, written to a java.io.OutputStream
+   *
+   * @param os the java.io.OutputStream to write the XML text to
+   * @param pretty enable or disable pretty printing. Pretty printing will only
+   *               insert indentation and newlines where it will not affect the
+   *               content of the XML.
+   * @param xmlTextEscapeStyle determine whether to wrap values of elements of type
+   *                       xs:string in CDATA tags in order to preserve
+   *                       whitespace.
+   */
+  def this(os: java.io.OutputStream, pretty: Boolean, xmlTextEscapeStyle: XMLTextEscapeStyle) = {
+    this(new SXMLTextInfosetOutputter(os, pretty, XMLTextEscapeStyleConversions.styleToScala(xmlTextEscapeStyle)))
+  }
 
   override val infosetOutputter = outputter
 }

--- a/daffodil-japi/src/main/scala/org/apache/daffodil/japi/packageprivate/Utils.scala
+++ b/daffodil-japi/src/main/scala/org/apache/daffodil/japi/packageprivate/Utils.scala
@@ -30,6 +30,9 @@ import org.apache.daffodil.api.{ ValidationMode => SValidationMode }
 import org.apache.daffodil.debugger.{ InteractiveDebugger => SInteractiveDebugger }
 import org.apache.daffodil.debugger.{ InteractiveDebuggerRunner => SInteractiveDebuggerRunner }
 
+import org.apache.daffodil.infoset.{ XMLTextEscapeStyle => SXMLTextEscapeStyle }
+import org.apache.daffodil.japi.infoset._
+
 private[japi] object ValidationConversions {
 
   def modeToScala(mode: ValidationMode): SValidationMode.Type = {
@@ -39,6 +42,18 @@ private[japi] object ValidationConversions {
       case ValidationMode.Full => SValidationMode.Full
     }
     smode
+  }
+}
+
+private[japi] object XMLTextEscapeStyleConversions {
+
+  def styleToScala(style: XMLTextEscapeStyle): SXMLTextEscapeStyle.Value = {
+    val sxmlTextEscapeStyle: SXMLTextEscapeStyle.Value = style match {
+      case XMLTextEscapeStyle.Standard => SXMLTextEscapeStyle.Standard
+      case XMLTextEscapeStyle.CDATA => SXMLTextEscapeStyle.CDATA
+      case _ => throw new Exception("Unrecognized value: %s for parameter: xmlTextEscapeStyle. Must be 'Standard' or 'CDATA'.".format(style))
+    }
+    sxmlTextEscapeStyle
   }
 }
 

--- a/daffodil-japi/src/test/resources/test/japi/mySchemaCDATA.dfdl.xsd
+++ b/daffodil-japi/src/test/resources/test/japi/mySchemaCDATA.dfdl.xsd
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<schema xmlns="http://www.w3.org/2001/XMLSchema"
+  targetNamespace="http://example.com" xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/"
+  xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tns="http://example.com">
+
+  <annotation>
+    <appinfo source="http://www.ogf.org/dfdl/">
+      <dfdl:format ref="tns:GeneralFormat" />
+    </appinfo>
+  </annotation>
+
+  <include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+
+  <element name="string" type="xsd:string" dfdl:lengthKind="delimited" dfdl:terminator="$"/>
+  <element name="float" type="xsd:float"
+    dfdl:representation="text"
+    dfdl:textNumberRep="standard"
+    dfdl:lengthKind="delimited"
+    dfdl:encoding="UTF-8"
+    dfdl:textNumberPattern="0.000"
+    dfdl:textStandardDecimalSeparator="." />
+
+</schema>

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/infoset/XMLTextEscapeStyle.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/infoset/XMLTextEscapeStyle.scala
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.daffodil.infoset
+/**
+ * XMLTextEscapeStyle determines how to wrap values of elements of type xs:string
+ *
+ * Standard - Special characters (quotation mark, ampersand, less-than, greater-than)
+ * in the text of xs:string elements are escaped, while non-special characters are
+ * written as is.
+ *
+ * CDATA - The text of xs:string elements are wrapped in CDATA tags if the string
+ * contains whitespace or special characters (quotation mark, ampersand, less-than,
+ * greater-than)
+ */
+object XMLTextEscapeStyle extends Enumeration {
+  type XMLTextEscapeStyle = Value
+  val Standard, CDATA = Value
+}

--- a/daffodil-sapi/src/main/scala/org/apache/daffodil/sapi/infoset/Infoset.scala
+++ b/daffodil-sapi/src/main/scala/org/apache/daffodil/sapi/infoset/Infoset.scala
@@ -40,6 +40,8 @@ import org.apache.daffodil.infoset.DIComplex
 import org.apache.daffodil.infoset.DIArray
 import org.apache.daffodil.dpath.NodeInfo
 
+import org.apache.daffodil.sapi.packageprivate._
+
 /**
  * Abstract class used to determine how the infoset representation should be
  * input from a call to [[DataProcessor.unparse(input* DataProcessor.unparse]]. This uses a Cursor API, such
@@ -52,7 +54,7 @@ abstract class InfosetInputter extends SInfosetInputter {
   /**
    * Return the current infoset inputter event type
    */
-  def getEventType(): InfosetInputterEventType 
+  def getEventType(): InfosetInputterEventType
 
   /**
    * Get the local name of the current event. This will only be called when the
@@ -216,7 +218,7 @@ abstract class InfosetOutputter extends SInfosetOutputter {
  * classes, we can document these classes and have a small and clean scaladoc.
  */
 
- 
+
 /**
  * [[InfosetOutputter]] to build an infoset represented as a scala.xml.Node
  *
@@ -248,8 +250,15 @@ class XMLTextInfosetOutputter private (outputter: SXMLTextInfosetOutputter)
    * @param pretty enable or disable pretty printing. Pretty printing will only
    *               insert indentation and newlines where it will not affect the
    *               content of the XML.
+   * @param xmlTextEscapeStyle determine whether to wrap values of elements of type
+   *                       xs:string in CDATA tags in order to preserve
+   *                       whitespace.
    */
-  def this(os: java.io.OutputStream, pretty: Boolean) = this(new SXMLTextInfosetOutputter(os, pretty))
+  def this(os: java.io.OutputStream, pretty: Boolean,
+    xmlTextEscapeStyle: XMLTextEscapeStyle.Value = XMLTextEscapeStyle.Standard) = {
+    this(new SXMLTextInfosetOutputter(os, pretty,
+    XMLTextEscapeStyleConversions.styleToScala(xmlTextEscapeStyle)))
+  }
 
   override val infosetOutputter = outputter
 }

--- a/daffodil-sapi/src/main/scala/org/apache/daffodil/sapi/infoset/XMLTextEscapeStyle.scala
+++ b/daffodil-sapi/src/main/scala/org/apache/daffodil/sapi/infoset/XMLTextEscapeStyle.scala
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.daffodil.sapi.infoset
+/**
+ * XMLTextEscapeStyle determines how to wrap values of elements of type xs:string
+ *
+ * Standard - Special characters (quotation mark, ampersand, less-than, greater-than)
+ * in the text of xs:string elements are escaped, while non-special characters are
+ * written as is.
+ *
+ * CDATA - The text of xs:string elements are wrapped in CDATA tags if the string
+ * contains whitespace or special characters (quotation mark, ampersand, less-than,
+ * greater-than)
+ */
+object XMLTextEscapeStyle extends Enumeration {
+  type XMLTextEscapeStyle = Value
+  val Standard, CDATA = Value
+}

--- a/daffodil-sapi/src/main/scala/org/apache/daffodil/sapi/packageprivate/Utils.scala
+++ b/daffodil-sapi/src/main/scala/org/apache/daffodil/sapi/packageprivate/Utils.scala
@@ -30,6 +30,9 @@ import org.apache.daffodil.api.{ ValidationMode => SValidationMode }
 import org.apache.daffodil.debugger.{ InteractiveDebugger => SInteractiveDebugger }
 import org.apache.daffodil.debugger.{ InteractiveDebuggerRunner => SInteractiveDebuggerRunner }
 
+import org.apache.daffodil.infoset.{ XMLTextEscapeStyle => SXMLTextEscapeStyle }
+import org.apache.daffodil.sapi.infoset._
+
 private[sapi] object ValidationConversions {
 
   def modeToScala(mode: ValidationMode.Value): SValidationMode.Type = {
@@ -50,6 +53,17 @@ private[sapi] object ValidationConversions {
       case SValidationMode.Custom(v) => ValidationMode.Custom(v)
     }
     mode
+  }
+}
+
+private[sapi] object XMLTextEscapeStyleConversions {
+
+  def styleToScala(style: XMLTextEscapeStyle.Value): SXMLTextEscapeStyle.Value = {
+    val sxmlTextEscapeStyle: SXMLTextEscapeStyle.Value = style match {
+      case XMLTextEscapeStyle.Standard => SXMLTextEscapeStyle.Standard
+      case XMLTextEscapeStyle.CDATA => SXMLTextEscapeStyle.CDATA
+    }
+    sxmlTextEscapeStyle
   }
 }
 

--- a/daffodil-sapi/src/test/resources/test/sapi/mySchemaCDATA.dfdl.xsd
+++ b/daffodil-sapi/src/test/resources/test/sapi/mySchemaCDATA.dfdl.xsd
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<schema xmlns="http://www.w3.org/2001/XMLSchema"
+  targetNamespace="http://example.com" xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/"
+  xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tns="http://example.com">
+
+  <annotation>
+    <appinfo source="http://www.ogf.org/dfdl/">
+      <dfdl:format ref="tns:GeneralFormat" />
+    </appinfo>
+  </annotation>
+
+  <include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+
+  <element name="string" type="xsd:string" dfdl:lengthKind="delimited" dfdl:terminator="$"/>
+  <element name="float" type="xsd:float"
+    dfdl:representation="text"
+    dfdl:textNumberRep="standard"
+    dfdl:lengthKind="delimited"
+    dfdl:encoding="UTF-8"
+    dfdl:textNumberPattern="0.000"
+    dfdl:textStandardDecimalSeparator="." />
+
+</schema>

--- a/daffodil-schematron/src/test/scala/org/apache/daffodil/validation/schematron/EmbeddedTesting.scala
+++ b/daffodil-schematron/src/test/scala/org/apache/daffodil/validation/schematron/EmbeddedTesting.scala
@@ -52,8 +52,7 @@ trait EmbeddedTesting {
       val bos = new ByteArrayOutputStream()
       val r1 = dp.parse(
         new InputSourceDataInputStream(new ByteArrayInputStream(bytes)),
-        new XMLTextInfosetOutputter(bos, true))
-
+        new XMLTextInfosetOutputter(bos, pretty = true))
       verbose match {
         case Always | AnyError if r1.isError() => r1.getDiagnostics.foreach(println)
         case Always => println(bos.toString)


### PR DESCRIPTION
Add a new constructor parameter (an enum XMLTextEscapeStyle with
Standard and CDATA as values) to XMLTextInfosetOutputter. When CDATA is
passed instead of Standard, wrap simple XML elements' text contents in
CDATA brackets to preserve any whitespace they contain.

DAFFODIL-2346-preserve-whitespace-in-dfdl-infoset