### PR TITLE
Modify GitHub action concurrency to not cancel main branch CI runs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,10 +24,9 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
-# Cancel CI runs in progress when a branch or pull request is updated.
-
+# Cancel CI runs in progress when a pull request is updated.
 concurrency:
-  group: ${{ github.actor }}-${{ github.head_ref || github.ref_name }}-${{ github.workflow }}
+  group: ${{ github.head_ref || ((github.ref_name != 'main' && github.ref_name) || github.run_id) }}-${{ github.workflow }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
If a CI run isn't a pull request (i.e. github.head_ref isn't defined), then we currently fall back to github.ref_name. But this value isn't unique (e.g. it is just "main" for merges into the main branch), so it means merges into the main branch are in the same concurrency group which can lead to multiple main CI runs to be canceled and appear as failing.

This instead uses the github.run_id as the fallback value, which is unique for non-PR's so they will be canceled. This also removes the github.actor since we don't really need to differentiate between different users making updates to the same PR. We only ever want to run an action for the latest PR commit and cancel all previous ones, regardless of the actor.

DAFFODIL-2789