### PR TITLE
Fix comment in TDML test

### DIFF
--- a/daffodil-test/src/test/resources/org/apache/daffodil/section13/text_number_props/TextNumberProps.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section13/text_number_props/TextNumberProps.tdml
@@ -1531,7 +1531,7 @@
   </tdml:parserTestCase>
 
 <!--
-     Test Name: textStandardDecimalSeparator10
+     Test Name: textStandardDecimalSeparator09u
         Schema: textNumberPattern
           Root: tnp20
        Purpose: This test demonstrates that textStandardDecimalSeparator is used when unparsing if the pattern specifies


### PR DESCRIPTION
Commit f8a786734237cfb6469e76dcd3c1a0d015ba114c added a new TDML test but referenced the wrong test name in the associated comment. This fixes that comment.

DAFFODIL-2805