### PR TITLE
Appease scalafmt with extraneous comma

### DIFF
--- a/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/GroupDef.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/GroupDef.scala
@@ -141,7 +141,7 @@ sealed abstract class GlobalGroupDef(
     if (dais.nonEmpty)
       SDW(
         WarnID.InvalidAnnotationPoint,
-        "Annotations placed directly on a group definition will be ignored by DFDL. Any annotation expected to be processed by DFDL should instead be placed on the group reference, sequence or choice."
+        "Annotations placed directly on a group definition will be ignored by DFDL. Any annotation expected to be processed by DFDL should instead be placed on the group reference, sequence or choice.",
       )
   }
 


### PR DESCRIPTION
In my last PR I missed that scalafmt wasn't happy after I removed what I thought was an extraneous comma.  The PR page said that all checks had passed, but it must have been stale and needed refreshing to see the scalamt fail.