### PR TITLE
Correctly check for errors when parsing text calendars

### DIFF
--- a/daffodil-test/src/test/resources/org/apache/daffodil/section05/simple_types/SimpleTypes.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section05/simple_types/SimpleTypes.tdml
@@ -5123,6 +5123,15 @@
       </xs:complexType>
     </xs:element>
 
+    <xs:element name="time33">
+      <xs:complexType>
+        <xs:sequence>
+          <xs:element name="e1" type="xs:string" dfdl:lengthKind="explicit" dfdl:length="4" />
+          <xs:element name="e2" type="xs:time" minOccurs="0" dfdl:lengthKind="delimited" dfdl:calendarPatternKind="explicit" dfdl:calendarPattern="HHmm" />
+        </xs:sequence>
+      </xs:complexType>
+    </xs:element>
+
     <xs:element name="dateTimeImp" type="xs:dateTime" dfdl:calendarPatternKind="implicit" dfdl:lengthKind="delimited" />
     <xs:element name="dateTime01" type="xs:dateTime" dfdl:calendarPatternKind="explicit" dfdl:calendarPattern="'It is 'hh:mmaa' on the 'dd'st of 'MMM', year 'yyyy"
                 dfdl:lengthKind="explicit" dfdl:length="44" 
@@ -5716,18 +5725,17 @@
      Test Name: dateEpochFillIn2
         Schema: dateTimeSchema
           Root: date28
-       Purpose: This test demonstrates that if a formatting character is not provided, the time is filled in with the epoch time.
+       Purpose: This test demonstrates that if a formatting character is not provided it is an SDE
 -->
   
   <tdml:parserTestCase name="dateEpochFillIn2" root="date28"
     model="dateTimeSchema" description="Section 13 Simple Types - epoch fill in - DFDL-13-164R">
 
     <tdml:document><![CDATA[]]></tdml:document>
-    <tdml:infoset>
-      <tdml:dfdlInfoset>
-        <date28>1970-01-01</date28>
-      </tdml:dfdlInfoset>
-    </tdml:infoset>
+    <tdml:errors>
+      <tdml:error>Schema Definition Error</tdml:error>
+      <tdml:error>dfdl:calendarPatttern contains no pattern letters</tdml:error>
+    </tdml:errors>
   </tdml:parserTestCase>
 
 <!--
@@ -7197,7 +7205,7 @@
   
   <!--
     Test name: time_calendarTimeZone_EST
-       Schema: constructorSchema
+       Schema: dateTimeSchema
          Root: time32
       Purpose: This test demonstrates the ability to construct a xs:time object
                with a time zone specified.
@@ -7218,6 +7226,46 @@
         </time32>
       </tdml:dfdlInfoset>
     </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <!--
+    Test name: time_optional_empty
+       Schema: dateTimeSchema
+         Root: time33
+      Purpose: This test demonstrates parsing an empty optional time field
+  -->
+
+  <tdml:parserTestCase name="time_optional_empty" root="time33" model="dateTimeSchema"
+    description="Section 13 - Simple Types - xs:time calendarTimeZone EST  - DFDL-13-XXXR">
+
+    <tdml:document>
+      <tdml:documentPart type="text">ABCD</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <time33>
+          <e1>ABCD</e1>
+        </time33>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <!--
+    Test name: time_optional_invalid
+       Schema: dateTimeSchema
+         Root: time33
+      Purpose: This test demonstrates parsing an non-well-formed optional time field
+  -->
+
+  <tdml:parserTestCase name="time_optional_nonWellFormed" root="time33" model="dateTimeSchema"
+    description="Section 13 - Simple Types - xs:time calendarTimeZone EST  - DFDL-13-XXXR">
+
+    <tdml:document>
+      <tdml:documentPart type="text">ABCDaaaa</tdml:documentPart>
+    </tdml:document>
+    <tdml:errors>
+      <tdml:error>Left over data</tdml:error>
+    </tdml:errors>
   </tdml:parserTestCase>
   
   <!--
@@ -7349,18 +7397,18 @@
         Schema: dateTimeSchema
           Root: time23
        Purpose: This test demonstrates that for any pattern that omits components,
-                the values for the omitted components are supplied from the Unix epoch 1970-01-01T00:00:00.000
+                the values for the omitted components are supplied from the Unix epoch 1970-01-01T00:00:00.000.
+                It is an SDE if the property contains no pattern letters
 -->
   
   <tdml:parserTestCase name="epochFillIn2" root="time23"
     model="dateTimeSchema" description="Section 13 Simple Types - Patterns with ommitted components - DFDL-13-164R">
 
     <tdml:document><![CDATA[]]></tdml:document>
-    <tdml:infoset>
-      <tdml:dfdlInfoset>
-        <time23>00:00:00</time23>
-      </tdml:dfdlInfoset>
-    </tdml:infoset>
+    <tdml:errors>
+      <tdml:error>Schema Definition Error</tdml:error>
+      <tdml:error>dfdl:calendarPatttern contains no pattern letters</tdml:error>
+    </tdml:errors>
   </tdml:parserTestCase>
 
 <!--
@@ -7369,17 +7417,17 @@
           Root: time24
        Purpose: This test demonstrates that for any pattern that omits components,
                 the values for the omitted components are supplied from the Unix epoch 1970-01-01T00:00:00.000
+                It is an SDE if the property contains no pattern letters
 -->
   
   <tdml:parserTestCase name="epochFillIn3" root="time24"
     model="dateTimeSchema" description="Section 13 Simple Types - Patterns with ommitted components - DFDL-13-164R">
 
     <tdml:document><![CDATA[.]]></tdml:document>
-    <tdml:infoset>
-      <tdml:dfdlInfoset>
-        <time24>00:00:00</time24>
-      </tdml:dfdlInfoset>
-    </tdml:infoset>
+    <tdml:errors>
+      <tdml:error>Schema Definition Error</tdml:error>
+      <tdml:error>dfdl:calendarPatttern contains no pattern letters</tdml:error>
+    </tdml:errors>
   </tdml:parserTestCase>
 
 <!--

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section05/simple_types/TestSimpleTypes.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section05/simple_types/TestSimpleTypes.scala
@@ -863,4 +863,9 @@ class TestSimpleTypes {
     runner.runOneTest("hexBinary_specifiedLengthUnaligned")
   }
 
+  @Test def test_time_optional_empty(): Unit = { runner.runOneTest("time_optional_empty") }
+  @Test def test_time_optional_nonWellFormed(): Unit = {
+    runner.runOneTest("time_optional_nonWellFormed")
+  }
+
 }


### PR DESCRIPTION
The SimpleDateFormat parse() method does not set the error index on the ParsePosition if there is an error. Instead, it only sets the normal index to the last successful parse position of the input string.

Daffodil currently relies on the error index, which means our error checking is incorrect.

Fortunately, in most cases, this doesn't matter because our error checking also requires that we parse the entire input string, so if the index is zero it wouldn't match the string length and we would still see it as an error. The one exception to this is if the input string is zero length, in which case we do not correctly error and just create a date/time with value zero.

This is fixed by correctly checking index for zero instead of inspecting the error index.

This also does a little refactoring to replace the very old cache implementation with the much newer Evaluatable for creating SimpleDateFormat instances.

DAFFODIL-2821