### PR TITLE
Throw exceptions when scala-xml cannot continue

### DIFF
--- a/daffodil-lib/src/main/scala/org/apache/daffodil/lib/xml/DaffodilConstructingLoader.scala
+++ b/daffodil-lib/src/main/scala/org/apache/daffodil/lib/xml/DaffodilConstructingLoader.scala
@@ -171,7 +171,17 @@ class DaffodilConstructingLoader private[xml] (
 
   override def reportSyntaxError(pos: Int, msg: String): Unit = {
     val exc = makeSAXParseException(pos, msg)
-    errorHandler.error(exc)
+    errorHandler.fatalError(exc)
+    if (msg == "'<' not allowed in attrib value") {
+      // DAFFODIL-2586
+      // There is a bug in scala-xml which causes an infinite loop when
+      // this error condition is reached. The loop expects the scanner
+      // to advance but in this case it does not. When this error is
+      // seen, an exception needs to be thrown to stop processing.
+      //
+      // See: https://github.com/scala/scala-xml/blob/v2.1.0/shared/src/main/scala/scala/xml/parsing/MarkupParserCommon.scala#L67-L72
+      throw exc
+    }
   }
 
   /*

--- a/daffodil-test/src/test/resources/org/apache/daffodil/usertests/UserSubmittedTests.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/usertests/UserSubmittedTests.tdml
@@ -245,4 +245,13 @@
 			<ex:r2>1</ex:r2>
 		</tdml:dfdlInfoset></tdml:infoset>
 	</tdml:unparserTestCase>
+
+	<tdml:parserTestCase name="test_DFDL_2586" root="root" model="invalid_xml.dfdl.xsd"
+						 description="FIXME">
+		<tdml:document>1</tdml:document>
+		<tdml:errors>
+			<tdml:error>not allowed in attrib value</tdml:error>
+		</tdml:errors>
+	</tdml:parserTestCase>
+
 </tdml:testSuite>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/usertests/invalid_xml.dfdl.xsd
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/usertests/invalid_xml.dfdl.xsd
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/"
+           targetNamespace="http://example.com">
+
+  <xs:annotation>
+    <xs:appinfo source="http://www.ogf.org/dfdl/">
+      <dfdl:format
+      textBidi="no"
+      separatorSuppressionPolicy="trailingEmpty"
+      floating="no"
+      encodingErrorPolicy="replace"
+      outputNewLine="%CR;%LF;"
+      leadingSkip="0"
+      trailingSkip="0"
+      alignment="1"
+      alignmentUnits="bytes"
+      textPadKind="none"
+      textTrimKind="none"
+      truncateSpecifiedLengthString="no"
+      escapeSchemeRef=""
+      representation="binary"
+      encoding="ASCII"
+      separator = ""
+      initiator = ""
+      terminator = ""
+      ignoreCase = "yes"
+      sequenceKind="ordered"
+      initiatedContent="no"
+      fillByte="%SP;"
+      lengthKind="implicit"
+      byteOrder="littleEndian
+  />
+    </xs:appinfo>
+  </xs:annotation>
+
+  <xs:element name="root" type="xs:string" dfdl:lengthKind="explicit" dfdl:length="1"/>
+
+</xs:schema>

--- a/daffodil-test/src/test/scala/org/apache/daffodil/usertests/TestUserSubmittedTests.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/usertests/TestUserSubmittedTests.scala
@@ -26,7 +26,6 @@ object TestUserSubmittedTests {
   val testDir = "/org/apache/daffodil/usertests/"
   val runner = Runner(testDir, "UserSubmittedTests.tdml")
   val runner2 = Runner(testDir, "nameDOB_test.tdml")
-
   @AfterClass def shutDown(): Unit = {
     runner.reset
     runner2.reset
@@ -42,6 +41,7 @@ class TestUserSubmittedTests {
     runner.runOneTest("test_prefix_separator_as_variable")
   }
   @Test def test_DFDL_2262(): Unit = { runner.runOneTest("test_DFDL_2262") }
+  @Test def test_DFDL_2586(): Unit = { runner.runOneTest("test_DFDL_2586") }
   @Test def test_DFDL_2399(): Unit = { runner.runOneTest("test_DFDL_2399") }
 
   // DAFFODIL-2378 (decided as not a bug. These tests characterize that behavior.)


### PR DESCRIPTION
The error handlers for SAX parsing accumulate fatal errors into a list and allowing parsing to continue. In a certain case with a malformed XML document, the same error is being continiously reported by scala-xml causing an infinite loop. This change now throws an exception in this case to allow processing to continue.

[DAFFODIL-2586](https://issues.apache.org/jira/browse/DAFFODIL-2586)