### PR TITLE
Allow DataProcessor's copy function to be public.

### DIFF
--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/DataProcessor.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/DataProcessor.scala
@@ -188,7 +188,7 @@ class DataProcessor private (
     this(ssrd, tunables, ExternalVariablesLoader.loadVariables(compilerExternalVars, ssrd, ssrd.originalVariables),
       false, None, validationMode, compilerExternalVars)
 
-  private def copy(
+  def copy(
     ssrd: SchemaSetRuntimeData = ssrd,
     tunables: DaffodilTunables = tunables,
     areDebugging : Boolean = areDebugging,


### PR DESCRIPTION
I need this function for various test rigs I am creating for large schemas where copying the DP saves 10 seconds a test for reloading another one just because I can't copy the object.

DAFFODIL-2723