### PR TITLE
Fix generated C code for offset between 2 array slots

### DIFF
--- a/daffodil-runtime2/src/main/scala/org/apache/daffodil/runtime2/generators/CodeGeneratorState.scala
+++ b/daffodil-runtime2/src/main/scala/org/apache/daffodil/runtime2/generators/CodeGeneratorState.scala
@@ -592,13 +592,14 @@ class CodeGeneratorState(private val root: ElementBase) {
   }
 
   // Generates an array's ERD, offsets, childrenERDs, initERD, parseSelf, unparseSelf, getArraySize
-  private def addArrayImplementation(e: ElementBase): Unit = {
+  private def addArrayImplementation(elem: ElementBase): Unit = {
     val C = structs.top.C
-    val arrayName = s"array_${cStructName(e)}$C"
-    val erd = erdName(e)
-    val maxOccurs = e.maxOccurs
-    val minOccurs = e.minOccurs
-    val qNameInit = defineQNameInit(e)
+    val e = elem.namedQName.local
+    val arrayName = s"array_${cStructName(elem)}$C"
+    val erd = erdName(elem)
+    val maxOccurs = elem.maxOccurs
+    val minOccurs = elem.minOccurs
+    val qNameInit = defineQNameInit(elem)
 
     // Add the array's ERD, offsets, childrenERDs
     val arrayERD =
@@ -653,7 +654,7 @@ class CodeGeneratorState(private val root: ElementBase) {
          |    {
          |${structs.top.unparserStatements.mkString("\n")}
          |    }""".stripMargin
-    val arraySizeStatements = getOccursCount(e)
+    val arraySizeStatements = getOccursCount(elem)
 
     val prototypeFunctions =
       s"""static void ${arrayName}_parseSelf($C *instance, PState *pstate);


### PR DESCRIPTION
The C code generator interpolates an ElementBase instead of a String into the computation for the offset between 2 array slots, which can result in a namespace prefix being printed as well as the local name, causing the C compiler to issue an error about the semi-colon.

CodeGeneratorState.scala: Rename addArrayImplementation's parameter from "e" to "elem".  Define a local constant String value "e" with the elem's local name.  Keep interpolating $e into the computation.

DAFFODIL-2777