### PR TITLE
Deep copy Attributes with SAX performance unparse command

### DIFF
--- a/daffodil-cli/src/main/scala/org/apache/daffodil/InfosetTypes.scala
+++ b/daffodil-cli/src/main/scala/org/apache/daffodil/InfosetTypes.scala
@@ -43,6 +43,7 @@ import org.xml.sax.ContentHandler
 import org.xml.sax.InputSource
 import org.xml.sax.XMLReader
 import org.xml.sax.Locator
+import org.xml.sax.helpers.AttributesImpl
 import org.xml.sax.helpers.DefaultHandler
 
 import org.apache.daffodil.api.DFDL
@@ -598,7 +599,7 @@ case class SAXInfosetHandler(dataProcessor: DataProcessor, forPerformance: Boole
       events += SaxEventStartDocument()
 
     override def startElement(uri: String, localName: String, qName: String, atts: Attributes): Unit =
-      events += SaxEventStartElement(uri, localName, qName, atts)
+      events += SaxEventStartElement(uri, localName, qName, new AttributesImpl(atts))
 
     override def startPrefixMapping(prefix: String, uri: String): Unit =
       events += SaxEventStartPrefixMapping(prefix, uri)


### PR DESCRIPTION
When running the CLI performance unparse command with the `-I sax` option, we deep copy all SAX events and convert them to array of objects so we can replay those events in the actual performance loop. This avoids the overhead of parsing the XML infoset when testing SAX.

However, we don't currently deep copy the Attributes parameter in the startElement function. So if a SAX XMLReader implementation reuses/mutates the same Attributes object for multiple calls to startEvent (which Xerces does), then all of our StartElement events will share the same Attributes object with mutated values, leading to unexpected failures.

To fix this, this creates an AttributesImpl object from the Attributes object passed into the startElement function, which takes a persistent snapshot that is safe to store in our array of events.

DAFFODIL-2400