### PR TITLE
Add codegen-c support for runtime length hexBinary

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -13,30 +13,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: Dependency scan
+name: Dependency Graph
 
-# Controls when the workflow will run
+# Run after pushing a commit to the main branch.
+
 on:
-  # Triggers the workflow on push or pull request events but only for the "main" branch
   push:
-    branches: [ "main" ]
-    
-  # Allows you to run this workflow manually from the Actions tab
-  workflow_dispatch:
+    branches:
+      - main
 
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # This workflow contains a single job called "build"
-  build:
-    # The type of runner that the job will run on
+  dependency-graph:
+    name: Dependency Graph
     runs-on: ubuntu-22.04
 
-    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v3.5.2
+      - name: Check out Repository
+        uses: actions/checkout@v3.5.2
 
-      - name: Sbt Dependency Submission
-        # You may pin to the exact commit or the version.
-        # uses: scalacenter/sbt-dependency-submission@ab086b50c947c9774b70f39fc7f6e20ca2706c91
+      - name: Submit Dependency Graph
         uses: scalacenter/sbt-dependency-submission@v2.1.2

--- a/daffodil-codegen-c/src/main/scala/org/apache/daffodil/codegen/c/generators/BinaryValueCodeGenerator.scala
+++ b/daffodil-codegen-c/src/main/scala/org/apache/daffodil/codegen/c/generators/BinaryValueCodeGenerator.scala
@@ -20,7 +20,6 @@ package org.apache.daffodil.codegen.c.generators
 import org.apache.daffodil.core.dsom.ElementBase
 import org.apache.daffodil.lib.schema.annotation.props.gen.BitOrder
 import org.apache.daffodil.lib.schema.annotation.props.gen.ByteOrder
-import org.apache.daffodil.lib.schema.annotation.props.gen.LengthKind
 import org.apache.daffodil.lib.util.Maybe.Nope
 
 // Base trait which provides common code to generate C code for primitive value elements
@@ -43,10 +42,6 @@ trait BinaryValueCodeGenerator {
     e.schemaDefinitionUnless(
       e.maybeByteOrderEv == Nope || e.byteOrderEv.isConstant,
       "Runtime dfdl:byteOrder expressions not supported.",
-    )
-    e.schemaDefinitionUnless(
-      e.lengthKind == LengthKind.Prefixed || e.elementLengthInBitsEv.isConstant,
-      "Runtime dfdl:length expressions not supported.",
     )
 
     // Call the given partially applied function values with their remaining unbound argument (deref)

--- a/daffodil-codegen-c/src/test/resources/org/apache/daffodil/codegen/c/ex_nums.tdml
+++ b/daffodil-codegen-c/src/test/resources/org/apache/daffodil/codegen/c/ex_nums.tdml
@@ -21,7 +21,9 @@
   description="TDML tests for ex_nums.dfdl.xsd"
   xmlns:daf="urn:ogf:dfdl:2013:imp:daffodil.apache.org:2018:ext"
   xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/"
-  xmlns:tdml="http://www.ibm.com/xmlns/dfdl/testData">
+  xmlns:ex="http://example.com"
+  xmlns:tdml="http://www.ibm.com/xmlns/dfdl/testData"
+  xmlns:xs="http://www.w3.org/2001/XMLSchema">
 
   <!--
       Run all tests:
@@ -49,6 +51,44 @@
     </tdml:document>
     <tdml:infoset>
       <tdml:dfdlInfoset type="file">infosets/ex_nums.dat.xml</tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <!--
+      Test runtime length hexBinary works
+  -->
+
+  <tdml:defineSchema name="length">
+    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+    <dfdl:format ref="GeneralFormat" representation="binary"/>
+    <xs:element name="e1">
+      <xs:complexType>
+        <xs:sequence>
+          <xs:element name="len" type="xs:int"/>
+          <xs:element name="hex" type="xs:hexBinary"
+                      dfdl:length="{ (../ex:len idiv 4) * 4 }"
+                      dfdl:lengthKind="explicit"/>
+        </xs:sequence>
+      </xs:complexType>
+    </xs:element>
+  </tdml:defineSchema>
+
+  <tdml:parserTestCase
+    model="length"
+    name="length"
+    root="e1"
+    roundTrip="onePass">
+    <tdml:document>
+      <tdml:documentPart type="byte">00000004</tdml:documentPart>
+      <tdml:documentPart type="byte">00000004</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <e1>
+          <len>4</len>
+          <hex>00000004</hex>
+        </e1>
+      </tdml:dfdlInfoset>
     </tdml:infoset>
   </tdml:parserTestCase>
 

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/Evaluatable.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/Evaluatable.scala
@@ -451,7 +451,7 @@ trait ExprEvalMixin[T <: AnyRef]
  * of the property.
  */
 abstract class EvaluatableExpression[ExprType <: AnyRef](
-  override protected val expr: CompiledExpression[ExprType],
+  override val expr: CompiledExpression[ExprType],
   ci: DPathCompileInfo,
 ) extends Evaluatable[ExprType](ci)
   with ExprEvalMixin[ExprType] {

--- a/daffodil-test/src/test/scala/org/apache/daffodil/codegen/c/TestExNums.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/codegen/c/TestExNums.scala
@@ -38,6 +38,7 @@ class TestExNums {
   import TestExNums._
 
   @Test def s_ex_nums(): Unit = { runnerS.runOneTest("ex_nums") }
+  @Test def s_length(): Unit = { runnerS.runOneTest("length") }
   @Test def s_parse_error_off(): Unit = { runnerS.runOneTest("parse_error_off") }
   @Test def s_parse_error_limited(): Unit = { runnerS.runOneTest("parse_error_limited") }
   @Test def s_parse_error_on(): Unit = { runnerS.runOneTest("parse_error_on") }
@@ -46,6 +47,7 @@ class TestExNums {
   @Test def s_unparse_error_on(): Unit = { runnerS.runOneTest("unparse_error_on") }
 
   @Test def c_ex_nums(): Unit = { runnerC.runOneTest("ex_nums") }
+  @Test def c_length(): Unit = { runnerC.runOneTest("length") }
   @Test def c_parse_error_off(): Unit = { runnerC.runOneTest("parse_error_off") }
   @Test def c_parse_error_limited(): Unit = { runnerC.runOneTest("parse_error_limitedC") }
   @Test def c_parse_error_on(): Unit = { runnerC.runOneTest("parse_error_on") }


### PR DESCRIPTION
Extend Daffodil's C code generator to support runtime length hexBinary elements.  Also make some cleanups for better consistency.

DAFFODIL-2819

dependency-scan.yml: Saw a better example somewhere (it was called dependency-graph.yml) so modify and rename to match that example.

DaffodilCCodeGenerator.scala: Change comments and names in compileCode and pickCommand to be more similar to another codegen.  Extend generateCode to handle RepOrderedWithMinMaxSequenceChild.

BinaryValueCodeGenerator.scala: Remove restriction on runtime lengths.

CodeGeneratorState.scala: Add cExpression to implement a poor man's C code expression generator until Daffodil adds custom code generation functionality to compiled DFDL expressions.  Remove namespace prefixes in makeLegalForC to ensure they don't appear in C code.  Extend arrayMaxOccurs to handle more cases.  Make cStructFieldAccess do a better job of converting a DFDL expression written as a path to a C struct field dereference.

HexBinaryCodeGenerator.scala: Allow specified length hexBinary elements to use runtime lengths as well as constant lengths.

ex_nums.tdml: Add a new test to check support for runtime length hexBinary elements.

Evaluatable.scala: Allow codegen-c to get compiled expression from EvaluatableExpression.

TestExNums.scala: Make both daffodil and daffodilC run new test.