### PR TITLE
Remove leftover deprecated variables and methods

### DIFF
--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/SchemaSet.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/SchemaSet.scala
@@ -34,13 +34,10 @@ import org.apache.daffodil.api.DaffodilSchemaSource
 import org.apache.daffodil.api.UnitTestSchemaSource
 import org.apache.daffodil.schema.annotation.props.LookupLocation
 import org.apache.daffodil.api.DaffodilTunables
-import org.apache.daffodil.externalvars.Binding
 import org.apache.daffodil.processors.TypeCalculatorCompiler.TypeCalcMap
 import org.apache.daffodil.grammar.Gram
 import org.apache.daffodil.grammar.SchemaSetGrammarMixin
 import org.apache.daffodil.util.TransitiveClosure
-
-import scala.collection.immutable.Queue
 
 object SchemaSet {
   def apply(
@@ -48,14 +45,12 @@ object SchemaSet {
   schemaSource: DaffodilSchemaSource,
   shouldValidateDFDLSchemas: Boolean,
   checkAllTopLevel: Boolean,
-  tunables: DaffodilTunables,
-  compilerExternalVarSettings: Queue[Binding]) = {
+  tunables: DaffodilTunables) = {
     val ss = new SchemaSet(optPFRootSpec,
       schemaSource,
       shouldValidateDFDLSchemas,
       checkAllTopLevel,
-      tunables,
-      compilerExternalVarSettings)
+      tunables)
     ss.initialize()
     ss
   }
@@ -96,8 +91,7 @@ final class SchemaSet private (
   val schemaSource: DaffodilSchemaSource,
   val shouldValidateDFDLSchemas: Boolean,
   val checkAllTopLevel: Boolean,
-  val tunables: DaffodilTunables,
-  protected val compilerExternalVarSettings: Queue[Binding])
+  val tunables: DaffodilTunables)
   extends SchemaComponentImpl(<schemaSet/>, None)
   with SchemaSetIncludesAndImportsMixin
   with SchemaSetGrammarMixin {
@@ -159,8 +153,7 @@ final class SchemaSet private (
       UnitTestSchemaSource(sch, Option(root).getOrElse("anon"), optTmpDir),
       false,
       false,
-      tunableOpt.getOrElse(DaffodilTunables()),
-      Queue.empty)
+      tunableOpt.getOrElse(DaffodilTunables()))
 
   lazy val schemaFileList = schemas.map(s => s.uriString)
 

--- a/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/SchemaSetRuntime1Mixin.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/SchemaSetRuntime1Mixin.scala
@@ -21,7 +21,6 @@ import org.apache.daffodil.api.DFDL
 import org.apache.daffodil.api.ValidationMode
 import org.apache.daffodil.dsom.SchemaSet
 import org.apache.daffodil.exceptions.Assert
-import org.apache.daffodil.externalvars.ExternalVariablesLoader
 import org.apache.daffodil.grammar.VariableMapFactory
 import org.apache.daffodil.processors.DataProcessor
 import org.apache.daffodil.processors.Processor
@@ -54,22 +53,6 @@ trait SchemaSetRuntime1Mixin {
     }
     val alldvs = dvs.union(predefinedVars)
     val vmap = VariableMapFactory.create(alldvs)
-    //
-    // Here we verify that any external variable bindings supplied at schema compilation time
-    // are properly structured - the variables they reference exist, are external, and the
-    // supplied value string is convertible into the declared variable's type.
-    //
-    // But... then we throw it away. We don't save the external variable bindings as
-    // part of the saved data structure representing the compiled schema.
-    // Because external variables really have to be bound at runtime, and the schema has
-    // to work with and without any such bindings.
-    //
-    // This same checking must be done at runtime, so we share that same code here at schema compile time.
-    // This is yet another example of where runtime1-specific code is being used in a general
-    // schema-compilation role. So even if building a runtime 2, you would still want to keep much of
-    // the runtime 1 code around.
-    //
-    ExternalVariablesLoader.loadVariables(compilerExternalVarSettings, this, vmap)
     vmap
   }.value
 
@@ -104,7 +87,7 @@ trait SchemaSetRuntime1Mixin {
       typeCalcMap)
     if (root.numComponents > root.numUniqueComponents)
       Logger.log.debug(s"Compiler: component counts: unique ${root.numUniqueComponents}, actual ${root.numComponents}.")
-    val dataProc = new DataProcessor(ssrd, tunable, self.compilerExternalVarSettings)
+    val dataProc = new DataProcessor(ssrd, tunable)
     if (dataProc.isError) {
     } else {
       Logger.log.debug(s"Parser = ${ssrd.parser.toString}.")

--- a/daffodil-tdml-lib/src/main/scala/org/apache/daffodil/tdml/processor/TDMLDFDLProcessor.scala
+++ b/daffodil-tdml-lib/src/main/scala/org/apache/daffodil/tdml/processor/TDMLDFDLProcessor.scala
@@ -55,8 +55,6 @@ trait AbstractTDMLDFDLProcessorFactory {
 
   def withTunables(tunables: Map[String, String]): R
 
-  def withExternalDFDLVariables(externalVarBindings: Seq[Binding]): R
-
   def getProcessor(schemaSource: DaffodilSchemaSource, useSerializedProcessor: Boolean,
     optRootName: Option[String] = None, optRootNamespace: Option[String] = None,
     tunables: Map[String, String]): TDML.CompileResult

--- a/daffodil-tdml-processor/src/main/scala/org/apache/daffodil/tdml/processor/DaffodilTDMLDFDLProcessor.scala
+++ b/daffodil-tdml-processor/src/main/scala/org/apache/daffodil/tdml/processor/DaffodilTDMLDFDLProcessor.scala
@@ -88,9 +88,6 @@ final class TDMLDFDLProcessorFactory private (
   override def withTunables(tunables: Map[String, String]): TDMLDFDLProcessorFactory =
     copy(compiler = compiler.withTunables(tunables))
 
-  override def withExternalDFDLVariables(externalVarBindings: Seq[Binding]): TDMLDFDLProcessorFactory =
-    copy(compiler = compiler.withExternalDFDLVariablesImpl(externalVarBindings))
-
   /**
    * This doesn't fetch a serialized processor, it runs whatever the processor is
    * through a serialize then unserialize path to get a processor as if

--- a/daffodil-tdml-processor/src/main/scala/org/apache/daffodil/tdml/processor/Runtime2TDMLDFDLProcessor.scala
+++ b/daffodil-tdml-processor/src/main/scala/org/apache/daffodil/tdml/processor/Runtime2TDMLDFDLProcessor.scala
@@ -61,9 +61,6 @@ final class Runtime2TDMLDFDLProcessorFactory private(
   override def withTunables(tunables: Map[String, String]): Runtime2TDMLDFDLProcessorFactory =
     copy(compiler = compiler.withTunables(tunables))
 
-  override def withExternalDFDLVariables(externalVarBindings: Seq[Binding]): Runtime2TDMLDFDLProcessorFactory =
-    copy(compiler = compiler.withExternalDFDLVariablesImpl(externalVarBindings))
-
   // Return result is a TDML.CompileResult - so it's the result
   // of compiling the schema for the test.
   override def getProcessor(


### PR DESCRIPTION
Remove leftover deprecated variables and methods.

- daffodil-core/src/main/scala/org/apache/daffodil/compiler/Compiler.scala: Remove deprecated variable compilerExternalVarSettings and method withExternalDFDLVariablesImpl. Update some var's to val's
- daffodil-core/src/main/scala/org/apache/daffodil/dsom/SchemaSet.scala: Remove deprecated variable compilerExternalVarSettings.
- daffodil-core/src/main/scala/org/apache/daffodil/runtime1/SchemaSetRuntime1Mixin.scala: Remove ExternalVariablesLoader and references to compilerExternalVarSettings.
- daffodil-tdml-lib/src/main/scala/org/apache/daffodil/tdml/processor/TDMLDFDLProcessor.scala: Remove deprecated method withExternalDFDLVariables.
- daffodil-tdml-processor/src/main/scala/org/apache/daffodil/tdml/processor/DaffodilTDMLDFDLProcessor.scala: Remove deprecated method withExternalDFDLVariables.
- daffodil-tdml-processor/src/main/scala/org/apache/daffodil/tdml/processor/Runtime2TDMLDFDLProcessor.scala: Remove deprecated method withExternalDFDLVariables.

[DAFFODIL-2743](https://issues.apache.org/jira/projects/DAFFODIL/issues/DAFFODIL-2743?filter=allissues)
