### PR TITLE
Add macOS build support

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -123,11 +123,32 @@ Now when you open a new "MSYS2 MSYS" window from the Start Menu to
 build Daffodil from source, the sbt and daffodil commands you type
 will be able to call the C compiler.
 
+## macOS
+
+Install the Xcode Command Line Tools:
+
+    xcode-select --install
+
+You can use the [Homebrew] package manager to install most of the tools
+needed to build Daffodil:
+
+    brew install clang-format
+    brew install git
+    brew install llvm # needed by iwyu
+    brew install include-what-you-use
+    brew install libmxml
+    brew install openjdk@11
+    brew install sbt
+
+Now you can build Daffodil from source and the sbt and daffodil
+commands you type will be able to call the C compiler.
+
 [C99]: https://en.wikipedia.org/wiki/C99
+[EPEL]: https://docs.fedoraproject.org/en-US/epel/
+[Homebrew]: https://brew.sh/
 [JDK]: https://adoptopenjdk.net/
 [Mini-XML]: https://www.msweet.org/mxml/
 [MSYS2]: https://www.msys2.org/
 [SBT]: https://www.scala-sbt.org/
 [clang]: https://clang.llvm.org/get_started.html
 [gcc]: https://linuxize.com/post/how-to-install-gcc-on-ubuntu-20-04/
-[EPEL]: https://docs.fedoraproject.org/en-US/epel/

--- a/daffodil-runtime2/src/main/resources/org/apache/daffodil/runtime2/c/libcli/stack.c
+++ b/daffodil-runtime2/src/main/resources/org/apache/daffodil/runtime2/c/libcli/stack.c
@@ -26,7 +26,7 @@
 // Initialize stack with preallocated array
 
 void
-stack_init(stack_t *p_stack, stack_item_t *p_array, ptrdiff_t capacity)
+stack_init(c_stack_t *p_stack, stack_item_t *p_array, ptrdiff_t capacity)
 {
     p_stack->p_after = p_array;
     p_stack->p_array = p_array;
@@ -36,7 +36,7 @@ stack_init(stack_t *p_stack, stack_item_t *p_array, ptrdiff_t capacity)
 // Check whether stack is empty
 
 bool
-stack_is_empty(stack_t *p_stack)
+stack_is_empty(c_stack_t *p_stack)
 {
     return p_stack->p_after == p_stack->p_array;
 }
@@ -44,7 +44,7 @@ stack_is_empty(stack_t *p_stack)
 // Check whether stack is full
 
 bool
-stack_is_full(stack_t *p_stack)
+stack_is_full(c_stack_t *p_stack)
 {
     ptrdiff_t count = p_stack->p_after - p_stack->p_array;
     return count >= p_stack->capacity;
@@ -53,7 +53,7 @@ stack_is_full(stack_t *p_stack)
 // Pop element from stack
 
 stack_item_t
-stack_pop(stack_t *p_stack)
+stack_pop(c_stack_t *p_stack)
 {
     if (stack_is_empty(p_stack))
     {
@@ -66,7 +66,7 @@ stack_pop(stack_t *p_stack)
 // Push element into stack
 
 void
-stack_push(stack_t *p_stack, stack_item_t item)
+stack_push(c_stack_t *p_stack, stack_item_t item)
 {
     if (stack_is_full(p_stack))
     {
@@ -79,7 +79,7 @@ stack_push(stack_t *p_stack, stack_item_t item)
 // Get stack's top element
 
 stack_item_t
-stack_top(stack_t *p_stack)
+stack_top(c_stack_t *p_stack)
 {
     if (stack_is_empty(p_stack))
     {

--- a/daffodil-runtime2/src/main/resources/org/apache/daffodil/runtime2/c/libcli/stack.h
+++ b/daffodil-runtime2/src/main/resources/org/apache/daffodil/runtime2/c/libcli/stack.h
@@ -35,30 +35,30 @@ typedef struct
     stack_item_t *p_after;  // Pointer to one past top element
     stack_item_t *p_array;  // Pointer to stack's array
     ptrdiff_t     capacity; // Size of stack's array
-} stack_t;
+} c_stack_t;
 
 // Initialize stack with preallocated array
 
-extern void stack_init(stack_t *p_stack, stack_item_t *p_array, ptrdiff_t capacity);
+extern void stack_init(c_stack_t *p_stack, stack_item_t *p_array, ptrdiff_t capacity);
 
 // Check whether stack is empty
 
-extern bool stack_is_empty(stack_t *p_stack);
+extern bool stack_is_empty(c_stack_t *p_stack);
 
 // Check whether stack is full
 
-extern bool stack_is_full(stack_t *p_stack);
+extern bool stack_is_full(c_stack_t *p_stack);
 
 // Pop element from stack
 
-extern stack_item_t stack_pop(stack_t *p_stack);
+extern stack_item_t stack_pop(c_stack_t *p_stack);
 
 // Push element into stack
 
-extern void stack_push(stack_t *p_stack, stack_item_t item);
+extern void stack_push(c_stack_t *p_stack, stack_item_t item);
 
 // Get stack's top element
 
-extern stack_item_t stack_top(stack_t *p_stack);
+extern stack_item_t stack_top(c_stack_t *p_stack);
 
 #endif // STACK_H

--- a/daffodil-runtime2/src/main/resources/org/apache/daffodil/runtime2/c/libcli/xml_writer.c
+++ b/daffodil-runtime2/src/main/resources/org/apache/daffodil/runtime2/c/libcli/xml_writer.c
@@ -18,6 +18,7 @@
 // clang-format off
 #include "xml_writer.h"
 #include <assert.h>      // for assert
+#include <inttypes.h>    // for PRIi64, PRIu64
 #include <mxml.h>        // for mxmlNewOpaquef, mxml_node_t, mxmlElementSetAttr, mxmlGetOpaque, mxmlNewElement, mxmlDelete, mxmlGetElement, mxmlNewOpaque, mxmlNewXML, mxmlSaveFile, MXML_NO_CALLBACK
 #include <stdbool.h>     // for bool, false, true
 #include <stdint.h>      // for uint8_t, int16_t, int32_t, int64_t, int8_t, uint16_t, uint32_t, uint64_t
@@ -251,7 +252,7 @@ xmlSimpleElem(XMLWriter *writer, const ERD *erd, const void *valueptr)
         text = mxmlNewOpaquef(simple, "%i", *(const int32_t *)valueptr);
         break;
     case PRIMITIVE_INT64:
-        text = mxmlNewOpaquef(simple, "%li", *(const int64_t *)valueptr);
+        text = mxmlNewOpaquef(simple, "%" PRIi64, *(const int64_t *)valueptr);
         break;
     case PRIMITIVE_INT8:
         text = mxmlNewOpaquef(simple, "%hhi", *(const int8_t *)valueptr);
@@ -263,7 +264,7 @@ xmlSimpleElem(XMLWriter *writer, const ERD *erd, const void *valueptr)
         text = mxmlNewOpaquef(simple, "%u", *(const uint32_t *)valueptr);
         break;
     case PRIMITIVE_UINT64:
-        text = mxmlNewOpaquef(simple, "%lu", *(const uint64_t *)valueptr);
+        text = mxmlNewOpaquef(simple, "%" PRIu64, *(const uint64_t *)valueptr);
         break;
     case PRIMITIVE_UINT8:
         text = mxmlNewOpaquef(simple, "%hhu", *(const uint8_t *)valueptr);

--- a/daffodil-runtime2/src/main/resources/org/apache/daffodil/runtime2/c/libruntime/p_endian.h
+++ b/daffodil-runtime2/src/main/resources/org/apache/daffodil/runtime2/c/libruntime/p_endian.h
@@ -15,26 +15,23 @@
  * limitations under the License.
  */
 
-#ifndef XML_WRITER_H
-#define XML_WRITER_H
-
-// clang-format off
-#include <stdio.h>    // for FILE
-#include "infoset.h"  // for VisitEventHandler
-#include "stack.h"    // for c_stack_t
-// clang-format on
-
-// XMLWriter - infoset visitor with methods to output XML
-
-typedef struct XMLWriter
-{
-    const VisitEventHandler handler;
-    FILE *                  stream;
-    c_stack_t                 stack;
-} XMLWriter;
-
-// XMLWriter methods to pass to walkInfoset method
-
-extern const VisitEventHandler xmlWriterMethods;
-
-#endif // XML_WRITER_H
+// for be64toh, le64toh, be32toh, le32toh
+// for htobe64, htole64, htobe32, htole32
+#if defined(__APPLE__)
+#include <machine/endian.h>
+#include <libkern/OSByteOrder.h>
+#define htobe16(x) OSSwapHostToBigInt16(x)
+#define htole16(x) OSSwapHostToLittleInt16(x)
+#define be16toh(x) OSSwapBigToHostInt16(x)
+#define le16toh(x) OSSwapLittleToHostInt16(x)
+#define htobe32(x) OSSwapHostToBigInt32(x)
+#define htole32(x) OSSwapHostToLittleInt32(x)
+#define be32toh(x) OSSwapBigToHostInt32(x)
+#define le32toh(x) OSSwapLittleToHostInt32(x)
+#define htobe64(x) OSSwapHostToBigInt64(x)
+#define htole64(x) OSSwapHostToLittleInt64(x)
+#define be64toh(x) OSSwapBigToHostInt64(x)
+#define le64toh(x) OSSwapLittleToHostInt64(x)
+#else
+#include <endian.h>
+#endif

--- a/daffodil-runtime2/src/main/resources/org/apache/daffodil/runtime2/c/libruntime/parsers.c
+++ b/daffodil-runtime2/src/main/resources/org/apache/daffodil/runtime2/c/libruntime/parsers.c
@@ -18,11 +18,11 @@
 // clang-format off
 #include "parsers.h"
 #include <assert.h>   // for assert
-#include <endian.h>   // for be64toh, le64toh, be32toh, le32toh
 #include <stdbool.h>  // for bool, false, true
 #include <stdio.h>    // for fread
 #include <stdlib.h>   // for free, malloc
 #include "errors.h"   // for eof_or_error, Error, add_diagnostic, get_diagnostics, ERR_FIXED_VALUE, ERR_HEXBINARY_ALLOC, ERR_PARSE_BOOL, Error::(anonymous), Diagnostics
+#include "p_endian.h" // for be64toh, le64toh, be32toh, le32toh
 // clang-format on
 
 // Helper macros to get "n" highest bits from a byte's high end

--- a/daffodil-runtime2/src/main/resources/org/apache/daffodil/runtime2/c/libruntime/unparsers.c
+++ b/daffodil-runtime2/src/main/resources/org/apache/daffodil/runtime2/c/libruntime/unparsers.c
@@ -18,10 +18,10 @@
 // clang-format off
 #include "unparsers.h"
 #include <assert.h>   // for assert
-#include <endian.h>   // for htobe64, htole64, htobe32, htole32
 #include <stdbool.h>  // for bool
 #include <stdio.h>    // for fwrite
 #include "errors.h"   // for eof_or_error, add_diagnostic, get_diagnostics, ERR_FIXED_VALUE, Diagnostics, Error
+#include "p_endian.h" // for htobe64, htole64, htobe32, htole32
 // clang-format on
 
 // Helper macros to get "n" highest bits from a byte's high end


### PR DESCRIPTION
Add build documentation and update code to support building on macOS. Rename existing stack_t struct to avoid conflict with built-in type definition on macO. Use int64 and uint64 primitives for integer types to fix compilation warnings. Add portable endian header file for macOS endian definitions, as these are not located in endian.h. This was tested on macOS 10.15.7.

DAFFODIL-2744

BUILD.md: Add macOS dependency installation to build documentation.

stack.h: Rename stack_t struct to c_stack_t in order to avoid naming conflict with macOS types.

stack.c: Rename stack_t struct to c_stack_t in order to avoid naming conflict with macOS types.

xml_writer.h: Rename stack_t struct to c_stack_t in order to avoid naming conflict with macOS types.

xml_writer.c: Use PRIi64 and PRIu64 integer types to avoid compilation warnings on macOS.

p_endian.h: Add portable endian header file for including proper endian header files and defines on macOS.

parsers.c: Import portable endian header file.

unparsers.c: Import portable endian header file.