### PR TITLE
Improved diagnostic message for enumeration invalid key/value

### DIFF
--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/TypeCalculator.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/TypeCalculator.scala
@@ -153,7 +153,7 @@ class KeysetValueTypeCalculatorOrdered(valueMap: HashMap[DataValuePrimitive, Dat
       })
       ans1 match {
         case None => {
-          (DataValue.NoValue, One(s"Key ${x} not found in keyset-value mapping"))
+          (DataValue.NoValue, One(s"Value ${x} not found in enumeration dfdlx:repValues"))
         }
         case Some((_, _, v)) => (v, Maybe.Nope)
       }
@@ -163,7 +163,7 @@ class KeysetValueTypeCalculatorOrdered(valueMap: HashMap[DataValuePrimitive, Dat
   override def outputTypeCalc(x: DataValuePrimitive, xType: NodeInfo.Kind): (DataValuePrimitiveNullable, Maybe[Error]) = {
     unparseMap.get(x) match {
       case Some(v) => (v, Maybe.Nope)
-      case None => (DataValue.NoValue, One(s"Value ${x} not found in keyset-value mapping"))
+      case None => (DataValue.NoValue, One(s"Value ${x} not found in enumeration"))
     }
   }
 
@@ -173,20 +173,16 @@ class KeysetValueTypeCalculatorUnordered(valueMap: HashMap[DataValuePrimitive, D
   extends TypeCalculator(srcType, dstType) {
 
   override def inputTypeCalc(x: DataValuePrimitive, xType: NodeInfo.Kind): (DataValuePrimitiveNullable, Maybe[Error]) = {
-    if (valueMap.contains(x)) {
-      valueMap.get(x) match {
-        case Some(a) => (a, Maybe.Nope)
-        case None => (DataValue.NoValue, One(s"Value ${x} not found in keyset-value mapping"))
-      }
-    } else {
-      (DataValue.NoValue, One(s"Key ${x} not found in keyset-value mapping"))
-
+    valueMap.get(x) match {
+      case Some(a) => (a, Maybe.Nope)
+      case None => (DataValue.NoValue, One(s"Value ${x} not found in enumeration dfdlx:repValues"))
     }
   }
+
   override def outputTypeCalc(x: DataValuePrimitive, xType: NodeInfo.Kind): (DataValuePrimitiveNullable, Maybe[Error]) = {
     unparseMap.get(x) match {
       case Some(v) => (v, Maybe.Nope)
-      case None => (DataValue.NoValue, One(s"Value ${x} not found in keyset-value mapping"))
+      case None => (DataValue.NoValue, One(s"Value ${x} not found in enumeration"))
     }
   }
 

--- a/daffodil-test/src/test/resources/org/apache/daffodil/extensions/type_calc/inputTypeCalc.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/extensions/type_calc/inputTypeCalc.tdml
@@ -295,6 +295,15 @@
       </xs:restriction>
     </xs:simpleType>
 
+    <xs:simpleType name="enumWithRange" dfdlx:repType="tns:enumVal">
+      <xs:restriction base="xs:string">
+        <xs:enumeration value="VALUE=0" dfdlx:repValues="0"/>
+        <xs:enumeration value="VALUE=1" dfdlx:repValues="1"/>
+        <xs:enumeration value="VALUE=2" dfdlx:repValueRanges="4 5"/>
+      </xs:restriction>
+    </xs:simpleType>
+
+
     <xs:element name="root">
       <xs:complexType>
         <xs:sequence>
@@ -302,6 +311,15 @@
         </xs:sequence>
       </xs:complexType>
     </xs:element>
+
+    <xs:element name="r2">
+      <xs:complexType>
+        <xs:sequence>
+          <xs:element name="int2" type="tns:enumWithRange"/>
+        </xs:sequence>
+      </xs:complexType>
+    </xs:element>
+
   </tdml:defineSchema>
 
   <tdml:parserTestCase name="inherited_LengthKind"
@@ -320,5 +338,77 @@
       </tdml:dfdlInfoset>
     </tdml:infoset>
   </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="valueNotFound_1"
+    root="root" model="inputTypeCalc-Inherited.dfdl.xsd"
+    description="Demonstrates a case where the provided value doesn't match any value in the enumeration">
+
+    <tdml:document>
+    <tdml:documentPart type="byte">
+    00 00 00 03
+    </tdml:documentPart>
+    </tdml:document>
+    <tdml:errors>
+      <tdml:error>Value</tdml:error>
+      <tdml:error>3</tdml:error>
+      <tdml:error>not found</tdml:error>
+      <tdml:error>enumeration</tdml:error>
+      <tdml:error>repValues</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+  <tdml:unparserTestCase name="unparseValueNotFound_1"
+    root="root" model="inputTypeCalc-Inherited.dfdl.xsd"
+    description="Demonstrates a case where the provided key doesn't match any key in the enumeration">
+
+    <tdml:infoset>
+      <tdml:dfdlInfoset xmlns:xs="http://www.w3.org/2001/XMLSchema"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+        <root><int>BAD_KEY</int></root>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+    <tdml:errors>
+      <tdml:error>Value</tdml:error>
+      <tdml:error>BAD_KEY</tdml:error>
+      <tdml:error>not found</tdml:error>
+      <tdml:error>enumeration</tdml:error>
+    </tdml:errors>
+  </tdml:unparserTestCase>
+
+  <tdml:parserTestCase name="valueNotFound_2"
+    root="r2" model="inputTypeCalc-Inherited.dfdl.xsd"
+    description="Demonstrates a case where the provided value doesn't match any value in the enumeration">
+
+    <tdml:document>
+    <tdml:documentPart type="byte">
+    00 00 00 03
+    </tdml:documentPart>
+    </tdml:document>
+    <tdml:errors>
+      <tdml:error>Value</tdml:error>
+      <tdml:error>3</tdml:error>
+      <tdml:error>not found</tdml:error>
+      <tdml:error>enumeration</tdml:error>
+      <tdml:error>repValues</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+  <tdml:unparserTestCase name="unparseValueNotFound_2"
+    root="r2" model="inputTypeCalc-Inherited.dfdl.xsd"
+    description="Demonstrates a case where the provided key doesn't match any key in the enumeration">
+
+    <tdml:infoset>
+      <tdml:dfdlInfoset xmlns:xs="http://www.w3.org/2001/XMLSchema"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+        <r2><int2>BAD_KEY</int2></r2>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+    <tdml:errors>
+      <tdml:error>Value</tdml:error>
+      <tdml:error>BAD_KEY</tdml:error>
+      <tdml:error>not found</tdml:error>
+      <tdml:error>enumeration</tdml:error>
+    </tdml:errors>
+  </tdml:unparserTestCase>
 
 </tdml:testSuite>

--- a/daffodil-test/src/test/scala/org/apache/daffodil/extensions/TestInputTypeValueCalc.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/extensions/TestInputTypeValueCalc.scala
@@ -53,6 +53,11 @@ class TestInputTypeValueCalc {
 
   @Test def test_inherited_LengthKind(): Unit = { runner.runOneTest("inherited_LengthKind") }
 
+  @Test def test_valueNotFound_1(): Unit = { runner.runOneTest("valueNotFound_1") }
+  @Test def test_unparseValueNotFound_1(): Unit = { runner.runOneTest("unparseValueNotFound_1") }
+  @Test def test_valueNotFound_2(): Unit = { runner.runOneTest("valueNotFound_2") }
+  @Test def test_unparseValueNotFound_2(): Unit = { runner.runOneTest("unparseValueNotFound_2") }
+
   @Test def test_InputTypeCalc_expression_01(): Unit = { exprRunner.runOneTest("InputTypeCalc_expression_01") }
   @Test def test_OutputTypeCalc_expression_01(): Unit = { exprRunner.runOneTest("OutputTypeCalc_expression_01") }
   @Test def test_InputTypeCalc_expression_02(): Unit = { exprRunner.runOneTest("InputTypeCalc_expression_02") }


### PR DESCRIPTION
Before attempting to pass an invalid value in an enumeration would result in an error referencing a keyset-value mapping with no mention of the enumeration itself. This should more obviously point to the fact that the given value is not present in the enumeration.

DAFFODIL-2607