### PR TITLE
Reduce the maximum length of xs:hexBinary to Int.MaxValue / 2

### DIFF
--- a/daffodil-lib/src/main/scala/org/apache/daffodil/util/Misc.scala
+++ b/daffodil-lib/src/main/scala/org/apache/daffodil/util/Misc.scala
@@ -37,6 +37,7 @@ import java.nio.file.Paths
 import scala.collection.JavaConverters._
 
 import org.apache.daffodil.equality._
+import org.apache.daffodil.exceptions.Assert
 
 /**
  * Various reusable utilities that I couldn't easily find a better place for.
@@ -310,6 +311,7 @@ object Misc {
   private val hexLookup = "0123456789ABCDEF".toArray
 
   def bytes2Hex(bytes: Array[Byte]): String = {
+    Assert.invariant(bytes.length <= Int.MaxValue / 2)
     val hexArr = new Array[Char](bytes.length * 2)
     var bytIdx = 0
     var hexIdx = 0

--- a/daffodil-propgen/src/main/resources/org/apache/daffodil/xsd/dafext.xsd
+++ b/daffodil-propgen/src/main/resources/org/apache/daffodil/xsd/dafext.xsd
@@ -308,7 +308,7 @@
             </xs:documentation>
           </xs:annotation>
         </xs:element>
-        <xs:element name="maxHexBinaryLengthInBytes" default="2147483647" minOccurs="0">
+        <xs:element name="maxHexBinaryLengthInBytes" default="1073741823" minOccurs="0">
           <xs:annotation>
             <xs:documentation>
               The maximum size allowed for an xs:hexBinary element.
@@ -317,6 +317,12 @@
           <xs:simpleType>
             <xs:restriction base="xs:int">
               <xs:minInclusive value="1" />
+              <!--
+                The maxInclusive value is set to (Int.MaxValue / 2) since each byte in
+                hex binary becomes 2 hex chars, and the maximum length of a string in
+                Java is Int.MaxValue
+              -->
+              <xs:maxInclusive value="1073741823" />
             </xs:restriction>
           </xs:simpleType>
         </xs:element>


### PR DESCRIPTION
xs:hexBinary is represented as an Array[Byte], which has a Java implementation maximum length of Int.MaxValue and is what we currently limit hexBinary data to. However, when we output hexBinary bytes to an infoset we convert it to a String, with each byte converted to two characters, effectively doubling the length. Since Java Strings have the same Int.MaxValue length limit, the maximum size of hexBinary that we can actually support is only half of Int.MaxValue. This changes the default and maximum value of the maxHexBinaryLengthInBytes tunable, and thus the length of xs:hexBinary elements, to 1073741823.

Backwards/Compatibility:

The default and maximum value of the maxHexBinaryLengthInBytes tunable, and thus the maximum length of xs:hexBinary elements, is reduced in half from 2147483647 to 1073741823 bytes. Schemas requiring larger values should switch to the Binary Large Object extension or convert the single large hexBinary element to an array of multiple smaller hexBinary elements.

DAFFODIL-2782