### PR TITLE
Allow string constructor for dfdl:hexBinary

### DIFF
--- a/daffodil-lib/src/main/scala/org/apache/daffodil/util/Misc.scala
+++ b/daffodil-lib/src/main/scala/org/apache/daffodil/util/Misc.scala
@@ -277,13 +277,13 @@ object Misc {
         if (i >= 48 && i <= 57) i - 48 // number 0-9
         else if (i >= 65 && i <= 70) (i - 65) + 10 // capital A-F
         else if (i >= 97 && i <= 102) (i - 97) + 10 // lowercase a-f
-        else throw new java.lang.IllegalArgumentException("Hex character must be 0-9, a-z, or A-Z, but was '" + c + "'")
+        else throw new NumberFormatException("Hex character must be 0-9, a-z, or A-Z, but was '" + c + "'")
       v
     }
 
     val len = hex.length
     if (len % 2 != 0) {
-      throw new java.lang.IllegalArgumentException("Hex string must have an even number of characters, but was " + len)
+      throw new NumberFormatException("Hex string must have an even number of characters, but was " + len + " for " + hex)
     }
     val numBytes: Int = len / 2
     val arr = new Array[Byte](numBytes)

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/dpath/ConverterOps2.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/dpath/ConverterOps2.scala
@@ -28,6 +28,7 @@ import org.apache.daffodil.infoset.DataValue.DataValueDate
 import org.apache.daffodil.infoset.DataValue.DataValueDateTime
 import org.apache.daffodil.infoset.DataValue.DataValuePrimitive
 import org.apache.daffodil.infoset.DataValue.DataValueTime
+import org.apache.daffodil.util.Misc
 
 case object AnyAtomicToString extends ToString {
   val name = "AnyAtomicToString"
@@ -80,7 +81,7 @@ case object StringToHexBinary extends Converter with HexBinaryKind {
 
   override def computeValue(a: DataValuePrimitive, dstate: DState): DataValueByteArray = {
     val result = a.getAnyRef match {
-      case s: String => hexStringToByteArray(s)
+      case s: String => Misc.hex2Bytes(s)
       case hb: Array[Byte] => hb
       case x => throw new NumberFormatException("%s cannot be cast to dfdl:hexBinary\ndfdl:hexBinary received an unrecognized type! Must be String or HexBinary.".format(x.toString))
     }

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/dpath/XSHexBinary.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/dpath/XSHexBinary.scala
@@ -20,35 +20,9 @@ package org.apache.daffodil.dpath
 import java.math.{ BigInteger => JBigInt, BigDecimal => JBigDecimal }
 import org.apache.daffodil.infoset.DataValue.DataValuePrimitive
 import org.apache.daffodil.infoset.DataValue.DataValueByteArray
+import org.apache.daffodil.util.Misc
 
 trait HexBinaryKind {
-
-  /**
-   * http://travisdazell.blogspot.com/2012/11/converting-hex-string-to-byte-array-in.html
-   */
-  protected def hexStringToByteArray(str: String): Array[Byte] = {
-    val len = str.length
-
-    if ((len % 2) != 0)
-      throw new NumberFormatException("Failed to evaluate expression: A hexBinary value must contain an even number of characters.")
-
-    val arr = new Array[Byte](len / 2)
-    var i = 0
-    while (i < len) {
-      val upper = Character.digit(str.charAt(i), 16)
-      val lower = Character.digit(str.charAt(i + 1), 16)
-
-      if (upper == -1)
-        throw new NumberFormatException("Failed to evaluate expression: Invalid hexadecimal digit '%c' at index %d of '%s'".format(str.charAt(i), i, str))
-      if (lower == -1)
-        throw new NumberFormatException("Failed to evaluate expression: Invalid hexadecimal digit '%c' at index %d of '%s'".format(str.charAt(i + 1), i + 1, str))
-
-      val byte = (upper << 4) + (lower)
-      arr(i / 2) = byte.asInstanceOf[Byte]
-      i += 2
-    }
-    return arr
-  }
 
   protected def reduce(numeric: Any): Array[Byte] = {
     val res: Array[Byte] = numeric match {
@@ -67,7 +41,7 @@ trait HexBinaryKind {
       case bi: JBigInt if (bi.bitLength <= 63) => reduce(bi.longValue())
       case bi: JBigInt => bi.toByteArray()
       case bd: JBigDecimal if (try { bd.toBigIntegerExact(); true } catch { case e: ArithmeticException => false }) => reduce(bd.toBigIntegerExact())
-      case str: String => reduce(new JBigInt(str))
+      case str: String => Misc.hex2Bytes(str)
       case _ => throw new NumberFormatException("%s could not fit into a long".format(numeric.toString))
     }
     res

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section05/simple_types/SimpleTypes.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section05/simple_types/SimpleTypes.tdml
@@ -8182,8 +8182,7 @@
     </tdml:document>
     <tdml:errors>
       <tdml:error>Parse Error</tdml:error>
-      <tdml:error>PPPDABAIAB</tdml:error>
-      <tdml:error>Invalid hexadecimal digit</tdml:error>
+      <tdml:error>Hex character must be</tdml:error>
     </tdml:errors>        
   </tdml:parserTestCase>
 

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section05/simple_types/SimpleTypesUnparse.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section05/simple_types/SimpleTypesUnparse.tdml
@@ -61,8 +61,6 @@
       </xs:sequence>
     </xs:complexType>
   </xs:element>
-    
-    <xs:element name="hb_11" type="xs:hexBinary" dfdl:fillByte="a" dfdl:lengthKind="explicit" dfdl:length="1" dfdl:outputValueCalc="{ dfdl:hexBinary('a1') }"/>
 
   <xs:element name="ehb_09">
     <xs:complexType>
@@ -79,15 +77,23 @@
       </xs:sequence>
     </xs:complexType>
   </xs:element>
-   
-    <xs:element name="hb_12">
-      <xs:complexType>
-        <xs:sequence dfdl:separator=",">
-          <xs:element name="input" type="xs:string" dfdl:lengthKind="delimited"/> 
-          <xs:element name="out" type="xs:hexBinary" dfdl:fillByte="a" dfdl:lengthKind="explicit" dfdl:length="1" dfdl:outputValueCalc="{ dfdl:hexBinary(../ex:input) }"/>
-        </xs:sequence>
-      </xs:complexType>
-    </xs:element>
+
+  <xs:element name="ehb_11">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="hb_11" type="xs:hexBinary" dfdl:fillByte="a" dfdl:lengthKind="explicit" dfdl:length="1" dfdl:outputValueCalc="{ dfdl:hexBinary('a1') }"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="hb_12">
+    <xs:complexType>
+      <xs:sequence dfdl:separator=",">
+        <xs:element name="input" type="xs:string" dfdl:lengthKind="delimited"/>
+        <xs:element name="out" type="xs:hexBinary" dfdl:fillByte="a" dfdl:lengthKind="explicit" dfdl:length="1" dfdl:outputValueCalc="{ dfdl:hexBinary(xs:byte(../ex:input)) }"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
 
   <xs:element name="ehb_13">
     <xs:complexType>
@@ -406,11 +412,11 @@
     Schema: SimpleTypes-binary
     Purpose: This document demonstrates the use of outputValueCalc for hexBinary with the dfdl:hexBinary constructor function
   -->
-  <tdml:unparserTestCase name="hexBinary_unparse_13" root="hb_11"
-      model="SimpleTypes-binary">
+  <tdml:unparserTestCase name="hexBinary_unparse_13" root="ehb_11"
+      model="SimpleTypes-binary" roundTrip="false">
     <tdml:infoset>
       <tdml:dfdlInfoset>
-        <ex:hb_11></ex:hb_11>
+        <ex:ehb_11></ex:ehb_11>
       </tdml:dfdlInfoset>
     </tdml:infoset>
     <tdml:document>
@@ -428,13 +434,13 @@
     <tdml:infoset>
       <tdml:dfdlInfoset>
         <ex:hb_12>
-          <ex:input>208</ex:input>
+          <ex:input>-48</ex:input>
           <ex:out>D0</ex:out>
         </ex:hb_12>
       </tdml:dfdlInfoset>
     </tdml:infoset>
     <tdml:document>
-      <tdml:documentPart type="byte"><![CDATA[3230382cd0]]></tdml:documentPart>
+      <tdml:documentPart type="byte"><![CDATA[2D34382CD0]]></tdml:documentPart>
     </tdml:document>
   </tdml:unparserTestCase>
 

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section23/dfdl_functions/Functions.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section23/dfdl_functions/Functions.tdml
@@ -6707,7 +6707,7 @@
     </xs:element>
     
     <xs:element name="dfdlHexBinary01" type="xs:hexBinary" dfdl:inputValueCalc="{ dfdl:hexBinary(xs:short(208)) }"/>
-    <xs:element name="dfdlHexBinary02" type="xs:hexBinary" dfdl:inputValueCalc="{ dfdl:hexBinary('208') }"/>
+    <xs:element name="dfdlHexBinary02" type="xs:hexBinary" dfdl:inputValueCalc="{ dfdl:hexBinary('0208') }"/>
     <xs:element name="dfdlHexBinary03" type="xs:hexBinary" dfdl:inputValueCalc="{ dfdl:hexBinary(-2084) }"/>
     <xs:element name="dfdlHexBinary04" type="xs:hexBinary" dfdl:inputValueCalc="{ dfdl:hexBinary(200000000000000000000) }"/>
     <xs:element name="dfdlHexBinary05" type="xs:hexBinary" dfdl:inputValueCalc="{ dfdl:hexBinary(xs:integer(32768)) }"/>
@@ -8875,7 +8875,7 @@
       <tdml:documentPart type="text">ABCDEF12345</tdml:documentPart>
     </tdml:document>
     <tdml:errors>
-      <tdml:error>A hexBinary value must contain an even number of characters</tdml:error>
+      <tdml:error>even number of characters</tdml:error>
     </tdml:errors>
   </tdml:parserTestCase>
   
@@ -8896,7 +8896,7 @@
     </tdml:document>
     <tdml:errors>
       <tdml:error>Parse Error</tdml:error>
-      <tdml:error>Invalid hexadecimal digit</tdml:error>
+      <tdml:error>Hex character must be</tdml:error>
     </tdml:errors>
   </tdml:parserTestCase>
   
@@ -11808,7 +11808,7 @@
     </tdml:document>
     <tdml:infoset>
       <tdml:dfdlInfoset>
-        <ex:dfdlHexBinary02>D0</ex:dfdlHexBinary02>
+        <ex:dfdlHexBinary02>0208</ex:dfdlHexBinary02>
       </tdml:dfdlInfoset>
     </tdml:infoset>
   </tdml:parserTestCase>

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section05/simple_types/TestSimpleTypesUnparse.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section05/simple_types/TestSimpleTypesUnparse.scala
@@ -33,11 +33,7 @@ object TestSimpleTypesUnparse {
 
 class TestSimpleTypesUnparse {
   import TestSimpleTypesUnparse._
- 
-  //DFDL-1454
-  //dfdl:hexBinary not behaving like xs:hexBinary 
-  //@Test def test_hexBinary_unparse_13() { runner.runOneTest("hexBinary_unparse_13") }
-  
+
   @Test def test_hexBinary_unparse_01(): Unit = { runner.runOneTest("hexBinary_unparse_01") }
   @Test def test_hexBinary_unparse_02(): Unit = { runner.runOneTest("hexBinary_unparse_02") }
   @Test def test_hexBinary_unparse_03(): Unit = { runner.runOneTest("hexBinary_unparse_03") }
@@ -50,7 +46,9 @@ class TestSimpleTypesUnparse {
   @Test def test_hexBinary_unparse_10(): Unit = { runner.runOneTest("hexBinary_unparse_10") }
   @Test def test_hexBinary_unparse_11(): Unit = { runner.runOneTest("hexBinary_unparse_11") }
   @Test def test_hexBinary_unparse_12(): Unit = { runner.runOneTest("hexBinary_unparse_12") }
+  @Test def test_hexBinary_unparse_13(): Unit = { runner.runOneTest("hexBinary_unparse_13") }
   @Test def test_hexBinary_unparse_14(): Unit = { runner.runOneTest("hexBinary_unparse_14") }
+
   @Test def test_hexBinary_unparse_15(): Unit = { runner.runOneTest("hexBinary_unparse_15") }
   @Test def test_hexBinary_unparse_16(): Unit = { runner.runOneTest("hexBinary_unparse_16") }
   @Test def test_hexBinary_unparse_17(): Unit = { runner.runOneTest("hexBinary_unparse_17") }


### PR DESCRIPTION
The constructor for dfdl:hexBinary raises a schema definition error when passed a string as input. This change updates it to behave in the same way as xs:hexBinary by using string input as hex characters.

[DAFFODIL-1454](https://issues.apache.org/jira/browse/DAFFODIL-1454)
