### PR TITLE
Update CI workflows and build tools

### DIFF
--- a/.github/workflows/dependency-scan.yml
+++ b/.github/workflows/dependency-scan.yml
@@ -29,7 +29,7 @@ jobs:
   # This workflow contains a single job called "build"
   build:
     # The type of runner that the job will run on
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,8 +24,10 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+# Cancel CI runs in progress when a branch or pull request is updated.
+
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+  group: ${{ github.actor }}-${{ github.head_ref || github.ref_name }}-${{ github.workflow }}
   cancel-in-progress: true
 
 jobs:
@@ -40,7 +42,7 @@ jobs:
         distribution: [ temurin ]
         java_version: [ 8, 11, 17 ]
         scala_version: [ 2.12.17 ]
-        os: [ ubuntu-20.04, windows-2019 ]
+        os: [ ubuntu-22.04, windows-2022 ]
         include:
           - os: macos-12
             shell: bash
@@ -49,11 +51,11 @@ jobs:
             scala_version: 2.12.17
             env_cc: cc
             env_ar: ar
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             shell: bash
-            env_cc: clang-10
-            env_ar: llvm-ar-10
-          - os: windows-2019
+            env_cc: clang
+            env_ar: llvm-ar-14
+          - os: windows-2022
             shell: msys2 {0}
             env_cc: clang
             env_ar: llvm-ar
@@ -67,7 +69,7 @@ jobs:
       CC: ${{ matrix.env_cc }}
       SBT: sbt -J-Xms1024m -J-Xmx5120m -J-XX:ReservedCodeCacheSize=512m -J-XX:MaxMetaspaceSize=1024m ++${{ matrix.scala_version }} coverage
       SONARSCAN: ${{
-                     matrix.os == 'ubuntu-20.04' &&
+                     matrix.os == 'ubuntu-22.04' &&
                      matrix.java_version == '11' &&
                      matrix.scala_version == '2.12.17' &&
                      github.event_name == 'push' &&
@@ -195,7 +197,7 @@ jobs:
   single-commit:
     name: Single Commit Pull Request
     if: github.event_name == 'pull_request'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Check Single Commit
         uses: actions/github-script@v6.3.3

--- a/BUILD.md
+++ b/BUILD.md
@@ -19,16 +19,16 @@
 
 Daffodil's build requirements include:
 
-* JDK 8 or higher
-* SBT 0.13.8 or higher
+* Java 8 or higher
+* sbt 0.13.8 or higher
 * C compiler C99 or higher
 * Mini-XML Version 3.0 or higher
 
-You will need the Java Software Development Kit ([JDK]) and the Scala
-Build Tool ([SBT]) to build Daffodil, run all tests, create packages,
-and more.  You can install the latest [Java 11 LTS][JDK] version and
-the latest [SBT] version following their websites' instructions or
-install them using your operating system's package manager.
+You will need the Java Software Development Kit ([Java]) and the Scala
+Build Tool ([sbt]) to build Daffodil, run all tests, create packages,
+and more.  You can install the latest [Java LTS][Java] version and the
+latest [sbt] version following their websites' instructions or install
+them using your operating system's package manager.
 
 Since Daffodil now has a C backend as well as a Scala backend, you
 will need a C compiler supporting the [C99] standard or later and the
@@ -59,27 +59,27 @@ environment variables `CC` and `AR` to the clang binaries' names:
 
     export CC=clang AR=llvm-ar
 
-However, Fedora has no [sbt][SBT] package in its own repositories.
-You'll have to install the latest [SBT] version following its
+However, Fedora has no [sbt] package in its own repositories.
+You'll have to install the latest [sbt] version following its
 website's instructions.
 
 Now you can build Daffodil from source and the sbt and daffodil
 commands you type will be able to call the C compiler.
 
-## Ubuntu 20.04
+## Ubuntu
 
 You can use the `apt` package manager to install most of the tools
 needed to build Daffodil:
 
-    sudo apt install build-essential clang-10 clang-format-10 default-jdk git libmxml-dev
+    sudo apt install build-essential clang clang-format default-jdk git libmxml-dev
 
 If you want to use clang instead of gcc, you'll have to set your
 environment variables `CC` and `AR` to the clang binaries' names:
 
-    export CC=clang-10 AR=llvm-ar-10
+    export CC=clang AR=llvm-ar-14 # or llvm-ar-10 or whatever you have
 
-However, Ubuntu has no [sbt][SBT] package in its own repositories.
-You'll have to install the latest [SBT] version following its
+However, Ubuntu has no [sbt] package in its own repositories.
+You'll have to install the latest [sbt] version following its
 website's instructions.
 
 Now you can build Daffodil from source and the sbt and daffodil
@@ -87,7 +87,7 @@ commands you type will be able to call the C compiler.
 
 ## Windows 10
 
-Install the latest [Java 11 LTS][JDK] version and the latest [SBT]
+Install the latest [Java LTS][Java] version and the latest [sbt]
 version following their websites' instructions.
 
 Install [MSYS2] following its website's instructions and open a new
@@ -137,7 +137,7 @@ needed to build Daffodil:
     brew install llvm # needed by iwyu
     brew install include-what-you-use
     brew install libmxml
-    brew install openjdk@11
+    brew install openjdk
     brew install sbt
 
 Now you can build Daffodil from source and the sbt and daffodil
@@ -146,9 +146,9 @@ commands you type will be able to call the C compiler.
 [C99]: https://en.wikipedia.org/wiki/C99
 [EPEL]: https://docs.fedoraproject.org/en-US/epel/
 [Homebrew]: https://brew.sh/
-[JDK]: https://adoptopenjdk.net/
+[Java]: https://adoptium.net/
 [Mini-XML]: https://www.msweet.org/mxml/
 [MSYS2]: https://www.msys2.org/
-[SBT]: https://www.scala-sbt.org/
 [clang]: https://clang.llvm.org/get_started.html
 [gcc]: https://linuxize.com/post/how-to-install-gcc-on-ubuntu-20-04/
+[sbt]: https://www.scala-sbt.org/

--- a/DEVELOP.md
+++ b/DEVELOP.md
@@ -280,7 +280,7 @@ When an application uses Daffodil's Java or Scala API, it will need to
 put fewer Daffodil jars and third-party dependency jars on its
 classpath (omitting the jars needed only by Daffodil's CLI).  The best
 way for a Java or Scala application to use Daffodil is to get
-Daffodil's Java API from Maven or get Daffodil's Scala API from SBT:
+Daffodil's Java API from Maven or get Daffodil's Scala API from sbt:
 
 ```xml
 <dependency>
@@ -393,13 +393,13 @@ links to every website page (sorted in alphabetical order).
 ### Tests
 
 The majority of Daffodil tests are written inside TDML files with
-corresponding Scala unit tests which allow your IDE or SBT to run
+corresponding Scala unit tests which allow your IDE or sbt to run
 these tests within the TDML files.  Daffodil also has some pure Scala
 unit tests for testing smaller parts of Daffodil at a lower level.
 Both kinds of tests are important, although new Daffodil tests tend to
 be written in TDML and focus on testing issues with Daffodil's
 processing of DFDL schemas and parsing data or unparsing data.  You
-can run both kinds of tests with SBT using this command:
+can run both kinds of tests with sbt using this command:
 
 ```text
 sbt test
@@ -428,7 +428,7 @@ work on that issue more easily.  The developer is free to decide
 whether to define the schema and test data inline in the TDML file or
 leave the schema and test data in separate files which the TDML file
 reads.  For easier development, you can run TDML tests in the same
-directory without needing your IDE or SBT using this command:
+directory without needing your IDE or sbt using this command:
 
 ```text
 daffodil test nums.tdml
@@ -451,7 +451,7 @@ Daffodil also has integration tests in the daffodil-cli module which
 test Daffodil's command line interface.  If a developer changes any
 part of Daffodil's command line interface, the developer should test
 that change in an integration test too.  You can run integration tests
-with SBT using this command:
+with sbt using this command:
 
 ```text
 sbt IntegrationTest/test

--- a/README.md
+++ b/README.md
@@ -40,16 +40,17 @@ For more information about Daffodil, see <https://daffodil.apache.org/>.
 
 ## Build Requirements
 
-* JDK 8 or higher
-* SBT 0.13.8 or higher
+* Java 8 or higher
+* sbt 0.13.8 or higher
 * C compiler C99 or higher
 * Mini-XML Version 3.0 or higher
 
-See [BUILD.md](BUILD.md) for more details.
+See [BUILD.md](BUILD.md) for more details and [DEVELOP.md](DEVELOP.md)
+for a developer guide.
 
 ## Getting Started
 
-[SBT] is the officially supported tool to build Daffodil.  Below are
+[sbt] is the officially supported tool to build Daffodil.  Below are
 some of the more commonly used commands for Daffodil development.
 
 ### Compile
@@ -108,6 +109,6 @@ Apache Daffodil is licensed under the [Apache License, v2.0].
 [Daffodil JIRA]: https://issues.apache.org/jira/projects/DAFFODIL/
 [Github Actions]: https://github.com/apache/daffodil/actions?query=branch%3Amain+
 [Releases]: http://daffodil.apache.org/releases/
-[SBT]: https://www.scala-sbt.org/
 [Website]: https://daffodil.apache.org/
 [sbt-scoverage]: https://github.com/scoverage/sbt-scoverage/
+[sbt]: https://www.scala-sbt.org/

--- a/containers/release-candidate/Dockerfile
+++ b/containers/release-candidate/Dockerfile
@@ -42,7 +42,7 @@ RUN \
     winetricks && \
   dnf clean all
 
-# Enable SBT pgp plugin
+# Enable sbt-pgp plugin
 COPY src/plugins.sbt /root/.sbt/1.0/plugins/
 
 # Install wix, including changes to allow WiX to run in wine on Linux. See

--- a/daffodil-cli/build.sbt
+++ b/daffodil-cli/build.sbt
@@ -101,24 +101,24 @@ rpmPrefix := Some(defaultLinuxInstallLocation.value)
 //
 
 //
-// Here we set the variables that are supported by the SBT Native Packager plug-in.
+// Here we set the variables that are supported by the sbt Native Packager plug-in.
 // We also get fairly aggressive in editing/modifying the XML in order
 // to control and use some specific features that are supported by WiX
-// but which are not properly suported by the SBT plug-in.
+// but which are not properly suported by the sbt plug-in.
 //
 
 // Force the correct installation directory name. This overwrites
 // 'daffodil-cli', which is the directory that we invoke sbt in.
-// The SBT WiX plug-in incorrectly assumes that the directory of
+// The sbt WiX plug-in incorrectly assumes that the directory of
 // invocation is the same name as the direcotry you eventually
 // want to install into.
 Windows / name := "Daffodil"
 
-// The Windows packager SBT plug-in maps the packageSummary variable
+// The Windows packager sbt plug-in maps the packageSummary variable
 // into the WiX productName field. Another strange choice.
 Windows / packageSummary := "Daffodil"
 
-// The Windows packager SBT plug-in limits the length of the packageDescription
+// The Windows packager sbt plug-in limits the length of the packageDescription
 // field to a single line. Use the short packageSummary from the RPM config.
 Windows / packageDescription := (Rpm / packageSummary).value
 
@@ -179,7 +179,7 @@ wixFiles ++= Seq(
   (Windows / sourceDirectory).value / "WixUI_Daffodil.wxs",
 )
 
-// The SBT Native Packager plug-in assumes that we want to give the user
+// The sbt Native Packager plug-in assumes that we want to give the user
 // a Feature Tree to select from. One of the 'features' that the plug-in
 // offers up is a set of all shortcuts and menu links. Daffodil is
 // actually a command-line executable, so we do not include

--- a/daffodil-cli/src/windows/Product_en-us.wxl
+++ b/daffodil-cli/src/windows/Product_en-us.wxl
@@ -21,14 +21,14 @@
    <String Id="ApplicationName">Daffodil</String>
    <String Id="ManufacturerName">Apache</String>
    
-   <!-- SBT Native Packager plug-in uses 'ManufacturerFullName' instead of 'ManufacturerName'. -->
+   <!-- sbt Native Packager plug-in uses 'ManufacturerFullName' instead of 'ManufacturerName'. -->
    <!-- This doesn't matter most places, but in the directory structure we have to be short and have no spaces. -->
    <String Id="ManufacturerFullName">Apache</String>
    
-   <!-- SBT Native Packager plug-in uses 'ProductDescription' as the title on the installer window. -->
+   <!-- sbt Native Packager plug-in uses 'ProductDescription' as the title on the installer window. -->
    <String Id="ProductDescription">Daffodil Installer</String>
    
-   <!-- SBT Native Packager plug-in does not support comments, so this next line is ignored. -->
+   <!-- sbt Native Packager plug-in does not support comments, so this next line is ignored. -->
    <String Id="Comments">Installs Daffodil</String>
  
    <!-- Set up the License Agreement dialog. -->

--- a/daffodil-runtime2/src/main/resources/org/apache/daffodil/runtime2/c/Makefile
+++ b/daffodil-runtime2/src/main/resources/org/apache/daffodil/runtime2/c/Makefile
@@ -36,10 +36,11 @@ $(PROGRAM): $(HEADERS) $(SOURCES)
 	$(CC) $(CFLAGS) $(INCLUDES) $(SOURCES) $(LIBS) -o $(PROGRAM)
 
 # Step 1.5: Run the tests if you are a developer making changes to the
-# C code, otherwise you can skip this step.  On Ubuntu 20.04, you will
-# need to manually build and install a C test framework library called
-# Criterion (https://github.com/Snaipe/Criterion); note building
-# Criterion requires meson ninja-build libffi-dev libgit2-dev.
+# C code, otherwise you can skip this step.  On Ubuntu, you will need
+# to manually build and install a C test framework library called
+# Criterion (https://github.com/Snaipe/Criterion).  Also note that
+# building Criterion from source will require running "sudo apt
+# install meson ninja-build libffi-dev libgit2-dev" first.
 
 TPROGRAM = ./ctests
 EXCLUDES = %/daffodil_main.c %/generated_code.c

--- a/daffodil-sapi/src/test/scala/org/apache/daffodil/example/TestScalaAPI.scala
+++ b/daffodil-sapi/src/test/scala/org/apache/daffodil/example/TestScalaAPI.scala
@@ -107,10 +107,10 @@ class TestScalaAPI {
    *
    * Note that this function contains an ObjectInputStream for
    * deserialization, but one that is extended to override the resolveClass
-   * function. This override is necessary to work around a bug when running
-   * tests in SBT that causes an incorrect class loader to be used. Normal
-   * users of the Scala API should not need this and can serialize/deserialize
-   * as one would normally do with a standard Object{Input,Output}Stream.
+   * function. This override is necessary because running tests in sbt causes
+   * an incorrect class loader to be used. Normal users of the Scala API
+   * should not need this and can serialize/deserialize as one would normally
+   * do with a standard Object{Input,Output}Stream.
    */
   private def reserializeDataProcessor(dp: DataProcessor): DataProcessor = {
     val baos = new ByteArrayOutputStream()
@@ -121,9 +121,9 @@ class TestScalaAPI {
     val bais = new ByteArrayInputStream(baos.toByteArray())
     val ois = new ObjectInputStream(bais) {
       /**
-       * This override is here because of a bug in sbt where the wrong class loader is being
-       * used when deserializing an object.
-       * For more information, see https://github.com/sbt/sbt/issues/163
+       * This override is here because running tests in sbt causes the wrong
+       * class loader to be used when deserializing an object.  For more
+       * information, see https://github.com/sbt/sbt/issues/163
        */
       override protected def resolveClass(desc: java.io.ObjectStreamClass): Class[_] = {
         try {


### PR DESCRIPTION
Tell CI not to cancel runs from 2 or more PRs made from the same head ref.  Bump older tools or names to newer tools or names.

dependency-scan.yml: Bump ubuntu from 20.04 to 22.04.

main.yml: Add github.actor to concurrency.group to avoid cancelling runs when 2 or more contributors make PRs from the same head ref (saw fix elsewhere, copy it just in case).  Bump ubuntu and its env_cc, env_ar from 20.04 to 22.04.  Also bump windows-2019 to windows-2022.

BUILD.md: Modernize build instructions by using more correct names Java/sbt instead of JDK/SBT, removing unneeded version numbers, and changing Java URL to Adoptium instead of AdoptOpenJDK.

DEVELOP.md: Use more correct name sbt instead of SBT.

README.md: Use more correct names Java/sbt instead of JDK/SBT.

Dockerfile: Use more correct name sbt instead of SBT.

daffodil-cli/build.sbt: Use more correct name sbt instead of SBT.

Product_en-us.wxl: Use more correct name sbt instead of SBT.

c/Makefile: Remove Ubuntu version to avoid updating Makefile again.

TestScalaAPI.scala: Use more correct name sbt instead of SBT (https://www.scala-sbt.org/1.x/docs/Faq.html).

DAFFODIL-2756