### PR TITLE
Require the first schema to include the DFDL namespace.

### DIFF
--- a/daffodil-test/src/test/resources/org/apache/daffodil/section00/general/otherAnnotationLanguage2.xsd
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section00/general/otherAnnotationLanguage2.xsd
@@ -17,20 +17,15 @@
 -->
 
 <schema xmlns="http://www.w3.org/2001/XMLSchema"
-  targetNamespace="urn:otherAnnotationLanguage" 
-  xmlns:tns="urn:otherAnnotationLanguage"
+  targetNamespace="urn:otherAnnotationLanguage2"
+  xmlns:tns="urn:otherAnnotationLanguage2"
   xmlns:xs="http://www.w3.org/2001/XMLSchema"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
   xmlns:fn="http://www.w3.org/2005/xpath-functions">
 
-  <!--
-  Check that other language schemas can be properly nested.
-  -->
-  <xs:import namespace="urn:otherAnnotationLanguage2" schemaLocation="otherAnnotationLanguage2.xsd" />
-
-  <element name="otherAnnotation">
+  <element name="otherAnnotation2">
     <complexType>
-       <attribute ref="tns:otherAnnotationAttribute"/>
+       <attribute ref="tns:otherAnnotationAttribute2"/>
     </complexType>
   </element>
 
@@ -39,6 +34,6 @@
   have attributes. These attributes should be legal in DFDL, as they're not describing data, they're
   just describing annotations on the schema that a DFDL processor should be ignoring.
    -->
-  <attribute name="otherAnnotationAttribute" type="string"/>
+  <attribute name="otherAnnotationAttribute2" type="string"/>
 
 </schema>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section00/general/schemaWithoutDFDLNamespace.xsd
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section00/general/schemaWithoutDFDLNamespace.xsd
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<schema xmlns="http://www.w3.org/2001/XMLSchema"
+        targetNamespace="http://example.com">
+  <element name="root"/>
+</schema>
+

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section00/general/testSchemaWithoutDFDLNamespace.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section00/general/testSchemaWithoutDFDLNamespace.tdml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<tdml:testSuite suiteName="SchemaWithoutDFDLNamespace"
+                description="Tests that an error is generated if the top-level document is not in the DFDL namespace"
+                xmlns:tdml="http://www.ibm.com/xmlns/dfdl/testData"
+                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                xmlns:ex="http://example.com"
+                xmlns:tns="urn:foo"
+                xmlns:daf="urn:ogf:dfdl:2013:imp:daffodil.apache.org:2018:ext"
+                xmlns:oth="urn:otherAnnotationLanguage">
+
+
+  <tdml:parserTestCase name="schemaWithoutDFDLNamespace" root="root" model="schemaWithoutDFDLNamespace.xsd">
+    <tdml:document>foo</tdml:document>
+    <tdml:errors>
+      <tdml:error>Non-DFDL Schema file</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+</tdml:testSuite>

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section00/general/TestSchemaWithoutDFDLNamespace.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section00/general/TestSchemaWithoutDFDLNamespace.scala
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.daffodil.section00.general
+
+import org.apache.daffodil.tdml.Runner
+import org.junit.AfterClass
+import org.junit.Test
+
+object TestSchemaWithoutDFDLNamespace {
+  val testDir = "/org/apache/daffodil/section00/general/"
+  val runner: Runner = Runner(testDir, "testSchemaWithoutDFDLNamespace.tdml")
+
+  @AfterClass def shutDown(): Unit = {
+    runner.reset()
+  }
+}
+
+class TestSchemaWithoutDFDLNamespace {
+
+  import TestSchemaWithoutDFDLNamespace._
+
+  @Test def test_schemaWithoutDFDLNamespace(): Unit = { runner.runOneTest("schemaWithoutDFDLNamespace") }
+
+}


### PR DESCRIPTION
If a schema document is passed to Daffodil that does not contain a DFDL namespace, it is currently ignored and a warning is emitted. If this is the only document then no operation actually occurs and this condition can be masked when warnings are disabled. Enforce the first schema to include the DFDL namespace but emit warnings on subsequent imports or inclusions.

[DAFFODIL-2441](https://issues.apache.org/jira/browse/DAFFODIL-2441)