### PR TITLE
Update tests for nested separators

### DIFF
--- a/daffodil-test-ibm1/src/test/resources/test-suite/tresys-contributed/nested-separator-delimited.tdml
+++ b/daffodil-test-ibm1/src/test/resources/test-suite/tresys-contributed/nested-separator-delimited.tdml
@@ -202,8 +202,6 @@
     </tdml:infoset>
   </tdml:parserTestCase>
 
-
-
   <tdml:defineSchema name="nest1">
     <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
     <dfdl:format ref="ex:GeneralFormat" occursCountKind="parsed" />
@@ -223,31 +221,17 @@
   </tdml:defineSchema>
 
   <tdml:parserTestCase name="nest1" root="nest1"
-    model="nest1" description="Unambiguous nested separators, no terminators.">
+    model="nest1" description="Verify that improperly defined schemas fails with the correct error message">
 
     <tdml:document>
       <tdml:documentPart type="text"><![CDATA[0,1,2;3,4,5;6,7;8;9!]]></tdml:documentPart>
     </tdml:document>
 
-    <tdml:infoset>
-      <tdml:dfdlInfoset xmlns:xs="http://www.w3.org/2001/XMLSchema"
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-        <nest1>
-          <a>0</a>
-          <a>1</a>
-          <a>2</a>
-          <a>3</a>
-          <a>4</a>
-          <a>5</a>
-          <a>6</a>
-          <a>7</a>
-          <a>8</a>
-          <a>9</a>
-        </nest1>
-      </tdml:dfdlInfoset>
-    </tdml:infoset>
+    <tdml:errors>
+      <tdml:error>Terminator</tdml:error>
+      <tdml:error>not found</tdml:error>
+    </tdml:errors>
   </tdml:parserTestCase>
-
 
   <tdml:defineSchema name="nest2">
     <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
@@ -256,7 +240,7 @@
       to keep track of what's got priority over what else. (i.e., that inner
       wins) -->
     <xs:element name="nest2" dfdl:lengthKind="implicit"
-      dfdl:terminator="ddd">
+      dfdl:terminator="! ddd">
       <xs:complexType>
         <xs:sequence dfdl:separator="; ddd">
           <xs:element name="b" minOccurs="0" maxOccurs="unbounded"

--- a/daffodil-test-ibm1/src/test/scala/org/apache/daffodil/TresysTests.scala
+++ b/daffodil-test-ibm1/src/test/scala/org/apache/daffodil/TresysTests.scala
@@ -107,10 +107,8 @@ class TresysTests {
   @Test def test_nested_separator_delimited_basicNest(): Unit = { runnerNSD.runOneTest("basicNest") }
   @Test def test_nested_separator_delimited_basicNest2(): Unit = { runnerNSD.runOneTest("basicNest2")}
 
-  // Nested delimiter issues - DAFFODIL-2101
-  // @Test def test_nested_separator_delimited_nest1() { runnerNSD.runOneTest("nest1")}
-  // Nested delimiter issues - DAFFODIL-2101
-  // @Test def test_nested_separator_delimited_nest2() { runnerNSD.runOneTest("nest2")}
+  @Test def test_nested_separator_delimited_nest1(): Unit = { runnerNSD.runOneTest("nest1")}
+  @Test def test_nested_separator_delimited_nest2(): Unit = { runnerNSD.runOneTest("nest2")}
   @Test def test_nested_separator_delimited_nest3(): Unit = { runnerNSD.runOneTest("nest3")}
 
   @Test def test_runtime_diagnostics1(): Unit = { runnerRD.runOneTest("PE1") }


### PR DESCRIPTION
The nest1 test was not defined correctly and has been removed. The nest2 test needed a small modification to look for the appropriate '!' terminator, so that has been added and the test has been uncommented. With this small change, the nest2 test works as expected.

DAFFODIL-2101