### PR TITLE
Add macOS runner

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,6 +24,10 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
+
 jobs:
 
   # Build Daffodil and run some checks.
@@ -38,6 +42,13 @@ jobs:
         scala_version: [ 2.12.17 ]
         os: [ ubuntu-20.04, windows-2019 ]
         include:
+          - os: macos-12
+            shell: bash
+            distribution: temurin
+            java_version: 17
+            scala_version: 2.12.17
+            env_cc: cc
+            env_ar: ar
           - os: ubuntu-20.04
             shell: bash
             env_cc: clang-10
@@ -69,6 +80,10 @@ jobs:
       ############################################################
       # Setup
       ############################################################
+
+      - name: Install Dependencies (macOS)
+        if: runner.os == 'macOS'
+        run: brew install libmxml
 
       - name: Install Dependencies (Linux)
         if: runner.os == 'Linux'

--- a/daffodil-runtime2/src/main/resources/org/apache/daffodil/runtime2/c/libcli/xml_reader.c
+++ b/daffodil-runtime2/src/main/resources/org/apache/daffodil/runtime2/c/libcli/xml_reader.c
@@ -143,7 +143,7 @@ strtofnum(const char *text, float *valueptr)
 // with our own error checking)
 
 static const Error *
-strtonum(const char *text, intmax_t minval, intmax_t maxval, intmax_t *valueptr)
+strtoinum(const char *text, intmax_t minval, intmax_t maxval, intmax_t *valueptr)
 {
     // Should point to text's end after conversion
     char *endptr = NULL;
@@ -450,19 +450,19 @@ xmlSimpleElem(XMLReader *reader, const ERD *erd, void *valueptr)
             case PRIMITIVE_HEXBINARY:
                 return strtohexbinary(text, (HexBinary *)valueptr);
             case PRIMITIVE_INT16:
-                error = strtonum(text, INT16_MIN, INT16_MAX, &num);
+                error = strtoinum(text, INT16_MIN, INT16_MAX, &num);
                 *(int16_t *)valueptr = (int16_t)num;
                 return error;
             case PRIMITIVE_INT32:
-                error = strtonum(text, INT32_MIN, INT32_MAX, &num);
+                error = strtoinum(text, INT32_MIN, INT32_MAX, &num);
                 *(int32_t *)valueptr = (int32_t)num;
                 return error;
             case PRIMITIVE_INT64:
-                error = strtonum(text, INT64_MIN, INT64_MAX, &num);
+                error = strtoinum(text, INT64_MIN, INT64_MAX, &num);
                 *(int64_t *)valueptr = (int64_t)num;
                 return error;
             case PRIMITIVE_INT8:
-                error = strtonum(text, INT8_MIN, INT8_MAX, &num);
+                error = strtoinum(text, INT8_MIN, INT8_MAX, &num);
                 *(int8_t *)valueptr = (int8_t)num;
                 return error;
             case PRIMITIVE_UINT16:


### PR DESCRIPTION
Update code to support building on macOS Monterey. Rename strtonum function to avoid conflict with built-in standard function definition on macOS. Add macOS GitHub runner and concurrency control to cancel in-progress GitHub jobs. This was tested on macOS 12.6.1.

DAFFODIL-2747

main.yml: Add macOS runner and dependency installation step. Add concurrency control to cancel in-progress GitHub jobs.

xml_reader.c: Rename strtonum function to strtoinum in order to avoid naming conflict with macOS functions.