### PR TITLE
Update test to use valid UTF-8

### DIFF
--- a/daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/Entities.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/Entities.tdml
@@ -495,7 +495,7 @@ is multiple bytes in UTF-8 encoding that is used - DFDL-6-042R"
 is multiple bytes in UTF-8 encoding that is used"
     model="Entities_01-Embedded.dfdl.xsd" root="seq_10" roundTrip="false">
     <tdml:document>
-      <tdml:documentPart type="byte">30 ab 31 32 32 7f</tdml:documentPart>
+      <tdml:documentPart type="byte">30 c2 ab 31 32 32 7f</tdml:documentPart>
     </tdml:document>
     <tdml:infoset>
       <tdml:dfdlInfoset>

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section06/entities/TestEntities.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section06/entities/TestEntities.scala
@@ -79,8 +79,7 @@ class TestEntities {
   @Test def test_byte_entities_6_06(): Unit = { runner_01.runOneTest("byte_entities_6_06") }
   @Test def test_byte_entities_6_07(): Unit = { runner_01.runOneTest("byte_entities_6_07") }
   @Test def test_byte_entities_6_08(): Unit = { runner_01.runOneTest("byte_entities_6_08") }
-  // DAFFODIL-2102
-  //  @Test def test_byte_entities_6_10() { runner_01.runOneTest("byte_entities_6_10") }
+  @Test def test_byte_entities_6_10(): Unit = { runner_01.runOneTest("byte_entities_6_10") }
 
   @Test def test_whitespace_01(): Unit = { runner_01.runOneTest("whitespace_01") }
   @Test def test_whitespace_02(): Unit = { runner_01.runOneTest("whitespace_02") }


### PR DESCRIPTION
The test for 'test_byte_entities_6_10' is looking for a terminator with a code point of 0xab. Update the test to use the UTF-8 representation of that code point as 0xc2ab.

[DAFFODIL-2102](https://issues.apache.org/jira/browse/DAFFODIL-2102)