### PR TITLE
Fix min/maxOccurs validation for optional elements

### DIFF
--- a/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/unparsers/runtime1/SequenceChildUnparsers.scala
+++ b/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/unparsers/runtime1/SequenceChildUnparsers.scala
@@ -112,8 +112,7 @@ abstract class RepeatingChildUnparser(
     }
 
     // State could be Success or Failure here.
-
-    endArray(state)
+    endArray(state, state.occursPos - 1)
   }
 
   /**

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section02/validation_errors/Validation.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section02/validation_errors/Validation.tdml
@@ -2157,5 +2157,50 @@
       <tdml:error>5.0</tdml:error>
     </tdml:validationErrors>
   </tdml:parserTestCase>
-  
+
+  <tdml:defineSchema name="validationOptional">
+    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd" />
+    <dfdl:format ref="ex:GeneralFormat" lengthKind="delimited" />
+
+    <xs:element name="a">
+      <xs:complexType>
+        <xs:sequence dfdl:separator="/">
+          <xs:element name="b" type="xs:string" />
+          <xs:element name="num" type="xs:int" minOccurs="0" />
+          <xs:element name="c" minOccurs="0">
+            <xs:complexType>
+              <xs:sequence dfdl:separator="/">
+                <xs:element name="str" type="xs:string" />
+                <xs:element name="float" type="xs:float" dfdl:textNumberPattern="0.0" />
+                <xs:element name="int" type="xs:int" />
+              </xs:sequence>
+            </xs:complexType>
+          </xs:element>
+        </xs:sequence>
+      </xs:complexType>
+    </xs:element>
+  </tdml:defineSchema>
+
+  <tdml:parserTestCase name="optional_element_1" root="a"
+    model="validationOptional"
+    roundTrip="onePass"
+    validation="on">
+    <tdml:document>B/2/A/2.0/4</tdml:document>
+
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <a>
+          <b>B</b>
+          <num>2</num>
+          <c>
+            <str>A</str>
+            <float>2.0</float>
+            <int>4</int>
+          </c>
+        </a>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+    <tdml:validationErrors />
+  </tdml:parserTestCase>
+
 </tdml:testSuite>

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section02/validation_errors/TestValidationErr.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section02/validation_errors/TestValidationErr.scala
@@ -186,4 +186,6 @@ class TestValidationErr {
   @Test def test_doubleInclusiveInf(): Unit = { runner.runOneTest("doubleInclusiveInf") }
   @Test def test_doubleInclusiveNegInf(): Unit = { runner.runOneTest("doubleInclusiveNegInf") }
   @Test def test_doubleInclusiveNaN(): Unit = { runner.runOneTest("doubleInclusiveNaN") }
+
+  @Test def test_optional_element_1(): Unit = { runner.runOneTest("optional_element_1") }
 }


### PR DESCRIPTION
Commit dd60b6067d made changes to validation so that it took into account absent elements that incremented the array iteration count but did not actually change the array size. It did this by just counting the actual elements in the infoset. Unfortunately, that change was very subtly broken for optional elements since it assumed maybeLastChild was always a DIArray, but it could actually be a DISimple/DIComplex for optional elements since they use very similar array logic.

We could modify this logic to take DISimple/DIComplex nodes into account, but later commit 16c738c38f added new state to differentiate between the occurs index and the iteration index. So this just modifies the array validation logic so it is very similar to the old logic, but uses the new state that accounts for absent elements.

DAFFODIL-2808