### PR TITLE
Only add positionally required separators for arrays with occursCountKind="implicit"

### DIFF
--- a/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/processors/unparsers/UnseparatedSequenceUnparsers.scala
+++ b/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/processors/unparsers/UnseparatedSequenceUnparsers.scala
@@ -43,8 +43,6 @@ class RepOrderedUnseparatedSequenceChildUnparser(
   extends RepeatingChildUnparser(childUnparser, srd, erd)
   with Unseparated {
 
-  private val ock = erd.maybeOccursCountKind.get
-
   override def checkArrayPosAgainstMaxOccurs(state: UState): Boolean = {
     if (ock eq OccursCountKind.Implicit)
       state.arrayPos <= maxRepeats(state)

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/SequenceChildBases.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/processors/parsers/SequenceChildBases.scala
@@ -460,7 +460,7 @@ trait MinMaxRepeatsMixin {
 
   def erd: ElementRuntimeData
 
-  private val ock = erd.maybeOccursCountKind.get
+  final val ock = erd.maybeOccursCountKind.get
 
   private val minRepeats_ = {
     val mr =
@@ -551,8 +551,6 @@ abstract class OccursCountMinMaxParser(
   extends RepeatingChildParser(childParser, srd, erd, "MinMax") {
 
   Assert.invariant(erd.maybeOccursCountKind.isDefined)
-
-  private val ock = erd.maybeOccursCountKind.get
 
   Assert.invariant(ock == OccursCountKind.Implicit ||
     ock == OccursCountKind.Parsed)

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section23/dfdl_expressions/expressions.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section23/dfdl_expressions/expressions.tdml
@@ -1375,6 +1375,43 @@
       </xs:complexType>
     </xs:element>
 
+    <!-- same idea as ocke10, but uses occursCountKind="expression" -->
+    <xs:element name="ocke9">
+      <xs:complexType>
+        <xs:sequence>
+          <xs:element name="exists" type="xs:boolean" dfdl:terminator=":"
+            dfdl:textBooleanTrueRep="true" dfdl:textBooleanFalseRep="false" />
+          <xs:sequence dfdl:separator="|" dfdl:separatorPosition="infix">
+            <xs:element name="field1" type="xs:string" minOccurs="0"
+              dfdl:occursCountKind="expression"
+              dfdl:occursCount="{ if (../ex:exists eq fn:true()) then 1 else 0 }" />
+            <xs:element name="field2" type="xs:string" dfdl:occursCountKind="implicit" maxOccurs="unbounded" />
+          </xs:sequence>
+        </xs:sequence>
+      </xs:complexType>
+    </xs:element>
+
+    <!-- same idea as ocke9, but uses occursCountKind="implicit" plus a discriminator -->
+    <xs:element name="ocke10">
+      <xs:complexType>
+        <xs:sequence>
+          <xs:element name="exists" type="xs:boolean" dfdl:terminator=":"
+            dfdl:textBooleanTrueRep="true" dfdl:textBooleanFalseRep="false" />
+          <xs:sequence dfdl:separator="|" dfdl:separatorPosition="infix">
+            <xs:element name="field1" type="xs:string" minOccurs="0"
+              dfdl:occursCountKind="implicit">
+              <xs:annotation>
+                <xs:appinfo source="http://www.ogf.org/dfdl/">
+                  <dfdl:discriminator>{ ../ex:exists eq fn:true() }</dfdl:discriminator>
+                </xs:appinfo>
+              </xs:annotation>
+            </xs:element>
+            <xs:element name="field2" type="xs:string" dfdl:occursCountKind="implicit" maxOccurs="unbounded" />
+          </xs:sequence>
+        </xs:sequence>
+      </xs:complexType>
+    </xs:element>
+
     <xs:element name="expr_space" dfdl:lengthKind="implicit">
       <xs:complexType>
         <xs:sequence dfdl:separator=",">
@@ -1763,6 +1800,72 @@
       <tdml:error>xs:unsignedLong</tdml:error>
     </tdml:errors>
   </tdml:parserTestCase>
+
+  <tdml:unparserTestCase name="ocke_optional_separator_01" root="ocke9"
+    model="expressions-Embedded.dfdl.xsd" description="occursCountKind expression - DFDL-23-011R">
+
+    <tdml:document>true:field1|field2a|field2b|field2c</tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <ex:ocke9 xmlns:ex="http://example.com">
+          <ex:exists>true</ex:exists>
+          <ex:field1>field1</ex:field1>
+          <ex:field2>field2a</ex:field2>
+          <ex:field2>field2b</ex:field2>
+          <ex:field2>field2c</ex:field2>
+        </ex:ocke9>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:unparserTestCase>
+
+  <tdml:unparserTestCase name="ocke_optional_separator_02" root="ocke9"
+    model="expressions-Embedded.dfdl.xsd" description="occursCountKind expression - DFDL-23-011R">
+
+    <tdml:document>false:field2a|field2b|field2c</tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <ex:ocke9 xmlns:ex="http://example.com">
+          <ex:exists>false</ex:exists>
+          <ex:field2>field2a</ex:field2>
+          <ex:field2>field2b</ex:field2>
+          <ex:field2>field2c</ex:field2>
+        </ex:ocke9>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:unparserTestCase>
+
+  <tdml:unparserTestCase name="ocke_optional_separator_03" root="ocke10"
+    model="expressions-Embedded.dfdl.xsd" description="occursCountKind expression - DFDL-23-011R">
+
+    <tdml:document>true:field1|field2a|field2b|field2c</tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <ex:ocke10 xmlns:ex="http://example.com">
+          <ex:exists>true</ex:exists>
+          <ex:field1>field1</ex:field1>
+          <ex:field2>field2a</ex:field2>
+          <ex:field2>field2b</ex:field2>
+          <ex:field2>field2c</ex:field2>
+        </ex:ocke10>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:unparserTestCase>
+
+  <tdml:unparserTestCase name="ocke_optional_separator_04" root="ocke10"
+    model="expressions-Embedded.dfdl.xsd" description="occursCountKind expression - DFDL-23-011R">
+
+    <tdml:document>false:field2a|field2b|field2c</tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <ex:ocke10 xmlns:ex="http://example.com">
+          <ex:exists>false</ex:exists>
+          <ex:field2>field2a</ex:field2>
+          <ex:field2>field2b</ex:field2>
+          <ex:field2>field2c</ex:field2>
+        </ex:ocke10>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:unparserTestCase>
 
 <!--
      Test Name: internal_space_preserved

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section23/dfdl_expressions/TestDFDLExpressions.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section23/dfdl_expressions/TestDFDLExpressions.scala
@@ -237,6 +237,11 @@ class TestDFDLExpressions {
   @Test def test_ocke_array_index_step_dne(): Unit = { runner.runOneTest("ocke_array_index_step_dne") }
   @Test def test_ocke_non_upward(): Unit = { runner.runOneTest("ocke_non_upward") }
   @Test def test_ocke_single_upward(): Unit = { runner.runOneTest("ocke_single_upward") }
+  @Test def test_ocke_optional_separator_01(): Unit = { runner.runOneTest("ocke_optional_separator_01") }
+  @Test def test_ocke_optional_separator_02(): Unit = { runner.runOneTest("ocke_optional_separator_02") }
+  @Test def test_ocke_optional_separator_03(): Unit = { runner.runOneTest("ocke_optional_separator_03") }
+  @Test def test_ocke_optional_separator_04(): Unit = { runner.runOneTest("ocke_optional_separator_04") }
+
   @Test def test_internal_space_preserved(): Unit = { runner.runOneTest("internal_space_preserved") }
   @Test def test_internal_space_preserved2(): Unit = { runner.runOneTest("internal_space_preserved2") }
   @Test def test_internal_space_preserved3a(): Unit = { runner.runOneTest("internal_space_preserved3a") }


### PR DESCRIPTION
If a schema has a separated array/optional with occursCountKind as fixed or expression, then we currently always unparse maxOccurs separators even if there were less than maxOccurs instances in the infoset. This is incorrect--we should only output a separator for each instance in the infoset and no more, regardless of the value of min/maxOccurs. Only with occursCountKind set to implicit should min/maxOccurs be taken into account when unparsing positionally required separators.

The unparsePositionallyRequiredSeps function handles the separator logic for implicit arrays, but should be skipped otherwise. This modifies the condition so it is only considered for the implicit case.

Also makes the "ock" variable in the MinMaxRepatsMixin public since it is useful in a number of places, including this new check.

[DAFFODIL-2231](https://issues.apache.org/jira/browse/DAFFODIL-2231)