### PR TITLE
Update URL to GitHub Actions badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 <!-- markdownlint-disable line-length -->
 <!-- markdownlint-disable no-inline-html -->
 [<img src="https://daffodil.apache.org/assets/themes/apache/img/apache-daffodil-logo.svg" height="85" align="left" alt="Apache Daffodil"/>][Website]
-[<img src="https://img.shields.io/github/workflow/status/apache/daffodil/CI/main.svg" align="right"/>][GitHub Actions]
+[<img src="https://img.shields.io/github/actions/workflow/status/apache/daffodil/main.yml?branch=main" align="right"/>][GitHub Actions]
 <br clear="right" />
 [<img src="https://img.shields.io/codecov/c/github/apache/daffodil/main.svg" align="right"/>][CodeCov]
 <br clear="right" />


### PR DESCRIPTION
sheilds.io changed the format of their GitHub actions URL to deal with potential ambiguities. This updates the badge URL to their new format, which references a workflow file plus a branch instead of the workflow name, which resolves any ambiguities.

DAFFODIL-2776