### PR TITLE
Add test showing both name and ref defined causes an SDE

### DIFF
--- a/daffodil-test/src/test/resources/org/apache/daffodil/section00/general/general.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section00/general/general.tdml
@@ -217,4 +217,32 @@
         <tdml:error>in no namespace</tdml:error>
     </tdml:errors>
   </tdml:parserTestCase>
+
+  <tdml:defineSchema name="nameAndRef">
+    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd" />
+    <dfdl:format ref="ex:GeneralFormat" />
+    <xs:element name="root1">
+      <xs:complexType>
+        <xs:sequence>
+          <xs:element name="nameAndRef" type="xs:string" ref="ex:root2" dfdl:lengthKind="delimited" />
+        </xs:sequence>
+      </xs:complexType>
+    </xs:element>
+    <xs:element name="root2" type="xs:string" dfdl:lengthKind="delimited" />
+  </tdml:defineSchema>
+
+  <tdml:parserTestCase name="nameAndRefError_01" root="root1" model="nameAndRef">
+
+    <tdml:document>
+      <tdml:documentPart type="text"></tdml:documentPart>
+    </tdml:document>
+
+    <tdml:errors>
+      <tdml:error>Schema Definition Error</tdml:error>
+      <tdml:error>name</tdml:error>
+      <tdml:error>type</tdml:error>
+      <tdml:error>cannot appear</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
 </tdml:testSuite>

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section00/general/TestGeneral.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section00/general/TestGeneral.scala
@@ -62,6 +62,8 @@ class TestGeneral {
   @Test def test_litNil1FullPath(): Unit = { runner.runOneTest("litNil1FullPath") }
   @Test def test_referentialIntegrity(): Unit = { runner.runOneTest("referentialIntegrity") }
 
+  @Test def test_nameAndRefError_01(): Unit = { runner.runOneTest("nameAndRefError_01") }
+
   // Test causes exception as the file is not found
   // @Test def test_fileDNE() { runner.runOneTest("fileDNE") }
 


### PR DESCRIPTION
Add a test to verify that an SDE is thrown if a schema uses both name
and ref to define an element.

[DAFFODIL-768](https://issues.apache.org/jira/browse/DAFFODIL-768)