### PR TITLE
Allow appinfo annotations that contain no-namespace XML

### DIFF
--- a/daffodil-propgen/src/main/resources/org/apache/daffodil/xsd/DFDL_part2_attributes.xsd
+++ b/daffodil-propgen/src/main/resources/org/apache/daffodil/xsd/DFDL_part2_attributes.xsd
@@ -61,12 +61,15 @@
     except it applies to elements instead of attributes (xs:any vs
     xs:anyAttribute). See the description above for how this group works to
     enable strict validation of dfdl namespace elements and lax validation of
-    other elements.
+    other elements. Note that in addition to specifying ##other (i.e. non-DFDL
+    namespace) as lax, we must also specify ##local (i.e. no-namespace) as lax.
+    Only specifying ##other does not match no-namespace elements.
   -->
   <xsd:group name="anyOther">
-    <xsd:sequence>
+    <xsd:choice>
       <xsd:any namespace="##other" processContents="lax" />
-    </xsd:sequence>
+      <xsd:any namespace="##local" processContents="lax" />
+    </xsd:choice>
   </xsd:group>
 
   <xsd:attributeGroup name="BaseAG">

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section00/general/schemaWithOtherAnnotations.dfdl.xsd
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section00/general/schemaWithOtherAnnotations.dfdl.xsd
@@ -47,6 +47,14 @@
       <xs:appinfo source="urn:otherAnnotationLanguage">
         <oth:otherAnnotation oth:otherAnnotationAttribute="other"/>
       </xs:appinfo>
+      <xs:appinfo source="urn:otherAnnotationLanguageNoNamespace">
+        <noNamespace xmlns="">This contains elements in no namespace</noNamespace>
+      </xs:appinfo>
+      <xs:appinfo source="urn:otherAnnotationLanguageMixedContent">
+        This is mixed content
+        <mixedContent xmlns="">Mixed contains and elements in no namespace</mixedContent>
+        This is mixed content
+      </xs:appinfo>
       <xs:appinfo source="http://www.ogf.org/dfdl/dfdl-1.0/">
         <dfdl:element lengthKind="delimited"/>
       </xs:appinfo>


### PR DESCRIPTION
The anyOther group is intended to allow any XML content at all. However, the namespace="##other" only allows XML that has a namespace that isn't DFDL. If it doesn't have a namespace at all, it is not allowed.

This changes anyOther to be a choice of any with either ##other or ##local to allow either namespaced or non-namespaced annotations.

DAFFODIL-2800