### PR TITLE
Update last places mentioning runtime2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -108,7 +108,7 @@ jobs:
       - name: Install mxml library (Windows)
         if: runner.os == 'Windows'
         run: |
-          # Our runtime2 tests may break if mxml library is compiled with clang
+          # Our codegen-c tests may break if mxml library is compiled with clang
           export AR=ar CC=cc
           cd mxml
           ./configure --prefix=/usr --disable-shared --disable-threads

--- a/.sonar-project.properties
+++ b/.sonar-project.properties
@@ -16,7 +16,7 @@
 sonar.organization=apache
 sonar.projectKey=apache-daffodil
 
-sonar.modules=daffodil-cli,daffodil-core,daffodil-io,daffodil-japi,daffodil-lib,daffodil-macro-lib,daffodil-propgen,daffodil-runtime1,daffodil-runtime1-layers,daffodil-runtime1-unparser,daffodil-runtime2,daffodil-sapi,daffodil-tdml-lib,daffodil-tdml-processor,daffodil-test,daffodil-test-ibm1,daffodil-udf
+sonar.modules=daffodil-cli,daffodil-codegen-c,daffodil-core,daffodil-io,daffodil-japi,daffodil-lib,daffodil-macro-lib,daffodil-propgen,daffodil-runtime1,daffodil-runtime1-layers,daffodil-runtime1-unparser,daffodil-sapi,daffodil-tdml-lib,daffodil-tdml-processor,daffodil-test,daffodil-test-ibm1,daffodil-udf
 sonar.sources=src/main
 sonar.tests=src/it,src/test
 sonar.c.file.suffixes=-


### PR DESCRIPTION
Fix two more places mentioning runtime2 (ripgrep doesn't search hidden files by default, unfortunately).

.github/workflows/main.yml: Rename runtime2 to codegen-c.

.sonar-project.properties: Rename daffodil-runtime2 to daffodil-codegen-c.

DAFFODIL-2796