### PR TITLE
WIP: Draft - Config feature to allow XMLConversionControl to preserve CRLF and CR in data

### DIFF
--- a/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/Facets.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/Facets.scala
@@ -191,6 +191,16 @@ trait Facets { self: Restriction =>
           // The XSD numeric character entity &#xE000; can be used to match ASCII NUL
           // (char code 0).
           //
+          // This remapping is for pattern facets, which are inside a DFDL schema,
+          // and so will not contain CR characters, since XML reading will convert those
+          // to LF. To discuss CR in this pattern we can't use `&#x0d;` syntax because that
+          // turns into a CR which gets turned into a LF. Plus the pattern value is
+          // an XML attribute, the value of which gets its whitespace collapsed, all
+          // line-ending chars converted to spaces, and adjacent spaces collapsed to one.
+          //
+          // So a pattern facet must use `\r` and '\n' to describe line-endings within the pattern.
+          // And in general one must be careful about whitespace.
+          //
           val remapped: String = XMLUtils.remapPUAToXMLIllegalCharacters(v)
           (f, remapped.r)
         }


### PR DESCRIPTION
Review ideas.

Ignore JAPI/SAPI changes for now.

Look only at XMLTextInfosetInputter and XMLTextInfosetOutputter, and ignore all the other variants thereof.

Because the changes across JAPI/SAPI and these inputters/outputters are very redundant. All same everywhere.

The real guts of this thing are:

changes to config file so that we can add

`<xmlConversionControl carriageReturnMapping="PreserveCR"/>
`

Which causes CRs to be presreved by remapping to the PUA. 

This can be extended with other attributes to control other aspects of XML Conversion as is needed for other open tickets (DAFFODIL-2346).

The actual remapping code has been consolidated and revised, but is mostly the same. 

DAFFODIL-1559