### PR TITLE
Create a separate file for a portable GeneralFormat

### DIFF
--- a/daffodil-cli/src/test/resources/org/apache/daffodil/cli/blob_backtracking.dfdl.xsd
+++ b/daffodil-cli/src/test/resources/org/apache/daffodil/cli/blob_backtracking.dfdl.xsd
@@ -22,11 +22,11 @@
   xmlns:dfdlx="http://www.ogf.org/dfdl/dfdl-1.0/extensions"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
-  <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+  <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormatPortable.dfdl.xsd"/>
 
   <annotation>
     <appinfo source="http://www.ogf.org/dfdl/">
-      <dfdl:format ref="tns:GeneralFormatPortable"
+      <dfdl:format ref="tns:GeneralFormat"
         representation="binary"
         encodingErrorPolicy="replace" />
     </appinfo>

--- a/daffodil-cli/src/test/resources/org/apache/daffodil/cli/large_blob.dfdl.xsd
+++ b/daffodil-cli/src/test/resources/org/apache/daffodil/cli/large_blob.dfdl.xsd
@@ -22,11 +22,11 @@
   xmlns:dfdlx="http://www.ogf.org/dfdl/dfdl-1.0/extensions"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
-  <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+  <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormatPortable.dfdl.xsd"/>
 
   <annotation>
     <appinfo source="http://www.ogf.org/dfdl/">
-      <dfdl:format ref="tns:GeneralFormatPortable"
+      <dfdl:format ref="tns:GeneralFormat"
         representation="binary"
         encodingErrorPolicy="replace" />
     </appinfo>

--- a/daffodil-core/src/test/scala/org/apache/daffodil/core/api/TestDsomCompiler3.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/core/api/TestDsomCompiler3.scala
@@ -73,7 +73,7 @@ class TestDsomCompiler3 {
       // Verify things still work using specified tmpDir
       //
       val Seq(schema) = sset.schemas
-      val Seq(schemaDoc, _) = schema.schemaDocuments
+      val schemaDoc = schema.schemaDocuments.head
       val Seq(decl) = schemaDoc.globalElementDecls.map { _.asRoot }
       val Seq(ct) = schemaDoc.globalComplexTypeDefs
       assertEquals("example1", ct.name)

--- a/daffodil-core/src/test/scala/org/apache/daffodil/core/dpath/TestDFDLExpressionTree.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/core/dpath/TestDFDLExpressionTree.scala
@@ -45,7 +45,7 @@ class TestDFDLExpressionTree extends Parsers {
     val schemaCompiler = Compiler()
     val sset = schemaCompiler.compileNode(testSchema).sset
     val Seq(schema) = sset.schemas
-    val Seq(schemaDoc, _) = schema.schemaDocuments
+    val schemaDoc = schema.schemaDocuments.head
     val Seq(declf) = schemaDoc.globalElementDecls
     val decl = declf.asRoot
     val erd = decl.elementRuntimeData
@@ -68,7 +68,7 @@ class TestDFDLExpressionTree extends Parsers {
     val schemaCompiler = Compiler()
     val sset = schemaCompiler.compileNode(testSchema).sset
     val Seq(schema) = sset.schemas
-    val Seq(schemaDoc, _) = schema.schemaDocuments
+    val schemaDoc = schema.schemaDocuments.head
     val Seq(declf) = schemaDoc.globalElementDecls
     val decl = declf.asRoot
     val erd = decl
@@ -398,7 +398,7 @@ class TestDFDLExpressionTree extends Parsers {
     val schemaCompiler = Compiler()
     val sset = schemaCompiler.compileNode(testSchema).sset
     val Seq(schema) = sset.schemas
-    val Seq(schemaDoc, _) = schema.schemaDocuments
+    val schemaDoc = schema.schemaDocuments.head
     val Seq(declf) = schemaDoc.globalElementDecls
     val decl = declf.asRoot
     decl.elementRuntimeData

--- a/daffodil-core/src/test/scala/org/apache/daffodil/core/dsom/TestAppinfoSyntax.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/core/dsom/TestAppinfoSyntax.scala
@@ -62,7 +62,7 @@ class TestAppinfoSyntax {
     val compiler = Compiler()
     val sset = compiler.compileNode(sc).sset
     val Seq(sch) = sset.schemas
-    val Seq(a, _) = sch.schemaDocuments
+    val a = sch.schemaDocuments.head
     val Seq(ao: Elem) = a.dfdlAppInfos
     val Some(ns) = ao.attribute(nnURI, "nonNativeAttribute1")
     assertEquals(expected, ns.toString())
@@ -103,7 +103,7 @@ class TestAppinfoSyntax {
     val compiler = Compiler()
     val sset = compiler.compileNode(sc).sset
     val Seq(sch) = sset.schemas
-    val Seq(a, _) = sch.schemaDocuments
+    val a = sch.schemaDocuments.head
     val Seq(ao: Elem, bo: Elem) = a.dfdlAppInfos
     val Some(anna) = ao.attribute(nnURI, "nonNativeAttribute1")
     val Some(bnna) = bo.attribute(nnURI, "nonNativeAttribute2")
@@ -146,7 +146,7 @@ class TestAppinfoSyntax {
     val compiler = Compiler()
     val sset = compiler.compileNode(sc).sset
     val Seq(sch) = sset.schemas
-    val Seq(a, _) = sch.schemaDocuments
+    val a = sch.schemaDocuments.head
     val Seq(ao: Elem) = a.dfdlAppInfos
     val Some(anna) = ao.attribute(nnURI, "nonNativeAttribute1")
     assertEquals(expected, anna.toString())
@@ -192,7 +192,7 @@ class TestAppinfoSyntax {
     val compiler = Compiler()
     val sset = compiler.compileNode(sc).sset
     val Seq(sch) = sset.schemas
-    val Seq(a, _) = sch.schemaDocuments
+    val a = sch.schemaDocuments.head
     val Seq(ao: Elem) = a.dfdlAppInfos
     val Some(anna) = ao.attribute(nnURI, "nonNativeAttribute1")
     assertEquals(expected, anna.toString())
@@ -242,7 +242,7 @@ class TestAppinfoSyntax {
     val compiler = Compiler()
     val sset = compiler.compileNode(sc).sset
     val Seq(sch) = sset.schemas
-    val Seq(a, _) = sch.schemaDocuments
+    val a = sch.schemaDocuments.head
     val Seq(ao: Elem) = a.dfdlAppInfos
     val Some(anna) = ao.attribute(nnURI, "nonNativeAttribute1")
     assertEquals(expected, anna.toString())

--- a/daffodil-core/src/test/scala/org/apache/daffodil/core/dsom/TestDsomCompiler.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/core/dsom/TestDsomCompiler.scala
@@ -76,7 +76,7 @@ class TestDsomCompiler {
     val compiler = Compiler()
     val sset = compiler.compileNode(testSchema).sset
     val Seq(schema) = sset.schemas
-    val Seq(schemaDoc, _) = schema.schemaDocuments
+    val schemaDoc = schema.schemaDocuments.head
     val Seq(decl) = schemaDoc.globalElementDecls.map { _.asRoot }
 
     val tnr = decl.textNumberRep
@@ -182,7 +182,7 @@ class TestDsomCompiler {
     val sset = Compiler().compileNode(sc).sset
 
     val Seq(schema) = sset.schemas
-    val Seq(schemaDoc, _) = schema.schemaDocuments
+    val schemaDoc = schema.schemaDocuments.head
     val Seq(decl) = schemaDoc.globalElementDecls.map { _.asRoot }
     val Seq(ct) = schemaDoc.globalComplexTypeDefs
     assertEquals("example1", ct.name)
@@ -213,7 +213,7 @@ class TestDsomCompiler {
 
     val sset = Compiler().compileNode(w).sset
     val Seq(schema) = sset.schemas
-    val Seq(schemaDoc, _) = schema.schemaDocuments
+    val schemaDoc = schema.schemaDocuments.head
     val geds @ Seq(_) = schemaDoc.globalElementDecls; assertNotNull(geds)
     val Seq(ct) = schemaDoc.globalComplexTypeDefs
     assertEquals("example1", ct.name)
@@ -240,7 +240,7 @@ class TestDsomCompiler {
 
     val sset = SchemaSet(testSchema)
     val Seq(sch) = sset.schemas
-    val Seq(sd, _) = sch.schemaDocuments
+    val sd = sch.schemaDocuments.head
 
     // No annotations
     val Seq(gct) = sd.globalComplexTypeDefs
@@ -344,7 +344,7 @@ class TestDsomCompiler {
 
     val sset = SchemaSet(testSchema)
     val Seq(sch) = sset.schemas
-    val Seq(sd, _) = sch.schemaDocuments
+    val sd = sch.schemaDocuments.head
 
     // Explore global group defs
     val Seq(_, root, _*) = sd.globalElementDecls
@@ -379,7 +379,7 @@ class TestDsomCompiler {
 
     val sset = SchemaSet(testSchema)
     val Seq(sch) = sset.schemas
-    val Seq(sd) = sch.schemaDocuments
+    val sd = sch.schemaDocuments.head
 
     val Seq(a1d, _, _, _, _, _) = sd.globalElementDecls // Obtain global element nodes
     val a1 = a1d.asRoot
@@ -401,7 +401,7 @@ class TestDsomCompiler {
 
     val sset = SchemaSet(testSchema)
     val Seq(sch) = sset.schemas
-    val Seq(sd) = sch.schemaDocuments
+    val sd = sch.schemaDocuments.head
 
     val Seq(_, x, _, _, _, _) = sd.globalElementDecls.map {
       _.asRoot
@@ -422,7 +422,7 @@ class TestDsomCompiler {
 
     val sset = SchemaSet(testSchema)
     val Seq(sch) = sset.schemas
-    val Seq(sd) = sch.schemaDocuments
+    val sd = sch.schemaDocuments.head
 
     val Seq(_, ge2, ge3, ge4, ge5, ge6) = sd.globalElementDecls.map {
       _.asRoot
@@ -455,7 +455,7 @@ class TestDsomCompiler {
     val sset = SchemaSet(testSchema)
     val Seq(sch) = sset.schemas
     val root = sset.root
-    val Seq(sd, _) = sch.schemaDocuments
+    val sd = sch.schemaDocuments.head
 
     // No annotations
     val Seq(gct) = sd.globalComplexTypeDefs
@@ -506,7 +506,7 @@ class TestDsomCompiler {
 
     val sset = SchemaSet(testSchema)
     val Seq(sch) = sset.schemas
-    val Seq(sd, _) = sch.schemaDocuments
+    val sd = sch.schemaDocuments.head
 
     // No annotations
     val Seq(g) = sd.globalComplexTypeDefs;
@@ -560,7 +560,7 @@ class TestDsomCompiler {
     // val ibm7132Schema = "test/TestRefChainingIBM7132.dfdl.xml"
     val sset = SchemaSet(ibm7132Schema)
     // val Seq(sch) = sset.schemas
-    val Seq(sd) = sset.allSchemaDocuments
+    val sd = sset.allSchemaDocuments.head
 
     val Seq(ge1f) = sd.globalElementDecls // Obtain global element nodes
     val ge1 = ge1f.asRoot
@@ -592,7 +592,7 @@ class TestDsomCompiler {
     )
     val sset = SchemaSet(testSchema)
     val Seq(sch) = sset.schemas
-    val Seq(sd, _) = sch.schemaDocuments
+    val sd = sch.schemaDocuments.head
 
     val Seq(ge1f) = sd.globalElementDecls // Obtain global element nodes
     val ge1 = ge1f.asRoot
@@ -611,7 +611,7 @@ class TestDsomCompiler {
     )
     val sset = SchemaSet(testSchema)
     val Seq(sch) = sset.schemas
-    val Seq(sd, _) = sch.schemaDocuments
+    val sd = sch.schemaDocuments.head
 
     val Seq(ge1f) = sd.globalElementDecls // Obtain global element nodes
     val ge1 = ge1f.asRoot.referencedElement
@@ -654,7 +654,7 @@ class TestDsomCompiler {
     )
     val sset = SchemaSet(testSchema)
     val Seq(sch) = sset.schemas
-    val Seq(sd, _) = sch.schemaDocuments
+    val sd = sch.schemaDocuments.head
 
     val Seq(ge1f) = sd.globalElementDecls // Obtain global element nodes
     val ge1 = ge1f.asRoot.referencedElement
@@ -683,7 +683,7 @@ class TestDsomCompiler {
 
     val sset = SchemaSet(testSchema)
     val Seq(sch) = sset.schemas
-    val Seq(sd, _) = sch.schemaDocuments
+    val sd = sch.schemaDocuments.head
 
     val Seq(_, gedf, _*) = sd.globalElementDecls
     val root = gedf.asRoot
@@ -719,7 +719,7 @@ class TestDsomCompiler {
     )
     val sset = SchemaSet(testSchema)
     val Seq(sch) = sset.schemas
-    val Seq(sd, _) = sch.schemaDocuments
+    val sd = sch.schemaDocuments.head
 
     val Seq(ge1f) = sd.globalElementDecls // Obtain global element nodes
     val ge1 = ge1f.asRoot.referencedElement
@@ -1121,7 +1121,7 @@ class TestDsomCompiler {
     val compiler = Compiler()
     val sset = compiler.compileNode(testSchema).sset
     val Seq(schema) = sset.schemas
-    val Seq(schemaDoc, _) = schema.schemaDocuments
+    val schemaDoc = schema.schemaDocuments.head
     val Seq(declf) = schemaDoc.globalElementDecls
     val decl = declf.asRoot
 
@@ -1161,7 +1161,7 @@ class TestDsomCompiler {
     val compiler = Compiler()
     val sset = compiler.compileNode(testSchema).sset
     val Seq(schema) = sset.schemas
-    val Seq(schemaDoc, _) = schema.schemaDocuments
+    val schemaDoc = schema.schemaDocuments.head
     val Seq(declf) = schemaDoc.globalElementDecls
     val decl = declf.asRoot
 

--- a/daffodil-core/src/test/scala/org/apache/daffodil/core/dsom/TestIsScannable.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/core/dsom/TestIsScannable.scala
@@ -55,7 +55,7 @@ class TestIsScannable {
     val sset = Compiler().compileNode(sc).sset
 
     val Seq(schema) = sset.schemas
-    val Seq(schemaDoc, _) = schema.schemaDocuments
+    val schemaDoc = schema.schemaDocuments.head
     val list = schemaDoc.globalElementDecls.head.asRoot
     assertTrue(list.isScannable)
     val Seq(child) = list.termChildren
@@ -86,7 +86,7 @@ class TestIsScannable {
     val sset = Compiler().compileNode(sc).sset
 
     val Seq(schema) = sset.schemas
-    val Seq(schemaDoc, _) = schema.schemaDocuments
+    val schemaDoc = schema.schemaDocuments.head
     val list = schemaDoc.globalElementDecls.head.asRoot
     assertFalse(list.isScannable)
     val Seq(child) = list.termChildren
@@ -121,7 +121,7 @@ class TestIsScannable {
     val sset = Compiler().compileNode(sc).sset
 
     val Seq(schema) = sset.schemas
-    val Seq(schemaDoc, _) = schema.schemaDocuments
+    val schemaDoc = schema.schemaDocuments.head
     val list = schemaDoc.globalElementDecls.head.asRoot
     assertFalse(list.isScannable)
     val Seq(child) = list.termChildren

--- a/daffodil-core/src/test/scala/org/apache/daffodil/core/dsom/TestMiddleEndAttributes.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/core/dsom/TestMiddleEndAttributes.scala
@@ -45,7 +45,7 @@ class TestMiddleEndAttributes {
 
     val sset = SchemaSet(testSchema)
     val Seq(sch) = sset.schemas
-    val Seq(sd, _) = sch.schemaDocuments
+    val sd = sch.schemaDocuments.head
 
     // Explore global element decl
     val Seq(e1) = sd.globalElementDecls
@@ -72,7 +72,7 @@ class TestMiddleEndAttributes {
 
     val sset = SchemaSet(testSchema)
     val Seq(sch) = sset.schemas
-    val Seq(sd, _) = sch.schemaDocuments
+    val sd = sch.schemaDocuments.head
 
     // Explore global element decl
     val Seq(e1) = sd.globalElementDecls
@@ -102,7 +102,7 @@ class TestMiddleEndAttributes {
 
     val sset = SchemaSet(testSchema)
     val Seq(sch) = sset.schemas
-    val Seq(sd, _) = sch.schemaDocuments
+    val sd = sch.schemaDocuments.head
 
     // Explore global element decl
     val Seq(e1) = sd.globalElementDecls
@@ -135,7 +135,7 @@ class TestMiddleEndAttributes {
 
     val sset = SchemaSet(testSchema)
     val Seq(sch) = sset.schemas
-    val Seq(sd, _) = sch.schemaDocuments
+    val sd = sch.schemaDocuments.head
 
     // Explore global element decl
     val Seq(e1) = sd.globalElementDecls
@@ -170,7 +170,7 @@ class TestMiddleEndAttributes {
 
     val sset = SchemaSet(testSchema)
     val Seq(sch) = sset.schemas
-    val Seq(sd, _) = sch.schemaDocuments
+    val sd = sch.schemaDocuments.head
 
     // Explore global element decl
     val Seq(_, e2) = sd.globalElementDecls
@@ -211,7 +211,7 @@ class TestMiddleEndAttributes {
 
     val sset = SchemaSet(testSchema)
     val Seq(sch) = sset.schemas
-    val Seq(sd, _) = sch.schemaDocuments
+    val sd = sch.schemaDocuments.head
 
     // Explore global element decl
     val Seq(e1, _) = sd.globalElementDecls

--- a/daffodil-core/src/test/scala/org/apache/daffodil/core/dsom/TestMiddleEndAttributes2.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/core/dsom/TestMiddleEndAttributes2.scala
@@ -41,7 +41,7 @@ class TestMiddleEndAttributes2 {
 
     val sset = SchemaSet(testSchema)
     val Seq(sch) = sset.schemas
-    val Seq(sd, _) = sch.schemaDocuments
+    val sd = sch.schemaDocuments.head
 
     // Explore global element decl
     val Seq(e1) = sd.globalElementDecls

--- a/daffodil-core/src/test/scala/org/apache/daffodil/core/dsom/TestMiddleEndAttributes3.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/core/dsom/TestMiddleEndAttributes3.scala
@@ -52,7 +52,7 @@ class TestMiddleEndAttributes3 {
 
     val sset = SchemaSet(testSchema)
     val Seq(sch) = sset.schemas
-    val Seq(sd, _) = sch.schemaDocuments
+    val sd = sch.schemaDocuments.head
 
     // Explore global element decl
     val Seq(e) = sd.globalElementDecls
@@ -101,7 +101,7 @@ class TestMiddleEndAttributes3 {
 
     val sset = SchemaSet(testSchema)
     val Seq(sch) = sset.schemas
-    val Seq(sd, _) = sch.schemaDocuments
+    val sd = sch.schemaDocuments.head
 
     // Explore global element decl
     val Seq(e) = sd.globalElementDecls

--- a/daffodil-core/src/test/scala/org/apache/daffodil/core/dsom/TestSimpleTypeUnions.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/core/dsom/TestSimpleTypeUnions.scala
@@ -71,7 +71,7 @@ class TestSimpleTypeUnions {
 
     val sset = SchemaSet(testSchema1)
     val Seq(sch) = sset.schemas
-    val Seq(sd, _) = sch.schemaDocuments
+    val sd = sch.schemaDocuments.head
 
     // Explore global element decl
     val Seq(e1) = sd.globalElementDecls

--- a/daffodil-japi/src/test/resources/test/japi/ambig_elt.dfdl.xsd
+++ b/daffodil-japi/src/test/resources/test/japi/ambig_elt.dfdl.xsd
@@ -22,11 +22,11 @@
   xmlns:dfdlx="http://www.ogf.org/dfdl/dfdl-1.0/extensions"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
-  <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+  <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormatPortable.dfdl.xsd"/>
 
   <annotation>
     <appinfo source="http://www.ogf.org/dfdl/">
-      <dfdl:format ref="tns:GeneralFormatPortable"
+      <dfdl:format ref="tns:GeneralFormat"
         representation="binary"
         encodingErrorPolicy="replace" lengthKind="implicit" />
     </appinfo>

--- a/daffodil-japi/src/test/resources/test/japi/blob_backtracking.dfdl.xsd
+++ b/daffodil-japi/src/test/resources/test/japi/blob_backtracking.dfdl.xsd
@@ -22,11 +22,11 @@
   xmlns:dfdlx="http://www.ogf.org/dfdl/dfdl-1.0/extensions"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
-  <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+  <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormatPortable.dfdl.xsd"/>
 
   <annotation>
     <appinfo source="http://www.ogf.org/dfdl/">
-      <dfdl:format ref="tns:GeneralFormatPortable"
+      <dfdl:format ref="tns:GeneralFormat"
         representation="binary"
         encodingErrorPolicy="replace" />
     </appinfo>

--- a/daffodil-lib/src/main/resources/org/apache/daffodil/xsd/DFDLGeneralFormatBase.dfdl.xsd
+++ b/daffodil-lib/src/main/resources/org/apache/daffodil/xsd/DFDLGeneralFormatBase.dfdl.xsd
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<xs:schema xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/"
+  xmlns:xs="http://www.w3.org/2001/XMLSchema">
+
+  <!-- Intended for inclusion into other schemas. Has no targetNamespace on purpose -->
+  <xs:annotation>
+    <xs:appinfo source="http://www.ogf.org/dfdl/">
+
+      <!--
+        This set of properties should never change. It can be added to 
+        if properties are missing, but should not be changed.
+        
+        Changes should be introduced by way of defining new formats in
+        terms of this one, which override definitions. See below in 
+        the file for examples. 
+       -->
+      <dfdl:defineFormat name="GeneralFormatBase">
+        <dfdl:format
+          alignment="1"
+          alignmentUnits="bytes"
+          binaryFloatRep="ieee"
+          binaryNumberCheckPolicy="lax"
+          binaryNumberRep="binary"
+          binaryCalendarEpoch="1970-01-01T00:00:00"
+          bitOrder="mostSignificantBitFirst"
+          byteOrder="bigEndian"
+          calendarCenturyStart="53"
+          calendarCheckPolicy="strict"
+          calendarDaysInFirstWeek="4"
+          calendarFirstDayOfWeek="Sunday"
+          calendarLanguage="en"
+          calendarObserveDST="yes"
+          calendarPatternKind="implicit"
+          calendarTimeZone=""
+          choiceLengthKind="implicit"
+          decimalSigned="yes"
+          documentFinalTerminatorCanBeMissing="no"
+          emptyValueDelimiterPolicy="both"
+          encodingErrorPolicy="replace"
+          encoding="US-ASCII"
+          escapeSchemeRef=""
+          fillByte="%#r20;"
+          floating="no"
+          ignoreCase="no"
+          initiatedContent="no"
+          initiator=""
+          leadingSkip="0"
+          lengthKind="implicit"
+          lengthUnits="bytes"
+          occursCountKind="implicit"
+          outputNewLine="%LF;"
+          representation="text"
+          separator=""
+          separatorPosition="infix"
+          separatorSuppressionPolicy="anyEmpty"
+          sequenceKind="ordered"
+          terminator=""
+          textBidi="no"
+          textBooleanPadCharacter="%SP;"
+          textCalendarJustification="left"
+          textCalendarPadCharacter="%SP;"
+          textNumberCheckPolicy="lax"
+          textNumberJustification="right"
+          textNumberPadCharacter="%SP;"
+          textNumberPattern="#,##0.###;-#,##0.###"
+          textNumberRep="standard"
+          textNumberRounding="explicit"
+          textNumberRoundingIncrement="0"
+          textNumberRoundingMode="roundHalfEven"
+          textOutputMinLength="0"
+          textPadKind="none"
+          textStandardBase="10"
+          textStandardDecimalSeparator="."
+          textStandardExponentRep="E"
+          textStandardGroupingSeparator=","
+          textStandardInfinityRep="Inf"
+          textStandardNaNRep="NaN"
+          textStandardZeroRep=""
+          textStringJustification="left"
+          textStringPadCharacter="%SP;"
+          textTrimKind="none"
+          trailingSkip="0"
+          truncateSpecifiedLengthString="no"
+          utf16Width="fixed"
+        />
+      </dfdl:defineFormat>
+      
+    </xs:appinfo>
+  </xs:annotation>
+
+</xs:schema>

--- a/daffodil-lib/src/main/resources/org/apache/daffodil/xsd/DFDLGeneralFormatPortable.dfdl.xsd
+++ b/daffodil-lib/src/main/resources/org/apache/daffodil/xsd/DFDLGeneralFormatPortable.dfdl.xsd
@@ -27,9 +27,11 @@
 
       <dfdl:defineFormat name="GeneralFormat">
         <dfdl:format ref="GeneralFormatBase"
-            emptyElementParsePolicy="treatAsEmpty"/>
+          calendarTimeZone="UTC"
+          encodingErrorPolicy="error"
+        />   
       </dfdl:defineFormat>
-        
+
     </xs:appinfo>
   </xs:annotation>
 

--- a/daffodil-sapi/src/test/resources/test/sapi/ambig_elt.dfdl.xsd
+++ b/daffodil-sapi/src/test/resources/test/sapi/ambig_elt.dfdl.xsd
@@ -22,11 +22,11 @@
   xmlns:dfdlx="http://www.ogf.org/dfdl/dfdl-1.0/extensions"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
-  <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+  <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormatPortable.dfdl.xsd"/>
 
   <annotation>
     <appinfo source="http://www.ogf.org/dfdl/">
-      <dfdl:format ref="tns:GeneralFormatPortable"
+      <dfdl:format ref="tns:GeneralFormat"
         representation="binary"
         encodingErrorPolicy="replace" lengthKind="implicit" />
     </appinfo>

--- a/daffodil-test-ibm1/src/test/resources/test-suite/ibm-contributed/dpaextdeltxt101-err.dfdl.xsd
+++ b/daffodil-test-ibm1/src/test/resources/test-suite/ibm-contributed/dpaextdeltxt101-err.dfdl.xsd
@@ -29,7 +29,7 @@
     specifically intended for negative testing that produce SDE, have 
     to be isolated from schema for tests that do not have SDEs.
 	-->
-	<xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd" />
+	<xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormatPortable.dfdl.xsd" />
 	
 	<xs:annotation>
 		<xs:appinfo source="http://www.ogf.org/dfdl/">
@@ -37,7 +37,7 @@
 				This is the new schema level default format block. It doesn't get a
 				name
 			-->
-			<dfdl:format ref="GeneralFormatPortable" 
+			<dfdl:format ref="GeneralFormat" 
 			  initiator="" terminator="" leadingSkip="0" trailingSkip="0"  textBidi="no" floating="no"   encoding="utf-8" byteOrder="bigEndian" alignment="1" alignmentUnits="bytes" fillByte="f" 
         occursCountKind="implicit" 
 				truncateSpecifiedLengthString="no" ignoreCase="no"

--- a/daffodil-test-ibm1/src/test/resources/test-suite/ibm-contributed/dpaextdeltxt101.dfdl.xsd
+++ b/daffodil-test-ibm1/src/test/resources/test-suite/ibm-contributed/dpaextdeltxt101.dfdl.xsd
@@ -24,7 +24,7 @@
 	attributeFormDefault="unqualified" >
 	<!--
 	-->
-	<xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd" />
+	<xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormatPortable.dfdl.xsd" />
 	
 	<xs:annotation>
 		<xs:appinfo source="http://www.ogf.org/dfdl/">
@@ -32,7 +32,7 @@
 				This is the new schema level default format block. It doesn't get a
 				name
 			-->
-			<dfdl:format ref="GeneralFormatPortable" 
+			<dfdl:format ref="GeneralFormat" 
 			  initiator="" terminator="" leadingSkip="0" trailingSkip="0"  textBidi="no" floating="no"   encoding="utf-8" byteOrder="bigEndian" alignment="1" alignmentUnits="bytes" fillByte="f" 
         occursCountKind="implicit" 
 				truncateSpecifiedLengthString="no" ignoreCase="no"

--- a/daffodil-test-ibm1/src/test/resources/test-suite/tresys-contributed/AF.dfdl.xsd
+++ b/daffodil-test-ibm1/src/test/resources/test-suite/tresys-contributed/AF.dfdl.xsd
@@ -21,11 +21,11 @@
   xmlns:xsd="http://www.w3.org/2001/XMLSchema"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tns="http://example.com">
 
-  <include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+  <include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormatPortable.dfdl.xsd"/>
 
   <annotation>
     <appinfo source="http://www.ogf.org/dfdl/">
-      <dfdl:format ref="tns:GeneralFormatPortable" separator="" initiator="" terminator=""
+      <dfdl:format ref="tns:GeneralFormat" separator="" initiator="" terminator=""
         emptyValueDelimiterPolicy="none" lengthKind="delimited"
         textNumberRep="standard" representation="text" ignoreCase='no'
         occursCountKind="parsed" initiatedContent="no" leadingSkip='0' encoding="US-ASCII"

--- a/daffodil-test-ibm1/src/test/resources/test-suite/tresys-contributed/AW.dfdl.xsd
+++ b/daffodil-test-ibm1/src/test/resources/test-suite/tresys-contributed/AW.dfdl.xsd
@@ -21,11 +21,11 @@
   xmlns:xsd="http://www.w3.org/2001/XMLSchema"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tns="http://example.com">
 
-<include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+<include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormatPortable.dfdl.xsd"/>
 
   <annotation>
     <appinfo source="http://www.ogf.org/dfdl/">
-      <dfdl:format ref="tns:GeneralFormatPortable" lengthKind="delimited" separator=""
+      <dfdl:format ref="tns:GeneralFormat" lengthKind="delimited" separator=""
         leadingSkip='0' encoding="US-ASCII" ignoreCase='no' initiator=""
         terminator="" initiatedContent="no" textNumberRep="standard"
         separatorSuppressionPolicy="anyEmpty" separatorPosition="infix"

--- a/daffodil-test-ibm1/src/test/resources/test-suite/tresys-contributed/AY.dfdl.xsd
+++ b/daffodil-test-ibm1/src/test/resources/test-suite/tresys-contributed/AY.dfdl.xsd
@@ -21,12 +21,12 @@
   xmlns:xsd="http://www.w3.org/2001/XMLSchema"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tns="http://example.com">
 
-<include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+<include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormatPortable.dfdl.xsd"/>
 
 <annotation>
     <appinfo source="http://www.ogf.org/dfdl/">
 
-      <dfdl:format ref="tns:GeneralFormatPortable" lengthKind="delimited" separator=""
+      <dfdl:format ref="tns:GeneralFormat" lengthKind="delimited" separator=""
         leadingSkip='0' encoding="US-ASCII" ignoreCase='no' initiator=""
         terminator="" initiatedContent="no" textNumberRep="standard"
         separatorSuppressionPolicy="anyEmpty" separatorPosition="infix"

--- a/daffodil-test-ibm1/src/test/resources/test-suite/tresys-contributed/AZ.dfdl.xsd
+++ b/daffodil-test-ibm1/src/test/resources/test-suite/tresys-contributed/AZ.dfdl.xsd
@@ -21,11 +21,11 @@
   xmlns:xsd="http://www.w3.org/2001/XMLSchema"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tns="http://example.com">
 
-<include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+<include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormatPortable.dfdl.xsd"/>
 
 <annotation>
     <appinfo source="http://www.ogf.org/dfdl/">
-      <dfdl:format ref="tns:GeneralFormatPortable" lengthKind="delimited" separator=""
+      <dfdl:format ref="tns:GeneralFormat" lengthKind="delimited" separator=""
         leadingSkip='0' encoding="US-ASCII" ignoreCase='no' initiator=""
         terminator="" initiatedContent="no" textNumberRep="standard"
         separatorSuppressionPolicy="anyEmpty" separatorPosition="infix"

--- a/daffodil-test-ibm1/src/test/resources/test-suite/tresys-contributed/mixed-binary-text.tdml
+++ b/daffodil-test-ibm1/src/test/resources/test-suite/tresys-contributed/mixed-binary-text.tdml
@@ -26,8 +26,8 @@
 
   <tdml:defineSchema name="v">
 
-    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
-    <dfdl:format ref="ex:GeneralFormatPortable" lengthKind="delimited"
+    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormatPortable.dfdl.xsd"/>
+    <dfdl:format ref="ex:GeneralFormat" lengthKind="delimited"
       encoding="utf-8" lengthUnits='characters'/>
 
     <xs:element name="c">

--- a/daffodil-test-ibm1/src/test/resources/test-suite/tresys-contributed/nested-separator-delimited.tdml
+++ b/daffodil-test-ibm1/src/test/resources/test-suite/tresys-contributed/nested-separator-delimited.tdml
@@ -156,8 +156,8 @@
   </tdml:parserTestCase>
 
   <tdml:defineSchema name="basicNest2">
-    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
-    <dfdl:format ref="ex:GeneralFormatPortable" occursCountKind="parsed" />
+    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormatPortable.dfdl.xsd"/>
+    <dfdl:format ref="ex:GeneralFormat" occursCountKind="parsed" />
 
     <xs:element name="e1" dfdl:lengthKind="implicit"
       dfdl:terminator=".">
@@ -295,8 +295,8 @@
   </tdml:parserTestCase>
 
   <tdml:defineSchema name="nest3">
-    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
-    <dfdl:format ref="ex:GeneralFormatPortable" occursCountKind="parsed" />
+    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormatPortable.dfdl.xsd"/>
+    <dfdl:format ref="ex:GeneralFormat" occursCountKind="parsed" />
     <!-- test the issue of shared prefixes among the delimiters. This makes
       it challenging to determine longest match, as several contenders must
       be

--- a/daffodil-test-ibm1/src/test/resources/test-suite/tresys-contributed/nilled.tdml
+++ b/daffodil-test-ibm1/src/test/resources/test-suite/tresys-contributed/nilled.tdml
@@ -47,9 +47,9 @@
   </tdml:defineConfig>
 
   <tdml:defineSchema name="s1" elementFormDefault="qualified">
-    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd" />
+    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormatPortable.dfdl.xsd" />
 
-    <dfdl:format ref="ex:GeneralFormatPortable" lengthKind="delimited"
+    <dfdl:format ref="ex:GeneralFormat" lengthKind="delimited"
       occursCountKind="implicit" nilValue="%ES;" 
       nilValueDelimiterPolicy="none" 
       nilKind="literalValue"

--- a/daffodil-test-ibm1/src/test/resources/test-suite/tresys-contributed/sepSuppression.tdml
+++ b/daffodil-test-ibm1/src/test/resources/test-suite/tresys-contributed/sepSuppression.tdml
@@ -48,9 +48,9 @@
   </tdml:defineConfig>
 
   <tdml:defineSchema name="s1">
-    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd" />
+    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormatPortable.dfdl.xsd" />
 
-    <dfdl:format ref="ex:GeneralFormatPortable" 
+    <dfdl:format ref="ex:GeneralFormat" 
       lengthKind="delimited"
       occursCountKind="implicit" />
 
@@ -481,9 +481,9 @@
   
   
   <tdml:defineSchema name="s2">
-    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd" />
+    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormatPortable.dfdl.xsd" />
     
-    <dfdl:format ref="ex:GeneralFormatPortable" 
+    <dfdl:format ref="ex:GeneralFormat" 
       lengthKind="delimited" 
       occursCountKind="implicit"/>    
     <!-- 
@@ -583,9 +583,9 @@
   </tdml:unparserTestCase>
     
   <tdml:defineSchema name="s3" elementFormDefault="unqualified">
-    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd" />
+    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormatPortable.dfdl.xsd" />
     
-    <dfdl:format ref="ex:GeneralFormatPortable" 
+    <dfdl:format ref="ex:GeneralFormat" 
       lengthKind="delimited" 
       occursCountKind="implicit"/>
       
@@ -644,9 +644,9 @@
   <!-- Same as s3 schema but emptyElementParsePolicy is now treatAsAbsent -->
 
   <tdml:defineSchema name="s3_absent" elementFormDefault="unqualified">
-    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd" />
+    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormatPortable.dfdl.xsd" />
 
-    <dfdl:format ref="ex:GeneralFormatPortable"
+    <dfdl:format ref="ex:GeneralFormat"
                  lengthKind="delimited"
                  occursCountKind="implicit"
                  emptyElementParsePolicy="treatAsAbsent"/>

--- a/daffodil-test-ibm1/src/test/resources/test-suite/tresys-contributed/sepSuppression2.tdml
+++ b/daffodil-test-ibm1/src/test/resources/test-suite/tresys-contributed/sepSuppression2.tdml
@@ -38,9 +38,9 @@
   </tdml:defineConfig>
 
   <tdml:defineSchema name="s0">
-    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd" />
+    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormatPortable.dfdl.xsd" />
 
-    <dfdl:format ref="ex:GeneralFormatPortable" 
+    <dfdl:format ref="ex:GeneralFormat" 
       lengthKind="delimited"
       occursCountKind="implicit"/>
 
@@ -126,9 +126,9 @@
   </tdml:unparserTestCase>
   
  <tdml:defineSchema name="s1">
-    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd" />
+    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormatPortable.dfdl.xsd" />
 
-    <dfdl:format ref="ex:GeneralFormatPortable" 
+    <dfdl:format ref="ex:GeneralFormat" 
       lengthKind="delimited"
       occursCountKind="implicit"/>
       
@@ -274,9 +274,9 @@
 
   <tdml:defineSchema name="s2" elementFormDefault="unqualified">
 
-    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd" />
+    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormatPortable.dfdl.xsd" />
 
-    <dfdl:format ref="ex:GeneralFormatPortable" />
+    <dfdl:format ref="ex:GeneralFormat" />
 
     <xs:element name="r" dfdl:lengthKind="implicit">
       <xs:complexType>

--- a/daffodil-test-ibm1/src/test/resources/test-suite/tresys-contributed/unseparated.tdml
+++ b/daffodil-test-ibm1/src/test/resources/test-suite/tresys-contributed/unseparated.tdml
@@ -45,8 +45,8 @@
   </tdml:defineConfig>
 
   <tdml:defineSchema name="s1" elementFormDefault="unqualified">
-    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd" />
-    <dfdl:format ref="ex:GeneralFormatPortable" />
+    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormatPortable.dfdl.xsd" />
+    <dfdl:format ref="ex:GeneralFormat" />
     <xs:element name="E">
       <xs:complexType>
         <xs:sequence>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section05/simple_types/Blobs.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section05/simple_types/Blobs.tdml
@@ -38,9 +38,9 @@
 
   <tdml:defineSchema name="Blob.dfdl.xsd">
 
-    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormatPortable.dfdl.xsd"/>
 
-    <dfdl:format ref="ex:GeneralFormatPortable"
+    <dfdl:format ref="ex:GeneralFormat"
       representation="binary"
       encodingErrorPolicy="replace" />
 

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section05/simple_types/SimpleTypes.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section05/simple_types/SimpleTypes.tdml
@@ -25,8 +25,8 @@
   defaultRoundTrip="true">
 
   <tdml:defineSchema name="SimpleTypes-Embedded.dfdl.xsd">
-    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
-    <dfdl:format ref="ex:GeneralFormatPortable" lengthKind="implicit" representation="text"
+    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormatPortable.dfdl.xsd"/>
+    <dfdl:format ref="ex:GeneralFormat" lengthKind="implicit" representation="text"
         lengthUnits="bytes" encoding="US-ASCII" initiator="" terminator=""
         separator="" textNumberCheckPolicy="lax" ignoreCase="no" textNumberRep="standard"
         textPadKind="padChar" textTrimKind="padChar"/>
@@ -203,8 +203,8 @@
   </tdml:defineSchema>
 
   <tdml:defineSchema name="SimpleTypes-binary">
-    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
-    <dfdl:format ref="ex:GeneralFormatPortable" representation="binary"
+    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormatPortable.dfdl.xsd"/>
+    <dfdl:format ref="ex:GeneralFormat" representation="binary"
       lengthUnits="bytes"
       textPadKind="padChar" textTrimKind="padChar" />
 

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section07/discriminators/multipleDiscriminators.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section07/discriminators/multipleDiscriminators.tdml
@@ -24,9 +24,9 @@
 
   <tdml:defineSchema name="multipleDiscriminators">
 
-    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormatPortable.dfdl.xsd"/>
 
-    <dfdl:format ref="ex:GeneralFormatPortable" />
+    <dfdl:format ref="ex:GeneralFormat" />
 
     <xs:element name="root">
       <xs:complexType>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section13/nillable/nillable.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section13/nillable/nillable.tdml
@@ -322,9 +322,9 @@
   </tdml:parserTestCase>
 
   <tdml:defineSchema name="s2">
-    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd" />
+    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormatPortable.dfdl.xsd" />
     
-    <dfdl:format ref="ex:GeneralFormatPortable" 
+    <dfdl:format ref="ex:GeneralFormat" 
     lengthKind="delimited" 
     useNilForDefault="no"/>
     

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section14/sequence_groups/SequenceGroupInitiatedContent.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section14/sequence_groups/SequenceGroupInitiatedContent.tdml
@@ -115,9 +115,9 @@
   </tdml:parserTestCase>
   
   <tdml:defineSchema name="s2" elementFormDefault="unqualified">
-    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormatPortable.dfdl.xsd"/>
     
-    <dfdl:format ref="ex:GeneralFormatPortable" 
+    <dfdl:format ref="ex:GeneralFormat" 
       occursCountKind='parsed'
       lengthKind="delimited"/>
 

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section16/array_optional_elem/ArrayOptionalElem.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section16/array_optional_elem/ArrayOptionalElem.tdml
@@ -28,13 +28,13 @@
   defaultRoundTrip="true">
   
   <tdml:defineSchema name="s1">
-    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormatPortable.dfdl.xsd"/>
 
-    <dfdl:format lengthKind="explicit" length="1" ref="ex:GeneralFormatPortable"
+    <dfdl:format lengthKind="explicit" length="1" ref="ex:GeneralFormat"
       separator="" initiator="" terminator="" occursCountKind="implicit"
       ignoreCase="no" textNumberRep="standard" representation="text" />
     <dfdl:defineFormat name="root">
-      <dfdl:format lengthKind="implicit" ref="ex:GeneralFormatPortable"
+      <dfdl:format lengthKind="implicit" ref="ex:GeneralFormat"
         separator="" initiator="" terminator="" representation="text" />
     </dfdl:defineFormat>
     
@@ -51,10 +51,10 @@
   </tdml:defineSchema>
 
   <tdml:defineSchema name="array-optionalElem.dfdl.xsd">
-    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormatPortable.dfdl.xsd"/>
 
     <dfdl:format lengthKind="delimited" lengthUnits="bytes"
-      ref="ex:GeneralFormatPortable" encoding="UTF-8" separator="" initiator="" terminator=""
+      ref="ex:GeneralFormat" encoding="UTF-8" separator="" initiator="" terminator=""
       occursCountKind="parsed" ignoreCase="no" textNumberRep="standard"
       representation="text" />
 
@@ -130,10 +130,9 @@
   </tdml:parserTestCase>
   
   <tdml:defineSchema name="arrays1">
-    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
 
-    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
-    <dfdl:format ref="ex:GeneralFormatPortable" occursCountKind="implicit"
+    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormatPortable.dfdl.xsd"/>
+    <dfdl:format ref="ex:GeneralFormat" occursCountKind="implicit"
       lengthKind="delimited" separatorSuppressionPolicy="trailingEmptyStrict"
       separatorPosition="prefix" />
 
@@ -278,8 +277,8 @@
   </tdml:parserTestCase>
   
   <tdml:defineSchema name="arrayExpressions-portable">
-    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
-    <dfdl:format ref="ex:GeneralFormatPortable" />
+    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormatPortable.dfdl.xsd"/>
+    <dfdl:format ref="ex:GeneralFormat" />
     
     <dfdl:defineVariable name="counter" type="xs:int" />
     
@@ -323,8 +322,8 @@
   </tdml:defineSchema>
   
   <tdml:defineSchema name="arrayExpressions">
-    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
-    <dfdl:format ref="ex:GeneralFormatPortable" />
+    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormatPortable.dfdl.xsd"/>
+    <dfdl:format ref="ex:GeneralFormat" />
     
     <dfdl:defineVariable name="counter" type="xs:int" />
 
@@ -674,10 +673,10 @@
   </tdml:parserTestCase>
 
   <tdml:defineSchema name="array-ockImplicitSeparators.dfdl.xsd" elementFormDefault="unqualified">
-    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormatPortable.dfdl.xsd"/>
 
     <dfdl:format lengthKind="delimited" lengthUnits="bytes"
-      ref="ex:GeneralFormatPortable" encoding="UTF-8" separator="" initiator="" terminator=""
+      ref="ex:GeneralFormat" encoding="UTF-8" separator="" initiator="" terminator=""
       occursCountKind="implicit" ignoreCase="no" textNumberRep="standard"
       representation="text" />
 
@@ -746,10 +745,10 @@
   </tdml:defineSchema>
 
   <tdml:defineSchema name="array-ockImplicitSeparators.dfdl.xsd-strict" elementFormDefault="unqualified">
-    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormatPortable.dfdl.xsd"/>
 
     <dfdl:format lengthKind="delimited" lengthUnits="bytes"
-      ref="ex:GeneralFormatPortable" encoding="UTF-8" separator="" initiator="" terminator=""
+      ref="ex:GeneralFormat" encoding="UTF-8" separator="" initiator="" terminator=""
       occursCountKind="implicit" ignoreCase="no" textNumberRep="standard"
       representation="text" />
      
@@ -914,10 +913,10 @@
   </tdml:parserTestCase>
 
   <tdml:defineSchema name="nestedSequence" elementFormDefault="unqualified">
-    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormatPortable.dfdl.xsd"/>
 
     <dfdl:format lengthKind="delimited" lengthUnits="bytes"
-      ref="ex:GeneralFormatPortable" encoding="UTF-8" separator="" initiator="" terminator=""
+      ref="ex:GeneralFormat" encoding="UTF-8" separator="" initiator="" terminator=""
       occursCountKind="implicit" ignoreCase="no" textNumberRep="standard"
       representation="text" />
 
@@ -949,10 +948,10 @@
   </tdml:defineSchema>
       
   <tdml:defineSchema name="nestedSequence-strict" elementFormDefault="unqualified">
-    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormatPortable.dfdl.xsd"/>
 
     <dfdl:format lengthKind="delimited" lengthUnits="bytes"
-      ref="ex:GeneralFormatPortable" encoding="UTF-8" separator="" initiator="" terminator=""
+      ref="ex:GeneralFormat" encoding="UTF-8" separator="" initiator="" terminator=""
       occursCountKind="implicit" ignoreCase="no" textNumberRep="standard"
       representation="text" />
       
@@ -1039,8 +1038,8 @@
   </tdml:parserTestCase>
   
  <tdml:defineSchema name="adjacent"  elementFormDefault="unqualified">
-    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
-    <dfdl:format ref="ex:GeneralFormatPortable" lengthKind="delimited"/>
+    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormatPortable.dfdl.xsd"/>
+    <dfdl:format ref="ex:GeneralFormat" lengthKind="delimited"/>
     
     <xs:element name="r">
       <xs:complexType>
@@ -1071,8 +1070,8 @@
   </tdml:parserTestCase>
 
  <tdml:defineSchema name="dfdl2263"  elementFormDefault="unqualified">
-    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
-    <dfdl:format ref="ex:GeneralFormatPortable" lengthKind="delimited"/>
+    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormatPortable.dfdl.xsd"/>
+    <dfdl:format ref="ex:GeneralFormat" lengthKind="delimited"/>
 
     <xs:element name="input">
       <xs:complexType>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section16/array_optional_elem/UnparseArrayDelimitedOptionalElem.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section16/array_optional_elem/UnparseArrayDelimitedOptionalElem.tdml
@@ -23,13 +23,13 @@
   xmlns:ex="http://example.com" xmlns:daf="urn:ogf:dfdl:2013:imp:daffodil.apache.org:2018:ext">
 
   <tdml:defineSchema name="s1">
-    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormatPortable.dfdl.xsd"/>
 
-    <dfdl:format lengthKind="explicit" length="1" ref="ex:GeneralFormatPortable" encodingErrorPolicy="replace"
+    <dfdl:format lengthKind="explicit" length="1" ref="ex:GeneralFormat" encodingErrorPolicy="replace"
       separator="" initiator="" terminator="" occursCountKind="implicit"
       ignoreCase="no" textNumberRep="standard" representation="text" separatorSuppressionPolicy="anyEmpty" textPadKind="padChar" textStringPadCharacter="."/>
     <dfdl:defineFormat name="root">
-      <dfdl:format lengthKind="delimited" ref="ex:GeneralFormatPortable" separatorSuppressionPolicy="anyEmpty"
+      <dfdl:format lengthKind="delimited" ref="ex:GeneralFormat" separatorSuppressionPolicy="anyEmpty"
         separator="," initiator="" terminator="" representation="text" separatorPosition="infix" textPadKind="padChar" textStringPadCharacter="."/>
     </dfdl:defineFormat>
 

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section16/array_optional_elem/arrays_optional_elements.dfdl.xsd
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section16/array_optional_elem/arrays_optional_elements.dfdl.xsd
@@ -17,15 +17,14 @@
 -->
 
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/">
-  <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
 
-  <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+  <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormatPortable.dfdl.xsd"/>
   
   <xs:annotation>
     <xs:appinfo source="http://www.ogf.org/dfdl/">
 
       <dfdl:defineFormat name="untrimmed">
-        <dfdl:format ref="GeneralFormatPortable" separator="" initiator="" terminator="" leadingSkip='0' textTrimKind="none" initiatedContent="no"
+        <dfdl:format ref="GeneralFormat" separator="" initiator="" terminator="" leadingSkip='0' textTrimKind="none" initiatedContent="no"
         ignoreCase="no" representation="text" lengthKind="delimited" encoding="ASCII"
         alignment="implicit" alignmentUnits="bytes" trailingSkip="0" escapeSchemeRef='' byteOrder="littleEndian"/>
       </dfdl:defineFormat>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section16/array_optional_elem/backtracking.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section16/array_optional_elem/backtracking.tdml
@@ -25,11 +25,9 @@
 
   <tdml:defineSchema name="s">
 
-    <xsd:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd" />
-
     <!-- Must be utf-8, or it chooses the other backend which does more copying and so doesn't show up the bug. -->
-    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
-    <dfdl:format ref="ex:GeneralFormatPortable" encoding="UTF-8" lengthKind="delimited" />
+    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormatPortable.dfdl.xsd"/>
+    <dfdl:format ref="ex:GeneralFormat" encoding="UTF-8" lengthKind="delimited" />
 
     <xsd:element name="A">
       <xsd:complexType>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section17/calc_value_properties/outputValueCalc3.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section17/calc_value_properties/outputValueCalc3.tdml
@@ -30,9 +30,9 @@
 
   <tdml:defineSchema name="s" elementFormDefault="unqualified">
 
-    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd" />
+    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormatPortable.dfdl.xsd" />
 
-    <dfdl:format ref="ex:GeneralFormatPortable" sequenceKind='ordered' initiator=""
+    <dfdl:format ref="ex:GeneralFormat" sequenceKind='ordered' initiator=""
       terminator="" separator="" initiatedContent='no' leadingSkip='0' trailingSkip='0'
       textStringPadCharacter='%SP;' lengthUnits="bits" alignment="1" alignmentUnits="bits"
       representation="binary" encoding="ASCII" binaryNumberRep="binary" byteOrder="littleEndian"

--- a/daffodil-test/src/test/resources/org/apache/daffodil/usertests/SepTests.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/usertests/SepTests.tdml
@@ -39,9 +39,9 @@
 
   <tdml:defineSchema name="s1" elementFormDefault="unqualified">
 
-    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormatPortable.dfdl.xsd"/>
     <dfdl:format
-      ref="ex:GeneralFormatPortable"
+      ref="ex:GeneralFormat"
       representation="text"
       lengthKind="delimited"
       separatorPosition="infix"/>
@@ -134,9 +134,9 @@
 
   <tdml:defineSchema name="s2" elementFormDefault="unqualified">
 
-    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormatPortable.dfdl.xsd"/>
     <dfdl:format
-      ref="ex:GeneralFormatPortable"
+      ref="ex:GeneralFormat"
       representation="text"
       lengthKind="delimited"
       separatorPosition="infix"/>
@@ -188,9 +188,9 @@
 
   <tdml:defineSchema name="s3" elementFormDefault="unqualified">
 
-    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormatPortable.dfdl.xsd"/>
     <dfdl:format
-      ref="ex:GeneralFormatPortable"
+      ref="ex:GeneralFormat"
       representation="text"
       lengthKind="delimited"
       separatorPosition="infix"/>
@@ -289,9 +289,9 @@
 
   <tdml:defineSchema name="s4" elementFormDefault="unqualified">
 
-    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormatPortable.dfdl.xsd"/>
     <dfdl:format
-            ref="ex:GeneralFormatPortable"
+            ref="ex:GeneralFormat"
             representation="text"
             lengthKind="delimited"
             separatorPosition="infix"
@@ -383,9 +383,9 @@
   -->
   <tdml:defineSchema name="s5" elementFormDefault="unqualified">
 
-    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormatPortable.dfdl.xsd"/>
     <dfdl:format
-            ref="ex:GeneralFormatPortable"
+            ref="ex:GeneralFormat"
             representation="text"
             lengthKind="delimited"
             separatorPosition="infix"

--- a/daffodil-udf/src/test/resources/org/apache/daffodil/udf/genericUdfSchema.xsd
+++ b/daffodil-udf/src/test/resources/org/apache/daffodil/udf/genericUdfSchema.xsd
@@ -23,11 +23,11 @@
   xmlns:ssudf="http://example.com/scala/udf">
 
   <xs:include
-    schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd" />
+    schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormatPortable.dfdl.xsd" />
 
   <xs:annotation>
     <xs:appinfo source="http://www.ogf.org/dfdl/">
-      <dfdl:format ref="GeneralFormatPortable" initiator=""
+      <dfdl:format ref="GeneralFormat" initiator=""
         terminator="" leadingSkip="0" trailingSkip="0" textBidi="no"
         floating="no" encoding="ASCII" byteOrder="bigEndian"
         alignment="implicit" alignmentUnits="bits" fillByte="f"


### PR DESCRIPTION
The DFDLGeneralFormat.dfdl.xsd file defines the emptyElementParsePolicy extension property in the GeneralFormat format. Even if a schema uses GeneralFormatPortable, which does not deine this exension property, IBM DFDL still sees it and creates an error. This means that it is impossible to use this file for portability tests.

To resolve this, this creates a new DFDLGeneralFormatPortable.dfdl.xsd file that does not contain any properties that IBM DFDL does not support. Additionally, the define format in this file uses the same GeneralFormat name as DFDLGeneralFormat.dfdl.xsd. This allows schema authors to alway reference the GeneralFormat format, and only change the xs:include to make a schema portable or not.

Compatibility/Deprecation:

The GeneralFormatPortable define format has been removed. Instead, portable schemas should import a new portable file and reference the "GeneralFormat" format. For example, a schema that previously looked like this:

    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd" />

    <dfdl:format ref="GeneralFormatPortable" ... />

Should now look like this:

    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormatPortable.dfdl.xsd" />

    <dfdl:format ref="GeneralFormat" ... />

DAFFODIL-2820