### PR TITLE
Support text numbers that parse to negative zero double

### DIFF
--- a/daffodil-test/src/test/resources/org/apache/daffodil/section05/simple_types/SimpleTypes.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section05/simple_types/SimpleTypes.tdml
@@ -3683,6 +3683,18 @@
     </tdml:errors>
   </tdml:unparserTestCase>
 
+  <tdml:parserTestCase name="double_negativeZero" root="doubleText"
+    model="SimpleTypes-Embedded.dfdl.xsd" description="Section 5 Schema types-double - DFDL-5-009R"
+    roundTrip="false">
+
+    <tdml:document><![CDATA[-0.0]]></tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <doubleText>-0.0</doubleText>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
   <tdml:parserTestCase name="float_text" root="floatText"
     model="SimpleTypes-Embedded.dfdl.xsd" description="Section 5 Simple type-float - DFDL-5-008R"
     roundTrip="false">

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section05/simple_types/TestSimpleTypes.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section05/simple_types/TestSimpleTypes.scala
@@ -821,6 +821,7 @@ class TestSimpleTypes {
     runner.runOneTest("characterDuringValidDouble")
   }
   @Test def test_double_unparseError(): Unit = { runner.runOneTest("double_unparseError") }
+  @Test def test_double_negativeZero(): Unit = { runner.runOneTest("double_negativeZero") }
 
   @Test def test_float_text(): Unit = { runner.runOneTest("float_text") }
   @Test def test_float_text2(): Unit = { runner.runOneTest("float_text2") }


### PR DESCRIPTION
ICU parses negative zero to a Double type, which we do not currently allow, expecting only Infinifity or NaN. This modifies the assertion to allow negative zero as well.

DAFFODIL-2818