### PR TITLE
Fix issue with groups containing choices: WIP

### DIFF
--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/infoset/PartialNextElementResolver.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/infoset/PartialNextElementResolver.scala
@@ -18,6 +18,7 @@
 package org.apache.daffodil.runtime1.infoset
 
 import org.apache.daffodil.lib.exceptions.Assert
+import org.apache.daffodil.lib.util.Logger
 import org.apache.daffodil.lib.util.MStackOf
 import org.apache.daffodil.lib.util.Maybe
 import org.apache.daffodil.lib.util.Maybe._
@@ -45,6 +46,7 @@ trait NextElementResolver { self: InfosetInputter =>
     nameSpace: String,
     hasNamespace: Boolean,
   ): ElementRuntimeData = {
+    Logger.log.debug(s"NextERDResovler -> trdStack: $trdStack")
     val iter = trdStack.iter
     iter.reset()
     var firstOne: Boolean = true
@@ -75,6 +77,10 @@ trait NextElementResolver { self: InfosetInputter =>
         // or it will issue an UnparseError if there are required elements in the
         // set of possible elements.
         //
+        Logger.log.debug(s"""
+          NextERDResovler -> current trd: $trd\n
+          NextERDResovler -> resolver: $resolver\n
+          NextERDResovler -> name: $name\n""")
         maybeERD = resolver.maybeNextElement(name, nameSpace, hasNamespace)
         // The cases where ERD is in a hidden context are addressed where the elements
         // are assigned their value i.e ElementUnparser
@@ -297,6 +303,10 @@ class SeveralPossibilitiesForNextElement(
     namespace: String,
     hasNamespace: Boolean,
   ): Maybe[ElementRuntimeData] = {
+    Logger.log.debug(s"""
+      NextERDResovler -> trd: $trd\n
+      NextERDResovler -> looking for: $local\n
+      NextERDResovler -> nextERDMap: $nextERDMap\n""")
     val optnextERD =
       if (hasNamespace) {
         val sqn = StepQName(
@@ -314,7 +324,7 @@ class SeveralPossibilitiesForNextElement(
           // It was statically determined at compile time that this
           // NextElementResolver does not have any possible NextERDs with the
           // same local name. Because of this, just find the first thing that
-          // matches and return it it is was found.
+          // matches and return it if it was found.
           nextERDMap.find(_._1.local == local).map(_._2)
         } else {
           // It was statically determined at compile time that some nextERDs

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section15/choice_groups/choice.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section15/choice_groups/choice.tdml
@@ -1805,6 +1805,26 @@ it sure is/
       </xs:complexType>
     </xs:element>
 
+    <xs:element name="dd10">
+      <xs:complexType>
+        <xs:sequence>
+          <xs:element name="prev" type="xs:string" dfdl:lengthKind="explicit" dfdl:length="1" />
+          <xs:element name="key" type="xs:string" dfdl:lengthKind="explicit" dfdl:length="1" />
+          <xs:choice dfdl:choiceDispatchKey="{ ./ex:key }">
+            <xs:sequence dfdl:choiceBranchKey="a">
+              <xs:element name="elt_a" type="xs:string" dfdl:lengthKind="explicit" dfdl:length="3" />
+            </xs:sequence>
+            <xs:sequence dfdl:choiceBranchKey="b">
+              <xs:element name="elt_b" type="xs:string" dfdl:lengthKind="explicit" dfdl:length="3" />
+              <xs:element name="elt_c" type="xs:string" dfdl:lengthKind="explicit" dfdl:length="3"
+                minOccurs="0" maxOccurs="1" dfdl:occursCountKind="expression" dfdl:occursCount="{ if (fn:exists(../ex:elt_b)) then 1 else 0 }" />
+            </xs:sequence>
+          </xs:choice>
+          <xs:element name="post" type="xs:string" dfdl:lengthKind="explicit" dfdl:length="1" />
+        </xs:sequence>
+      </xs:complexType>
+    </xs:element>
+
   </tdml:defineSchema>
 
   <tdml:parserTestCase name="direct_dispatch_01" root="dd1"
@@ -2042,6 +2062,39 @@ it sure is/
           <ex:elt_c>ccc</ex:elt_c>
           <ex:post>1</ex:post>
         </ex:dd9>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="dispatch_group_choice_2" root="dd10"
+    model="direct_dispatch_1" roundTrip="true"
+    description="simple case of direct dispatch - DFDL-15-001R. Uses group containing a choice with direct dispatch">
+    <tdml:document><![CDATA[0bbbbccc1]]></tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset xmlns:ex="http://example.com">
+        <ex:dd10>
+          <ex:prev>0</ex:prev>
+          <ex:key>b</ex:key>
+          <ex:elt_b>bbb</ex:elt_b>
+          <ex:elt_c>ccc</ex:elt_c>
+          <ex:post>1</ex:post>
+        </ex:dd10>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="dispatch_group_choice_3" root="dd10"
+    model="direct_dispatch_1" roundTrip="true"
+    description="simple case of direct dispatch - DFDL-15-001R. Uses group containing a choice with direct dispatch">
+    <tdml:document><![CDATA[0aaaa1]]></tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset xmlns:ex="http://example.com">
+        <ex:dd10>
+          <ex:prev>0</ex:prev>
+          <ex:key>a</ex:key>
+          <ex:elt_a>aaa</ex:elt_a>
+          <ex:post>1</ex:post>
+        </ex:dd10>
       </tdml:dfdlInfoset>
     </tdml:infoset>
   </tdml:parserTestCase>

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section15/choice_groups/TestChoice.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section15/choice_groups/TestChoice.scala
@@ -161,7 +161,16 @@ class TestChoice {
   @Test def test_direct_dispatch_17(): Unit = { runnerCH.runOneTest("direct_dispatch_17") }
 
   // DAFFODIL-2562
-  // @Test def test_dispatch_group_choice(): Unit = { runnerCH.runOneTest("dispatch_group_choice") }
+  @Test def test_dispatch_group_choice(): Unit = {
+    runnerCH.runOneTest("dispatch_group_choice")
+  }
+
+  @Test def test_dispatch_group_choice_2(): Unit = {
+    runnerCH.runOneTest("dispatch_group_choice_2")
+  }
+  @Test def test_dispatch_group_choice_3(): Unit = {
+    runnerCH.runOneTest("dispatch_group_choice_3")
+  }
 
   @Test def test_explicit_01(): Unit = { runnerCE.runOneTest("explicit_01") }
   @Test def test_explicit_02(): Unit = { runnerCE.runOneTest("explicit_02") }


### PR DESCRIPTION
There was an issue with groups containing choices were unable to successfully find their next element when unparsing. Essentially what was happening was that the element following the choice is required, but it's possible that due to the group being shared there are different possible next elements as the separate group references have different contexts. So, instead of returning an ErrorERD for a choice with a required next element, we return an Maybe.Nope which allows the trdStack to continue iterating.

This feels a little hacky in it's current implementation, but it does work and doesn't seem to break anything.  There may be a more suitable fix that gets the trdStack to iterate in this group/choice edge case, but wanted to open this up for discussion.

DAFFODIL-2615, DAFFODIL-2562