### PR TITLE
Avoid CI false negatives

### DIFF
--- a/daffodil-cli/src/test/scala/org/apache/daffodil/cliTest/TestCLIDebugger.scala
+++ b/daffodil-cli/src/test/scala/org/apache/daffodil/cliTest/TestCLIDebugger.scala
@@ -869,6 +869,7 @@ class TestCLIdebugger {
       cli.expect("Hello  breakpoint 1: e1")
       cli.sendLine("info data")
       cli.expect("4865 6c6c 6f                             Hello")
+      cli.sendLine("quit")
     } (ExitCode.Failure)
   }
 

--- a/daffodil-core/src/test/scala/org/apache/daffodil/api/TestParseIndividualMessages.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/api/TestParseIndividualMessages.scala
@@ -71,13 +71,8 @@ class TestParseIndividualMessages {
         //
         // If we need more than 4 bytes to successfully parse (we shouldn't for this schema)
         // then this will hang, because only 4 bytes are in fact available.
-        //
-        // Caution: if debugging, this will timeout if you stop inside here!
-        //
         val (pr: DFDL.ParseResult, xml: Node) =
-        SocketPairTestRig.withTimeout("Daffodil parse") {
           TestUtils.runDataProcessorOnInputStream(dp, cis, areTracing = false)
-        }
 
         assertFalse(pr.isError)
         assertEquals("1234", xml.text)


### PR DESCRIPTION
Two separate commits for easier review:

####  Adjust CLI test rig to avoid timeouts

Sometimes it can take a while for the CLI thread to start due to
resource constraints. This means the ExpectIt tests could fail just
waiting for the CLI start up, giving us false negatives.

To avoid this, we now configure the ExpectIt tests to never timeout and
run them in a separate thread. The main thread then waits for the CLI to
complete (with an infinite duration, it's better for a bad test to hang
than for a good test to time out due to resource constraints). After the
CLI completes, only then does the main thread wait the specified timeout
to allow the expect tests to finish. If those tests don't finish at this
point, then we interrupt the test thread and throw whatever exception is
created.

With this approach, we can ensure the expensive CLI logic is complete,
before we start considering the timeout, which should give he much less
expensive ExpectIt logic enough time to finish, especially since it does
not need to wait for CLI logic.

[DAFFODIL-2751](https://issues.apache.org/jira/browse/DAFFODIL-2751)

#### Adjust socket tests to avoid time outs

- Create socket producer/consumer pairs in the main thread without a
  timeout. The tests require these sockets to be created so just wait
  however long it takes. Sometimes it may take a while to create the
  sockets due to resource constraints which would lead to false
  negatives if we timed out.
- If a particular code hunk should never time out (unless the test
  breaks), then remove the withTimeout call. This means if the test ever
  fails we might hang forever, but that is unlikely, and it's better
  than getting random false negatives and trying to determine if they
  are spurious or not
- For tests that actually do test for a hang and require a timeout,
  adjust timeouts to be at least 1 second. This gives us more confidence
  that the test actually timed out and not that it just took too long to
  run the test

[DAFFODIL-2751](https://issues.apache.org/jira/browse/DAFFODIL-2751)