### PR TITLE
Change message to use propName instead of propNameArg

### DIFF
--- a/daffodil-lib/src/main/scala/org/apache/daffodil/cookers/EntityReplacer.scala
+++ b/daffodil-lib/src/main/scala/org/apache/daffodil/cookers/EntityReplacer.scala
@@ -657,7 +657,7 @@ sealed abstract class ListOfStringLiteralBase(propNameArg: String,
       val wsVisible = Misc.remapCodepointToVisibleGlyph(ws.toChar).toChar
       val hexCodePoint = "%04x".format(ws.toInt)
       context.SDE("The property '%s' cannot start or end with the string \"%s\"(Unicode hex code point U+%s), or consist entirely of whitespace."
-        + "\nDid you mean to use character entities like '%%SP;' or '%%NL;' to indicate whitespace in the data format instead?", propNameArg, wsVisible, hexCodePoint)
+        + "\nDid you mean to use character entities like '%%SP;' or '%%NL;' to indicate whitespace in the data format instead?", propName, wsVisible, hexCodePoint)
     }
 
     val rawList = raw.split("\\s+").toList


### PR DESCRIPTION
The diagnostic message uses the value of `propNameArg` which could be set to null. The `propName` variable contains an auto-generated value when one is not provided in the constructor.

[DAFFODIL-2647](https://issues.apache.org/jira/browse/DAFFODIL-2647)