### PR TITLE
Implement textNumberPattern 'V' virtual decimal point.

### DIFF
--- a/daffodil-core/src/main/scala/org/apache/daffodil/grammar/ElementBaseGrammarMixin.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/grammar/ElementBaseGrammarMixin.scala
@@ -642,7 +642,7 @@ trait ElementBaseGrammarMixin
 
   private lazy val textConverter = {
     primType match {
-      case _: NodeInfo.Numeric.Kind => ConvertTextNumberPrim(this)
+      case _: NodeInfo.Numeric.Kind => ConvertTextStandardNumberPrim(this)
       case PrimType.Boolean => ConvertTextBooleanPrim(this)
       case PrimType.Date => ConvertTextDatePrim(this)
       case PrimType.Time => ConvertTextTimePrim(this)

--- a/daffodil-core/src/main/scala/org/apache/daffodil/grammar/primitives/PrimitivesTextNumber.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/grammar/primitives/PrimitivesTextNumber.scala
@@ -18,16 +18,15 @@
 package org.apache.daffodil.grammar.primitives
 
 import com.ibm.icu.text.DecimalFormat
-
-
 import org.apache.daffodil.cookers.EntityReplacer
 import org.apache.daffodil.dpath.NodeInfo.PrimType
 import org.apache.daffodil.dsom._
+import org.apache.daffodil.exceptions.Assert
 import org.apache.daffodil.grammar.Gram
 import org.apache.daffodil.grammar.Terminal
 import org.apache.daffodil.processors.Delimiter
 import org.apache.daffodil.processors.parsers.ConvertTextCombinatorParser
-import org.apache.daffodil.processors.parsers.ConvertTextNumberParser
+import org.apache.daffodil.processors.parsers.ConvertTextStandardNumberParser
 import org.apache.daffodil.processors.parsers.Parser
 import org.apache.daffodil.processors.TextNumberFormatEv
 import org.apache.daffodil.processors.unparsers.ConvertTextCombinatorUnparser
@@ -46,8 +45,249 @@ case class ConvertTextCombinator(e: ElementBase, value: Gram, converter: Gram)
   override lazy val unparser = new ConvertTextCombinatorUnparser(e.termRuntimeData, value.unparser, converter.unparser)
 }
 
-case class ConvertTextNumberPrim(e: ElementBase)
-  extends Terminal(e, true) {
+// This is a separate object for unit testing purposes.
+private[primitives]
+object TextNumberPatternUtils {
+
+  /**
+   * A regex which matches textNumberPatterns that legally use the V
+   * (implied decimal point) character.
+   */
+   private[primitives] lazy val vregexStandard = {
+    //  DFDL v1.0 Spec says
+    //  It is a Schema Definition Error if any symbols other than "0", "1" through "9" or #
+    //  are used in the vpinteger region of the pattern.
+    //
+    // The prefix and suffix chars can surround the vpinteger region, and there can be
+    // a positive and a negative pattern.
+    //
+    // The prefix and suffix cannot be digits, # or P or V. No quoted chars in prefix either.
+    //
+     val prefixChars = """[^0-9#PV']?""" // same for suffix.
+     val beforeVChars = """#*[0-9]+"""
+     val afterVChars = """[0-9]+"""
+     //
+     // Each of the capture groups is defined here in order
+     //
+     val posPrefix = s"""($prefixChars)"""
+     val posBeforeV = s"""($beforeVChars)"""
+     val posAfterV = s"""($afterVChars)"""
+     val posSuffix = posPrefix
+     val negPrefix = posPrefix
+     val negBeforeV = posBeforeV
+     val negAfterV = posAfterV
+     val negSuffix = posPrefix
+     // don't forget the ^ and $ (start of data, end of data) because we want
+     // the match to consume all the characters, starting at the beginning.
+    val vPattern=
+     s"""^${posPrefix}${posBeforeV}V${posAfterV}${posSuffix}(?:;${negPrefix}${negBeforeV}V${negAfterV}${negSuffix})?$$"""
+    val re = vPattern.r
+    re
+  }
+
+
+
+  private[primitives] lazy val vregexZoned= {
+    // Note: for zoned, can only have a positive pattern
+    // Prefix or suffix can only be '+' character, to
+    // indicate leading or trailing sign, and can only
+    // one of those.
+    //
+    // Also we're not allowing the # character, since I think that
+    // makes no sense for zoned with virtual decimal point.
+    //
+    val prefixChars = """\+?""" // only + for prefix/suffix
+    val aroundVChars = """[0-9]+"""
+    //
+    // capture groups are defined here in sequence
+    //
+    val prefix = s"""($prefixChars)"""
+    val beforeV = s"""($aroundVChars)"""
+    val afterV = beforeV
+    val suffix = prefix
+    val vPattern = s"""^${prefix}${beforeV}V${afterV}${suffix}$$""" // only positive pattern allowed
+    val re = vPattern.r
+    re
+  }
+
+  /**
+   * Checks a pattern for suitability with V (virtual decimal point) in the pattern
+   * in the context of zoned textNumberRep.
+   *
+   * This is broken out separately for unit testing purposes.
+   *
+   * @param patternStripped the dfdl:textNumberPattern pattern - with all quoting removed.
+   * @return None if the pattern is illegal syntax for use with V (virtual decimal point)
+   *         otherwise Some(N) where N is the number of digits to the right of the V character.
+   */
+  private[primitives] def textDecimalVirtualPointForZoned(patternStripped: String): Option[Int] = {
+    val r = TextNumberPatternUtils.vregexZoned
+    r.findFirstMatchIn(patternStripped) match {
+      // note: cannot have both a prefix and suffix. Only one of them.
+      case Some(r(pre, _, afterV, suf)) if (pre.length + suf.length <= 1) => Some(afterV.length)
+      case _ => None
+    }
+  }
+
+  /**
+   * The apos character (') is the quoting character in ICU patterns (and DFDL textNumberPattern).
+   * This removes any unquoted P or V characters (which are not implemented by ICU)
+   * leaving a pattern string that is suitable for use with ICU.
+   * @param pattern the textNumberPattern string
+   * @return the pattern string with all unquoted P and unquoted V removed.
+   */
+  def removeUnquotedPV(pattern: String) : String = {
+    val uniqueQQString = "alsdflslkjskjslkkjlkkjfppooiipsldsflj"
+    // A single regex that matches an unquoted character
+    // where the quoting char is self quoting requires
+    // a zero-width look behind that matches a potentially
+    // unbounded number of quote chars. That's not allowed.
+    //
+    // Consider ''''''P. We want a regex that matches only the P here
+    // because it is preceded by an even number of quotes.
+    //
+    // I did some tests, and the formulations you think might work
+    // such as from stack-overflow, don't work.
+    // (See test howNotToUseRegexLookBehindWithReplaceAll)
+    //
+    // So we use this brute force technique of replacing all ''
+    // first, so we have only single quotes to deal with.
+    pattern.replaceAll("''", uniqueQQString).
+      replaceAll("(?<!')P", "").
+      replaceAll("(?<!')V", "").
+      replaceAll(uniqueQQString, "''")
+  }
+}
+
+trait ConvertTextNumberMixin {
+
+  def e: ElementBase
+
+  /**
+   * Convenience. The original value of textNumberPattern
+   */
+  @inline
+  final protected def pattern = e.textNumberPattern
+
+  /**
+   * Checks a pattern for suitability with V (virtual decimal point) in the pattern
+   * in the context of the corresponding textNumberRep. Computes number of digits to right of the V.
+   *
+   * SDE if pattern has a syntax error.
+   *
+   * @return the number of digits to the right of the V character. Must be 1 or greater.
+   *
+   */
+  protected def textDecimalVirtualPointFromPattern: Int
+
+  /**
+   * The pattern with escaped characters removed.
+   * This can be reliably searched for pattern characters,
+   * but cannot be used as an operational pattern given that
+   * potentially lots of things have been removed from it.
+   */
+  final protected lazy val patternStripped = {
+    // note: tick == apos == ' == single quote.
+    // First remove entirely all escaped ticks ie., ''
+    val noEscapedTicksRegex = """''""".r
+    val patternNoEscapedTicks = noEscapedTicksRegex.replaceAllIn(pattern, "")
+    // Next remove all tick-escaped characters entirely
+    val noQuotedRegex = """'[^']+'""".r
+    val patternNoQuoted = noQuotedRegex.replaceAllIn(patternNoEscapedTicks, "")
+    // the remaining string contains only pattern special characters
+    // and regular non-pattern characters
+    patternNoQuoted
+  }
+
+  protected final lazy val hasV = patternStripped.contains("V")
+  protected final lazy val hasP = patternStripped.contains("P")
+
+  /**
+   * analogous to the property dfdl:binaryDecimalVirtualPoint
+   *
+   * Value is 0 if there is no virtual decimal point.
+   * Value is the number of digits to the right of the 'V'
+   */
+  final lazy val textDecimalVirtualPoint: Int = {
+    if (!hasV && !hasP) 0 // no virtual point
+    else {
+      if (hasP) {
+        e.notYetImplemented("textNumberPattern with P symbol")
+      }
+      Assert.invariant(hasV)
+      //
+      // check for things incompatible with "V"
+      //
+      val virtualPoint = textDecimalVirtualPointFromPattern
+      Assert.invariant(virtualPoint >= 1) // if this fails the regex is broken.
+      virtualPoint
+    }
+  }
+
+  //
+  // We need 2 patterns
+  // 1. The original textNumberPattern string from the schema
+  // 2. Same but with the P or V removed.
+  //
+  // We need to use the original textNumberPattern in diagnostic messages
+  // since that's what the schema author wrote and expects to see.
+  // But if the pattern has P or V, then we need ICU at runtime to use the original
+  // but with the P or V removed since the P and V don't actually represent anything in the data.
+  final protected lazy val runtimePattern = {
+    if (hasV || hasP) {
+      val patternWithoutPV = TextNumberPatternUtils.removeUnquotedPV(pattern)
+      patternWithoutPV
+    }
+    else pattern
+  }
+
+  final protected def checkPatternWithICU(e: ElementBase) = {
+    // Load the pattern to make sure it is valid
+    try {
+      if (hasV || hasP) {
+        new DecimalFormat(runtimePattern)
+      } else {
+        new DecimalFormat(pattern)
+      }
+    } catch {
+      case ex: IllegalArgumentException =>
+        if (hasV || hasP) {
+          // we don't know what the diagnostic message will say here
+          // since it is from the ICU library.
+          // That library has only seen the pattern with the P and V
+          // removed. The messages might show that pattern which would
+          // confuse the schema author since that's not the pattern
+          // they wrote.
+          //
+          // So we try to explain....
+          e.SDE(
+            """Invalid textNumberPattern.
+              | The errors are about the pattern with the P (decimal scaling position)
+              | and V (virtual decimal point) characters removed: %s""".stripMargin, ex)
+        } else {
+          e.SDE("Invalid textNumberPattern: %s", ex)
+        }
+    }
+  }
+}
+
+case class ConvertTextStandardNumberPrim(e: ElementBase)
+  extends Terminal(e, true)
+  with ConvertTextNumberMixin {
+
+  final override protected lazy val textDecimalVirtualPointFromPattern: Int = {
+    val r = TextNumberPatternUtils.vregexStandard
+    r.findFirstMatchIn(patternStripped) match {
+      case Some(r(_, _, afterV, _, _, _, _, _)) => afterV.length
+      case None =>
+        e.SDE(
+          s"""The dfdl:textNumberPattern '%s' contains 'V' (virtual decimal point).
+             | Other than the sign indicators, it can contain only
+             | '#', then digits 0-9 then 'V' then digits 0-9.
+             | The positive part of the dfdl:textNumberPattern is mandatory.""".stripMargin('|'),
+          pattern)
+    }
+  }
 
   val zeroRepsRaw = e.textStandardZeroRep.filter { _ != "" }
   val zeroRepsRegex = zeroRepsRaw.map { zr =>
@@ -63,36 +303,23 @@ case class ConvertTextNumberPrim(e: ElementBase)
     EntityReplacer { _.replaceForUnparse(zr) }
   }
 
-  val textNumberFormatEv: TextNumberFormatEv = {
-    val (pattern, patternStripped) = {
-      val p = e.textNumberPattern
+  lazy val textNumberFormatEv: TextNumberFormatEv = {
 
-      if (p.startsWith(";")) {
-        e.SDE("Invalid textNumberPattern: The postive number pattern is mandatory")
+    if (textDecimalVirtualPoint > 0) {
+      e.primType match {
+        case PrimType.Double | PrimType.Float | PrimType.Decimal => // ok
+        case _ => e.SDE("The dfdl:textNumberPattern has a virtual decimal point 'V', but the type is an integer-only type: %s." ++
+          "The type must be xs:decimal, xs:double, or xs:float", e.primType.globalQName.toPrettyString)
+
       }
-
-      val noEscapedTicksRegex = """''""".r
-      val patternNoEscapedTicks = noEscapedTicksRegex.replaceAllIn(p, "")
-      val noQuotedRegex = """'[^']+'""".r
-      val patternNoQuoted = noQuotedRegex.replaceAllIn(patternNoEscapedTicks, "")
-
-      if (patternNoQuoted.contains("V")) {
-        e.notYetImplemented("textNumberPattern with V symbol")
-      }
-
-      if (patternNoQuoted.contains("P")) {
-        e.notYetImplemented("textNumberPattern with P symbol")
-      }
-
-      // Load the pattern to make sure it is valid
-      try {
-        new DecimalFormat(p)
-      } catch {
-        case ex: IllegalArgumentException => e.SDE("Invalid textNumberPattern: " + ex.getMessage())
-      }
-
-      (p, patternNoQuoted)
+      e.schemaDefinitionUnless(e.textStandardBase == 10,
+        "The dfdl:textNumberPattern 'V' (virtual decimal point) requires that " +
+          "dfdl:textStandardBase is 10, but its value was %s",
+        e.textStandardBase)
     }
+
+    e.schemaDefinitionWhen(pattern.startsWith(";"), "The positive part of the dfdl:textNumberPattern is required. The dfdl:textNumberPattern cannot begin with ';'.")
+    checkPatternWithICU(e)
 
     val (roundingIncrement: MaybeDouble, roundingMode) =
       e.textNumberRounding match {
@@ -114,7 +341,7 @@ case class ConvertTextNumberPrim(e: ElementBase)
     // group and decimal separators, even if the pattern doesn't contain the
     // associated character. This is because even when the pattern does not
     // contain the grouping/decimal separators, ICU stills seems to take the
-    // separators into account. And since ICU provides defaut values based on
+    // separators into account. And since ICU provides default values based on
     // locales, not setting them can cause subtle locale related bugs. We must
     // also require the separators if the prim type is not an integer type,
     // since ICU will use them even if the pattern does not specify them.
@@ -145,7 +372,7 @@ case class ConvertTextNumberPrim(e: ElementBase)
       infRep,
       nanRep,
       e.textNumberCheckPolicy,
-      pattern,
+      runtimePattern,
       e.textNumberRounding,
       roundingMode,
       roundingIncrement,
@@ -156,7 +383,9 @@ case class ConvertTextNumberPrim(e: ElementBase)
     ev
   }
 
-  lazy val parser: Parser = new ConvertTextNumberParser(textNumberFormatEv, zeroRepsRegex, e.elementRuntimeData)
+  lazy val parser: Parser =
+    new ConvertTextStandardNumberParser(textNumberFormatEv, zeroRepsRegex, e.elementRuntimeData, textDecimalVirtualPoint)
 
-  override lazy val unparser: Unparser = new ConvertTextNumberUnparser(textNumberFormatEv, zeroRepUnparse, e.elementRuntimeData)
+  override lazy val unparser: Unparser =
+    new ConvertTextNumberUnparser(textNumberFormatEv, zeroRepUnparse, e.elementRuntimeData, textDecimalVirtualPoint)
 }

--- a/daffodil-core/src/test/scala/org/apache/daffodil/grammar/primitives/TestPrimitives.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/grammar/primitives/TestPrimitives.scala
@@ -1,0 +1,159 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.daffodil.grammar.primitives
+
+import org.apache.daffodil.Implicits.intercept
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.Assert.fail
+
+import java.util.regex.PatternSyntaxException
+
+class TestPrimitives {
+
+  @Test def testVRegexPositiveAndNegativeWithPrefixesAndSuffixes() : Unit = {
+    val re = TextNumberPatternUtils.vregexStandard
+    val Some(myMatch) = re.findFirstMatchIn("A###012V34B;C####56V78D")
+    myMatch match {
+      case re("A", "###012", "34", "B", "C", "####56", "78", "D") => // ok
+    }
+  }
+
+  @Test def testVRegexOnlyPositivePattern(): Unit = {
+    val re = TextNumberPatternUtils.vregexStandard
+    val Some(myMatch) = re.findFirstMatchIn("A###012V34B")
+    myMatch match {
+      case re("A", "###012", "34", "B", null, null, null, null) =>
+    }
+  }
+
+  @Test def testVRegexOnlyPositivePatternNoPrefixNorSuffix(): Unit = {
+    val re = TextNumberPatternUtils.vregexStandard
+    val Some(myMatch) = re.findFirstMatchIn("###012V34")
+    myMatch match {
+      case re("", "###012", "34", "", null, null, null, null) =>
+    }
+  }
+
+  @Test def testVRegexTrailingSign(): Unit = {
+    val re = TextNumberPatternUtils.vregexStandard
+    val Some(myMatch) = re.findFirstMatchIn("012V34+") // for zoned, overpunched trailing sign.
+    myMatch match {
+      case re("", "012", "34", "+", null, null, null, null) =>
+    }
+  }
+
+  @Test def testVRegexZonedLeadingSign(): Unit = {
+    val re = TextNumberPatternUtils.vregexZoned
+    val optMyMatch = re.findFirstMatchIn("+012V34") // for zoned, overpunched leading sign.
+    val Some(re("+", "012", "34", "")) = optMyMatch
+  }
+
+  @Test def testVRegexZonedTrailingSign(): Unit = {
+    val re = TextNumberPatternUtils.vregexZoned
+    val optMyMatch = re.findFirstMatchIn("012V34+") // for zoned, overpunched trailing sign.
+    val Some(re("", "012", "34", "+")) = optMyMatch
+  }
+
+  @Test def testVRegexZonedNothingAfterSuffix(): Unit = {
+    val re = TextNumberPatternUtils.vregexZoned
+    val optMyMatch = re.findFirstMatchIn("012V34+garbage") // for zoned, overpunched trailing sign.
+    optMyMatch match {
+      case Some(re("", "012", "34", "+")) => fail("accepted trash at end of pattern")
+      case None => // ok
+    }
+  }
+
+  @Test def testVRegexZonedSignNotPlus(): Unit = {
+    val re = TextNumberPatternUtils.vregexZoned
+    val optMyMatch = re.findFirstMatchIn("A012V34")
+    optMyMatch match {
+      case Some(x @ re(_*)) => fail(s"accepted A as leading sign: $x")
+      case None => // ok
+    }
+  }
+
+  @Test def testVRegexZonedTwoSigns(): Unit = {
+    assertTrue(
+      TextNumberPatternUtils.textDecimalVirtualPointForZoned("+012V34+").isEmpty
+    )
+  }
+
+  @Test def testRemoveUnquotedPAndV_01(): Unit = {
+    val actually = "zVz''Va'PPP'''V'b'''"
+    val expected = "zz''a'P'''V'b'''"
+    assertEquals(expected, TextNumberPatternUtils.removeUnquotedPV(actually))
+  }
+
+  @Test def howToUseRegexLookBehindWithReplaceAll(): Unit = {
+    // despite the fact that we say "P not preceded by ...." that's not how you
+    // structure the regex.
+    val regexWithLookbehindAfter = "(?:P(?<!'))" // does not work.
+    val actual = "abc'PdefP'ghi".replaceAll(regexWithLookbehindAfter, "X")
+    // doesn't work. Quoted P gets replaced by X.
+    assertEquals("abc'XdefX'ghi", actual)
+
+    // you have to write the negative lookbehind part before the P
+    val P_not_preceded_by_quote = "(?<!')P" // works
+    val actual2 = "abc'PdefPghi".replaceAll(P_not_preceded_by_quote, "X")
+    assertEquals("abc'PdefXghi", actual2)
+  }
+
+  /**
+   * This test shows some formulations for unquoted P that one might
+   * try, do not work and are a waste of time.
+   */
+  @Test def howNotToUseRegexLookBehindWithReplaceAll(): Unit = {
+    val e = intercept[PatternSyntaxException] {
+      // P preceded by a non-quote, or an even number of paired quotes.
+      // or just P at the start of the string.
+      "((?<=([^']|('')+))P|^P)".r
+    }
+    // doesn't work because of the ('')+ in the lookbehind.
+    assertTrue(e.getMessage().contains("does not have an obvious maximum length"))
+    //
+    // Try bounding it to maximum of 10 paired quotes
+    //
+    val P_regex = "((?<=([^']|(''){1,10}))P|^P)"
+    // Works for even number of quotes
+    assertEquals("a''''''X", "a''''''P".replaceAll(P_regex, "X"))
+    // Nope. Doesn't work.
+    // This should leave the P alone. It's quoted because of 7 preceding quotes (3 matched pairs)
+    // then its own quote.
+    assertNotEquals("a'''''''P", "a'''''''P".replaceAll(P_regex, "X"))
+    assertEquals("a'''''''X", "a'''''''P".replaceAll(P_regex, "X"))
+  }
+
+  @Test def testZonedVRegexWithPrefix(): Unit = {
+    val re = TextNumberPatternUtils.vregexZoned
+    val Some(myMatch) = re.findFirstMatchIn("+012V34")
+    myMatch match {
+      case re("+", "012", "34", "") => // ok
+    }
+  }
+
+  @Test def testZonedVRegexWithSuffix(): Unit = {
+    val re = TextNumberPatternUtils.vregexZoned
+    val Some(myMatch) = re.findFirstMatchIn("012V34+")
+    myMatch match {
+      case re("", "012", "34", "+") => // ok
+    }
+  }
+}

--- a/daffodil-lib/src/main/scala/org/apache/daffodil/util/Numbers.scala
+++ b/daffodil-lib/src/main/scala/org/apache/daffodil/util/Numbers.scala
@@ -311,4 +311,22 @@ object Numbers {
   def asAnyRef(n: Any): AnyRef = {
     n.asInstanceOf[AnyRef]
   }
+
+  /** For any standard predefined subtype of JNumber, is the value numerically zero. */
+  def isZero(n1: JNumber) : Boolean = {
+    n1 match {
+      case d: JDouble => d.doubleValue() == 0.0
+      case f: JFloat => f.floatValue() == 0.0
+      case bd: JBigDecimal => bd.signum() == 0
+      case bi: JBigInt => bi.signum() == 0
+      case l: JLong => l.longValue == 0
+      case i: JInt => i.intValue == 0
+      case s: JShort => s.shortValue == 0
+      case b: JByte => b.byteValue == 0
+      // $COVERAGE-OFF$
+      case _ => Assert.invariantFailed(s"Unknown JNumber type: ${n1.getClass.getName}")
+      // $COVERAGE-ON$
+    }
+  }
+
 }

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/ConvertTextStandardNumberParser.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/ConvertTextStandardNumberParser.scala
@@ -17,7 +17,6 @@
 
 package org.apache.daffodil.processors.parsers
 
-
 import com.ibm.icu.math.{ BigDecimal => ICUBigDecimal }
 import com.ibm.icu.text.DecimalFormat
 
@@ -34,6 +33,9 @@ import org.apache.daffodil.processors.ElementRuntimeData
 import org.apache.daffodil.processors.Success
 import org.apache.daffodil.processors.TermRuntimeData
 import org.apache.daffodil.processors.TextNumberFormatEv
+
+import java.lang.{Long => JLong, Float => JFloat, Double => JDouble, Number => JNumber}
+import java.math.{BigDecimal => JBigDecimal}
 
 case class ConvertTextCombinatorParser(
   rd: TermRuntimeData,
@@ -54,11 +56,64 @@ case class ConvertTextCombinatorParser(
   }
 }
 
-case class ConvertTextNumberParser(
+trait TextDecimalVirtualPointMixin {
+  def textDecimalVirtualPoint: Int
+
+  final protected val virtualPointScaleFactor = scala.math.pow(10.0, textDecimalVirtualPoint)
+
+  final protected def applyTextDecimalVirtualPointForParse(num1: JNumber): JNumber = {
+    if (textDecimalVirtualPoint == 0) num1
+    else {
+      // scale for virtual decimal point
+      val scaledNum: JNumber = num1 match {
+        // Empirically, in our test suite, we do get Long back here, so the runtime sometimes represents small integer
+        // (or possibly even smaller decimal numbers with no fraction part) as Long.
+        case l: JLong => JBigDecimal.valueOf(l).scaleByPowerOfTen(-textDecimalVirtualPoint)
+        case bd: JBigDecimal => bd.scaleByPowerOfTen(-textDecimalVirtualPoint)
+        case f: JFloat => (f / virtualPointScaleFactor).toFloat
+        case d: JDouble => (d / virtualPointScaleFactor).toDouble
+        // $COVERAGE-OFF$
+        case _ => badType(num1)
+        // $COVERAGE-ON$
+      }
+      scaledNum
+    }
+  }
+
+  // $COVERAGE-OFF$
+  private def badType(num1: AnyRef) = {
+    Assert.invariantFailed(
+      s"""Number cannot be scaled for virtual decimal point,
+         |because it is not a decimal, float, or double.
+         |The type is ${num1.getClass.getSimpleName}.""".stripMargin)
+  }
+  // $COVERAGE-ON$
+
+  final protected def applyTextDecimalVirtualPointForUnparse(valueAsAnyRef: AnyRef) : JNumber = {
+    valueAsAnyRef match {
+      // This is not perfectly symmetrical with the parse side equivalent.
+      // Empirically in our test suite, we do not see JLong here.
+      case f: JFloat => (f * virtualPointScaleFactor).toFloat
+      case d: JDouble => (d * virtualPointScaleFactor).toDouble
+      case bd: JBigDecimal => bd.scaleByPowerOfTen(textDecimalVirtualPoint)
+
+      case n: JNumber =>
+        if (textDecimalVirtualPoint == 0) n
+        // $COVERAGE-OFF$ // both badType and the next case are coverage-off
+        else badType(n)
+      case _ => Assert.invariantFailed("Not a JNumber")
+      // $COVERAGE-ON$
+    }
+  }
+}
+
+case class ConvertTextStandardNumberParser(
   textNumberFormatEv: TextNumberFormatEv,
   zeroRepsRegex: List[Regex],
-  override val context: ElementRuntimeData)
-  extends TextPrimParser {
+  override val context: ElementRuntimeData,
+  override val textDecimalVirtualPoint: Int)
+  extends TextPrimParser
+  with TextDecimalVirtualPointMixin {
 
   override lazy val runtimeDependencies = Vector(textNumberFormatEv)
 
@@ -78,18 +133,25 @@ case class ConvertTextNumberParser(
     // will match either all or none of 'str', never part of it. Thus,
     // findFirstIn() either matches and it's a zero rep, or it doesn't and it's
     // not a zero
-    val numValue = zeroRepsRegex.find { _.findFirstIn(str).isDefined } match {
+    val numValue: DataValueNumber = zeroRepsRegex.find { _.findFirstIn(str).isDefined } match {
       case Some(_) => primNumeric.fromNumber(0)
       case None => {
         val df = textNumberFormatEv.evaluate(start).get
         val strCheckPolicy = if (df.isParseStrict) str else str.trim
         val pos = new ParsePosition(0)
-        val icuNum = df.parse(strCheckPolicy, pos)
+        val icuNum: Number = df.parse(strCheckPolicy, pos)
+
+
+        if (icuNum == null) {
+          PE(start, "Unable to parse %s from text: %s",
+            context.optPrimType.get.globalQName, str)
+          return
+        }
 
         // sometimes ICU will return their own custom BigDecimal, even if the
         // value could be represented as a BigInteger. We only want Java types,
         // so detect this and convert it to the appropriate type
-        val num = icuNum match {
+        val num1 = icuNum match {
           case bd: ICUBigDecimal => {
             if (bd.scale == 0) bd.unscaledValue
             else bd.toBigDecimal
@@ -97,13 +159,10 @@ case class ConvertTextNumberParser(
           case _ => icuNum
         }
 
+        val num2: JNumber = applyTextDecimalVirtualPointForParse(num1)
+
         // Verify that what was parsed was what was passed exactly in byte count.
         // Use pos to verify all characters consumed & check for errors!
-        if (num == null) {
-          PE(start, "Unable to parse %s from text: %s",
-            context.optPrimType.get.globalQName, str)
-          return
-        }
         if (pos.getIndex != strCheckPolicy.length) {
           val isValid =
             if (df.getPadPosition == DecimalFormat.PAD_AFTER_SUFFIX) {
@@ -128,7 +187,7 @@ case class ConvertTextNumberParser(
         }
 
         val numValue: DataValueNumber = try {
-          primNumeric.fromNumber(num)
+          primNumeric.fromNumber(num2)
         } catch {
           case e: InvalidPrimitiveDataException => {
             PE(start, "%s", e.getMessage)

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section13/text_number_props/TextNumberProps.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section13/text_number_props/TextNumberProps.tdml
@@ -391,6 +391,7 @@
     </tdml:document>
     <tdml:errors>
       <tdml:error>Schema Definition Error</tdml:error>
+      <tdml:error>positive part</tdml:error>
     </tdml:errors>
 
   </tdml:parserTestCase>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section13/zoned/pv.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section13/zoned/pv.tdml
@@ -1,0 +1,388 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<testSuite
+  suiteName="pv"
+  description="textNumberPattern with P and V"
+  xmlns:tdml="http://www.ibm.com/xmlns/dfdl/testData"
+  xmlns="http://www.ibm.com/xmlns/dfdl/testData"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/"
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns:ex="http://example.com"
+  xmlns:tns="http://example.com"
+  defaultRoundTrip="true">
+
+  <tdml:defineSchema name="s1" xmlns="http://www.w3.org/2001/XMLSchema"
+                     elementFormDefault="unqualified" useDefaultNamespace="false">
+    <include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+    <dfdl:format
+      ref="ex:GeneralFormat"
+      representation="text"
+      lengthKind="delimited"
+      decimalSigned="yes"
+      encoding="ISO-8859-1"
+      textNumberCheckPolicy="lax"
+      textNumberPadCharacter="0"
+      textNumberJustification="right"
+      textStandardZeroRep="zero Z%WSP*;Z%WSP*;Z"
+      textStandardNaNRep="NaN"
+      textStandardInfinityRep="Inf"
+      textNumberRep="standard"
+      lengthUnits="characters"/>
+
+    <element name="money" type="xs:decimal" dfdl:textNumberPattern="######0V00;-######0V00"/>
+    <element name="money2" type="xs:decimal" dfdl:textNumberPattern="[######0V00];(######0V00)"/>
+
+    <element name="bad01" type="xs:decimal" dfdl:textNumberPattern=";-######0V00"/>
+    <element name="bad02" type="xs:decimal" dfdl:textNumberPattern="######0V0#"/>
+    <element name="bad03" type="xs:decimal" dfdl:textNumberPattern="##0###0V0#"/>
+
+    <element name="badP01" type="xs:decimal" dfdl:textNumberPattern="PPP000V00"/>
+
+
+    <element name="float" type="xs:float" dfdl:textNumberPattern="##0V00;-##0V00"/>
+    <element name="double" type="xs:double" dfdl:textNumberPattern="##0V00;-##0V00"/>
+
+    <element name="byte" type="xs:byte" dfdl:textNumberPattern="0V0"/>
+
+  </tdml:defineSchema>
+
+
+  <parserTestCase name="vpattern_01" root="money" model="s1">
+    <document>999999999</document>
+    <infoset>
+      <dfdlInfoset>
+        <ex:money>9999999.99</ex:money>
+      </dfdlInfoset>
+    </infoset>
+  </parserTestCase>
+
+  <parserTestCase name="vpattern_02" root="money" model="s1"
+    roundTrip="twoPass">
+    <!-- plus sign not recreated on output -->
+    <document>+999999999</document>
+    <infoset>
+      <dfdlInfoset>
+        <ex:money>9999999.99</ex:money>
+      </dfdlInfoset>
+    </infoset>
+  </parserTestCase>
+
+  <parserTestCase name="vpattern_03" root="money" model="s1">
+    <document>-999999999</document>
+    <infoset>
+      <dfdlInfoset>
+        <ex:money>-9999999.99</ex:money>
+      </dfdlInfoset>
+    </infoset>
+  </parserTestCase>
+
+  <parserTestCase name="vpattern_04" root="money" model="s1">
+    <document>-999</document>
+    <infoset>
+      <dfdlInfoset>
+        <ex:money>-9.99</ex:money>
+      </dfdlInfoset>
+    </infoset>
+  </parserTestCase>
+
+  <parserTestCase name="vpattern_05" root="money2" model="s1">
+    <document>[999]</document>
+    <infoset>
+      <dfdlInfoset>
+        <ex:money2>9.99</ex:money2>
+      </dfdlInfoset>
+    </infoset>
+  </parserTestCase>
+
+  <parserTestCase name="vpattern_06" root="money2" model="s1">
+    <document>(999)</document>
+    <infoset>
+      <dfdlInfoset>
+        <ex:money2>-9.99</ex:money2>
+      </dfdlInfoset>
+    </infoset>
+  </parserTestCase>
+
+  <parserTestCase name="vpattern_zero" root="money" model="s1">
+    <document>zero</document>
+    <infoset>
+      <dfdlInfoset>
+        <ex:money>0</ex:money>
+      </dfdlInfoset>
+    </infoset>
+  </parserTestCase>
+
+  <parserTestCase name="vpattern_ZZZ" root="money" model="s1" roundTrip="twoPass">
+    <document>Z Z Z</document>
+    <infoset>
+      <dfdlInfoset>
+        <ex:money>0</ex:money>
+      </dfdlInfoset>
+    </infoset>
+  </parserTestCase>
+
+  <parserTestCase name="vpattern_float" root="float" model="s1">
+    <document>123</document>
+    <infoset>
+      <dfdlInfoset>
+        <ex:float>1.23</ex:float>
+      </dfdlInfoset>
+    </infoset>
+  </parserTestCase>
+
+  <parserTestCase name="vpattern_double" root="double" model="s1">
+    <document>123</document>
+    <infoset>
+      <dfdlInfoset>
+        <ex:double>1.23</ex:double>
+      </dfdlInfoset>
+    </infoset>
+  </parserTestCase>
+
+  <parserTestCase name="vpattern_float_NaN" root="float" model="s1">
+    <document>NaN</document>
+    <infoset>
+      <dfdlInfoset>
+        <ex:float>NaN</ex:float>
+      </dfdlInfoset>
+    </infoset>
+  </parserTestCase>
+
+  <parserTestCase name="vpattern_double_NaN" root="double" model="s1">
+    <document>NaN</document>
+    <infoset>
+      <dfdlInfoset>
+        <ex:double>NaN</ex:double>
+      </dfdlInfoset>
+    </infoset>
+  </parserTestCase>
+
+  <parserTestCase name="vpattern_float_Inf" root="float" model="s1">
+    <document>Inf</document>
+    <infoset>
+      <dfdlInfoset>
+        <ex:float>INF</ex:float>
+      </dfdlInfoset>
+    </infoset>
+  </parserTestCase>
+
+  <parserTestCase name="vpattern_double_Inf" root="double" model="s1">
+    <document>Inf</document>
+    <infoset>
+      <dfdlInfoset>
+        <ex:double>INF</ex:double>
+      </dfdlInfoset>
+    </infoset>
+  </parserTestCase>
+
+  <parserTestCase name="vpattern_bad_01" root="bad01" model="s1">
+    <document>999999999</document>
+    <errors>
+      <error>textNumberPattern</error>
+      <error>positive part of the dfdl:textNumberPattern is mandatory</error>
+    </errors>
+  </parserTestCase>
+
+  <parserTestCase name="vpattern_bad_02" root="bad02" model="s1">
+    <document>999999999</document>
+    <errors>
+      <error>textNumberPattern</error>
+      <error>'#', then digits 0-9 then 'V' then digits 0-9</error>
+    </errors>
+  </parserTestCase>
+
+  <parserTestCase name="vpattern_bad_03" root="bad03" model="s1">
+    <document>999999999</document>
+    <errors>
+      <error>textNumberPattern</error>
+      <error>'#', then digits 0-9 then 'V' then digits 0-9</error>
+    </errors>
+  </parserTestCase>
+
+  <parserTestCase name="vpattern_bad_P01" root="badP01" model="s1">
+    <document>999999999</document>
+    <errors>
+      <error>textNumberPattern</error>
+      <error>not yet implemented</error>
+    </errors>
+  </parserTestCase>
+
+  <parserTestCase name="float_vpattern_01" root="float" model="s1">
+    <document>99999</document>
+    <infoset>
+      <dfdlInfoset>
+        <ex:float>999.99</ex:float>
+      </dfdlInfoset>
+    </infoset>
+  </parserTestCase>
+
+  <parserTestCase name="double_vpattern_01" root="double" model="s1">
+    <document>99999</document>
+    <infoset>
+      <dfdlInfoset>
+        <ex:double>999.99</ex:double>
+      </dfdlInfoset>
+    </infoset>
+  </parserTestCase>
+
+  <parserTestCase name="bad_byte_vpattern_01" root="byte" model="s1">
+    <document>99</document>
+    <errors>
+      <error>textNumberPattern</error>
+      <error>xs:double</error>
+      <error>xs:float</error>
+      <error>xs:decimal</error>
+      <error>xs:byte</error>
+    </errors>
+  </parserTestCase>
+
+
+  <tdml:defineSchema name="zoned1" xmlns="http://www.w3.org/2001/XMLSchema"
+                     elementFormDefault="unqualified" useDefaultNamespace="false">
+    <include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+    <dfdl:format
+      ref="ex:GeneralFormat"
+      representation="text"
+      lengthKind="delimited"
+      decimalSigned="yes"
+      encoding="ISO-8859-1"
+      textNumberCheckPolicy="lax"
+      textNumberPadCharacter="0"
+      textNumberJustification="right"
+      textNumberRep="zoned"
+      textZonedSignStyle="asciiStandard"
+      lengthUnits="characters"/>
+
+    <element name="money" type="xs:decimal" dfdl:textNumberPattern="+0000000V00"/>
+    <element name="money2" type="xs:decimal" dfdl:textNumberPattern="0000000V00+"/>
+
+    <element name="bad01" type="xs:decimal" dfdl:textNumberPattern=";-######0V00"/>
+    <element name="bad02" type="xs:decimal" dfdl:textNumberPattern="######0V0#"/>
+    <element name="bad03" type="xs:decimal" dfdl:textNumberPattern="##0###0V0#"/>
+
+    <element name="badP01" type="xs:decimal" dfdl:textNumberPattern="PPP000V00"/>
+
+
+    <element name="float" type="xs:float" dfdl:textNumberPattern="##0V00"/>
+    <element name="double" type="xs:double" dfdl:textNumberPattern="##0V00"/>
+
+  </tdml:defineSchema>
+
+  <parserTestCase name="zoned_vpattern_01" root="money" model="zoned1">
+    <document>999999999</document>
+    <infoset>
+      <dfdlInfoset>
+        <ex:money>9999999.99</ex:money>
+      </dfdlInfoset>
+    </infoset>
+  </parserTestCase>
+
+  <parserTestCase name="zoned_vpattern_02" root="money" model="zoned1">
+    <document>y99999999</document>
+    <infoset>
+      <dfdlInfoset>
+        <ex:money>-9999999.99</ex:money>
+      </dfdlInfoset>
+    </infoset>
+  </parserTestCase>
+
+  <parserTestCase name="zoned_vpattern_03" root="money2" model="zoned1">
+    <document>999999999</document>
+    <infoset>
+      <dfdlInfoset>
+        <ex:money2>9999999.99</ex:money2>
+      </dfdlInfoset>
+    </infoset>
+  </parserTestCase>
+
+  <parserTestCase name="zoned_vpattern_03b" root="money2" model="zoned1">
+    <document>99999999y</document>
+    <infoset>
+      <dfdlInfoset>
+        <ex:money2>-9999999.99</ex:money2>
+      </dfdlInfoset>
+    </infoset>
+  </parserTestCase>
+
+  <parserTestCase name="zoned_vpattern_04" root="money" model="zoned1">
+    <document>y99</document>
+    <infoset>
+      <dfdlInfoset>
+        <ex:money>-9.99</ex:money>
+      </dfdlInfoset>
+    </infoset>
+  </parserTestCase>
+
+  <parserTestCase name="zoned_vpattern_05" root="money2" model="zoned1">
+    <document>99y</document>
+    <infoset>
+      <dfdlInfoset>
+        <ex:money2>-9.99</ex:money2>
+      </dfdlInfoset>
+    </infoset>
+  </parserTestCase>
+
+  <parserTestCase name="zoned_vpattern_bad_01" root="bad01" model="zoned1">
+    <document>999999999</document>
+    <errors>
+      <error>textNumberPattern</error>
+      <error>contain only digits 0-9</error>
+    </errors>
+  </parserTestCase>
+
+  <parserTestCase name="zoned_vpattern_bad_02" root="bad02" model="zoned1">
+    <document>999999999</document>
+    <errors>
+      <error>textNumberPattern</error>
+      <error>contain only digits 0-9</error>
+    </errors>
+  </parserTestCase>
+
+  <parserTestCase name="zoned_vpattern_bad_03" root="bad03" model="zoned1">
+    <document>999999999</document>
+    <errors>
+      <error>textNumberPattern</error>
+      <error>contain only digits 0-9</error>
+    </errors>
+  </parserTestCase>
+
+  <parserTestCase name="zoned_vpattern_bad_P01" root="badP01" model="zoned1">
+    <document>999999999</document>
+    <errors>
+      <error>textNumberPattern</error>
+      <error>not yet implemented</error>
+    </errors>
+  </parserTestCase>
+
+  <parserTestCase name="zoned_float_vpattern_01" root="float" model="zoned1">
+    <document>99999</document>
+    <errors>
+      <error>cannot be used with xs:float</error>
+    </errors>
+  </parserTestCase>
+
+  <parserTestCase name="zoned_double_vpattern_01" root="double" model="zoned1">
+    <document>99999</document>
+    <errors>
+      <error>cannot be used with xs:double</error>
+    </errors>
+  </parserTestCase>
+
+
+</testSuite>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section13/zoned/zoned.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section13/zoned/zoned.tdml
@@ -113,7 +113,9 @@
       <tdml:documentPart type="text">1988</tdml:documentPart>
     </tdml:document>
     <tdml:errors>
-      <tdml:error>Invalid characters used in textNubmerPattern for zoned number</tdml:error>
+      <tdml:error>textNumberPattern</tdml:error>
+      <tdml:error>'E'</tdml:error>
+      <tdml:error>zoned</tdml:error>
     </tdml:errors>
 
   </tdml:parserTestCase>

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section13/zoned/TestPV.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section13/zoned/TestPV.scala
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.daffodil.section13.zoned
+
+import org.apache.daffodil.tdml.Runner
+import org.junit.AfterClass
+import org.junit.Test
+
+object TestPV {
+  val testDir = "/org/apache/daffodil/section13/zoned/"
+  val runner = Runner(testDir, "pv.tdml")
+
+  @AfterClass def shutdown(): Unit = {
+    runner.reset
+  }
+
+}
+
+class TestPV {
+  import TestPV._
+
+  @Test def vpattern_01(): Unit = { runner.runOneTest("vpattern_01") }
+  @Test def vpattern_02(): Unit = { runner.runOneTest("vpattern_02") }
+  @Test def vpattern_03(): Unit = { runner.runOneTest("vpattern_03") }
+  @Test def vpattern_04(): Unit = { runner.runOneTest("vpattern_04") }
+  @Test def vpattern_05(): Unit = { runner.runOneTest("vpattern_05") }
+  @Test def vpattern_06(): Unit = { runner.runOneTest("vpattern_06") }
+
+  @Test def vpattern_zero(): Unit = { runner.runOneTest("vpattern_zero") }
+  @Test def vpattern_ZZZ(): Unit = { runner.runOneTest("vpattern_ZZZ") }
+
+  @Test def vpattern_float(): Unit = { runner.runOneTest("vpattern_float") }
+  @Test def vpattern_double(): Unit = { runner.runOneTest("vpattern_double") }
+  @Test def vpattern_float_NaN(): Unit = { runner.runOneTest("vpattern_float_NaN") }
+  @Test def vpattern_double_NaN(): Unit = { runner.runOneTest("vpattern_double_NaN") }
+  @Test def vpattern_float_Inf(): Unit = { runner.runOneTest("vpattern_float_Inf") }
+  @Test def vpattern_double_Inf(): Unit = { runner.runOneTest("vpattern_double_Inf") }
+
+  @Test def float_vpattern_01(): Unit = { runner.runOneTest("float_vpattern_01") }
+  @Test def double_vpattern_01(): Unit = { runner.runOneTest("double_vpattern_01") }
+
+  @Test def vpattern_bad_01(): Unit = { runner.runOneTest("vpattern_bad_01") }
+  @Test def vpattern_bad_02(): Unit = { runner.runOneTest("vpattern_bad_02") }
+  @Test def vpattern_bad_03(): Unit = { runner.runOneTest("vpattern_bad_03") }
+  @Test def vpattern_bad_P01(): Unit = { runner.runOneTest("vpattern_bad_P01") }
+
+
+  @Test def zoned_vpattern_01(): Unit = { runner.runOneTest("zoned_vpattern_01") }
+  @Test def zoned_vpattern_02(): Unit = { runner.runOneTest("zoned_vpattern_02") }
+  @Test def zoned_vpattern_03(): Unit = { runner.runOneTest("zoned_vpattern_03") }
+  @Test def zoned_vpattern_04(): Unit = { runner.runOneTest("zoned_vpattern_04") }
+  @Test def zoned_vpattern_05(): Unit = { runner.runOneTest("zoned_vpattern_05") }
+
+  @Test def bad_byte_vpattern_01(): Unit = { runner.runOneTest("bad_byte_vpattern_01") }
+
+  @Test def zoned_float_vpattern_01(): Unit = { runner.runOneTest("zoned_float_vpattern_01") }
+  @Test def zoned_double_vpattern_01(): Unit = { runner.runOneTest("zoned_double_vpattern_01") }
+
+  @Test def zoned_vpattern_bad_01(): Unit = { runner.runOneTest("zoned_vpattern_bad_01") }
+  @Test def zoned_vpattern_bad_02(): Unit = { runner.runOneTest("zoned_vpattern_bad_02") }
+  @Test def zoned_vpattern_bad_03(): Unit = { runner.runOneTest("zoned_vpattern_bad_03") }
+  @Test def zoned_vpattern_bad_P01(): Unit = { runner.runOneTest("zoned_vpattern_bad_P01") }
+
+}
+
+


### PR DESCRIPTION
Implements 'V' a major missing feature for Cobol data.

I have also updated the DFDLSchemas Cobol example to use a snapshot of this. And that works.
See https://github.com/DFDLSchemas/Cobol/pull/2

DAFFODIL-853