### PR TITLE
Remove ThreadLocal wrapper of ICU4J DecimalFormat

### DIFF
--- a/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/processors/unparsers/ConvertTextStandardNumberUnparser.scala
+++ b/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/processors/unparsers/ConvertTextStandardNumberUnparser.scala
@@ -65,7 +65,7 @@ case class ConvertTextNumberUnparser(
     // if we find this is not the case. Want something akin to:
     // Assert.invariant(value.isInstanceOf[S])
         
-    val df = textNumberFormatEv.evaluate(state).get
+    val df = textNumberFormatEv.evaluate(state)
     val dfs = df.getDecimalFormatSymbols
 
     val scaledValue = applyTextDecimalVirtualPointForUnparse(value)

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/EvTextNumber.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/EvTextNumber.scala
@@ -81,8 +81,8 @@ class TextNumberFormatEv(
   zeroRepsRaw: List[String],
   isInt: Boolean,
   primType: PrimType)
-  extends Evaluatable[ThreadLocal[DecimalFormat]](tci)
-  with InfosetCachedEvaluatable[ThreadLocal[DecimalFormat]] {
+  extends Evaluatable[DecimalFormat](tci)
+  with InfosetCachedEvaluatable[DecimalFormat] {
 
   override lazy val runtimeDependencies = (decimalSepEv.toList ++ groupingSepEv.toList ++ exponentRepEv.toList).toVector
 
@@ -107,6 +107,16 @@ class TextNumberFormatEv(
     tci.schemaDefinitionUnless(dupeStrings.size == 0, dupeStrings.mkString("\n"))
   }
 
+  /**
+   * Creates a thread-safe DecimalFormat that can be used to parse and format
+   * text numbers.
+   *
+   * Note that as of ICU 59, DecimalFormat is thread safe as long as the
+   * setters are called only during construction and not after being used to
+   * format/parse numbers. This function is the only place these setters should
+   * be called. Once returned, only the DecimalFormat parse() and format()
+   * functions should be called.
+   */
   private def generateNumFormat(
     decimalSep: MaybeChar,
     groupingSep: MaybeChar,
@@ -174,7 +184,7 @@ class TextNumberFormatEv(
     df
   }
 
-  override protected def compute(state: ParseOrUnparseState): ThreadLocal[DecimalFormat] = {
+  override protected def compute(state: ParseOrUnparseState): DecimalFormat = {
 
     val decimalSepList = if (decimalSepEv.isDefined) {
       val seps = decimalSepEv.get.evaluate(state)
@@ -205,14 +215,10 @@ class TextNumberFormatEv(
       groupingSep,
       exponentRep)
 
-    val numFormat = new ThreadLocal[DecimalFormat] with Serializable {
-      override def initialValue() = {
-        generateNumFormat(
-          decimalSepList,
-          groupingSep,
-          exponentRep)
-      }
-    }
+    val numFormat = generateNumFormat(
+      decimalSepList,
+      groupingSep,
+      exponentRep)
 
     numFormat
   }

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/ConvertTextStandardNumberParser.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/ConvertTextStandardNumberParser.scala
@@ -170,7 +170,7 @@ case class ConvertTextStandardNumberParser(
     val numValue: DataValueNumber = zeroRepsRegex.find { _.findFirstIn(str).isDefined } match {
       case Some(_) => primNumeric.fromNumber(0)
       case None => {
-        val df = textNumberFormatEv.evaluate(start).get
+        val df = textNumberFormatEv.evaluate(start)
         val strCheckPolicy = if (df.isParseStrict) str else str.trim
         val pos = new ParsePosition(0)
         val icuNum: Number = df.parse(strCheckPolicy, pos)

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/ZonedTextParsers.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/ZonedTextParsers.scala
@@ -88,7 +88,7 @@ case class ConvertZonedNumberParser(
       if (decodedNum(0) == '-')
         checkLength = checkLength + 1
 
-      val num1 = df.get.parse(decodedNum, pos)
+      val num1 = df.parse(decodedNum, pos)
 
       // Verify that what was parsed was what was passed exactly in byte count.
       // Use pos to verify all characters consumed & check for errors!


### PR DESCRIPTION
The DecimalFormat used for parsing and unparsing text numbers has been thread-safe since ICU 59. We have upgraded well past that, and so we no longer need to use ThreadLocal to ensure thread-saftey. Remove them from the TextNumberFormatEv and return a DecimalFormat that can be shared among threads, simplifying the code a bit and avoiding potential overhead related to ThreadLocal.

[DAFFODIL-2774](https://issues.apache.org/jira/browse/DAFFODIL-2774)