### PR TITLE
Store the last added child in the PState for use in separator logic

### DIFF
--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/infoset/InfosetImpl.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/infoset/InfosetImpl.scala
@@ -1111,15 +1111,6 @@ final class DIArray(
 
   final def length: Long = _contents.length
 
-  final def maybeMostRecentlyAddedChild(): Maybe[DIElement] = {
-    val len = contents.length
-    if (len == 0) Maybe.Nope
-    else {
-      val e = _contents(len - 1)
-      Maybe(e)
-    }
-  }
-
   final def totalElementCount: Long = {
     var a: Long = 0
     _contents.foreach { c => a += c.totalElementCount }
@@ -1631,25 +1622,6 @@ sealed class DIComplex(override val erd: ElementRuntimeData)
       _numChildren = childNodes.length
     }
     e.setParent(this)
-  }
-
-  /**
-   * Needed because at the point in the code where we need the
-   * most recently added child, that node has already been popped from
-   * the stack and the current node is its parent. This let's us get
-   * a handle on the child just added without changing the invariants of
-   * the way the node stack is handled in the PState/UState.
-   */
-  def maybeMostRecentlyAddedChild(): Maybe[DIElement] = {
-    val len = contents.length
-    if (len == 0) Maybe.Nope
-    else {
-      val lastChild = contents(len - 1)
-      lastChild match {
-        case a: DIArray => a.maybeMostRecentlyAddedChild()
-        case e: DIElement => Maybe(e)
-      }
-    }
   }
 
   def addChildToFastLookup(node: DINode): Unit = {

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/infoset/InfosetWalker.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/infoset/InfosetWalker.scala
@@ -380,7 +380,7 @@ class InfosetWalker private (
 
     } else {
       // no blocks on the container, figure out if we can take a step for the
-      // element and the child index of this container 
+      // element at the child index of this container
 
       val children = containerNode.contents
 
@@ -398,6 +398,13 @@ class InfosetWalker private (
           // This is a simple element that is not final, i.e. we are still
           // doing some parsing for this simple element. Wait until we finish
           // that parse before stepping into it.
+          false
+        } else if (elem.isComplex && elem.numChildren == 0 && !elem.isFinal) {
+          // This is a complex element that has no children and is not final.
+          // This means we don't yet know if it's just an empty complex element
+          // or if it's a complex element that is going to be nilled. We'll
+          // know for sure once it has children or is made final, but for now,
+          // do not step into it.
           false
         } else {
           true

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/infoset/SAXInfosetOutputter.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/infoset/SAXInfosetOutputter.scala
@@ -218,7 +218,7 @@ class SAXInfosetOutputter(xmlReader: DFDL.DaffodilParseXMLReader,
     }
 
     // handle xsi:nil attribute
-    if (diElem.isNilled) {
+    if (isNilled(diElem)) {
       val isNilled = "true"
       val nType: String = "CDATA"
       val nValue: String = isNilled

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/ElementCombinator1.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/ElementCombinator1.scala
@@ -29,6 +29,8 @@ import org.apache.daffodil.processors.Success
 import org.apache.daffodil.processors.TermRuntimeData
 import org.apache.daffodil.util.Logger
 import org.apache.daffodil.util.Maybe
+import org.apache.daffodil.util.Maybe.Nope
+import org.apache.daffodil.util.Maybe.One
 
 abstract class ElementParserBase(
   rd: TermRuntimeData,
@@ -252,7 +254,7 @@ class ElementParser(
       }
     }
     Logger.log.debug(s"priorElement = ${priorElement}")
-    pstate.setParent(currentElement)
+    pstate.setInfoset(currentElement, Nope)
   }
 
   def parseEnd(pstate: PState): Unit = {
@@ -266,7 +268,7 @@ class ElementParser(
         // Execute checkConstraints
         validate(pstate)
       }
-      if (priorElement ne null) pstate.setParent(priorElement)
+      if (priorElement ne null) pstate.setInfoset(priorElement, One(currentElement))
       move(pstate)
     } else { // failure.
       if (priorElement ne null) {
@@ -274,7 +276,7 @@ class ElementParser(
         // But we do not remove the child here. That's done at the
         // point of uncertainty when it restores the state of the
         // element after a failure.
-        pstate.setParent(priorElement)
+        pstate.setInfoset(priorElement, One(currentElement))
       }
     }
   }

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/ExpressionEvaluatingParsers.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/ExpressionEvaluatingParsers.scala
@@ -35,6 +35,7 @@ import org.apache.daffodil.processors.TypeCalculator
 import org.apache.daffodil.processors.VariableRuntimeData
 import org.apache.daffodil.schema.annotation.props.gen.FailureType
 import org.apache.daffodil.util.Logger
+import org.apache.daffodil.util.Maybe.Nope
 
 /**
  * Common parser base class for any parser that evaluates an expression.
@@ -103,7 +104,8 @@ trait WithDetachedParser {
      */
 
     val priorElement = pstate.infoset
-    pstate.setParent(pstate.infoset.diParent)
+    val priorElementLastChild = pstate.infosetLastChild
+    pstate.setInfoset(pstate.infoset.diParent, Nope)
 
     // This isn't actually a point of uncertainty, we just use the logic to
     // allow resetting the infoset after we create the detached parser
@@ -123,7 +125,7 @@ trait WithDetachedParser {
       res
     }
 
-    pstate.setParent(priorElement)
+    pstate.setInfoset(priorElement, priorElementLastChild)
 
     ans
   }

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/SeparatedSequenceChildParseResultHelper.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/SeparatedSequenceChildParseResultHelper.scala
@@ -304,7 +304,7 @@ class NonPositionalGroupSeparatedSequenceChildParseResultHelper(
     mgrd: ModelGroupRuntimeData,
     requiredOptional: RequiredOptionalStatus): ParseAttemptStatus = {
     if (pstate.isSuccess) {
-      val maybeElem = pstate.infoset.asComplex.maybeMostRecentlyAddedChild()
+      val maybeElem = pstate.infosetLastChild
       Assert.invariant(maybeElem.isDefined)
       val elem = maybeElem.get
       val maybeIsNilled = elem.maybeIsNilled // can't just call isNilled because that throws exceptions on not defined

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/SequenceChildParseResultHelper.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/SequenceChildParseResultHelper.scala
@@ -166,7 +166,7 @@ trait ElementSequenceChildParseResultHelper
       currentBitPosAfterChild == prevBitPosBeforeChild
     }
     if (pstate.isSuccess) {
-      val maybeElem = pstate.infoset.asComplex.maybeMostRecentlyAddedChild()
+      val maybeElem = pstate.infosetLastChild
       Assert.invariant(maybeElem.isDefined)
       val elem = maybeElem.get
       val maybeIsNilled = elem.maybeIsNilled // can't just call isNilled because that throws exceptions on not defined

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section00/general/TestInfosetWalker.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section00/general/TestInfosetWalker.scala
@@ -35,6 +35,6 @@ class TestInfosetWalker {
 
   @Test def test_infosetWalker_01() = { runner2.runOneTest("infosetWalker_01") }
   // DAFFODIL-2755
-  /*@Test*/ def test_infosetWalker_02() = { runner2.runOneTest("infosetWalker_02") }
+  @Test def test_infosetWalker_02() = { runner2.runOneTest("infosetWalker_02") }
   @Test def test_infosetWalker_03() = { runner2.runOneTest("infosetWalker_03") }
 }


### PR DESCRIPTION
In some cases, separator logic needs knowledge about the most recently added child of an element. This is currently handled by examining the infoset and finding its last child element using the maybeMostRecentlyAddedChild function.

The problem with this approach is that the InfosetWalker is allowed to "release" elements from the infoset that it thinks are no longer needed. There isn't a good way to tell the infoset that these last children are potentially still needed for separator logic, and so it could actually release them prior to the separator logic trying to access them, which leads to a null pointer exception.

To fix this, this modifies the PState to add a slot for the last modified child of the current infoset element, and modifies the ElementParser's to set this state appropriately. This way, the InfosetWalker is free to remove elements as it normally does, but the last child is still available when needed.

This also removes the maybeMostRecentlyAddedChild functions since this kind of access to the infoset can lead to null pointers.

Also modifies the SAXInfosetOutputter to check isNilled correctly, which supports checking if complex elements are nilled without being final yet. For similar reasons, modifies the InfosetWalker so that it does not walk into Complex elements if there is a chance that it could be nilled and we might not be sure.

DAFFODIL-2755