### PR TITLE
Set starting absolute bit positions of DOSs more often, avoid deadlocks

### DIFF
--- a/daffodil-core/src/main/scala/org/apache/daffodil/grammar/primitives/ElementCombinator.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/grammar/primitives/ElementCombinator.scala
@@ -218,9 +218,21 @@ case class SimpleTypeRetry(ctxt: ElementBase, v: Gram)
   extends Terminal(ctxt, true) {
   override def parser = v.parser
 
-  override def unparser = new SimpleTypeRetryUnparser(
-    ctxt.erd,
-    ctxt.maybeUnparseTargetLengthInBitsEv, v.unparser)
+  // When unparsing, the target length of this simple type might not actually
+  // match the actual unparsed length due to things like padding or fill. But
+  // if we can statically determine that the target length will be correct
+  // (e.g. there won't be things like padding/fill) then we can use that length
+  // during unparsing to provide more information about buffered data output
+  // streams which can be used to help to avoid deadlocked suspensions.
+  lazy val maybeExactTargetLength = {
+    if (!ctxt.shouldAddPadding && !ctxt.shouldAddFill && !ctxt.shouldCheckExcessLength) {
+      ctxt.maybeUnparseTargetLengthInBitsEv
+    } else {
+      Maybe.Nope
+    }
+  }
+
+  override def unparser = new SimpleTypeRetryUnparser(ctxt.erd, maybeExactTargetLength, v.unparser)
 }
 
 case class CaptureContentLengthStart(ctxt: ElementBase)

--- a/daffodil-io/src/main/scala/org/apache/daffodil/io/DirectOrBufferedDataOutputStream.scala
+++ b/daffodil-io/src/main/scala/org/apache/daffodil/io/DirectOrBufferedDataOutputStream.scala
@@ -966,6 +966,12 @@ object DirectOrBufferedDataOutputStream {
     Assert.invariant(bufDOS.isBuffering)
     Assert.invariant(!directDOS.isBuffering)
 
+    // If the buffered DOS already has a starting absolute bit position, ensure
+    // that it matches the ending bit position of the direct DOS we are about to
+    // deliver it to
+    val maybeBufStartPos = bufDOS.maybeAbsStartingBitPos0b
+    Assert.invariant(maybeBufStartPos.isEmpty || maybeBufStartPos.get == directDOS.maybeAbsBitPos0b.get)
+
     val finfoBitOrder = finfo.bitOrder // bit order we are supposed to write with
     val priorBitOrder = directDOS.cst.priorBitOrder // bit order that the directDOS had at last successful unparse. (prior is set after each unparser)
     if (finfoBitOrder ne priorBitOrder) {

--- a/daffodil-io/src/test/scala/org/apache/daffodil/io/TestDataOutputStream4.scala
+++ b/daffodil-io/src/test/scala/org/apache/daffodil/io/TestDataOutputStream4.scala
@@ -41,10 +41,10 @@ class TestDataOutputStream4 {
 
     val out = direct.addBuffered
     if (setAbs)
-      out.setAbsStartingBitPos0b(ULong(20))
+      out.setAbsStartingBitPos0b(ULong(19))
     val out2 = out.addBuffered
     if (setAbs)
-      out2.setAbsStartingBitPos0b(ULong(39))
+      out2.setAbsStartingBitPos0b(ULong(38))
 
     out.putLong(0x5a5a5, 19, finfo)
     // 101 1010 0101 1010 0101

--- a/daffodil-lib/src/main/scala/org/apache/daffodil/util/MaybeULong.scala
+++ b/daffodil-lib/src/main/scala/org/apache/daffodil/util/MaybeULong.scala
@@ -77,6 +77,8 @@ final class MaybeJULong(mi: MaybeULong)
   @inline final def isDefined = mi.isDefined
   @inline final def isEmpty = !isDefined
   override def toString = mi.toString
+
+  @inline def toMaybeULong = mi
 }
 
 object MaybeJULong {

--- a/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/processors/unparsers/SpecifiedLength2.scala
+++ b/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/processors/unparsers/SpecifiedLength2.scala
@@ -177,20 +177,21 @@ class SimpleTypeRetryUnparserSuspendableOperation(
   extends SuspendableOperation {
 
   override protected def maybeKnownLengthInBits(ustate: UState): MaybeULong = {
-    // Note that we cannot use a targetLengthInBitsEv to determine the
-    // knownLengthInBits. This is because even if an OVC/Simple element has fixed
-    // length, the result of the OVC might not actually write that many bits,
-    // relying on padding and/or right fill to fill in the remaining bits
-    //
-    // TODO: The above is too pessimistic. Many formats have no notion of
-    // padding nor filling, so the length could be computed from the targetLengthInBitsEv
-    // just fine
-    //
-    // We could make it the responsibility of the caller of this to supply or not
-    // the maybeUnparserTargetLengthInBitsEv depending on whether it can be
-    // depended upon or not.
-    //
-    MaybeULong.Nope
+    if (maybeUnparserTargetLengthInBitsEv.isDefined) {
+      // maybeUnparserTargetLengthInBitsEv should only be defined if we know at
+      // schema compile time that it will evaluate to a value, and that value
+      // will match the actual unparsed length (e.g. there will not be any
+      // padding/fill). Here we assert that if the target length evaluatable was
+      // passed into this class, then it must evaluate to a value. When we
+      // deliver buffered content, we will also assert that the starting bit
+      // position of the buffered DOS that results from this suspension matches
+      // the direct DOS (i.e. this length is used correctly)
+      val maybeLen = maybeUnparserTargetLengthInBitsEv.get.evaluate(ustate)
+      Assert.invariant(maybeLen.isDefined)
+      maybeLen.toMaybeULong
+    } else {
+      MaybeULong.Nope
+    }
   }
 
   protected def test(state: UState) = {

--- a/daffodil-test/src/test/scala/org/apache/daffodil/infoset/TestStringAsXml.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/infoset/TestStringAsXml.scala
@@ -167,7 +167,6 @@ class TestStringAsXml {
     val dp = compileSchema(Misc.getRequiredResource("/org/apache/daffodil/infoset/stringAsXml/namespaced/xsd/binMessage.dfdl.xsd"))
     val unparseInfoset = Misc.getRequiredResource("/org/apache/daffodil/infoset/stringAsXml/namespaced/binMessage_08.dat").toURL.openStream
     val (unparseDiags, _) = doParse(dp, unparseInfoset)
-    unparseDiags.foreach(System.err.println)
     assertTrue(unparseDiags.find(_.contains("Undeclared general entity \"name\"")).isDefined)
   }
 


### PR DESCRIPTION
Currently we are very pessimistic about specifying a known length of a
simple type suspension by always returning Nope (i.e. there is no known
length). This meant that it was impossible to determine the absolute
starting position of split buffers from those suspensions. And because
absolute bit positions are so important for allowing suspensions to
evaluate (e.g. alignment, length calculations) it increased the chance
that a suspension would deadlock.

To resolve this issue, this modifies the simple type suspension to use
the actual length where possible. This isn't always possible, like when
padding or right fill might be needed, but that often isn't the case.

Even with that change, the absolute starting positions could not be
calculated for a new split in cases where the current DOS did not have
an absolute position and only had a relative position. This meant
deadlocks were still fairly likely. So in these cases, we calculate and
store the length of the DOS (relative bit position + suspension length).
Once the absolute starting position of the DOS it determined, we can use
that length to set the starting absolute position of the following DOS.

Also add an assert to ensure that these new length calculations are
correct by checking that the ending bit position of one DOS matches the
starting bit position of the next DOS when merging. This discovered unit
tests with an off by one error.

These changes increase the chance of an absolute starting bit position
being known and allows more suspensions to be evaluated which should
lead to less deadlocks.

Unrelated, remove println from a previous commit that was used for
debugging and accidentally made it into the commit.

DAFFODIL-2717