### PR TITLE
Fix handling of NaN/Infinifty when parsing text integers

### DIFF
--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/dpath/NodeInfo.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/dpath/NodeInfo.scala
@@ -547,6 +547,8 @@ object NodeInfo extends Enum {
 
         num
       }
+
+      def isInteger: Boolean
     }
 
     // this should only be used for integer primitives that can fit inside a
@@ -573,11 +575,15 @@ object NodeInfo extends Enum {
             l >= min && l <= max
           }
         }
+        case d: JDouble if d.isInfinite || d.isNaN => false
+        case f: JFloat if f.isInfinite || f.isNaN => false
         case _ => {
           val l = n.longValue
           l >= min && l <= max
         }
       }
+
+      override def isInteger = true
     }
 
     trait PrimNumericFloat extends PrimNumeric { self: Numeric.Kind =>
@@ -595,6 +601,8 @@ object NodeInfo extends Enum {
           (d.isNaN || d.isInfinite) || (d >= min && d <= max)
         }
       }
+
+      override def isInteger = false
     }
 
     protected sealed trait FloatKind extends SignedNumeric.Kind
@@ -641,6 +649,8 @@ object NodeInfo extends Enum {
       override def isValid(n: Number): Boolean = true
 
       override val width: MaybeInt = MaybeInt.Nope
+
+      override def isInteger = false
     }
 
     protected sealed trait IntegerKind extends Decimal.Kind
@@ -652,6 +662,8 @@ object NodeInfo extends Enum {
       override def isValid(n: Number): Boolean = true
 
       override val width: MaybeInt = MaybeInt.Nope
+
+      override def isInteger = true
     }
 
     protected sealed trait LongKind extends Integer.Kind
@@ -701,11 +713,14 @@ object NodeInfo extends Enum {
       protected override def fromString(s: String): DataValueBigInt = new JBigInt(s)
       protected override def fromNumberNoCheck(n: Number): DataValueBigInt = asBigInt(n)
       def isValid(n: Number): Boolean = n match {
+        case bd: JBigDecimal => bd.signum >= 0
         case bi: JBigInt => bi.signum >= 0
         case _ => n.longValue >= 0
       }
 
       override val width: MaybeInt = MaybeInt.Nope
+
+      override def isInteger = true
     }
 
     protected sealed trait UnsignedLongKind extends NonNegativeInteger.Kind
@@ -722,6 +737,8 @@ object NodeInfo extends Enum {
       val max = new JBigInt(1, scala.Array.fill(8)(0xFF.toByte))
       val maxBD = new JBigDecimal(max)
       override val width: MaybeInt = MaybeInt(64)
+
+      override def isInteger = true
     }
 
     protected sealed trait UnsignedIntKind extends UnsignedLong.Kind

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/EvTextNumber.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/EvTextNumber.scala
@@ -169,6 +169,7 @@ class TextNumberFormatEv(
       df.setMaximumFractionDigits(0)
       df.setDecimalSeparatorAlwaysShown(false)
       df.setParseIntegerOnly(true)
+      df.setParseBigDecimal(false)
     }
 
     df

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section12/lengthKind/ExplicitTests.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section12/lengthKind/ExplicitTests.tdml
@@ -667,7 +667,7 @@
       </xs:complexType>
     </xs:element>
 
-    <xs:element name="runtimeSDE">
+    <xs:element name="runtimeLenInt">
       <xs:complexType>
         <xs:sequence>
           <xs:element name="len" type="xs:int"
@@ -692,7 +692,30 @@
       </xs:complexType>
     </xs:element>
 
-
+    <xs:element name="runtimeLenDouble">
+      <xs:complexType>
+        <xs:sequence>
+          <xs:element name="len" type="xs:double"
+            dfdl:lengthKind="explicit" dfdl:length="{ 3 }"
+            dfdl:outputValueCalc="{ dfdl:valueLength(../ex:address, 'bytes') }"/>
+          <xs:element name="address" dfdl:lengthKind="explicit"
+            dfdl:length="{ xs:long(../ex:len) }" dfdl:lengthUnits="bytes">
+            <xs:complexType>
+              <xs:sequence dfdl:sequenceKind="ordered">
+                <xs:element name="houseNumber" type="xs:string"
+                  dfdl:lengthKind="explicit" dfdl:length="{ 6 }" />
+                <xs:element name="street" type="xs:string"
+                  dfdl:lengthKind="explicit" dfdl:length="{ 20 }" dfdl:ref="trimmed" />
+                <xs:element name="city" type="xs:string"
+                  dfdl:lengthKind="explicit" dfdl:length="{ 20 }" dfdl:ref="trimmed" />
+                <xs:element name="state" type="xs:string"
+                  dfdl:lengthKind="explicit" dfdl:length="{ 2 }" />
+              </xs:sequence>
+            </xs:complexType>
+          </xs:element>
+        </xs:sequence>
+      </xs:complexType>
+    </xs:element>
 
   </tdml:defineSchema>
   
@@ -754,18 +777,45 @@
     </tdml:infoset>
   </tdml:parserTestCase>
 
-  <tdml:parserTestCase name="test_lengthRuntimeSDENaN"
-    root="runtimeSDE" model="test_ExplicitLengthChars" description="lengthKind='explicit' - DFDL-12-039R">
+  <tdml:parserTestCase name="test_lengthRuntimeIntNaN_PE"
+    root="runtimeLenInt" model="test_ExplicitLengthChars" description="lengthKind='explicit' - DFDL-12-039R">
     <tdml:document>
       <tdml:documentPart type="text"><![CDATA[NaN000118Ridgewood Circle    Rochester           NY]]></tdml:documentPart>
     </tdml:document>
     <tdml:errors>
-      <tdml:error>placeholder</tdml:error>
+      <tdml:error>Parse Error</tdml:error>
+      <tdml:error>xs:int</tdml:error>
+      <tdml:error>NaN</tdml:error>
     </tdml:errors>
   </tdml:parserTestCase>
 
-  <tdml:parserTestCase name="test_lengthRuntimeSDENegative"
-    root="runtimeSDE" model="test_ExplicitLengthChars" description="lengthKind='explicit' - DFDL-12-039R">
+  <tdml:parserTestCase name="test_lengthRuntimeDoubleNaN_PE"
+    root="runtimeLenDouble" model="test_ExplicitLengthChars" description="lengthKind='explicit' - DFDL-12-039R">
+    <tdml:document>
+      <tdml:documentPart type="text"><![CDATA[NaN000118Ridgewood Circle    Rochester           NY]]></tdml:documentPart>
+    </tdml:document>
+    <tdml:errors>
+      <tdml:error>Parse Error</tdml:error>
+      <tdml:error>NaN</tdml:error>
+      <tdml:error>double</tdml:error>
+      <tdml:error>xs:long</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="test_lengthRuntimeIntNegative_SDE"
+    root="runtimeLenInt" model="test_ExplicitLengthChars" description="lengthKind='explicit' - DFDL-12-039R">
+    <tdml:document>
+      <tdml:documentPart type="text"><![CDATA[-10000118Ridgewood Circle    Rochester           NY]]></tdml:documentPart>
+    </tdml:document>
+    <tdml:errors>
+      <tdml:error>Runtime Schema Definition Error</tdml:error>
+      <tdml:error>dfdl:length</tdml:error>
+      <tdml:error>-10</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="test_lengthRuntimeDoubleNegative_SDE"
+    root="runtimeLenDouble" model="test_ExplicitLengthChars" description="lengthKind='explicit' - DFDL-12-039R">
     <tdml:document>
       <tdml:documentPart type="text"><![CDATA[-10000118Ridgewood Circle    Rochester           NY]]></tdml:documentPart>
     </tdml:document>

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section12/lengthKind/TestLengthKindExplicit.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section12/lengthKind/TestLengthKindExplicit.scala
@@ -44,9 +44,11 @@ class TestLengthKindExplicit {
   @Test def test_ExplicitLengthCharsFixed() = { runner.runOneTest("ExplicitLengthCharsFixed") }
   @Test def test_ExplicitLengthBytesFixed50() = { runner.runOneTest("ExplicitLengthBytesFixed50") }
 
-  // This test should give runtime SDE, not parse error (DFDL-908)
-  //@Test def test_lengthRuntimeSDENaN() = { runner.runOneTest("test_lengthRuntimeSDE") }
-  @Test def test_lengthRuntimeSDENegative() = { runner.runOneTest("test_lengthRuntimeSDENegative") }
+  @Test def test_lengthRuntimeIntNaN_PE() = { runner.runOneTest("test_lengthRuntimeIntNaN_PE") }
+  @Test def test_lengthRuntimeDoubleNaN_PE() = { runner.runOneTest("test_lengthRuntimeDoubleNaN_PE") }
+  @Test def test_lengthRuntimeIntNegative_SDE() = { runner.runOneTest("test_lengthRuntimeIntNegative_SDE") }
+  @Test def test_lengthRuntimeDoubleNegative_SDE() = { runner.runOneTest("test_lengthRuntimeDoubleNegative_SDE") }
+
   @Test def test_ExplicitLengthBytesBroken() = { runner.runOneTest("test_ExplicitLengthBytesBroken") }
 
   @Test def test_ExplicitLengthBytesNotGiven() = { runner.runOneTest("test_ExplicitLengthBytesNotGiven") }


### PR DESCRIPTION
When parsing text integers, ICU still attempts to parse NaN and infinty representations and returns Double.NaN, Double.POSITIVE_INFINITY, or Double.NEGATIVE_INFINITY if matched. There is no way to disable this behavior in ICU.

So this modifies the ConvertTextStandardNumberParser to throw a PE when the prim type is an integer and ICU returns a Double, which means it must have parsed an NaN/Inf which is not considered valid by DFDL.

This also adds a new isInteger method to PrimNumeric to more easily determine if a numeric primitive type is an integer without having to do a match-case on types, and uses this new method in a few places.

Also modifies PrimNumericInteger so that doubles and floats that are NaN or infinite are not considered valid for integer types. This ensures we error instead of converting to zero, such as when used in expressions or reading values from an infoset.

Also adds an ICU specific test to detect if ICU ever changes this behavior.

Note that the original bug expects an SDE, but this is not correct. When and integer fails to parse because NaN or INF is the value, it should be a PE. It is also a PE if a length expression tries to convet a double NaN/INF to a long. It is only an SDE if the length value returned is negative. Tests are aded to verify this behavior.

[DAFFODIL-908](https://issues.apache.org/jira/browse/DAFFODIL-908)