### PR TITLE
Fix mixed content error in SAX unparse

### DIFF
--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/api/DFDLParserUnparser.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/api/DFDLParserUnparser.scala
@@ -252,6 +252,7 @@ object DFDL {
     var nilValue: Maybe[String] = Nope
     var causeError: Maybe[SAXException] = Nope
     var unparseResult: Maybe[UnparseResult] = Nope
+    var mixedContent: Maybe[String] = Nope
 
     def isError: Boolean = causeError.isDefined
 
@@ -263,6 +264,7 @@ object DFDL {
       nilValue = Nope
       causeError = Nope
       unparseResult = Nope
+      mixedContent = Nope
     }
 
     def isEmpty: Boolean = {
@@ -272,7 +274,8 @@ object DFDL {
         eventType.isEmpty &&
         nilValue.isEmpty &&
         causeError.isEmpty &&
-        unparseResult.isEmpty
+        unparseResult.isEmpty &&
+        mixedContent.isEmpty
     }
 
     override def toString: String = {
@@ -293,6 +296,7 @@ object DFDL {
         dest.localName = source.localName
         dest.nilValue = source.nilValue
         dest.simpleText = source.simpleText
+        dest.mixedContent = source.mixedContent
       }
     }
   }


### PR DESCRIPTION
Currently, when mixed content is found when unparsing with the SAX API, the DaffodilUnparseContentHandler throws an IllegalContentWhereEventExpected exception. This has two issues:

1. A SAX XMLReader API only expects SAXExceptions to be thrown from a ContentHandler
2. Throwing the exception here ends execution of the ContentHandler subroutine without signaling the unparse() subroutine/thread. This means the unparse thread is deadlocked waiting for more events that will never come.

To solve these issues, instead of throwing the exception, this just adds the mixed content string to the current SAXInfosetEvent. When the SAXInfosetInputter reads that event and sees the mixed content, it will throw the IllegalContentWhereEventExpected exception. This is now thrown in he unparse thread, which causes the unparse thread to stop unparsing and create an UnparseResult, send it to the ContentHandler thread, and cleanly exit. The ContentHandler thread can then receive the UnparseResult and convert it to a SAXException.

Also update a number of comments to make certain sections more clear.

DAFFODIL-2767