### PR TITLE
Properly handle dfdlx:repValues=''

### DIFF
--- a/daffodil-propgen/src/main/resources/org/apache/daffodil/xsd/DFDL_part1_simpletypes.xsd
+++ b/daffodil-propgen/src/main/resources/org/apache/daffodil/xsd/DFDL_part1_simpletypes.xsd
@@ -94,8 +94,15 @@
 
   <xsd:simpleType name="NonEmptyListOfDFDLStringLiteral">
     <xsd:restriction base="dfdl:ListOfDFDLStringLiteral">
+      <xsd:minLength value="1"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+  <xsd:simpleType name="NonEmptyListOfDFDLStringLiteral_nilValue">
+    <xsd:restriction base="dfdl:ListOfDFDLStringLiteral">
     <!-- used for dfdl:nilValue. We can give a much clearer diagnostic with a suggestion
-         on what the user should do instead. So we don't check this here. -->
+         on what the user should do instead, ie did they mean to use '%ES;'. So we don't
+         check this here. -->
       <!-- <xsd:minLength value="1"/> --> 
     </xsd:restriction>
   </xsd:simpleType>

--- a/daffodil-propgen/src/main/resources/org/apache/daffodil/xsd/DFDL_part2_attributes.xsd
+++ b/daffodil-propgen/src/main/resources/org/apache/daffodil/xsd/DFDL_part2_attributes.xsd
@@ -396,12 +396,12 @@
 
   <!-- 13.14 Properties for Nillable Elements -->
   <xsd:attribute name="nilKind" type="dfdl:NilKindEnum" />
-  <xsd:attribute name="nilValue" type="dfdl:NonEmptyListOfDFDLStringLiteral" />
+  <xsd:attribute name="nilValue" type="dfdl:NonEmptyListOfDFDLStringLiteral_nilValue" />
   <xsd:attribute name="nilValueDelimiterPolicy" type="dfdl:NilValueDelimiterPolicyEnum" />
 
   <xsd:attributeGroup name="NillableAG">
     <xsd:attribute name="nilKind" type="dfdl:NilKindEnum" />
-    <xsd:attribute name="nilValue" type="dfdl:NonEmptyListOfDFDLStringLiteral" />
+    <xsd:attribute name="nilValue" type="dfdl:NonEmptyListOfDFDLStringLiteral_nilValue" />
     <xsd:attribute name="nilValueDelimiterPolicy" type="dfdl:NilValueDelimiterPolicyEnum" />
   </xsd:attributeGroup>
 
@@ -921,7 +921,7 @@
     <xsd:attribute form="qualified" name="nilKind"
       type="dfdl:NilKindEnum" />
     <xsd:attribute form="qualified" name="nilValue"
-      type="dfdl:NonEmptyListOfDFDLStringLiteral" />
+      type="dfdl:NonEmptyListOfDFDLStringLiteral_nilValue" />
     <xsd:attribute form="qualified" name="nilValueDelimiterPolicy"
       type="dfdl:NilValueDelimiterPolicyEnum" />
   </xsd:attributeGroup>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/extensions/enum/enumInvalid.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/extensions/enum/enumInvalid.tdml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<testSuite
+  xmlns:ex="http://example.com"
+  xmlns:tdml="http://www.ibm.com/xmlns/dfdl/testData"
+  xmlns="http://www.ibm.com/xmlns/dfdl/testData"
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/"
+  xmlns:dfdlx="http://www.ogf.org/dfdl/dfdl-1.0/extensions"
+  xmlns:fn="http://www.w3.org/2005/xpath-functions"
+  xmlns:tns="http://example.com"
+  defaultRoundTrip="onePass"
+  defaultValidation="off">
+
+  <tdml:defineSchema
+    name="s3"
+    useDefaultNamespace="false"
+    elementFormDefault="unqualified"
+    xmlns="http://www.w3.org/2001/XMLSchema">
+
+    <include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+    <dfdl:format ref="ex:GeneralFormat" representation="binary"/>
+
+    <element name="r2">
+      <complexType>
+        <sequence>
+          <element name="e2" type="ex:enum2"/>
+        </sequence>
+      </complexType>
+    </element>
+
+    <simpleType name="enum2" dfdlx:repType="ex:myByte">
+      <restriction base="xs:string">
+        <enumeration value="valid" dfdlx:repValues="0"/>
+        <enumeration value="empty" dfdlx:repValues=""/>
+      </restriction>
+    </simpleType>
+
+  </tdml:defineSchema>
+
+  <parserTestCase name="emptyRepValues" model="s3" root="r2" validation="off">
+    <document>
+      <documentPart type="bits">01010101</documentPart>
+    </document>
+    <errors>
+      <error>Schema Definition Error</error>
+      <error>'' is not a valid value</error>
+      <error>NonEmptyListofDFDLStringLiteralOrNonEmptyListOfInteger</error>
+    </errors>
+  </parserTestCase>
+
+</testSuite>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/extensions/enum/enums.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/extensions/enum/enums.tdml
@@ -94,8 +94,6 @@
     </validationErrors>
   </parserTestCase>
 
-
-
   <unparserTestCase name="enumMiss1" model="s1" root="r1">
     <infoset>
       <tdml:dfdlInfoset xmlns="">

--- a/daffodil-test/src/test/scala/org/apache/daffodil/extensions/TestEnums.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/extensions/TestEnums.scala
@@ -25,6 +25,7 @@ object TestEnums {
   val testDir = "/org/apache/daffodil/extensions/enum/"
 
   val runner = Runner(testDir, "enums.tdml")
+  val runner2 = Runner(testDir, "enumInvalid.tdml", validateTDMLFile=false)
 
   @AfterClass def shutDown(): Unit = {
     runner.reset
@@ -39,4 +40,6 @@ class TestEnums {
   @Test def test_enumMiss1(): Unit = { runner.runOneTest("enumMiss1") }
 
   @Test def test_repTypeAlignment(): Unit = { runner.runOneTest("repTypeAlignment") }
+
+  @Test def test_emptyRepValues(): Unit = { runner2.runOneTest("emptyRepValues") }
 }


### PR DESCRIPTION
This should have been failing schema validation, but instead would result in an error when we attempted to pasre a number from an empty string.

DAFFODIL-2632