### PR TITLE
Add autolinking to the ASF Jira

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -24,6 +24,8 @@ github:
     squash:   false
     merge:    false
     rebase:   true
+  autolink_jira:
+    - DAFFODIL
 notifications:
     commits:      commits@daffodil.apache.org
     issues:       commits@daffodil.apache.org


### PR DESCRIPTION
Configure .asf.yml to add the DAFFODIL keyword to autolink to jira bugs. Anytime the a daffodil issue identifier appears in a commit message or comment GitHub will add a link to the Jira issue.

[DAFFODIL-2779](https://issues.apache.org/jira/browse/DAFFODIL-2779)