### PR TITLE
Add infosetWalkerSkipMin/Max tunables

### DIFF
--- a/daffodil-propgen/src/main/resources/org/apache/daffodil/xsd/dafext.xsd
+++ b/daffodil-propgen/src/main/resources/org/apache/daffodil/xsd/dafext.xsd
@@ -207,6 +207,40 @@
             </xs:restriction>
           </xs:simpleType>
         </xs:element>
+        <xs:element name="infosetWalkerSkipMin" default="32" minOccurs="0">
+          <xs:annotation>
+            <xs:documentation>
+              Daffodil periodically walks the internal infoset to send events to the configured
+              InfosetOutputter, skipping at least this number of walk attempts. Larger values
+              mean delayed InfosetOutputter events and more memory usage; Smaller values mean
+              more CPU usage. Set this value to zero to never skip any walk attempts. This is
+              specifically for advanced testing behavior and should not need to be changed by users.
+            </xs:documentation>
+          </xs:annotation>
+          <xs:simpleType>
+            <xs:restriction base="xs:int">
+              <xs:minInclusive value="0" />
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="infosetWalkerSkipMax" default="2048" minOccurs="0">
+          <xs:annotation>
+            <xs:documentation>
+              Daffodil periodically walks the internal infoset to send events to the configured
+              InfosetOutputter. On walks where no progress is made, the number of walks to skip
+              is increased with the assumption that something is blocking it (like an
+              unresolved point of uncertainty), up to this maximum value. Higher values mean
+              less attempts are made when blocked for a long time, but with potentially more
+              delays and memory usage before InfosetOutputter events are created. This is
+              specifically for advanced testing behavior and should not need to be changed by users.
+            </xs:documentation>
+          </xs:annotation>
+          <xs:simpleType>
+            <xs:restriction base="xs:int">
+              <xs:minInclusive value="0" />
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
         <xs:element name="inputFileMemoryMapLowThreshold" type="xs:int" default="33554432" minOccurs="0">
           <xs:annotation>
             <xs:documentation>

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/PState.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/PState.scala
@@ -694,7 +694,9 @@ object PState {
       output,
       walkHidden = false,
       ignoreBlocks = false,
-      releaseUnneededInfoset = !areDebugging && tunables.releaseUnneededInfoset)
+      releaseUnneededInfoset = !areDebugging && tunables.releaseUnneededInfoset,
+      walkSkipMin = tunables.infosetWalkerSkipMin,
+      walkSkipMax = tunables.infosetWalkerSkipMax)
 
     dis.cst.setPriorBitOrder(root.defaultBitOrder)
     val newState = new PState(

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section00/general/infosetWalker.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section00/general/infosetWalker.tdml
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<tdml:testSuite suiteName="InfosetWalker" description="Section 00 - InfosetWalker tests"
+  xmlns:tdml="http://www.ibm.com/xmlns/dfdl/testData"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/"
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns:ex="http://example.com"
+  xmlns:daf="urn:ogf:dfdl:2013:imp:daffodil.apache.org:2018:ext">
+
+  <!--
+    Disable skipping of walk() calls. If we are incorrectly releasing infoset
+    elements, this will likely cause a null expception
+  -->
+  <tdml:defineConfig name="cfg_infosetWalker_01">
+    <daf:tunables>
+      <daf:infosetWalkerSkipMin>0</daf:infosetWalkerSkipMin>
+    </daf:tunables>
+  </tdml:defineConfig>
+
+  <!--
+    Disable skipping of walk() calls, but do not release unneeded infosets.
+    Shows that setting releaseUnneededInfoset can avoid issues related to the
+    InfosetWalker incorrecly releasing elements.
+  -->
+  <tdml:defineConfig name="cfg_infosetWalker_02">
+    <daf:tunables>
+      <daf:infosetWalkerSkipMin>0</daf:infosetWalkerSkipMin>
+      <daf:releaseUnneededInfoset>false</daf:releaseUnneededInfoset>
+    </daf:tunables>
+  </tdml:defineConfig>
+
+
+  <tdml:defineSchema name="schema_01" elementFormDefault="unqualified">
+    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd" />
+
+    <dfdl:format ref="ex:GeneralFormat" lengthKind="delimited" />
+
+    <xs:element name="root_01">
+      <xs:complexType>
+        <xs:sequence dfdl:initiator="|" dfdl:terminator="|" dfdl:separator=";">
+          <xs:element name="first" type="xs:string" />
+          <xs:sequence dfdl:separator=";" dfdl:separatorPosition="postfix">
+            <xs:element name="field" type="xs:string" minOccurs="0" maxOccurs="unbounded" />
+          </xs:sequence>
+        </xs:sequence>
+      </xs:complexType>
+    </xs:element>
+
+  </tdml:defineSchema>
+
+  <tdml:parserTestCase name="infosetWalker_01" model="schema_01">
+    <tdml:document>
+      <tdml:documentPart type="text">|header;body1;body2;body3;|</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <ex:root_01 xmlns:ex="http://example.com">
+          <first>header</first>
+          <field>body1</field>
+          <field>body2</field>
+          <field>body3</field>
+        </ex:root_01>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="infosetWalker_02" model="schema_01" config="cfg_infosetWalker_01">
+    <tdml:document>
+      <tdml:documentPart type="text">|header;body1;body2;body3;|</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <ex:root_01 xmlns:ex="http://example.com">
+          <first>header</first>
+          <field>body1</field>
+          <field>body2</field>
+          <field>body3</field>
+        </ex:root_01>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="infosetWalker_03" model="schema_01" config="cfg_infosetWalker_02">
+    <tdml:document>
+      <tdml:documentPart type="text">|header;body1;body2;body3;|</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <ex:root_01 xmlns:ex="http://example.com">
+          <first>header</first>
+          <field>body1</field>
+          <field>body2</field>
+          <field>body3</field>
+        </ex:root_01>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+
+</tdml:testSuite>

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section00/general/TestInfosetWalker.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section00/general/TestInfosetWalker.scala
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.daffodil.section00.general
+
+import org.apache.daffodil.tdml.Runner
+import org.junit.AfterClass
+import org.junit.Test
+
+object TestInfosetWalker {
+  val testDir = "/org/apache/daffodil/section00/general/"
+  val runner2 = Runner(testDir, "infosetWalker.tdml")
+
+  @AfterClass def shutDown(): Unit = {
+    runner2.reset
+  }
+}
+
+class TestInfosetWalker {
+  import TestInfosetWalker._
+
+  @Test def test_infosetWalker_01() = { runner2.runOneTest("infosetWalker_01") }
+  // DAFFODIL-2755
+  /*@Test*/ def test_infosetWalker_02() = { runner2.runOneTest("infosetWalker_02") }
+  @Test def test_infosetWalker_03() = { runner2.runOneTest("infosetWalker_03") }
+}


### PR DESCRIPTION
Allows configuration of how often the InfosetWalker skips walk() calls. Setting to a value of zero disables skipping walk() calls. A value of zero is useful during testing to ensure the InfosetWalker isn't incorrectly removing infoset elements, which can lead to seemingly random null pointer exceptions.

Add multiple tests to show that the InfosetWalker currently removes infoset elements that are still needed by separator logic, that this does not arise in a particular case with the default skip min/max values, and that disabling infoset removal works around the issue.

DAFFODIL-2755

Note, this does not fix 2755, just makes it easier to create a reproducible test to trigger the issue.