### PR TITLE
Fixed issue where text alignment was expected for enum

### DIFF
--- a/daffodil-core/src/main/scala/org/apache/daffodil/dsom/ElementBase.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/dsom/ElementBase.scala
@@ -573,7 +573,7 @@ trait ElementBase
         // how explicit alignment interacts with text characters, or with binary packed decimal - as text chars
         // and packed decimal digits come with alignment constraints of their own.
         //
-        impliedRepresentation match {
+        repElement.impliedRepresentation match {
           case Representation.Text => {
             //
             // If they have text representation, alignment and the text encoding alignment must be compared.

--- a/daffodil-test/src/test/resources/org/apache/daffodil/extensions/enum/enums.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/extensions/enum/enums.tdml
@@ -109,4 +109,63 @@
     </errors>
   </unparserTestCase>
 
+  <tdml:defineSchema
+    name="s2"
+    useDefaultNamespace="false"
+    elementFormDefault="unqualified"
+    xmlns="http://www.w3.org/2001/XMLSchema">
+
+    <include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+    <dfdl:format ref="ex:GeneralFormat" representation="binary"
+      alignment="1" alignmentUnits="bits"
+      lengthUnits="bits"/>
+
+    <element name="r1">
+      <complexType>
+        <sequence>
+          <element name="e1" type="ex:enum1"/>
+          <element name="e2" type="ex:enum1"/>
+          <element name="e3" type="ex:enum1"/>
+          <element name="e4" type="ex:enum1"/>
+          <element name="e5" type="ex:enum1"/>
+          <element name="e6" type="ex:enum1"/>
+          <element name="e7" type="ex:enum1"/>
+          <element name="e8" type="ex:enum1"/>
+        </sequence>
+      </complexType>
+    </element>
+
+    <simpleType name="myBit" dfdl:lengthKind="explicit" dfdl:length="1">
+      <restriction base="xs:byte"/>
+    </simpleType>
+
+    <simpleType name="enum1" dfdlx:repType="ex:myBit">
+      <restriction base="xs:string">
+        <enumeration value="validA" dfdlx:repValues="0"/>
+        <enumeration value="validB" dfdlx:repValues="1"/>
+      </restriction>
+    </simpleType>
+
+  </tdml:defineSchema>
+
+  <parserTestCase name="repTypeAlignment" model="s2" root="r1">
+    <document>
+      <documentPart type="bits">01010101</documentPart>
+    </document>
+    <infoset>
+      <tdml:dfdlInfoset xmlns="">
+        <ex:r1>
+          <e1>validA</e1>
+          <e2>validB</e2>
+          <e3>validA</e3>
+          <e4>validB</e4>
+          <e5>validA</e5>
+          <e6>validB</e6>
+          <e7>validA</e7>
+          <e8>validB</e8>
+        </ex:r1>
+      </tdml:dfdlInfoset>
+    </infoset>
+  </parserTestCase>
+
 </testSuite>

--- a/daffodil-test/src/test/scala/org/apache/daffodil/extensions/TestEnums.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/extensions/TestEnums.scala
@@ -38,4 +38,5 @@ class TestEnums {
   @Test def test_enumInvalid1(): Unit = { runner.runOneTest("enumInvalid1") }
   @Test def test_enumMiss1(): Unit = { runner.runOneTest("enumMiss1") }
 
+  @Test def test_repTypeAlignment(): Unit = { runner.runOneTest("repTypeAlignment") }
 }


### PR DESCRIPTION
This small change checks against the repElement (the dfdx:repType) instead of the represented element in the enumeration (typically a string).

In the past we would typically expect the alignment to line up with whatever encoding was used for strings, but when using 1-bit alignment, daffodil wouuld complain about the strings being unaligned even though they are internally represented by something other than a string that is 1-bit aligned.

Now we check to see what kind of representation (text or binary) the repElement is and check alignment based on that.

DAFFODIL-2596