### PR TITLE
Remove timeout from socket test

### DIFF
--- a/daffodil-core/src/test/scala/org/apache/daffodil/core/api/TestParseIndividualMessages.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/core/api/TestParseIndividualMessages.scala
@@ -32,7 +32,7 @@ import scala.concurrent.Await
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 import scala.concurrent.TimeoutException
-import scala.concurrent.duration.DurationInt
+import scala.concurrent.duration.Duration
 import scala.xml.Node
 
 
@@ -125,16 +125,9 @@ class TestParseIndividualMessages {
         //
         pos.write(followingDataString.getBytes)
         pos.flush()
-        val (pr, xml) = Await.result(fut, 100.milliseconds)
-        if (!pr.isError) {
-          assertEquals("1234", xml.text)
-        } else {
-          //parse failed.
-          val diagString = pr.getDiagnostics.map {
-            _.getMessage()
-          }.mkString("\n")
-          fail("Parse failed, but did not time-out.\n" + diagString)
-        }
+        val (pr, xml) = Await.result(fut, Duration.Inf)
+        assertFalse(pr.isError)
+        assertEquals("1234", xml.text)
       }
     }
     sptr.run()


### PR DESCRIPTION
This timeout could lead to false negatives on continuous integration tests with limited resources. This test should always finish unless a bug is introduced to Daffodil, so just remove the timeout. This means if this test ever does fail due to a real bug, we might hang forever, but that is unlikely and it's better than getting false negatives and trying to determine if spurious or not.

DAFFODIL-2751