### PR TITLE
Implement 'P' textNumberPattern feature.

### DIFF
--- a/daffodil-core/src/test/scala/org/apache/daffodil/grammar/primitives/TestPrimitives.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/grammar/primitives/TestPrimitives.scala
@@ -17,6 +17,7 @@
 
 package org.apache.daffodil.grammar.primitives
 
+import com.ibm.icu.text.DecimalFormat
 import org.apache.daffodil.Implicits.intercept
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
@@ -29,51 +30,77 @@ import java.util.regex.PatternSyntaxException
 class TestPrimitives {
 
   @Test def testVRegexPositiveAndNegativeWithPrefixesAndSuffixes() : Unit = {
-    val re = TextNumberPatternUtils.vregexStandard
+    val re = TextNumberPatternUtils.vRegexStandard
     val Some(myMatch) = re.findFirstMatchIn("A###012V34B;C####56V78D")
     myMatch match {
-      case re("A", "###012", "34", "B", "C", "####56", "78", "D") => // ok
+      case re("A", "###012", "34", "B", "C", "####56V78", "D") => // ok
+    }
+  }
+
+  @Test def testVRegexPositiveAndNegativeWithPrefixesAndSuffixes2(): Unit = {
+    val re = TextNumberPatternUtils.vRegexStandard
+    val Some(myMatch) = re.findFirstMatchIn("'P'###012V34B;C####56V78D")
+    myMatch match {
+      case re("'P'", "###012", "34", "B", "C", "####56V78", "D") => // ok
+    }
+  }
+
+  @Test def testVRegexPositiveAndNegativeWithPrefixesAndSuffixes3(): Unit = {
+    val re = TextNumberPatternUtils.vRegexStandard
+    val optMatch = re.findFirstMatchIn("'P'###012V34'P';N0V0N")
+    println(optMatch)
+    optMatch match {
+      case Some(re("'P'", "###012", "34", "'P'", "N", "0V0", "N")) => // ok
+    }
+  }
+
+  @Test def testVRegexPositiveAndNegativeWithPrefixesAndSuffixes4(): Unit = {
+    val re = TextNumberPatternUtils.vRegexStandard
+    val optMatch = re.findFirstMatchIn("'P'###012V34'P';N#N")
+    println(optMatch)
+    optMatch match {
+      case Some(re("'P'", "###012", "34", "'P'", "N", "#", "N")) => // ok
     }
   }
 
   @Test def testVRegexOnlyPositivePattern(): Unit = {
-    val re = TextNumberPatternUtils.vregexStandard
+    val re = TextNumberPatternUtils.vRegexStandard
     val Some(myMatch) = re.findFirstMatchIn("A###012V34B")
     myMatch match {
-      case re("A", "###012", "34", "B", null, null, null, null) =>
+      case re("A", "###012", "34", "B", null, null, null) =>
     }
   }
 
   @Test def testVRegexOnlyPositivePatternNoPrefixNorSuffix(): Unit = {
-    val re = TextNumberPatternUtils.vregexStandard
+    val re = TextNumberPatternUtils.vRegexStandard
     val Some(myMatch) = re.findFirstMatchIn("###012V34")
     myMatch match {
-      case re("", "###012", "34", "", null, null, null, null) =>
+      case re("", "###012", "34", "", null, null, null) =>
     }
   }
 
   @Test def testVRegexTrailingSign(): Unit = {
-    val re = TextNumberPatternUtils.vregexStandard
+    val re = TextNumberPatternUtils.vRegexStandard
     val Some(myMatch) = re.findFirstMatchIn("012V34+") // for zoned, overpunched trailing sign.
     myMatch match {
-      case re("", "012", "34", "+", null, null, null, null) =>
+      case re("", "012", "34", "+", null, null, null) =>
     }
   }
 
   @Test def testVRegexZonedLeadingSign(): Unit = {
-    val re = TextNumberPatternUtils.vregexZoned
+    val re = TextNumberPatternUtils.vRegexZoned
     val optMyMatch = re.findFirstMatchIn("+012V34") // for zoned, overpunched leading sign.
     val Some(re("+", "012", "34", "")) = optMyMatch
   }
 
   @Test def testVRegexZonedTrailingSign(): Unit = {
-    val re = TextNumberPatternUtils.vregexZoned
+    val re = TextNumberPatternUtils.vRegexZoned
     val optMyMatch = re.findFirstMatchIn("012V34+") // for zoned, overpunched trailing sign.
     val Some(re("", "012", "34", "+")) = optMyMatch
   }
 
   @Test def testVRegexZonedNothingAfterSuffix(): Unit = {
-    val re = TextNumberPatternUtils.vregexZoned
+    val re = TextNumberPatternUtils.vRegexZoned
     val optMyMatch = re.findFirstMatchIn("012V34+garbage") // for zoned, overpunched trailing sign.
     optMyMatch match {
       case Some(re("", "012", "34", "+")) => fail("accepted trash at end of pattern")
@@ -82,7 +109,7 @@ class TestPrimitives {
   }
 
   @Test def testVRegexZonedSignNotPlus(): Unit = {
-    val re = TextNumberPatternUtils.vregexZoned
+    val re = TextNumberPatternUtils.vRegexZoned
     val optMyMatch = re.findFirstMatchIn("A012V34")
     optMyMatch match {
       case Some(x @ re(_*)) => fail(s"accepted A as leading sign: $x")
@@ -92,15 +119,44 @@ class TestPrimitives {
 
   @Test def testVRegexZonedTwoSigns(): Unit = {
     assertTrue(
-      TextNumberPatternUtils.textDecimalVirtualPointForZoned("+012V34+").isEmpty
+      TextNumberPatternUtils.textNumber_V_DecimalVirtualPointForZoned("+012V34+").isEmpty
     )
   }
 
   @Test def testRemoveUnquotedPAndV_01(): Unit = {
-    val actually = "zVz''Va'PPP'''V'b'''"
-    val expected = "zz''a'P'''V'b'''"
-    assertEquals(expected, TextNumberPatternUtils.removeUnquotedPV(actually))
+    val pattern = "PPzVz''Va'PPP'''V'b'''"
+    val expected = "zz''a'PPP''''b'''"
+    assertEquals(expected, TextNumberPatternUtils.removeUnquotedPV(pattern))
   }
+
+  /**
+   * This test shows that quoting of characters in ICU text number patterns
+   * and hence DFDL text number patterns can quote strings, not just individual
+   * characters.
+   *
+   * I found no examples of this anywhere. Everything shows patterns where
+   * quotes surround only single characters, or are doubled up for self quoting.
+   *
+   * This is ICU behavior however, DFDL v1.0 specifies that the prefix/suffix
+   * can only be single characters.
+   */
+  @Test def testICUDecimalFormatQuoting_01(): Unit = {
+    {
+      // Note that E is a pattern special character
+      val pattern = "'POSITIVE' #.0###;'NEGATIVE' #.0###"
+      val df = new DecimalFormat(pattern)
+      val actual = df.format(-6.847)
+      assertEquals("NEGATIVE 6.847", actual)
+    }
+    {
+      // here we quote only the E, not the other characters.
+      val pattern = "POSITIV'E' #.0###;NEGATIV'E' #.0###"
+      val df = new DecimalFormat(pattern)
+      val actual = df.format(6.847)
+      assertEquals("POSITIVE 6.847", actual)
+    }
+  }
+
 
   @Test def howToUseRegexLookBehindWithReplaceAll(): Unit = {
     // despite the fact that we say "P not preceded by ...." that's not how you
@@ -142,7 +198,7 @@ class TestPrimitives {
   }
 
   @Test def testZonedVRegexWithPrefix(): Unit = {
-    val re = TextNumberPatternUtils.vregexZoned
+    val re = TextNumberPatternUtils.vRegexZoned
     val Some(myMatch) = re.findFirstMatchIn("+012V34")
     myMatch match {
       case re("+", "012", "34", "") => // ok
@@ -150,10 +206,71 @@ class TestPrimitives {
   }
 
   @Test def testZonedVRegexWithSuffix(): Unit = {
-    val re = TextNumberPatternUtils.vregexZoned
+    val re = TextNumberPatternUtils.vRegexZoned
     val Some(myMatch) = re.findFirstMatchIn("012V34+")
     myMatch match {
       case re("", "012", "34", "+") => // ok
     }
   }
+
+  @Test def testStandardPOnLeft(): Unit = {
+    val re = TextNumberPatternUtils.pOnLeftRegexStandard
+    println(re)
+    val Some(myMatch) = re.findFirstMatchIn("+PPP000")
+    myMatch match {
+      case re("+", "PPP", "000", "", null, null, null) => // ok
+    }
+  }
+
+  @Test def testStandardPOnLeft2(): Unit = {
+    val re = TextNumberPatternUtils.pOnLeftRegexStandard
+    println(re)
+    val Some(myMatch) = re.findFirstMatchIn("+PPP000;-#")
+    myMatch match {
+      case re("+", "PPP", "000", "", "-", "#", "") => // ok
+    }
+  }
+
+  @Test def testStandardPOnLeft3(): Unit = {
+    val re = TextNumberPatternUtils.pOnLeftRegexStandard
+    println(re)
+    val Some(myMatch) = re.findFirstMatchIn("+PPP000;-P0")
+    myMatch match {
+      case re("+", "PPP", "000", "", "-", "P0", "") => // ok
+    }
+  }
+
+  @Test def testStandardPOnRight(): Unit = {
+    val re = TextNumberPatternUtils.pOnRightRegexStandard
+    val Some(myMatch) = re.findFirstMatchIn("000PPP+")
+    myMatch match {
+      case re("", "000", "PPP", "+", null, null, null) => // ok
+    }
+  }
+
+  @Test def testStandardPOnRight2(): Unit = {
+    val re = TextNumberPatternUtils.pOnRightRegexStandard
+    val Some(myMatch) = re.findFirstMatchIn("000PPP+;0P-")
+    myMatch match {
+      case re("", "000", "PPP", "+", "", "0P", "-") => // ok
+    }
+  }
+
+  @Test def testZonedPOnLeft(): Unit = {
+    val re = TextNumberPatternUtils.pOnLeftRegexZoned
+    val Some(myMatch) = re.findFirstMatchIn("+PPP000")
+    myMatch match {
+      case re("+", "PPP", "000", "") => // ok
+    }
+  }
+
+  @Test def testZonedPOnRight(): Unit = {
+    val re = TextNumberPatternUtils.pOnRightRegexZoned
+    val Some(myMatch) = re.findFirstMatchIn("000PPP+")
+    myMatch match {
+      case re("", "000", "PPP", "+") => // ok
+    }
+  }
+
+
 }

--- a/daffodil-propgen/src/main/resources/org/apache/daffodil/xsd/dafext.xsd
+++ b/daffodil-propgen/src/main/resources/org/apache/daffodil/xsd/dafext.xsd
@@ -684,6 +684,7 @@
           <xs:enumeration value="queryStylePathExpression" />
           <xs:enumeration value="regexPatternZeroLength" />
           <xs:enumeration value="textBidiError" />
+          <xs:enumeration value="textNumberPatternWarning" />
           <xs:enumeration value="textOutputMinLengthOutOfRange" />
           <xs:enumeration value="textStandardBaseUndefined" />
           <xs:enumeration value="unsupportedAttributeBlockDefault" />

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/ConvertTextStandardNumberParser.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/ConvertTextStandardNumberParser.scala
@@ -17,13 +17,11 @@
 
 package org.apache.daffodil.processors.parsers
 
-import com.ibm.icu.math.{ BigDecimal => ICUBigDecimal }
+import com.ibm.icu.math.{BigDecimal => ICUBigDecimal}
 import com.ibm.icu.text.DecimalFormat
 
 import java.text.ParsePosition
-
 import scala.util.matching.Regex
-
 import org.apache.daffodil.dpath.NodeInfo
 import org.apache.daffodil.dpath.InvalidPrimitiveDataException
 import org.apache.daffodil.exceptions.Assert
@@ -34,7 +32,8 @@ import org.apache.daffodil.processors.Success
 import org.apache.daffodil.processors.TermRuntimeData
 import org.apache.daffodil.processors.TextNumberFormatEv
 
-import java.lang.{Long => JLong, Float => JFloat, Double => JDouble, Number => JNumber}
+import java.lang.{Float => JFloat, Number => JNumber, Long => JLong, Double => JDouble}
+import java.math.MathContext
 import java.math.{BigDecimal => JBigDecimal}
 
 case class ConvertTextCombinatorParser(
@@ -59,7 +58,7 @@ case class ConvertTextCombinatorParser(
 trait TextDecimalVirtualPointMixin {
   def textDecimalVirtualPoint: Int
 
-  final protected val virtualPointScaleFactor = scala.math.pow(10.0, textDecimalVirtualPoint)
+  final protected lazy val virtualPointScaleFactor = scala.math.pow(10.0, textDecimalVirtualPoint)
 
   final protected def applyTextDecimalVirtualPointForParse(num1: JNumber): JNumber = {
     if (textDecimalVirtualPoint == 0) num1
@@ -68,7 +67,11 @@ trait TextDecimalVirtualPointMixin {
       val scaledNum: JNumber = num1 match {
         // Empirically, in our test suite, we do get Long back here, so the runtime sometimes represents small integer
         // (or possibly even smaller decimal numbers with no fraction part) as Long.
-        case l: JLong => JBigDecimal.valueOf(l).scaleByPowerOfTen(-textDecimalVirtualPoint)
+        case l: JLong => {
+          val scaled = JBigDecimal.valueOf(l).scaleByPowerOfTen(-textDecimalVirtualPoint)
+          if (textDecimalVirtualPoint < 0) scaled.toBigIntegerExact()
+          else scaled
+        }
         case bd: JBigDecimal => bd.scaleByPowerOfTen(-textDecimalVirtualPoint)
         case f: JFloat => (f / virtualPointScaleFactor).toFloat
         case d: JDouble => (d / virtualPointScaleFactor).toDouble
@@ -89,21 +92,52 @@ trait TextDecimalVirtualPointMixin {
   }
   // $COVERAGE-ON$
 
+
+  /**
+   * Always creates an integer from a JFloat, JDouble, or JBigDecimal
+   * by scaling the argument by the virtual decimal point scaling factor.
+   *
+   * If the argument is some other JNumber, i.e., not a JFloat, JDouble, or JBigDecimal
+   * it can only be an integer type. This method returns the argument value
+   * only if no virtual decimal point scaling is needed.
+   * Otherwise aborts since only JFloat, JDouble, or JDecimal can be scaled in this way.
+   *
+   * Floating point NaNs and Infinities are tolerated. (No scaling occurs.)
+   *
+   * @param valueAsAnyRef value to be scaled. Should be a JNumber. Aborts otherwise.
+   * @return a JNumber of the same concrete type as the argument.
+   */
   final protected def applyTextDecimalVirtualPointForUnparse(valueAsAnyRef: AnyRef) : JNumber = {
-    valueAsAnyRef match {
+    val res: JNumber = valueAsAnyRef match {
+      case jn: JNumber if (textDecimalVirtualPoint == 0) => jn
       // This is not perfectly symmetrical with the parse side equivalent.
       // Empirically in our test suite, we do not see JLong here.
-      case f: JFloat => (f * virtualPointScaleFactor).toFloat
-      case d: JDouble => (d * virtualPointScaleFactor).toDouble
-      case bd: JBigDecimal => bd.scaleByPowerOfTen(textDecimalVirtualPoint)
-
+      //
+      // If the base 10 data is 1.23 and it becomes a float, that's 1.2300000190734863
+      // That is to say, it isn't a perfect representation of 1.23, so we don't know for
+      // certain that when we unscale it by the virtualPointScaleFactor that it will
+      // become an integer. We just know it will be close to an integer.
+      // The same holds for a decimal number that was created via math involving division.
+      // In that case there may be fraction digits that will still exist even after we scale
+      // the value so that it "should be" an integer.
+      //
+      // So if it is float/double/decimal after scaling we round it to be exactly an
+      // integer.
+      //
+      case f: JFloat if f.isNaN || f.isInfinite => f
+      case f: JFloat => (f * virtualPointScaleFactor).round.toFloat
+      case d: JDouble if d.isNaN || d.isInfinite => d
+      case d: JDouble => (d * virtualPointScaleFactor).round.toDouble
+      case bd: JBigDecimal => bd.scaleByPowerOfTen(textDecimalVirtualPoint).round(MathContext.UNLIMITED)
       case n: JNumber =>
-        if (textDecimalVirtualPoint == 0) n
         // $COVERAGE-OFF$ // both badType and the next case are coverage-off
-        else badType(n)
+        badType(n)
       case _ => Assert.invariantFailed("Not a JNumber")
       // $COVERAGE-ON$
     }
+    // Result type is same as argument type.
+    Assert.invariant(res.getClass == valueAsAnyRef.getClass)
+    res
   }
 }
 

--- a/daffodil-test/src/test/resources/org/apache/daffodil/extensions/enum/enumInvalid.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/extensions/enum/enumInvalid.tdml
@@ -46,7 +46,7 @@
       </complexType>
     </element>
 
-    <simpleType name="enum2" dfdlx:repType="ex:myByte">
+    <simpleType name="enum2" dfdlx:repType="xs:byte">
       <restriction base="xs:string">
         <enumeration value="valid" dfdlx:repValues="0"/>
         <enumeration value="empty" dfdlx:repValues=""/>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section13/zoned/pv.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section13/zoned/pv.tdml
@@ -47,20 +47,47 @@
 
     <element name="money" type="xs:decimal" dfdl:textNumberPattern="######0V00;-######0V00"/>
     <element name="money2" type="xs:decimal" dfdl:textNumberPattern="[######0V00];(######0V00)"/>
+    <element name="money3" type="xs:decimal" dfdl:textNumberPattern="[######0V00];(#)"/>
+
 
     <element name="bad01" type="xs:decimal" dfdl:textNumberPattern=";-######0V00"/>
     <element name="bad02" type="xs:decimal" dfdl:textNumberPattern="######0V0#"/>
     <element name="bad03" type="xs:decimal" dfdl:textNumberPattern="##0###0V0#"/>
 
-    <element name="badP01" type="xs:decimal" dfdl:textNumberPattern="PPP000V00"/>
-
+    <!--
+    Should produce warning that negative pattern and positive pattern are not matching
+    -->
+    <element name="warn04" type="xs:decimal" dfdl:textNumberPattern="#0V00;-###"/>
 
     <element name="float" type="xs:float" dfdl:textNumberPattern="##0V00;-##0V00"/>
     <element name="double" type="xs:double" dfdl:textNumberPattern="##0V00;-##0V00"/>
 
     <element name="byte" type="xs:byte" dfdl:textNumberPattern="0V0"/>
 
+
+    <element name="pOnLeft" type="xs:decimal" dfdl:textNumberPattern="PP000;-PP000"/>
+
+    <element name="pOnRight" type="xs:decimal" dfdl:textNumberPattern="##0PP+;##0PP-"/>
+
   </tdml:defineSchema>
+
+  <parserTestCase name="ppattern_01" root="pOnLeft" model="s1">
+    <document>123</document>
+    <infoset>
+      <dfdlInfoset>
+        <ex:pOnLeft>0.00123</ex:pOnLeft>
+      </dfdlInfoset>
+    </infoset>
+  </parserTestCase>
+
+  <parserTestCase name="ppattern_02" root="pOnRight" model="s1">
+    <document>123-</document>
+    <infoset>
+      <dfdlInfoset>
+        <ex:pOnRight>-12300</ex:pOnRight>
+      </dfdlInfoset>
+    </infoset>
+  </parserTestCase>
 
 
   <parserTestCase name="vpattern_01" root="money" model="s1">
@@ -115,6 +142,15 @@
     <infoset>
       <dfdlInfoset>
         <ex:money2>-9.99</ex:money2>
+      </dfdlInfoset>
+    </infoset>
+  </parserTestCase>
+
+  <parserTestCase name="vpattern_07" root="money3" model="s1">
+    <document>(999)</document>
+    <infoset>
+      <dfdlInfoset>
+        <ex:money3>-9.99</ex:money3>
       </dfdlInfoset>
     </infoset>
   </parserTestCase>
@@ -215,12 +251,19 @@
     </errors>
   </parserTestCase>
 
-  <parserTestCase name="vpattern_bad_P01" root="badP01" model="s1">
+  <parserTestCase name="vpattern_warn_04" root="warn04" model="s1">
     <document>999999999</document>
-    <errors>
-      <error>textNumberPattern</error>
-      <error>not yet implemented</error>
-    </errors>
+    <infoset>
+      <dfdlInfoset>
+        <ex:warn04>9999999.99</ex:warn04>
+      </dfdlInfoset>
+    </infoset>
+    <warnings>
+      <warning>textNumberPattern</warning>
+      <warning>negative numeric part</warning>
+      <warning>###</warning>
+      <warning>#0V00</warning>
+    </warnings>
   </parserTestCase>
 
   <parserTestCase name="float_vpattern_01" root="float" model="s1">
@@ -275,9 +318,6 @@
     <element name="bad01" type="xs:decimal" dfdl:textNumberPattern=";-######0V00"/>
     <element name="bad02" type="xs:decimal" dfdl:textNumberPattern="######0V0#"/>
     <element name="bad03" type="xs:decimal" dfdl:textNumberPattern="##0###0V0#"/>
-
-    <element name="badP01" type="xs:decimal" dfdl:textNumberPattern="PPP000V00"/>
-
 
     <element name="float" type="xs:float" dfdl:textNumberPattern="##0V00"/>
     <element name="double" type="xs:double" dfdl:textNumberPattern="##0V00"/>
@@ -359,14 +399,6 @@
     <errors>
       <error>textNumberPattern</error>
       <error>contain only digits 0-9</error>
-    </errors>
-  </parserTestCase>
-
-  <parserTestCase name="zoned_vpattern_bad_P01" root="badP01" model="zoned1">
-    <document>999999999</document>
-    <errors>
-      <error>textNumberPattern</error>
-      <error>not yet implemented</error>
     </errors>
   </parserTestCase>
 

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section13/zoned/TestPV.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section13/zoned/TestPV.scala
@@ -40,6 +40,7 @@ class TestPV {
   @Test def vpattern_04(): Unit = { runner.runOneTest("vpattern_04") }
   @Test def vpattern_05(): Unit = { runner.runOneTest("vpattern_05") }
   @Test def vpattern_06(): Unit = { runner.runOneTest("vpattern_06") }
+  @Test def vpattern_07(): Unit = { runner.runOneTest("vpattern_07") }
 
   @Test def vpattern_zero(): Unit = { runner.runOneTest("vpattern_zero") }
   @Test def vpattern_ZZZ(): Unit = { runner.runOneTest("vpattern_ZZZ") }
@@ -57,7 +58,7 @@ class TestPV {
   @Test def vpattern_bad_01(): Unit = { runner.runOneTest("vpattern_bad_01") }
   @Test def vpattern_bad_02(): Unit = { runner.runOneTest("vpattern_bad_02") }
   @Test def vpattern_bad_03(): Unit = { runner.runOneTest("vpattern_bad_03") }
-  @Test def vpattern_bad_P01(): Unit = { runner.runOneTest("vpattern_bad_P01") }
+  @Test def vpattern_warn_04(): Unit = { runner.runOneTest("vpattern_warn_04") }
 
 
   @Test def zoned_vpattern_01(): Unit = { runner.runOneTest("zoned_vpattern_01") }
@@ -74,7 +75,10 @@ class TestPV {
   @Test def zoned_vpattern_bad_01(): Unit = { runner.runOneTest("zoned_vpattern_bad_01") }
   @Test def zoned_vpattern_bad_02(): Unit = { runner.runOneTest("zoned_vpattern_bad_02") }
   @Test def zoned_vpattern_bad_03(): Unit = { runner.runOneTest("zoned_vpattern_bad_03") }
-  @Test def zoned_vpattern_bad_P01(): Unit = { runner.runOneTest("zoned_vpattern_bad_P01") }
+
+  @Test def ppattern_01(): Unit = { runner.runOneTest("ppattern_01") }
+  @Test def ppattern_02(): Unit = { runner.runOneTest("ppattern_02") }
+
 
 }
 


### PR DESCRIPTION
The 'P' is also a COBOL feature from their picture clauses.

Also this change set incorporates additional review feedback on the 'V' feature change set.

Note that the 'P' and 'V' feature does not support some obscure textNumberPattern as yet such as:

1. a textNumberPattern with a trailing 'V' (no 0 digits after)

2. combining 'V' with an exponent specification.

Those usages are allowed technically by the DFDL v1.0 specification (the grammar in section 13.6.1.1 labeled Figure 4), but that usage is so obscure that I am NOT going to create a bug report about implementing these behaviors until someone complains.

Similarly it is technically possible to use say, CR (carriage return) or ASCII NUL as your plus sign
character. I claim that is a mistake in the DFDL spec to allow that, so use of line-ending characters is not allowed.

DAFFODIL-2763