### PR TITLE
Update scaladocs mentioning deprecated API

### DIFF
--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/SchemaSet.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/SchemaSet.scala
@@ -342,13 +342,9 @@ final class SchemaSet private (
   }
 
   /**
-   * The root element can be specified by a deprecated API call on the compiler
-   * object or the ProcessorFactory class, but the call on the ProcessorFactory class
-   * just overrides anything coming from the compiler object.
+   * You can define the root by passing the root specification to the Compiler.compileX method.
    *
-   * The right way is to pass the root specification to the Compiler.compileX method.
-   *
-   * Or, you can leave it unspecified, and this method will determine from the
+   * Or, you can leave the root unspecified, and this method will determine it from the
    * first element declaration of the first schema file.
    */
   lazy val root: Root = {
@@ -360,12 +356,12 @@ final class SchemaSet private (
           // if the root element and rootNamespace aren't provided at all, then
           // the first element of the first schema document is the root
           val sDocs = this.allSchemaDocuments
-          assuming(sDocs.length > 0)
-          val firstSchemaDocument = sDocs(0)
+          assuming(sDocs.nonEmpty)
+          val firstSchemaDocument = sDocs.head
           val gdecl = firstSchemaDocument.globalElementDecls
           val firstElement = {
-            schemaDefinitionUnless(gdecl.length >= 1, "No global elements in: " + firstSchemaDocument.uriString)
-            gdecl(0)
+            schemaDefinitionUnless(gdecl.nonEmpty, "No global elements in: " + firstSchemaDocument.uriString)
+            gdecl.head
           }
           firstElement
         }

--- a/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/SchemaSetRuntime1Mixin.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/SchemaSetRuntime1Mixin.scala
@@ -18,7 +18,6 @@
 package org.apache.daffodil.runtime1
 
 import org.apache.daffodil.api.DFDL
-import org.apache.daffodil.api.ValidationMode
 import org.apache.daffodil.dsom.SchemaSet
 import org.apache.daffodil.exceptions.Assert
 import org.apache.daffodil.grammar.VariableMapFactory
@@ -75,7 +74,6 @@ trait SchemaSetRuntime1Mixin {
     root.schemaDefinitionUnless(
       !rootERD.dpathElementCompileInfo.isOutputValueCalc,
       "The root element cannot have the dfdl:outputValueCalc property.")
-    val validationMode = ValidationMode.Off
     val p = if (!root.isError) parser else null
     val u = if (!root.isError) unparser else null
     val ssrd = new SchemaSetRuntimeData(
@@ -87,7 +85,7 @@ trait SchemaSetRuntime1Mixin {
       typeCalcMap)
     if (root.numComponents > root.numUniqueComponents)
       Logger.log.debug(s"Compiler: component counts: unique ${root.numUniqueComponents}, actual ${root.numComponents}.")
-    val dataProc = new DataProcessor(ssrd, tunable)
+    val dataProc = new DataProcessor(ssrd, tunable, variableMap.copy())
     if (dataProc.isError) {
     } else {
       Logger.log.debug(s"Parser = ${ssrd.parser.toString}.")

--- a/daffodil-core/src/test/scala/org/apache/daffodil/general/TestTunables.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/general/TestTunables.scala
@@ -63,14 +63,14 @@ class TestTunables {
     val dp1 = pf1.onPath("/")
     var dp2 = pf2.onPath("/")
 
-    val t1 = dp1.getTunables()
-    val t2 = dp2.getTunables()
+    val t1 = dp1.tunables
+    val t2 = dp2.tunables
 
     /* Set tunable at run-time via data processor */
     dp2 = dp2.withTunable("maxSkipLengthInBytes", "50")
 
-    val t3 = dp2.getTunables() // modified tunables at 'run-time'
-    val t4 = dp1.getTunables() // obtain first data processor to see if anything changed
+    val t3 = dp2.tunables // modified tunables at 'run-time'
+    val t4 = dp1.tunables // obtain first data processor to see if anything changed
 
     assertEquals(1026, t1.maxSkipLengthInBytes) // initial compiler-set value
     assertEquals(2048, t2.maxSkipLengthInBytes) // overwrite of compiler-set value

--- a/daffodil-core/src/test/scala/org/apache/daffodil/infoset/TestInfosetCursor.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/infoset/TestInfosetCursor.scala
@@ -27,7 +27,6 @@ import org.apache.daffodil.processors.DataProcessor
 import org.apache.daffodil.compiler.Compiler
 import org.apache.daffodil.processors.SequenceRuntimeData
 import org.apache.daffodil.processors.ChoiceRuntimeData
-
 import InfosetEventKind._
 import org.apache.daffodil.processors.ElementRuntimeData
 
@@ -91,7 +90,7 @@ class TestInfosetInputter {
     }
     val rootERD = u.ssrd.elementRuntimeData
     val infosetInputter = new ScalaXMLInfosetInputter(infosetXML)
-    infosetInputter.initialize(rootERD, u.getTunables())
+    infosetInputter.initialize(rootERD, u.tunables)
     (infosetInputter, rootERD)
   }
 

--- a/daffodil-core/src/test/scala/org/apache/daffodil/infoset/TestInfosetCursor1.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/infoset/TestInfosetCursor1.scala
@@ -49,7 +49,7 @@ class TestInfosetInputter1 {
     }
     val rootERD = u.ssrd.elementRuntimeData
     val ic = new XMLTextInfosetInputter(is)
-    ic.initialize(rootERD, u.getTunables())
+    ic.initialize(rootERD, u.tunables)
     ic
   }
 

--- a/daffodil-core/src/test/scala/org/apache/daffodil/infoset/TestInfosetCursorFromReader.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/infoset/TestInfosetCursorFromReader.scala
@@ -55,7 +55,7 @@ class TestInfosetInputterFromReader {
     }
     val rootERD = u.ssrd.elementRuntimeData
     val inputter = new ScalaXMLInfosetInputter(infosetXML)
-    inputter.initialize(rootERD, u.getTunables())
+    inputter.initialize(rootERD, u.tunables)
     val is = Adapter(inputter)
     (is, rootERD, inputter, u.tunables)
   }

--- a/daffodil-core/src/test/scala/org/apache/daffodil/infoset/TestInfosetCursorFromReader2.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/infoset/TestInfosetCursorFromReader2.scala
@@ -63,7 +63,7 @@ class TestInfosetInputterFromReader2 {
 
     val is = new StreamInputStream(strings)
     val inputter = new XMLTextInfosetInputter(is)
-    inputter.initialize(rootERD, u.getTunables())
+    inputter.initialize(rootERD, u.tunables)
     val ic = Adapter(inputter)
     (ic, rootERD, inputter)
   }

--- a/daffodil-core/src/test/scala/org/apache/daffodil/util/TestUtils.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/util/TestUtils.scala
@@ -338,17 +338,16 @@ class Fakes private () {
   lazy val fakeGroupRefFactory = GroupRefFactory(fs1.xml, fs1, 1, false)
 
   class FakeDataProcessor extends DFDL.DataProcessor {
-    def getValidationMode(): ValidationMode.Type = { ValidationMode.Full }
     override def save(output: DFDL.Output): Unit = {}
-    def getVariables(): VariableMap = VariableMapFactory.create(Nil)
     override def parse(input: InputSourceDataInputStream, output: InfosetOutputter): DFDL.ParseResult = null
     override def unparse(inputter: InfosetInputter, output: DFDL.Output): DFDL.UnparseResult = null
     override def getDiagnostics: Seq[Diagnostic] = Seq.empty
     override def isError: Boolean = false
-    override def getTunables(): DaffodilTunables = { tunables }
 
-    override def validationMode: ValidationMode.Type = ValidationMode.Full
+    override def tunables: DaffodilTunables = DaffodilTunables()
     override def variableMap: VariableMap = VariableMapFactory.create(Nil)
+    override def validationMode: ValidationMode.Type = ValidationMode.Full
+
     override def withExternalVariables(extVars: Seq[Binding]): DFDL.DataProcessor = this
     override def withExternalVariables(extVars: java.io.File): DFDL.DataProcessor = this
     override def withExternalVariables(extVars: Map[String,String]): DFDL.DataProcessor = this

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/api/DFDLParserUnparser.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/api/DFDLParserUnparser.scala
@@ -190,11 +190,11 @@ object DFDL {
     def withDebugger(dbg:AnyRef): DataProcessor
     def withDebugging(flag: Boolean): DataProcessor
 
-    def validationMode: ValidationMode.Type
-
-    def getTunables(): DaffodilTunables
     def save(output: DFDL.Output): Unit
+
+    def tunables: DaffodilTunables
     def variableMap: VariableMap
+    def validationMode: ValidationMode.Type
 }
 
   trait DataProcessor extends DataProcessorBase with WithDiagnostics {

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/DaffodilUnparseContentHandler.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/DaffodilUnparseContentHandler.scala
@@ -78,7 +78,7 @@ class DaffodilUnparseContentHandler(
   private var prefixMapping: NamespaceBinding = _
   private lazy val prefixMappingTrackingStack = new MStackOf[NamespaceBinding]
 
-  private lazy val tunablesBatchSize = dp.getTunables().saxUnparseEventBatchSize
+  private lazy val tunablesBatchSize = dp.tunables.saxUnparseEventBatchSize
 
   /**
    * we always have an extra buffer in the array that we use for the inputter.hasNext call. For each

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/PState.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/PState.scala
@@ -658,7 +658,7 @@ object PState {
     dataProc: DFDL.DataProcessor,
     areDebugging: Boolean): PState = {
 
-    val tunables = dataProc.getTunables()
+    val tunables = dataProc.tunables
     val doc = Infoset.newDocument(root).asInstanceOf[DIElement]
     createInitialPState(
       doc.asInstanceOf[InfosetDocument],
@@ -684,11 +684,11 @@ object PState {
      * This is a full deep copy as variableMap is mutable. Reusing
      * dataProc.VariableMap without a copy would not be thread safe.
      */
-    val variables = dataProc.variableMap.copy
+    val variables = dataProc.variableMap.copy()
 
     val diagnostics = Nil
     val mutablePState = MPState()
-    val tunables = dataProc.getTunables()
+    val tunables = dataProc.tunables
     val infosetWalker = InfosetWalker(
       doc.asInstanceOf[DIElement],
       output,

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/unparsers/UState.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/unparsers/UState.scala
@@ -680,7 +680,7 @@ object UState {
      * This is a full deep copy as variableMap is mutable. Reusing
      * dataProc.VariableMap without a copy would not be thread safe.
      */
-    val variables = dataProc.variableMap.copy
+    val variables = dataProc.variableMap.copy()
 
     val diagnostics = Nil
     val newState = new UStateMain(
@@ -689,7 +689,7 @@ object UState {
         variables,
         diagnostics,
         dataProc.asInstanceOf[DataProcessor],
-        dataProc.getTunables(),
+        dataProc.tunables,
         areDebugging)
     newState
   }

--- a/daffodil-runtime2/src/main/scala/org/apache/daffodil/runtime2/Runtime2DataProcessor.scala
+++ b/daffodil-runtime2/src/main/scala/org/apache/daffodil/runtime2/Runtime2DataProcessor.scala
@@ -39,35 +39,25 @@ import org.apache.daffodil.util.Maybe
 import org.apache.daffodil.util.Maybe.Nope
 
 /**
- * Effectively a scala proxy object that does its work via the underlying C-code.
- * Will need to consider how to use features of underlying C-code to get infoset,
- * walk infoset, generate XML for use by TDML tests.
+ * Effectively a scala proxy object that does its work via the underlying C-code
+ * to get infoset, walk infoset, and generate XML for use by TDML tests.
  */
 class Runtime2DataProcessor(executableFile: os.Path) extends DFDL.DataProcessorBase {
 
+  //$COVERAGE-OFF$
   override def withValidationMode(mode: ValidationMode.Type): DFDL.DataProcessor = ???
-
   override def withTunable(name: String, value: String): DFDL.DataProcessor = ???
-
   override def withTunables(tunables: Map[String, String]): DFDL.DataProcessor = ???
-
   override def withExternalVariables(extVars: Map[String, String]): DFDL.DataProcessor = ???
-
   override def withExternalVariables(extVars: File): DFDL.DataProcessor = ???
-
   override def withExternalVariables(extVars: Seq[Binding]): DFDL.DataProcessor = ???
-
   override def withDebugger(dbg:AnyRef): DFDL.DataProcessor = ???
-  
   override def withDebugging(flag: Boolean): DFDL.DataProcessor = ???
-
-  override def validationMode: ValidationMode.Type = ???
-
-  override def getTunables(): DaffodilTunables = ???
-
   override def save(output: DFDL.Output): Unit = ???
-
+  override def tunables: DaffodilTunables = ???
   override def variableMap: VariableMap = ???
+  override def validationMode: ValidationMode.Type = ???
+  //$COVERAGE-ON$
 
   /**
    * Returns an object which contains the result, and/or diagnostic information.


### PR DESCRIPTION
Ensure nothing mentions the deprecated API removed in previous commits
for DAFFODIL-2743.  Also fix some IDEA nits and improve DataProcessor
constructor.

SchemaSet.scala: Simplify scaladoc to stop mentioning deprecated API.
Fix some IDEA nits in the same code block with IDEA quick fixes.

SchemaSetRuntime1Mixin.scala: Make onPath call first DataProcessor
constructor instead of now-deleted second constructor.

DataProcessor.scala: Make SerializedDataProcessor extend first
DataProcessor constructor instead of now-deleted second
constructor. Change first DataProcessor constructor from private to
public, reorder its last 4 parameters, and make its last 2 parameters
optional.  Delete second DataProcessor constructor and remove its
scaladoc which had been saying it was using deprecated
compilerExternalVars.  Make copy call first constructor with reordered
parameters.  Remove another scaladoc which had been mentioning tunables
not even passed to method anymore.

DAFFODIL-2743