### PR TITLE
Validate occurrences on rendered elements

### DIFF
--- a/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/unparsers/runtime1/SequenceChildUnparsers.scala
+++ b/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/unparsers/runtime1/SequenceChildUnparsers.scala
@@ -111,11 +111,9 @@ abstract class RepeatingChildUnparser(
       }
     }
 
-    val actualOccurs = state.arrayPos
-
     // State could be Success or Failure here.
 
-    endArray(state, actualOccurs)
+    endArray(state)
   }
 
   /**

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/PState.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/PState.scala
@@ -108,6 +108,7 @@ object MPState {
 class MPState private () {
 
   val arrayIndexStack = MStackOfLong()
+
   def moveOverOneArrayIndexOnly() = arrayIndexStack.push(arrayIndexStack.pop + 1)
   def moveBackOneArrayIndexOnly() = arrayIndexStack.push(arrayIndexStack.pop - 1)
 

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section05/facets/NulChars.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section05/facets/NulChars.tdml
@@ -66,6 +66,19 @@
     </xs:complexType>
     </xs:element>
 
+    <xs:element name="sparseRoot">
+      <xs:complexType>
+        <xs:sequence dfdl:separator="%NUL;" dfdl:separatorSuppressionPolicy="anyEmpty" dfdl:separatorPosition="infix"
+                     dfdl:encoding="iso-8859-1">
+          <xs:element name="char" type="xs:string" minOccurs="0" maxOccurs="unbounded"
+                      dfdl:lengthPattern='[^\x{00}]' dfdl:lengthKind="pattern"
+                      dfdl:occursCountKind="parsed" dfdl:encoding="iso-8859-1"
+                      dfdl:emptyElementParsePolicy="treatAsAbsent">
+          </xs:element>
+        </xs:sequence>
+      </xs:complexType>
+    </xs:element>
+
   </tdml:defineSchema>
 
   <tdml:parserTestCase name="nulPattern1" model="nullTest"
@@ -81,13 +94,29 @@
   </tdml:parserTestCase>
 
   <tdml:parserTestCase name="nulPad1" model="nullTest"
-                       validation="on">
+                       validation="on" roundTrip="none">
     <tdml:document>
       <tdml:documentPart type="byte">00 00 00</tdml:documentPart>
     </tdml:document>
     <tdml:infoset>
       <tdml:dfdlInfoset>
         <ex:padRoot></ex:padRoot>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="nulPad2" model="nullTest" root="sparseRoot"
+                       validation="on" roundTrip="none">
+    <tdml:document>
+      <tdml:documentPart type="byte">00 00 31 00 00 32 00 00 33 00 00</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <ex:sparseRoot>
+          <ex:char>1</ex:char>
+          <ex:char>2</ex:char>
+          <ex:char>3</ex:char>
+        </ex:sparseRoot>
       </tdml:dfdlInfoset>
     </tdml:infoset>
   </tdml:parserTestCase>

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section05/facets/TestNulChars.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section05/facets/TestNulChars.scala
@@ -35,6 +35,6 @@ class TestNulChars {
   // DAFFODIL-2363 &#xE000; (NUL replacement into XML) can't be used in pattern facet. With full validation.
   @Test def test_nulPattern1() = { runner.runOneTest("nulPattern1") }
 
-  // DAFFODIL-2364 - infinite loop
-  // @Test def test_nulPad1() = { runner.runOneTest("nulPad1") }
+  @Test def test_nulPad1() = { runner.runOneTest("nulPad1") }
+  @Test def test_nulPad2() = { runner.runOneTest("nulPad2") }
 }


### PR DESCRIPTION
When processing an array Daffodil tracks the current index and it uses that final value to validate the number of occurrences found. If the emptyElementParsePolicy is set to absent, the index may not reflect the true size of the array. This change adds a separate counter to only increment when parsing results in a normal, non-absent, value.

[DAFFODIL-2364](https://issues.apache.org/jira/browse/DAFFODIL-2364)
