### PR TITLE
Handle configuration exceptions

### DIFF
--- a/daffodil-cli/src/main/scala/org/apache/daffodil/Main.scala
+++ b/daffodil-cli/src/main/scala/org/apache/daffodil/Main.scala
@@ -62,6 +62,7 @@ import com.siemens.ct.exi.main.api.sax.EXISource
 
 import org.apache.daffodil.api.DFDL
 import org.apache.daffodil.api.DaffodilConfig
+import org.apache.daffodil.api.DaffodilConfigException
 import org.apache.daffodil.api.DaffodilTunables
 import org.apache.daffodil.api.TDMLImplementation
 import org.apache.daffodil.api.URISchemaSource
@@ -1416,7 +1417,7 @@ object Main {
     val GenerateCodeError = Value(23)
     val TestError = Value(24)
     val PerformanceTestError = Value(25)
-
+    val ConfigError = Value(26)
 
     val LeftOverData = Value(31)
     val InvalidParserException = Value(32)
@@ -1471,6 +1472,10 @@ object Main {
       case e: GenericScallopException => {
         Logger.log.error(e.message)
         ExitCode.Usage
+      }
+      case e: DaffodilConfigException => {
+        Logger.log.error(e.message)
+        ExitCode.ConfigError
       }
       case e: Exception => {
         bugFound(e)

--- a/daffodil-cli/src/test/resources/org/apache/daffodil/CLI/single.dfdl.xsd
+++ b/daffodil-cli/src/test/resources/org/apache/daffodil/CLI/single.dfdl.xsd
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/" xmlns:tns="http://example.com"
+           targetNamespace="http://example.com">
+
+  <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd" />
+  <xs:annotation>
+    <xs:appinfo source="http://www.ogf.org/dfdl/">
+      <dfdl:format ref="ex:GeneralFormat"/>
+    </xs:appinfo>
+  </xs:annotation>
+
+  <xs:element name="single" type="xs:string"/>
+</xs:schema>

--- a/daffodil-cli/src/test/resources/org/apache/daffodil/CLI/single_conf_bad.txt
+++ b/daffodil-cli/src/test/resources/org/apache/daffodil/CLI/single_conf_bad.txt
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+This is not an XML file.

--- a/daffodil-cli/src/test/scala/org/apache/daffodil/cliTest/TestCLIParsing.scala
+++ b/daffodil-cli/src/test/scala/org/apache/daffodil/cliTest/TestCLIParsing.scala
@@ -694,4 +694,13 @@ class TestCLIparsing {
     } (ExitCode.Success)
   }
 
+  @Test def test_Invalid_Configuration_File(): Unit = {
+    val schema = path("daffodil-cli/src/test/resources/org/apache/daffodil/CLI/single.dfdl.xsd")
+    val config = path("daffodil-cli/src/test/resources/org/apache/daffodil/CLI/single_conf_bad.txt")
+
+    runCLI(args"parse -s $schema -c $config") { cli =>
+      cli.sendLine("0", inputDone = true)
+      cli.expectErr("Unable to load configuration")
+    } (ExitCode.ConfigError)
+  }
 }

--- a/daffodil-lib/src/test/resources/test/configBad.txt
+++ b/daffodil-lib/src/test/resources/test/configBad.txt
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+This is not an XML file.

--- a/daffodil-lib/src/test/scala/org/apache/daffodil/api/TestDaffodilTunablesAndConfig.scala
+++ b/daffodil-lib/src/test/scala/org/apache/daffodil/api/TestDaffodilTunablesAndConfig.scala
@@ -20,6 +20,7 @@ package org.apache.daffodil.api
 import org.junit.Test
 import org.apache.daffodil.util.Misc
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
 import org.junit.Assert.assertTrue
 
 class TestDaffodilTunablesAndConfig {
@@ -43,4 +44,9 @@ class TestDaffodilTunablesAndConfig {
     assertTrue(warnings.contains(WarnID.EncodingErrorPolicyError))
   }
 
+  @Test
+  def testDaffodilConfigBad(): Unit = {
+    val uri = Misc.getRequiredResource("test/configBad.txt")
+    assertThrows(classOf[DaffodilConfigException], () => DaffodilConfig.fromURI(uri))
+  }
 }


### PR DESCRIPTION
If an invalid configuration file is passed on the command line an unexpected exception occurs. This has been fixed to now handle this exception. All `SAXParseException`s thrown by the configuration loader are now caught and wrapped into a new `DaffodilConfigException` class. This Exception is now recognized by the CLI which logs the message and exits with a code of 26.

[DAFFODIL-1026](https://issues.apache.org/jira/browse/DAFFODIL-1026)
