### PR TITLE
Update parsing when emptyValueDelimiterPolicy is 'none'

### DIFF
--- a/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/LocalElementMixin.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/LocalElementMixin.scala
@@ -25,6 +25,7 @@ import org.apache.daffodil.lib.equality._
 import org.apache.daffodil.lib.exceptions.Assert
 import org.apache.daffodil.lib.schema.annotation.props.gen._
 import org.apache.daffodil.runtime1.dpath.NodeInfo.PrimType
+import org.apache.daffodil.runtime1.processors.parsers.DelimiterTextType
 
 /**
  * Common to local element decls and element references
@@ -84,6 +85,10 @@ trait LocalElementMixin extends ParticleMixin with LocalElementGrammarMixin {
       else if (
         isDefaultable && !hasTerminator && emptyValueDelimiterPolicy =:= EmptyValueDelimiterPolicy.Terminator
       ) true
+      else if (
+        hasInitiator && hasTerminator && emptyValueDelimiterPolicy =:= EmptyValueDelimiterPolicy.None
+      )
+        true
       else if (hasInitiator) {
         //
         // TODO: It is possible that this initiator expression cannot match zero length
@@ -123,5 +128,22 @@ trait LocalElementMixin extends ParticleMixin with LocalElementGrammarMixin {
       } else Assert.impossibleCase()
     res
   }.value
+
+  final def isDelimiterRequiredWhenEmpty(t: DelimiterTextType.Type): Boolean = {
+    val res = t match {
+      case DelimiterTextType.Initiator =>
+        if (!hasInitiator) false
+        else if (emptyValueDelimiterPolicy =:= EmptyValueDelimiterPolicy.Both) true
+        else if (emptyValueDelimiterPolicy =:= EmptyValueDelimiterPolicy.Initiator) true
+        else false
+      case DelimiterTextType.Terminator =>
+        if (!hasTerminator) false
+        else if (emptyValueDelimiterPolicy =:= EmptyValueDelimiterPolicy.Both) true
+        else if (emptyValueDelimiterPolicy =:= EmptyValueDelimiterPolicy.Terminator) true
+        else false
+      case _ => false
+    }
+    res
+  }
 
 }

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section12/delimiter_properties/DelimiterProperties.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section12/delimiter_properties/DelimiterProperties.tdml
@@ -1000,4 +1000,161 @@
       <tdml:error>zero</tdml:error>
     </tdml:errors>
   </tdml:parserTestCase>
+
+  <tdml:defineSchema name="emptyValueDelimiterPolicy">
+    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+    <dfdl:format ref="ex:GeneralFormat" lengthKind="delimited"/>
+    <xs:element name="none">
+      <xs:complexType>
+        <xs:sequence
+                dfdl:separator=","
+                dfdl:separatorPosition="infix"
+                dfdl:separatorSuppressionPolicy="trailingEmpty">
+          <xs:element
+                  name="FirstName"
+                  type="xs:string" />
+          <xs:element
+                  name="MiddleName"
+                  type="xs:string"
+                  dfdl:initiator="("
+                  dfdl:terminator=")"
+                  dfdl:emptyValueDelimiterPolicy="none" />
+          <xs:element
+                  name="LastName"
+                  type="xs:string" />
+        </xs:sequence>
+      </xs:complexType>
+    </xs:element>
+
+    <xs:element name="both">
+      <xs:complexType>
+        <xs:sequence
+                dfdl:separator=","
+                dfdl:separatorPosition="infix"
+                dfdl:separatorSuppressionPolicy="trailingEmpty">
+          <xs:element
+                  name="FirstName"
+                  type="xs:string" />
+          <xs:element
+                  name="MiddleName"
+                  type="xs:string"
+                  dfdl:initiator="("
+                  dfdl:terminator=")"
+                  dfdl:emptyValueDelimiterPolicy="both" />
+          <xs:element
+                  name="LastName"
+                  type="xs:string" />
+        </xs:sequence>
+      </xs:complexType>
+    </xs:element>
+
+    <xs:element name="initiator">
+      <xs:complexType>
+        <xs:sequence
+                dfdl:separator=","
+                dfdl:separatorPosition="infix"
+                dfdl:separatorSuppressionPolicy="trailingEmpty">
+          <xs:element
+                  name="FirstName"
+                  type="xs:string" />
+          <xs:element
+                  name="MiddleName"
+                  type="xs:string"
+                  dfdl:initiator="MI:"
+                  dfdl:terminator="."
+                  dfdl:emptyValueDelimiterPolicy="initiator" />
+          <xs:element
+                  name="LastName"
+                  type="xs:string" />
+        </xs:sequence>
+      </xs:complexType>
+    </xs:element>
+
+    <xs:element name="terminator">
+      <xs:complexType>
+        <xs:sequence
+                dfdl:separator=","
+                dfdl:separatorPosition="infix"
+                dfdl:separatorSuppressionPolicy="trailingEmpty">
+          <xs:element
+                  name="FirstName"
+                  type="xs:string" />
+          <xs:element
+                  name="MiddleName"
+                  type="xs:string"
+                  dfdl:initiator="MI:"
+                  dfdl:terminator="."
+                  dfdl:emptyValueDelimiterPolicy="terminator"/>
+          <xs:element
+                  name="LastName"
+                  type="xs:string" />
+        </xs:sequence>
+      </xs:complexType>
+    </xs:element>
+  </tdml:defineSchema>
+
+  <tdml:parserTestCase name="emptyValueDelimiterPolicy_none"
+                       model="emptyValueDelimiterPolicy"
+                       description=""
+                       root="none">
+    <tdml:document>John,,Doe</tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <none>
+          <FirstName>John</FirstName>
+          <MiddleName/>
+          <LastName>Doe</LastName>
+        </none>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="emptyValueDelimiterPolicy_both"
+                       model="emptyValueDelimiterPolicy"
+                       description=""
+                       root="both">
+    <tdml:document>John,(),Doe</tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <both>
+          <FirstName>John</FirstName>
+          <MiddleName/>
+          <LastName>Doe</LastName>
+        </both>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="emptyValueDelimiterPolicy_initiator"
+                       model="emptyValueDelimiterPolicy"
+                       description=""
+                       root="initiator">
+    <tdml:document>John,MI:,Doe</tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <initiator>
+          <FirstName>John</FirstName>
+          <MiddleName/>
+          <LastName>Doe</LastName>
+        </initiator>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="emptyValueDelimiterPolicy_terminator"
+                       model="emptyValueDelimiterPolicy"
+                       description=""
+                       root="terminator">
+    <tdml:document>John,.,Doe</tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <terminator>
+          <FirstName>John</FirstName>
+          <MiddleName/>
+          <LastName>Doe</LastName>
+        </terminator>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
 </tdml:testSuite>

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section12/delimiter_properties/TestDelimiterProperties.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section12/delimiter_properties/TestDelimiterProperties.scala
@@ -89,4 +89,17 @@ class TestDelimiterProperties {
   @Test def test_emptyInitiator2() = { runner_02.runOneTest("emptyInitiator2") }
   @Test def test_emptyInitiator3() = { runner_02.runOneTest("emptyInitiator3") }
   @Test def test_emptyInitiator4() = { runner_02.runOneTest("emptyInitiator4") }
+  @Test def test_emptyValueDelimiterPolicy_none() = {
+    runner_02.runOneTest("emptyValueDelimiterPolicy_none")
+  }
+  @Test def test_emptyValueDelimiterPolicy_both() = {
+    runner_02.runOneTest("emptyValueDelimiterPolicy_both")
+  }
+  @Test def test_emptyValueDelimiterPolicy_initiator() = {
+    runner_02.runOneTest("emptyValueDelimiterPolicy_initiator")
+  }
+  @Test def test_emptyValueDelimiterPolicy_terminator() = {
+    runner_02.runOneTest("emptyValueDelimiterPolicy_terminator")
+  }
+
 }


### PR DESCRIPTION
When a value is empty, has an initiator and terminator defined, and the emptyValueDelimiterPolicy is set to 'none', the initiator and terminator should not be found in the input stream and should not be emitted when unparsing. Daffodil was raising a parse error in this case. This update allows parsing to continue when the initiator or terminator are not required to appear.

[DAFFODIL-2205](https://issues.apache.org/jira/browse/DAFFODIL-2205)