### PR TITLE
Pass through dfdlx:trace argument unchanged

### DIFF
--- a/daffodil-core/src/main/scala/org/apache/daffodil/core/dpath/Expression.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/core/dpath/Expression.scala
@@ -2482,11 +2482,11 @@ case class DFDLXTraceExpr(nameAsParsed: String, fnQName: RefQName, args: List[Ex
   }
 
   override lazy val inherentType: NodeInfo.Kind = realArg.inherentType
-  override def targetTypeForSubexpression(subExp: Expression): NodeInfo.Kind = targetType
 
-  override lazy val compiledDPath = {
+  override def targetTypeForSubexpression(subExp: Expression): NodeInfo.Kind = inherentType
+
+  override lazy val compiledDPath =
     new CompiledDPath(DFDLXTrace(realArg.compiledDPath, msgText) +: conversions)
-  }
 }
 
 case class DAFErrorExpr(nameAsParsed: String, fnQName: RefQName, args: List[Expression])

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section23/dfdl_expressions/expressions2.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section23/dfdl_expressions/expressions2.tdml
@@ -261,6 +261,31 @@
 
   </tdml:parserTestCase>
 
+  <tdml:defineSchema name="traceReturnType">
+    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+    <dfdl:format ref="ex:GeneralFormat" />
+
+    <xs:element name="e1" dfdl:lengthKind="explicit"
+                dfdl:length="2" type="xs:string">
+      <xs:annotation>
+        <xs:appinfo source="http://www.ogf.org/dfdl/">
+          <dfdl:assert test="{dfdlx:trace(42, 'answer')}"/>
+        </xs:appinfo>
+      </xs:annotation>
+    </xs:element>
+  </tdml:defineSchema>
+
+  <tdml:parserTestCase name="traceReturnType"
+                       root="e1" model="traceReturnType"
+                       description="argument to trace passes back unchanged and can be used in assert">
+    <tdml:document>42</tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <ex:e1>42</ex:e1>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
   <tdml:parserTestCase name="unused_path_no_context_01" model="expressions_unused_path_no_context.dfdl.xsd"
     description="Section 06 - DFDL Expressions - DFDL-6-083R" root="e1">
     <tdml:document>

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section23/dfdl_expressions/TestDFDLExpressions.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section23/dfdl_expressions/TestDFDLExpressions.scala
@@ -1024,6 +1024,9 @@ class TestDFDLExpressions {
   // DFDL-1804
   @Test def test_traceComplex(): Unit = { runner7.runOneTest("traceComplex") }
 
+  // DFDL-2628
+  @Test def test_traceReturnType(): Unit = { runner7.runOneTest("traceReturnType") }
+
   //DFDL-1076
   @Test def test_nilled_01(): Unit = { runner2.runOneTest("nilled_01") }
 


### PR DESCRIPTION
An assertion with the test expression `{dfdlx:trace(42, 'answer')}` was converting the first argument to a boolean and then also attemping to convert it again when used as a return value. This update passes through the argument without converting its type to boolean.

[DAFFODIL-2628](https://issues.apache.org/jira/browse/DAFFODIL-2628)