### PR TITLE
Store Daffodil version in a file instead of in the manifest

### DIFF
--- a/daffodil-lib/src/main/scala/org/apache/daffodil/lib/util/Misc.scala
+++ b/daffodil-lib/src/main/scala/org/apache/daffodil/lib/util/Misc.scala
@@ -34,6 +34,7 @@ import java.nio.charset.{ Charset => JavaCharset }
 import java.nio.file.Files
 import java.nio.file.Paths
 import scala.collection.JavaConverters._
+import scala.io.Source
 
 import org.apache.daffodil.lib.equality._
 import org.apache.daffodil.lib.exceptions.Assert
@@ -250,12 +251,9 @@ object Misc {
    * Returns the primary version of daffodil from the jar
    */
   def getDaffodilVersion: String = {
-    val implVersion = this.getClass.getPackage.getImplementationVersion
-    if (implVersion == null) {
-      ""
-    } else {
-      implVersion
-    }
+    val uri = getRequiredResource("org/apache/daffodil/lib/VERSION")
+    val version = Source.fromInputStream(uri.toURL.openStream, "UTF-8").mkString
+    version
   }
 
   /**


### PR DESCRIPTION
Daffodil has a Misc.getDaffodilVersion() function which gets the daffodil version from the package manifest. This is used in places like the CLI --version option, when writing the version to a saved parser, or checking the version when reloading a parser.

But if Daffodil is assembled into a fat jar, that manifest file is usually replaced, which means the wrong version can be found when saving or reloading parsers.

To avoid this, this modifies the SBT configuration to write the version to a resource file in org/apache/daffodil/lib/VERSION using a resource generator. The Misc.getDaffodilVersion() function is modified to read the contents of this resource to get the version. This no longer depends on the manifest file and uses a resource path that should never be discarded or overwritten when creating a fat jar.

Also modifies the genManaged task to use the managedSources/Resources tasks so we don't need to update it if we add more source/resource generators. And remove the type since it isn't needed--this is just a convenience to generate all managed files.

DAFFODIL-2816