### PR TITLE
Update parse error message

### DIFF
--- a/daffodil-cli/src/main/scala/org/apache/daffodil/cli/Main.scala
+++ b/daffodil-cli/src/main/scala/org/apache/daffodil/cli/Main.scala
@@ -1138,7 +1138,7 @@ class Main(
                         if (loc.bitLimit0b.isDefined) {
                           (loc.bitLimit0b.get - loc.bitPos0b).toString
                         } else {
-                          "at least " + (inStream.inputSource.bytesAvailable * 8)
+                          "at least " + (inStream.inputSource.knownBytesAvailable * 8)
                         }
                       Logger.log.error(
                         s"Left over data after consuming 0 bits while streaming. Stopped after consuming ${loc.bitPos0b} bit(s) with ${remainingBits} bit(s) remaining.",
@@ -1176,7 +1176,7 @@ class Main(
                       dumpString
                     } else ""
                     val curBytePosition1b = inStream.inputSource.position + 1
-                    val bytesAvailable = inStream.inputSource.bytesAvailable
+                    val bytesAvailable = inStream.inputSource.knownBytesAvailable
                     val bytesLimit = math.min(8, bytesAvailable).toInt
                     val destArray = new Array[Byte](bytesLimit)
                     val destArrayFilled = inStream.inputSource.get(destArray, 0, bytesLimit)

--- a/daffodil-io/src/main/scala/org/apache/daffodil/io/DataInputStreamImplMixin.scala
+++ b/daffodil-io/src/main/scala/org/apache/daffodil/io/DataInputStreamImplMixin.scala
@@ -18,7 +18,6 @@
 package org.apache.daffodil.io
 
 import org.apache.daffodil.lib.exceptions.Assert
-import org.apache.daffodil.lib.util.MaybeULong
 
 trait DataInputStreamImplMixin
   extends DataInputStream
@@ -43,16 +42,6 @@ trait DataInputStreamImplMixin
     if (isAligned(bitAlignment1b)) return true
     val deltaBits = bitAlignment1b - (bitPos0b % bitAlignment1b)
     skip(deltaBits, finfo)
-  }
-
-  final override def remainingBits = {
-    if (this.bitLimit0b.isEmpty) MaybeULong.Nope
-    else {
-      val lim = bitLimit0b.get
-      Assert.invariant(lim >= 0)
-      val nBits = lim - bitPos0b
-      MaybeULong(nBits)
-    }
   }
 
 }

--- a/daffodil-io/src/main/scala/org/apache/daffodil/io/DataOutputStreamImplMixin.scala
+++ b/daffodil-io/src/main/scala/org/apache/daffodil/io/DataOutputStreamImplMixin.scala
@@ -313,11 +313,6 @@ trait DataOutputStreamImplMixin
    */
   var bitStartOffset0b: Int = 0
 
-  final override def remainingBits: MaybeULong = {
-    if (maybeRelBitLimit0b.isEmpty) MaybeULong.Nope
-    else MaybeULong(maybeRelBitLimit0b.get - relBitPos0b.toLong)
-  }
-
   var debugOutputStream: Maybe[ByteArrayOutputStream] = Nope
 
   /**

--- a/daffodil-io/src/main/scala/org/apache/daffodil/io/DataStreamCommon.scala
+++ b/daffodil-io/src/main/scala/org/apache/daffodil/io/DataStreamCommon.scala
@@ -19,8 +19,6 @@ package org.apache.daffodil.io
 
 import java.nio.ByteBuffer
 
-import org.apache.daffodil.lib.util.MaybeULong
-
 /**
  * This is an interface trait, and it defines methods shared by
  * both DataInputStream and DataOutputStream.
@@ -29,12 +27,6 @@ import org.apache.daffodil.lib.util.MaybeULong
  *
  */
 trait DataStreamCommon {
-
-  /**
-   * Returns number of bits remaining (if a limit is defined). Nope if not defined.
-   */
-
-  def remainingBits: MaybeULong
 
   /*
    * Methods for moving through data.

--- a/daffodil-io/src/main/scala/org/apache/daffodil/io/InputSource.scala
+++ b/daffodil-io/src/main/scala/org/apache/daffodil/io/InputSource.scala
@@ -116,9 +116,9 @@ abstract class InputSource {
    *
    * This should not be used to determine the length of the data, as more bytes
    * may become available in the future. This should really only be used for
-   * debug purposes.
+   * debug or diagnostic purposes.
    */
-  def bytesAvailable(): Long
+  def knownBytesAvailable(): Long
 
   /**
    * Return a single byte at the current byte position with a value in the
@@ -396,7 +396,7 @@ class BucketingInputSource(
    * Calculate how many bytes are currently buffered starting from the current
    * position
    */
-  def bytesAvailable(): Long = {
+  def knownBytesAvailable(): Long = {
     var available = 0L
     val (curBucketIndex, curByteIndex) = bytePositionToIndicies(curBytePosition0b)
 
@@ -528,7 +528,7 @@ class BucketingInputSource(
    * buckets arraybuffer does not grow too big. This will move all existing
    * buckets to the front of the buckets ArrayBuffer and update offsets
    * accordingly. This way, there are not a bunch of null empty buckets at the
-   * front of the buckets array taking up space. 
+   * front of the buckets array taking up space.
    */
   def compact(): Unit = {
     releaseBuckets()
@@ -559,7 +559,7 @@ class ByteBufferInputSource(byteBuffer: ByteBuffer) extends InputSource {
     bb.remaining >= nBytes
   }
 
-  def bytesAvailable(): Long = {
+  def knownBytesAvailable(): Long = {
     bb.remaining
   }
 

--- a/daffodil-io/src/main/scala/org/apache/daffodil/io/InputSourceDataInputStream.scala
+++ b/daffodil-io/src/main/scala/org/apache/daffodil/io/InputSourceDataInputStream.scala
@@ -128,6 +128,15 @@ final class InputSourceDataInputStream private (val inputSource: InputSource)
    */
   def hasReachedEndOfData: Boolean = inputSource.hasReachedEndOfData
 
+  /**
+   * Return the number of currently available bytes.
+   *
+   * This should not be used to determine the length of the data, as more bytes
+   * may become available in the future. This should really only be used for
+   * debug or diagnostic purposes.
+   */
+  def knownBytesAvailable: Long = inputSource.knownBytesAvailable
+
   def setBitPos0b(newBitPos0b: Long): Unit = {
     // threadCheck()
     Assert.invariant(newBitPos0b >= 0)
@@ -789,7 +798,7 @@ final class InputSourceDataInputStream private (val inputSource: InputSource)
     // need to call areBytesAvailable first to ensure at least length bytes are
     // buffered if they exist
     val available = inputSource.areBytesAvailable(nBytesRequested)
-    val bytesToRead = if (available) nBytesRequested else inputSource.bytesAvailable.toInt
+    val bytesToRead = if (available) nBytesRequested else inputSource.knownBytesAvailable.toInt
     val array = new Array[Byte](bytesToRead)
     inputSource.get(array, 0, bytesToRead)
 

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/PackedBinaryTraits.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/PackedBinaryTraits.scala
@@ -55,7 +55,7 @@ abstract class PackedBinaryDecimalBaseParser(
     val dis = start.dataInputStream
 
     if (!dis.isDefinedForLength(nBits)) {
-      PENotEnoughBits(start, nBits, dis.remainingBits)
+      PENotEnoughBits(start, nBits, dis)
       return
     }
 
@@ -83,7 +83,7 @@ abstract class PackedBinaryIntegerBaseParser(
     val dis = start.dataInputStream
 
     if (!dis.isDefinedForLength(nBits)) {
-      PENotEnoughBits(start, nBits, dis.remainingBits)
+      PENotEnoughBits(start, nBits, dis)
       return
     }
 

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/BinaryBooleanParsers.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/BinaryBooleanParsers.scala
@@ -62,7 +62,7 @@ abstract class BinaryBooleanParserBase(
     val dis = start.dataInputStream
 
     if (!dis.isDefinedForLength(nBits)) {
-      PENotEnoughBits(start, nBits, dis.remainingBits)
+      PENotEnoughBits(start, nBits, dis)
       return
     }
 

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/BinaryNumberParsers.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/BinaryNumberParsers.scala
@@ -36,7 +36,7 @@ class BinaryFloatParser(override val context: ElementRuntimeData) extends PrimPa
     val dis = start.dataInputStream
 
     if (!dis.isDefinedForLength(32)) {
-      PENotEnoughBits(start, 32, dis.remainingBits)
+      PENotEnoughBits(start, 32, dis)
       return
     }
 
@@ -52,7 +52,7 @@ class BinaryDoubleParser(override val context: ElementRuntimeData) extends PrimP
     val dis = start.dataInputStream
 
     if (!dis.isDefinedForLength(64)) {
-      PENotEnoughBits(start, 64, dis.remainingBits)
+      PENotEnoughBits(start, 64, dis)
       return
     }
 
@@ -109,7 +109,7 @@ abstract class BinaryDecimalParserBase(
     val nBits = getBitLength(start)
     val dis = start.dataInputStream
     if (!dis.isDefinedForLength(nBits)) {
-      PENotEnoughBits(start, nBits, dis.remainingBits)
+      PENotEnoughBits(start, nBits, dis)
       return
     }
 
@@ -179,7 +179,7 @@ abstract class BinaryIntegerBaseParser(
     }
     val dis = start.dataInputStream
     if (!dis.isDefinedForLength(nBits)) {
-      PENotEnoughBits(start, nBits, dis.remainingBits)
+      PENotEnoughBits(start, nBits, dis)
       return
     }
 

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/HexBinaryLengthParsers.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/HexBinaryLengthParsers.scala
@@ -52,7 +52,7 @@ sealed abstract class HexBinaryLengthParser(override val context: ElementRuntime
       // create and fill the byte array
       val dis = start.dataInputStream
       if (!dis.isDefinedForLength(nBits)) {
-        PENotEnoughBits(start, nBits, dis.remainingBits)
+        PENotEnoughBits(start, nBits, dis)
       } else {
         val array = start.dataInputStream.getByteArray(nBits.toInt, start)
         currentElement.setDataValue(array)

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/LayeredSequenceParser.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/LayeredSequenceParser.scala
@@ -17,7 +17,6 @@
 
 package org.apache.daffodil.runtime1.processors.parsers
 
-import org.apache.daffodil.lib.util.MaybeULong
 import org.apache.daffodil.runtime1.layers.LayerExecutionException
 import org.apache.daffodil.runtime1.layers.LayerNotEnoughDataException
 import org.apache.daffodil.runtime1.layers.LayerRuntimeInfo
@@ -62,7 +61,6 @@ class LayeredSequenceParser(
           le.schemaFileLocation,
           le.dataLocation,
           le.nBytesRequired * 8,
-          MaybeULong.Nope,
         )
       case e: Exception =>
         throw LayerExecutionException(

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/PrimitivesDateTime1.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/PrimitivesDateTime1.scala
@@ -203,7 +203,7 @@ case class ConvertBinaryCalendarSecMilliParser(
     val dis = start.dataInputStream
 
     if (!dis.isDefinedForLength(lengthInBits)) {
-      PENotEnoughBits(start, lengthInBits, dis.remainingBits)
+      PENotEnoughBits(start, lengthInBits, dis)
       return
     }
 

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/SpecifiedLengthParsers.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/SpecifiedLengthParsers.scala
@@ -67,7 +67,7 @@ sealed abstract class SpecifiedLengthParserBase(eParser: Parser, erd: RuntimeDat
     }
 
     if (shouldCheckDefinedForLength && !dis.isDefinedForLength(nBits)) {
-      PENotEnoughBits(pState, nBits, dis.remainingBits)
+      PENotEnoughBits(pState, nBits, dis)
       return
     }
 
@@ -96,7 +96,7 @@ sealed abstract class SpecifiedLengthParserBase(eParser: Parser, erd: RuntimeDat
       // skip left over bits
       val skipSuccess = dis.skip(bitsToSkip, pState)
       if (!skipSuccess) {
-        PENotEnoughBits(pState, bitsToSkip, dis.remainingBits)
+        PENotEnoughBits(pState, bitsToSkip, dis)
       }
     }
   }

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section05/simple_types/Blobs.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section05/simple_types/Blobs.tdml
@@ -48,6 +48,16 @@
       dfdl:lengthKind="explicit" dfdl:length="4"
       dfdlx:objectKind="bytes" />
 
+    <xs:element name="blob_01_complex" dfdl:lengthKind="explicit" dfdl:length="8">
+      <xs:complexType>
+        <xs:sequence>
+          <xs:element name="blob_01" type="xs:anyURI"
+                      dfdl:lengthKind="explicit" dfdl:length="4"
+                      dfdlx:objectKind="bytes" />
+        </xs:sequence>
+      </xs:complexType>
+    </xs:element>
+
     <xs:element name="blob_02" type="xs:anyURI"
       dfdl:lengthKind="explicit" dfdl:length="30" dfdl:lengthUnits="bits"
       dfdl:bitOrder="mostSignificantBitFirst"
@@ -145,7 +155,29 @@
       </tdml:dfdlInfoset>
     </tdml:infoset>
   </tdml:parserTestCase>
-  
+
+  <tdml:parserTestCase name="blob_01_insufficient" root="blob_01" model="Blob.dfdl.xsd">
+    <tdml:document>
+      <tdml:documentPart type="byte"><![CDATA[a1b1c1]]></tdml:documentPart>
+      <tdml:documentPart type="bits">1</tdml:documentPart>
+    </tdml:document>
+    <tdml:errors>
+      <tdml:error>Needed 32 bit(s)</tdml:error>
+      <tdml:error>found only 25</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="blob_01_insufficient_complex" root="blob_01_complex" model="Blob.dfdl.xsd">
+    <tdml:document>
+      <tdml:documentPart type="byte"><![CDATA[a1b1c1]]></tdml:documentPart>
+      <tdml:documentPart type="bits">1</tdml:documentPart>
+    </tdml:document>
+    <tdml:errors>
+      <tdml:error>Needed 64 bit(s)</tdml:error>
+      <tdml:error>found only 25</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
   <!-- 30 bits of blob data, MSBF -->
   <tdml:parserTestCase name="blob_02" root="blob_02" model="Blob.dfdl.xsd">
     <tdml:document>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section12/lengthKind/ExplicitTests.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section12/lengthKind/ExplicitTests.tdml
@@ -605,7 +605,8 @@
       <tdml:documentPart type="text"><![CDATA[000118Ridgewood Circle    Rochester           NY123]]></tdml:documentPart>
     </tdml:document>
     <tdml:errors>
-      <tdml:error>6467715464</tdml:error>
+      <tdml:error>Needed 16</tdml:error>
+      <tdml:error>found only 8</tdml:error>
       <tdml:error>insufficient</tdml:error>
       <tdml:error>parse error</tdml:error>
     </tdml:errors>
@@ -1335,6 +1336,56 @@
     <tdml:errors>
       <tdml:error>16 out of range</tdml:error>
       <tdml:error>between 1 and 8</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+  <tdml:defineSchema name="insufficientBits">
+    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+    <dfdl:format ref="ex:GeneralFormat"
+                 representation="binary"
+                 alignment="1"
+                 alignmentUnits="bits"
+    />
+
+    <xs:element name="complex" dfdl:lengthKind="explicit" dfdl:length="16">
+      <xs:complexType>
+        <xs:sequence>
+          <xs:element name="child" type="xs:int" dfdl:lengthKind="explicit" dfdl:length="4" />
+        </xs:sequence>
+      </xs:complexType>
+    </xs:element>
+
+    <xs:element name="nineBits" dfdl:lengthKind="explicit" dfdl:length="2">
+      <xs:complexType>
+        <xs:sequence>
+          <xs:element name="bit" type="xs:int" dfdl:lengthKind="explicit" dfdl:lengthUnits="bits" dfdl:length="1"/>
+          <xs:element name="byte" type="xs:int" dfdl:lengthKind="explicit" dfdl:lengthUnits="bits" dfdl:length="8"/>
+        </xs:sequence>
+      </xs:complexType>
+    </xs:element>
+  </tdml:defineSchema>
+
+  <tdml:parserTestCase name="insufficientBitsComplex" root="complex" model="insufficientBits"
+                       description="Tests that we get the correct error message when there are not enough bits remaining in the stream">
+    <tdml:document>
+      <tdml:documentPart type="byte">
+        12 34
+      </tdml:documentPart>
+    </tdml:document>
+    <tdml:errors>
+      <tdml:error>32 bit(s) but found only 16</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="insufficientBitsByte" root="nineBits" model="insufficientBits"
+                       description="Tests that we get the correct error message when there are not enough bits remaining in the stream when unaligned">
+    <tdml:document>
+      <tdml:documentPart type="byte">
+        ff
+      </tdml:documentPart>
+    </tdml:document>
+    <tdml:errors>
+      <tdml:error>8 bit(s) but found only 7</tdml:error>
     </tdml:errors>
   </tdml:parserTestCase>
 

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section05/simple_types/TestBlobs.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section05/simple_types/TestBlobs.scala
@@ -37,6 +37,10 @@ class TestBlobs {
   import TestBlobs._
 
   @Test def test_blob_01(): Unit = { runner.runOneTest("blob_01") }
+  @Test def test_blob_01_insufficient(): Unit = { runner.runOneTest("blob_01_insufficient") }
+  @Test def test_blob_01_insufficient_complex(): Unit = {
+    runner.runOneTest("blob_01_insufficient_complex")
+  }
   @Test def test_blob_02(): Unit = { runner.runOneTest("blob_02") }
   @Test def test_blob_03(): Unit = { runner.runOneTest("blob_03") }
   @Test def test_blob_04(): Unit = { runner.runOneTest("blob_04") }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section12/lengthKind/TestLengthKindExplicit.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section12/lengthKind/TestLengthKindExplicit.scala
@@ -153,4 +153,12 @@ class TestLengthKindExplicit {
   @Test def test_invalidByteBitLengthExpr(): Unit = {
     runner.runOneTest("invalidByteBitLengthExpr")
   }
+
+  @Test def test_insufficientBitsComplex(): Unit = {
+    runner.runOneTest("insufficientBitsComplex")
+  }
+
+  @Test def test_insufficientBitsByte(): Unit = {
+    runner.runOneTest("insufficientBitsByte")
+  }
 }


### PR DESCRIPTION
When there are not enough bits for parsing, an error message will be displayed showing the number of bits available. Sometimes this value uses the number of bits remaining in the limit and doesn't consider that this could be greater than the number of bits actually available in the data stream. This change selects the lesser of the two values when that information is known.

The TDML runner has also been updated to only place a limit on the parser when the length of the document under test doesn't end on a byte boundary.

[DAFFODIL-2645](https://issues.apache.org/jira/browse/DAFFODIL-2645)
