### PR TITLE
Implement 'P' textNumberPattern feature.

### DIFF
--- a/daffodil-core/src/main/scala/org/apache/daffodil/grammar/primitives/PrimitivesTextNumber.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/grammar/primitives/PrimitivesTextNumber.scala
@@ -45,27 +45,48 @@ case class ConvertTextCombinator(e: ElementBase, value: Gram, converter: Gram)
   override lazy val unparser = new ConvertTextCombinatorUnparser(e.termRuntimeData, value.unparser, converter.unparser)
 }
 
-// This is a separate object for unit testing purposes.
+/**
+ * This is a separate object so that we can easily unit test these subtle regular
+ * expressions.
+ */
 private[primitives]
 object TextNumberPatternUtils {
+
+  //  DFDL v1.0 Spec says
+  //  It is a Schema Definition Error if any symbols other than "0", "1" through "9" or #
+  //  are used in the vpinteger region of the pattern.
+  //
+  // The prefix and suffix chars can surround the vpinteger region, and there can be
+  // a positive and a negative pattern.
+  //
+  //
+  //
+  /**
+   * The prefix and suffix are quoted any single character
+   * or a single non-special character (excepting + and - which are allowed
+   * though they appear in the table of special characters for textNumberFormat).
+   *
+   * By default these regex will not allow line-ending chars either.
+   */
+  val prefixChars = """(?:'.'|[^0-9#PVE\.\,\;\*\@\'])?""" // same for suffix.
+
+  /**
+   * sharps and at least 1 digit before the V.
+   */
+  val beforeVChars = """#*[0-9]+"""
+
+  /**
+   * one or more digits after the V. (No trailing sharps)
+   */
+  val afterVChars = """[0-9]+"""
+
 
   /**
    * A regex which matches textNumberPatterns that legally use the V
    * (implied decimal point) character.
    */
-   private[primitives] lazy val vregexStandard = {
-    //  DFDL v1.0 Spec says
-    //  It is a Schema Definition Error if any symbols other than "0", "1" through "9" or #
-    //  are used in the vpinteger region of the pattern.
-    //
-    // The prefix and suffix chars can surround the vpinteger region, and there can be
-    // a positive and a negative pattern.
-    //
-    // The prefix and suffix cannot be digits, # or P or V. No quoted chars in prefix either.
-    //
-     val prefixChars = """[^0-9#PV']?""" // same for suffix.
-     val beforeVChars = """#*[0-9]+"""
-     val afterVChars = """[0-9]+"""
+  lazy val vRegexStandard = {
+
      //
      // Each of the capture groups is defined here in order
      //
@@ -80,14 +101,72 @@ object TextNumberPatternUtils {
      // don't forget the ^ and $ (start of data, end of data) because we want
      // the match to consume all the characters, starting at the beginning.
     val vPattern=
-     s"""^${posPrefix}${posBeforeV}V${posAfterV}${posSuffix}(?:;${negPrefix}${negBeforeV}V${negAfterV}${negSuffix})?$$"""
+     s"""^${posPrefix}${posBeforeV}V${posAfterV}${posSuffix}""" ++
+       s"""(?:;${negPrefix}${negBeforeV}(?:V${negAfterV}${negSuffix})?)?$$"""
     val re = vPattern.r
     re
   }
 
+  /*
+   * There are two regex used for 'P' pattern case. One if the P chars
+   * appear to the left of the digits, the other for P chars on the right
+   * of the digits.
+   *
+   * When P is on left of the digits, there must be 1 or more digits.
+   * When P is on right of the digits there must be 1 or more digits, and there may be sharps.
+   */
+  val afterPChars = """[0-9]+""" // P is left, digits are after
+  val beforePChars = """#*[0-9]+""" // P is right, digits are before (sharps before the digits).
 
+  /**
+   * A regex which matches textNumberPatterns that legally use the P
+   * (implied decimal point) character, on the LEFT of the digits.
+   */
+  lazy val pOnLeftRegexStandard = {
+    //
+    // Each of the capture groups is defined here in order
+    //
+    val posPrefix = s"""($prefixChars)"""
+    val posPs = s"""(P+)"""
+    val posAfterP = s"""($afterPChars)"""
+    val posSuffix = posPrefix
+    val negPrefix = posPrefix
+    val negPs = posPs
+    val negAfterP = posAfterP
+    val negSuffix = posPrefix
+    // don't forget the ^ and $ (start of data, end of data) because we want
+    // the match to consume all the characters, starting at the beginning.
+    val vPattern =
+    s"""^${posPrefix}$posPs${posAfterP}${posSuffix}(?:;${negPrefix}$negPs${negAfterP}${negSuffix})?$$"""
+    val re = vPattern.r
+    re
+  }
 
-  private[primitives] lazy val vregexZoned= {
+  /**
+   * A regex which matches textNumberPatterns that legally use the P
+   * (implied decimal point) character, on the RIGHT of the digits.
+   */
+  lazy val pOnRightRegexStandard = {
+    //
+    // Each of the capture groups is defined here in order
+    //
+    val posPrefix = s"""($prefixChars)"""
+    val posBeforeP = s"""($beforePChars)"""
+    val posPs = s"""(P+)"""
+    val posSuffix = posPrefix
+    val negPrefix = posPrefix
+    val negBeforeP = posBeforeP
+    val negPs = posPs
+    val negSuffix = posPrefix
+    // don't forget the ^ and $ (start of data, end of data) because we want
+    // the match to consume all the characters, starting at the beginning.
+    val vPattern =
+    s"""^${posPrefix}${posBeforeP}$posPs${posSuffix}(?:;${negPrefix}${negBeforeP}$negPs${negSuffix})?$$"""
+    val re = vPattern.r
+    re
+  }
+
+  lazy val vRegexZoned= {
     // Note: for zoned, can only have a positive pattern
     // Prefix or suffix can only be '+' character, to
     // indicate leading or trailing sign, and can only
@@ -114,19 +193,64 @@ object TextNumberPatternUtils {
    * Checks a pattern for suitability with V (virtual decimal point) in the pattern
    * in the context of zoned textNumberRep.
    *
-   * This is broken out separately for unit testing purposes.
+   * This method is here in this object for unit testing purposes.
    *
    * @param patternStripped the dfdl:textNumberPattern pattern - with all quoting removed.
    * @return None if the pattern is illegal syntax for use with V (virtual decimal point)
    *         otherwise Some(N) where N is the number of digits to the right of the V character.
    */
-  private[primitives] def textDecimalVirtualPointForZoned(patternStripped: String): Option[Int] = {
-    val r = TextNumberPatternUtils.vregexZoned
+  def textNumber_V_DecimalVirtualPointForZoned(patternStripped: String): Option[Int] = {
+    val r = TextNumberPatternUtils.vRegexZoned
     r.findFirstMatchIn(patternStripped) match {
       // note: cannot have both a prefix and suffix. Only one of them.
-      case Some(r(pre, _, afterV, suf)) if (pre.length + suf.length <= 1) => Some(afterV.length)
+      case Some(r(pre, _, afterV, suf)) if (pre.length + suf.length <= 1) =>
+        Some(afterV.length)
       case _ => None
     }
+  }
+
+  lazy val pOnLeftRegexZoned = {
+    // Note: for zoned, can only have a positive pattern
+    // Prefix or suffix can only be '+' character, to
+    // indicate leading or trailing sign, and can only
+    // one of those.
+    //
+    // Also we're not allowing the # character, since I think that
+    // makes no sense for zoned with virtual decimal point.
+    //
+    val prefixChars = """\+?""" // only + for prefix/suffix
+    //
+    // capture groups are defined here in sequence
+    //
+    val prefix = s"""($prefixChars)"""
+    val ps = s"""(P+)"""
+    val afterP = s"""($afterPChars)"""
+    val suffix = prefix
+    val vPattern = s"""^${prefix}$ps${afterP}${suffix}$$""" // only positive pattern allowed
+    val re = vPattern.r
+    re
+  }
+
+  lazy val pOnRightRegexZoned = {
+    // Note: for zoned, can only have a positive pattern
+    // Prefix or suffix can only be '+' character, to
+    // indicate leading or trailing sign, and can only
+    // one of those.
+    //
+    // Also we're not allowing the # character, since I think that
+    // makes no sense for zoned with virtual decimal point.
+    //
+    val prefixChars = """\+?""" // only + for prefix/suffix
+    //
+    // capture groups are defined here in sequence
+    //
+    val prefix = s"""($prefixChars)"""
+    val beforeP = s"""($beforePChars)"""
+    val ps = s"""(P+)"""
+    val suffix = prefix
+    val vPattern = s"""^${prefix}${beforeP}$ps${suffix}$$""" // only positive pattern allowed
+    val re = vPattern.r
+    re
   }
 
   /**
@@ -137,25 +261,32 @@ object TextNumberPatternUtils {
    * @return the pattern string with all unquoted P and unquoted V removed.
    */
   def removeUnquotedPV(pattern: String) : String = {
-    val uniqueQQString = "alsdflslkjskjslkkjlkkjfppooiipsldsflj"
-    // A single regex that matches an unquoted character
-    // where the quoting char is self quoting requires
-    // a zero-width look behind that matches a potentially
-    // unbounded number of quote chars. That's not allowed.
-    //
-    // Consider ''''''P. We want a regex that matches only the P here
-    // because it is preceded by an even number of quotes.
-    //
-    // I did some tests, and the formulations you think might work
-    // such as from stack-overflow, don't work.
-    // (See test howNotToUseRegexLookBehindWithReplaceAll)
-    //
-    // So we use this brute force technique of replacing all ''
-    // first, so we have only single quotes to deal with.
-    pattern.replaceAll("''", uniqueQQString).
-      replaceAll("(?<!')P", "").
-      replaceAll("(?<!')V", "").
-      replaceAll(uniqueQQString, "''")
+    //    val uniqueQQString = "alsdflslkjskjslkkjlkkjfppooiipsldsflj" // FIXME: use split-based technique.
+    //    // A single regex that matches an unquoted character
+    //    // where the quoting char is self quoting requires
+    //    // a zero-width look behind that matches a potentially
+    //    // unbounded number of quote chars. That's not allowed.
+    //    //
+    //    // Consider ''''''P. We want a regex that matches only the P here
+    //    // because it is preceded by an even number of quotes.
+    //    //
+    //    // I did some tests, and the formulations you think might work
+    //    // such as from stack-overflow, don't work.
+    //    // (See test howNotToUseRegexLookBehindWithReplaceAll)
+    //    //
+    //    // So we use this brute force technique of replacing all ''
+    //    // first, so we have only single quotes to deal with.
+    //    pattern.replaceAll("''", uniqueQQString).
+    //      replaceAll("(?<!')P", "").
+    //      replaceAll("(?<!')V", "").
+    //      replaceAll(uniqueQQString, "''")
+    //  }
+    val regex = "'.*?'|.".r
+    val res = regex.findAllIn(pattern)
+      .filterNot(_ == "P")
+      .filterNot(_ == "V")
+      .mkString("")
+    res
   }
 }
 
@@ -170,13 +301,23 @@ trait ConvertTextNumberMixin {
   final protected def pattern = e.textNumberPattern
 
   /**
-   * Checks a pattern for suitability with V (virtual decimal point) in the pattern
-   * in the context of the corresponding textNumberRep. Computes number of digits to right of the V.
+   * Analogous to the property dfdl:binaryDecimalVirtualPoint
    *
-   * SDE if pattern has a syntax error.
+   * Value is 0 if there is no virtual decimal point.
    *
-   * @return the number of digits to the right of the V character. Must be 1 or greater.
+   * Value is the number of digits to the right of the 'V' for V patterns.
    *
+   * For P patterns, the value is the number of P characters when
+   * the P chars are on the right of the digits, or it is negated if the
+   * P chars are on the left of the digits.
+   *
+   * Examples:
+   *
+   * "000.00" returns 2, so text "12345" yields 123.45
+   *
+   * "PP000" returns 5, so text "123" yields 0.00123
+   *
+   * "000PP" returns -2 so text "123" yields 12300.0
    */
   protected def textDecimalVirtualPointFromPattern: Int
 
@@ -186,41 +327,57 @@ trait ConvertTextNumberMixin {
    * but cannot be used as an operational pattern given that
    * potentially lots of things have been removed from it.
    */
-  final protected lazy val patternStripped = {
+  final protected lazy val patternNoQuoted = {
     // note: tick == apos == ' == single quote.
     // First remove entirely all escaped ticks ie., ''
     val noEscapedTicksRegex = """''""".r
     val patternNoEscapedTicks = noEscapedTicksRegex.replaceAllIn(pattern, "")
     // Next remove all tick-escaped characters entirely
     val noQuotedRegex = """'[^']+'""".r
-    val patternNoQuoted = noQuotedRegex.replaceAllIn(patternNoEscapedTicks, "")
+    val res = noQuotedRegex.replaceAllIn(patternNoEscapedTicks, "")
     // the remaining string contains only pattern special characters
     // and regular non-pattern characters
-    patternNoQuoted
+    res
   }
 
-  protected final lazy val hasV = patternStripped.contains("V")
-  protected final lazy val hasP = patternStripped.contains("P")
+  protected final lazy val hasV = patternNoQuoted.contains("V")
+  protected final lazy val hasP = patternNoQuoted.contains("P")
 
   /**
-   * analogous to the property dfdl:binaryDecimalVirtualPoint
+   * Analogous to the property dfdl:binaryDecimalVirtualPoint
    *
    * Value is 0 if there is no virtual decimal point.
-   * Value is the number of digits to the right of the 'V'
+   *
+   * Value is the number of digits to the right of the 'V' for V patterns.
+   *
+   * For P patterns, the value is the number of P characters when
+   * the P chars are on the right of the digits, or it is negated if the
+   * P chars are on the left of the digits.
+   *
+   * Examples:
+   *
+   * "000.00" returns 2, so text "12345" yields 123.45
+   *
+   * "PP000" returns 2, so text "123" yields 0.00123
+   *
+   * "000PP" returns -2 so text "123" yields 12300.0
    */
   final lazy val textDecimalVirtualPoint: Int = {
-    if (!hasV && !hasP) 0 // no virtual point
-    else {
-      if (hasP) {
-        e.notYetImplemented("textNumberPattern with P symbol")
-      }
-      Assert.invariant(hasV)
+    lazy val virtualPoint = textDecimalVirtualPointFromPattern
+    if (hasV) {
       //
       // check for things incompatible with "V"
       //
-      val virtualPoint = textDecimalVirtualPointFromPattern
       Assert.invariant(virtualPoint >= 1) // if this fails the regex is broken.
       virtualPoint
+    } else if (hasP) {
+      //
+      // check for things incompatible with "V"
+      //
+      Assert.invariant(virtualPoint != 0) // if this fails the regex is broken.
+      virtualPoint
+    } else {
+      0 // no virtual point since we have neither V nor P in the pattern.
     }
   }
 
@@ -275,17 +432,67 @@ case class ConvertTextStandardNumberPrim(e: ElementBase)
   extends Terminal(e, true)
   with ConvertTextNumberMixin {
 
+
   final override protected lazy val textDecimalVirtualPointFromPattern: Int = {
-    val r = TextNumberPatternUtils.vregexStandard
-    r.findFirstMatchIn(patternStripped) match {
-      case Some(r(_, _, afterV, _, _, _, _, _)) => afterV.length
-      case None =>
-        e.SDE(
-          s"""The dfdl:textNumberPattern '%s' contains 'V' (virtual decimal point).
-             | Other than the sign indicators, it can contain only
-             | '#', then digits 0-9 then 'V' then digits 0-9.
-             | The positive part of the dfdl:textNumberPattern is mandatory.""".stripMargin('|'),
+    if (hasV) {
+      val r = TextNumberPatternUtils.vRegexStandard
+      r.findFirstMatchIn(patternNoQuoted) match {
+        case Some(r(_, _, afterV, _, _, _, _, _)) => afterV.length
+        case None =>
+          e.SDE(
+            s"""The dfdl:textNumberPattern '%s' contains 'V' (virtual decimal point).
+               | Other than the sign indicators, it can contain only
+               | '#', then digits 0-9 then 'V' then digits 0-9.
+               | The positive part of the dfdl:textNumberPattern is mandatory.""".stripMargin('|'),
+            pattern)
+      }
+    } else if (hasP) {
+      val rr = TextNumberPatternUtils.pOnRightRegexStandard
+      val rl = TextNumberPatternUtils.pOnLeftRegexStandard
+      val rightMatch = rr.findFirstMatchIn(patternNoQuoted)
+      val leftMatch = rl.findFirstMatchIn(patternNoQuoted)
+      (leftMatch, rightMatch) match {
+        case (None, None) => e.SDE(
+        """The dfdl:textNumberPattern '%s' contains 'P' (virtual decimal point positioners).
+            |However, it did not match the allowed syntax which allows the sign indicator
+            |plus digits on only one side of the P symbols.""".stripMargin,
           pattern)
+        case (Some(rl(_, ps, digits, _, negPre, negPs, negDigits, _)), None) => {
+          checkPPPMatchSyntax(ps, digits, negPre, negPs, negDigits)
+          ps.length + digits.length
+        }
+        case (None, Some(rr(_, digits, ps, _, negPre, negDigits, negPs, _))) => {
+          checkPPPMatchSyntax(ps, digits, negPre, negPs, negDigits)
+          - ps.length // negate value.
+        }
+        case _ => Assert.invariantFailed("Should not match both left P and right P regular expressions.")
+      }
+    } else {
+      0 // there is no V nor P, so there is no virtual decimal point scaling involved.
+    }
+  }
+
+  /**
+   * Check for common errors in the pattern matches for 'P' patterns.
+   *
+   * @param ps        match string for positive pattern P characters
+   * @param digits    match string for positive pattern digits (and sharps)
+   * @param negPre    negative prefix match (null if there is no negative pattern at all)
+   * @param negPs     match string for negative pattern P character (or null)
+   * @param negDigits match string for negative pattern P digits (and sharps)
+   */
+  private def checkPPPMatchSyntax(ps: String, digits: String, negPre: String, negPs: String, negDigits: String): Unit = {
+    Assert.invariant(ps.length >= 1)
+    digits.length >= 1
+    if (negPre ne null) {
+      e.schemaDefinitionUnless(ps == negPs,
+        """In the dfdl:textNumberPattern '%s' the P Symbols do not match
+          | between positive and negative patterns""".stripMargin,
+        pattern)
+      e.schemaDefinitionUnless(digits == negDigits,
+        """In the dfdl:textNumberPattern '%s' the '#' and digit symbols do not match
+          | between positive and negative patterns""".stripMargin,
+        pattern)
     }
   }
 
@@ -346,8 +553,8 @@ case class ConvertTextStandardNumberPrim(e: ElementBase)
     // also require the separators if the prim type is not an integer type,
     // since ICU will use them even if the pattern does not specify them.
     val requireDecGroupSeps =
-      patternStripped.contains(",") || patternStripped.contains(".") ||
-      patternStripped.contains("E") || patternStripped.contains("@") ||
+      patternNoQuoted.contains(",") || patternNoQuoted.contains(".") ||
+      patternNoQuoted.contains("E") || patternNoQuoted.contains("@") ||
       !isInt
 
     val decSep =

--- a/daffodil-core/src/main/scala/org/apache/daffodil/grammar/primitives/PrimitivesZoned.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/grammar/primitives/PrimitivesZoned.scala
@@ -20,6 +20,7 @@ package org.apache.daffodil.grammar.primitives
 
 import org.apache.daffodil.dpath.NodeInfo.PrimType
 import org.apache.daffodil.dsom._
+import org.apache.daffodil.exceptions.Assert
 import org.apache.daffodil.grammar.Gram
 import org.apache.daffodil.grammar.Terminal
 import org.apache.daffodil.processors.TextNumberFormatEv
@@ -49,51 +50,70 @@ case class ConvertZonedNumberPrim(e: ElementBase)
   with ConvertTextNumberMixin {
 
   final override protected lazy val textDecimalVirtualPointFromPattern: Int = {
-    TextNumberPatternUtils.textDecimalVirtualPointForZoned(patternStripped).getOrElse {
-      e.SDE(
-        s"""The dfdl:textNumberPattern '%s' contains 'V' (virtual decimal point).
-           |Other than the leading or trailing '+' sign indicator,
-           |it can contain only digits 0-9.""".stripMargin('|'),
-        pattern)
+    if (hasV) {
+      TextNumberPatternUtils.textNumber_V_DecimalVirtualPointForZoned(patternNoQuoted).getOrElse {
+        e.SDE(
+          s"""The dfdl:textNumberPattern '%s' contains 'V' (virtual decimal point).
+             |Other than the leading or trailing '+' sign indicator,
+             |it can contain only digits 0-9.""".stripMargin('|'),
+          pattern)
+      }
+    } else if (hasP) {
+      val rr = TextNumberPatternUtils.pOnRightRegexZoned
+      val rl = TextNumberPatternUtils.pOnLeftRegexZoned
+      val rightMatch = rr.findFirstMatchIn(patternNoQuoted)
+      val leftMatch = rl.findFirstMatchIn(patternNoQuoted)
+      (leftMatch, rightMatch) match {
+        case (None, None) => e.SDE(
+          """The dfdl:textNumberPattern '%s' contains 'P' (decimal scaling position symbol(s)).
+            |However, it did not match the allowed syntax which allows the sign indicator
+            |plus digits on only one side of the P symbols.""".stripMargin,
+          pattern)
+        case (Some(rl(_, ps, digits, _)), None) => ps.length + digits.length
+        case (None, Some(rr(_, digits, ps, _))) => -ps.length // negate value.
+        case _ => Assert.invariantFailed("Should not match both left P and right P regular expressions.")
+      }
+    } else {
+      0 // neither P nor V in pattern
     }
   }
 
   lazy val textNumberFormatEv: TextNumberFormatEv = {
 
-    if (patternStripped.contains("@")) {
+    if (patternNoQuoted.contains("@")) {
       e.SDE("The '@' symbol may not be used in textNumberPattern for textNumberRep='zoned'")
     }
 
-    if (patternStripped.contains("E")) {
+    if (patternNoQuoted.contains("E")) {
       e.SDE("The 'E' symbol may not be used in textNumberPattern for textNumberRep='zoned'")
     }
 
-    e.schemaDefinitionWhen(patternStripped.contains(";"),
+    e.schemaDefinitionWhen(patternNoQuoted.contains(";"),
       "Negative patterns may not be used in textNumberPattern for textNumberRep='zoned'")
 
     e.primType match {
       case PrimType.Double | PrimType.Float => e.SDE("textNumberRep='zoned' does not support Doubles/Floats")
       case PrimType.UnsignedLong | PrimType.UnsignedInt | PrimType.UnsignedShort | PrimType.UnsignedByte => {
         if (e.textNumberCheckPolicy == TextNumberCheckPolicy.Lax) {
-          if ((patternStripped(0) != '+') && (patternStripped(patternStripped.length - 1) != '+'))
+          if ((patternNoQuoted(0) != '+') && (patternNoQuoted(patternNoQuoted.length - 1) != '+'))
             e.SDE("textNumberPattern must have '+' at the beginning or the end of the pattern when textNumberRep='zoned' and textNumberPolicy='lax' for unsigned numbers")
         }
       }
       case _ => {
-        if ((patternStripped(0) != '+') && (patternStripped(patternStripped.length - 1) != '+'))
+        if ((patternNoQuoted(0) != '+') && (patternNoQuoted(patternNoQuoted.length - 1) != '+'))
           e.SDE("textNumberPattern must have '+' at the beginning or the end of the pattern when textNumberRep='zoned' for signed numbers")
       }
     }
 
-    if ((patternStripped(0) == '+') && (patternStripped(patternStripped.length - 1) == '+'))
+    if ((patternNoQuoted(0) == '+') && (patternNoQuoted(patternNoQuoted.length - 1) == '+'))
       e.SDE("The textNumberPattern may either begin or end with a '+', not both.")
 
     if (textDecimalVirtualPoint > 0) {
       e.primType match {
         case PrimType.Decimal => // ok
         case _ => e.SDE(
-          """The dfdl:textNumberPattern has a virtual decimal point 'V' and dfdl:textNumberRep='zoned'.
-            | The type must be xs:decimal, but was: %s.""".stripMargin, e.primType.globalQName.toPrettyString)
+          """The dfdl:textNumberPattern has a virtual decimal point 'V' or decimal scaling 'P' and dfdl:textNumberRep='zoned'.
+            | The type must be xs:decimal but was: %s.""".stripMargin, e.primType.globalQName.toPrettyString)
       }
     }
 

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section13/zoned/pv.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section13/zoned/pv.tdml
@@ -52,15 +52,35 @@
     <element name="bad02" type="xs:decimal" dfdl:textNumberPattern="######0V0#"/>
     <element name="bad03" type="xs:decimal" dfdl:textNumberPattern="##0###0V0#"/>
 
-    <element name="badP01" type="xs:decimal" dfdl:textNumberPattern="PPP000V00"/>
-
-
     <element name="float" type="xs:float" dfdl:textNumberPattern="##0V00;-##0V00"/>
     <element name="double" type="xs:double" dfdl:textNumberPattern="##0V00;-##0V00"/>
 
     <element name="byte" type="xs:byte" dfdl:textNumberPattern="0V0"/>
 
+
+    <element name="pOnLeft" type="xs:decimal" dfdl:textNumberPattern="PP000;-PP000"/>
+
+    <element name="pOnRight" type="xs:decimal" dfdl:textNumberPattern="##0PP+;##0PP-"/>
+
   </tdml:defineSchema>
+
+  <parserTestCase name="ppattern_01" root="pOnLeft" model="s1">
+    <document>123</document>
+    <infoset>
+      <dfdlInfoset>
+        <ex:pOnLeft>0.00123</ex:pOnLeft>
+      </dfdlInfoset>
+    </infoset>
+  </parserTestCase>
+
+  <parserTestCase name="ppattern_02" root="pOnRight" model="s1">
+    <document>123-</document>
+    <infoset>
+      <dfdlInfoset>
+        <ex:pOnRight>-12300</ex:pOnRight>
+      </dfdlInfoset>
+    </infoset>
+  </parserTestCase>
 
 
   <parserTestCase name="vpattern_01" root="money" model="s1">
@@ -215,14 +235,6 @@
     </errors>
   </parserTestCase>
 
-  <parserTestCase name="vpattern_bad_P01" root="badP01" model="s1">
-    <document>999999999</document>
-    <errors>
-      <error>textNumberPattern</error>
-      <error>not yet implemented</error>
-    </errors>
-  </parserTestCase>
-
   <parserTestCase name="float_vpattern_01" root="float" model="s1">
     <document>99999</document>
     <infoset>
@@ -275,9 +287,6 @@
     <element name="bad01" type="xs:decimal" dfdl:textNumberPattern=";-######0V00"/>
     <element name="bad02" type="xs:decimal" dfdl:textNumberPattern="######0V0#"/>
     <element name="bad03" type="xs:decimal" dfdl:textNumberPattern="##0###0V0#"/>
-
-    <element name="badP01" type="xs:decimal" dfdl:textNumberPattern="PPP000V00"/>
-
 
     <element name="float" type="xs:float" dfdl:textNumberPattern="##0V00"/>
     <element name="double" type="xs:double" dfdl:textNumberPattern="##0V00"/>
@@ -359,14 +368,6 @@
     <errors>
       <error>textNumberPattern</error>
       <error>contain only digits 0-9</error>
-    </errors>
-  </parserTestCase>
-
-  <parserTestCase name="zoned_vpattern_bad_P01" root="badP01" model="zoned1">
-    <document>999999999</document>
-    <errors>
-      <error>textNumberPattern</error>
-      <error>not yet implemented</error>
     </errors>
   </parserTestCase>
 

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section13/zoned/TestPV.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section13/zoned/TestPV.scala
@@ -57,7 +57,6 @@ class TestPV {
   @Test def vpattern_bad_01(): Unit = { runner.runOneTest("vpattern_bad_01") }
   @Test def vpattern_bad_02(): Unit = { runner.runOneTest("vpattern_bad_02") }
   @Test def vpattern_bad_03(): Unit = { runner.runOneTest("vpattern_bad_03") }
-  @Test def vpattern_bad_P01(): Unit = { runner.runOneTest("vpattern_bad_P01") }
 
 
   @Test def zoned_vpattern_01(): Unit = { runner.runOneTest("zoned_vpattern_01") }
@@ -74,7 +73,10 @@ class TestPV {
   @Test def zoned_vpattern_bad_01(): Unit = { runner.runOneTest("zoned_vpattern_bad_01") }
   @Test def zoned_vpattern_bad_02(): Unit = { runner.runOneTest("zoned_vpattern_bad_02") }
   @Test def zoned_vpattern_bad_03(): Unit = { runner.runOneTest("zoned_vpattern_bad_03") }
-  @Test def zoned_vpattern_bad_P01(): Unit = { runner.runOneTest("zoned_vpattern_bad_P01") }
+
+  @Test def ppattern_01(): Unit = { runner.runOneTest("ppattern_01") }
+  @Test def ppattern_02(): Unit = { runner.runOneTest("ppattern_02") }
+
 
 }
 


### PR DESCRIPTION
Also a Cobol feature.

Also this change set incorporates additional review feedback on the 'V' feature change set.

Note that the 'P' and 'V' feature does not support some obscure textNumberPattern as yet such as:

1. a textNumberPattern with a trailing 'V' (no 0 digits after)

2. combining 'V' with an exponent specification.

Those usages are allowed technically by the DFDL v1.0 specification (the grammar in section 13.6.1.1 labeled Figure 4), but that usage is so obscure that I am NOT going to create a bug report about implementing these behaviors until someone complains.

DAFFODIL-2763