### PR TITLE
Pass schemas to Exificient via String, not stream

### DIFF
--- a/daffodil-cli/src/main/scala/org/apache/daffodil/Main.scala
+++ b/daffodil-cli/src/main/scala/org/apache/daffodil/Main.scala
@@ -707,7 +707,7 @@ object Main {
       val ef = DefaultEXIFactory.newInstance
       if (schemaUriOpt.isDefined && infosetType == InfosetType.EXISA) {
         val gf = GrammarFactory.newInstance
-        val grammar = gf.createGrammars(schemaUriOpt.get.toURL.openStream(), DFDLCatalogResolver.get)
+        val grammar = gf.createGrammars(schemaUriOpt.get.toString, DFDLCatalogResolver.get)
         ef.setGrammars(grammar)
       }
       Some(ef)


### PR DESCRIPTION
Passing the schemas in by stream resulted in not having correct path information and made it impossible for the DFDLCatalogResolver to resolve the paths to included schemas. Instead we want to pass the path of the schema in to Exificient and maintain that correct path information.

DAFFODIL-1959