### PR TITLE
Only update debug setting on change

### DIFF
--- a/daffodil-cli/src/test/scala/org/apache/daffodil/cliTest/TestCLIParsing.scala
+++ b/daffodil-cli/src/test/scala/org/apache/daffodil/cliTest/TestCLIParsing.scala
@@ -590,6 +590,19 @@ class TestCLIparsing {
     } (ExitCode.LeftOverData)
   }
 
+  @Test def test_XXX_CLI_Parsing_Stream_03(): Unit = {
+    val schema = path("daffodil-cli/src/test/resources/org/apache/daffodil/CLI/cli_schema_02.dfdl.xsd")
+
+    runCLI(args"--trace parse --stream -s $schema") { cli =>
+      cli.send("123", inputDone = true)
+      cli.expect("<a>1</a>")
+      cli.expect("bitPosition: 8")
+      cli.expect("<a>2</a>")
+      cli.expect("bitPosition: 16")
+      cli.expect("<a>3</a>")
+    } (ExitCode.Success)
+  }
+
   @Test def test_CLI_Parsing_XCatalog_Resolution_Failure(): Unit = {
     val schema = path("daffodil-cli/src/test/resources/org/apache/daffodil/CLI/xcatalog_import_failure.dfdl.xsd")
     val xcatalog = path("daffodil-cli/src/test/resources/org/apache/daffodil/CLI/xcatalog_invalid.xml")

--- a/daffodil-io/src/main/scala/org/apache/daffodil/io/DataInputStreamImplMixin.scala
+++ b/daffodil-io/src/main/scala/org/apache/daffodil/io/DataInputStreamImplMixin.scala
@@ -25,8 +25,10 @@ trait DataInputStreamImplMixin extends DataInputStream
   with LocalBufferMixin {
 
   override def setDebugging(setting: Boolean): Unit = {
-    if (bitPos0b > 0) throw new IllegalStateException("Must call before any access to data")
-    cst.debugging = setting
+    if (setting != cst.debugging) {
+      if (bitPos0b > 0) throw new IllegalStateException("Must call before any access to data")
+      cst.debugging = setting
+    }
   }
 
   final override def isAligned(bitAlignment1b: Int): Boolean = {


### PR DESCRIPTION
Daffodil currently throws an unhandled exception when attempting a streaming parse with tracing enabled. When the debug setting is changed, an exception is thrown if processing has already started on the input. In a streaming context, this setting is applied on each infoset and causes an exception to be thrown the second time the debug setting is set. This update only checks and sets the debug setting if the value has changed.

[DAFFODIL-2624](https://issues.apache.org/jira/browse/DAFFODIL-2624)