### PR TITLE
Improve SAX parse/unparse performance

### DIFF
--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/infoset/SAXInfosetInputter.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/infoset/SAXInfosetInputter.scala
@@ -96,15 +96,14 @@ class SAXInfosetInputter(
     } else {
       throw new NonTextFoundInSimpleContentException(getLocalName())
     }
-    primType match {
-      case _: NodeInfo.String.Kind =>
-        val remapped = XMLUtils.remapPUAToXMLIllegalCharacters(res)
-        remapped
-      case _: NodeInfo.AnyURI.Kind if resolveRelativeInfosetBlobURIs && res.nonEmpty =>
-        val absUri = resolveRelativeBlobURIs(res)
-        absUri
-      case _ =>
-        res
+    if (primType eq NodeInfo.String) {
+      val remapped = XMLUtils.remapPUAToXMLIllegalCharacters(res)
+      remapped
+    } else if (resolveRelativeInfosetBlobURIs && (primType eq NodeInfo.AnyURI) && res.nonEmpty) {
+      val absUri = resolveRelativeBlobURIs(res)
+      absUri
+    } else {
+      res
     }
   }
 

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/RuntimeData.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/RuntimeData.scala
@@ -632,9 +632,9 @@ sealed class ElementRuntimeData(
 
   def isComplexType = !isSimpleType
 
-  def prefix = this.minimizedScope.getPrefix(namedQName.namespace)
+  lazy val prefix = this.minimizedScope.getPrefix(namedQName.namespace)
 
-  def prefixedName = {
+  lazy val prefixedName = {
     if (prefix != null) {
       prefix + ":" + name
     } else {


### PR DESCRIPTION
Four changes are made to improve SAX unparse performance. For this PR, they commits are separated for easier review. The changes are:

1. Use a cached thread pool for coroutine threads. Instead of creating a new thread everytime a new coroutine is created (i.e. everytime we unparse something with SAX), coroutines now get threads from a cached thread pool. This allows reuse of previously created threads, avoiding the overhead of creating threads.

2. Initialize SAX prefixMapping with TopScope instead of null. Avoids some null checks and throw/catch of NullPointerExceptions.

3. Store the prefix string in ElementRuntimeData instead of a def. Looking up the prefix shows up in profiling. There's no need to relook it up everytime, so just store it as a lazy val.

4. Replace match case with reference equality. Type matching uses instanceof, which has some amount of overhead
compared to straight reference equality. Also reorder the anyURI condition so the resolve uri condition is first, since it is almost always going to be false short circuit the condition.