### PR TITLE
Add osgiCheck to CI build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -161,6 +161,9 @@ jobs:
       - name: Run Rat Check
         run: $SBT ratCheck || (cat target/rat.txt; exit 1)
 
+      - name: Run OSGI Check
+        run: $SBT osgiCheck
+
       - name: Run Unit Tests
         run: $SBT test
 


### PR DESCRIPTION
This change adds the sbt task, osgiCheck, to the build workflow.

[DAFFODIL-2683](https://issues.apache.org/jira/browse/DAFFODIL-2683)
