### PR TITLE
Allows include/import schemaLocations to have relative up path steps.

### DIFF
--- a/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/IIBase.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/IIBase.scala
@@ -23,13 +23,15 @@ import java.net.URISyntaxException
 import java.net.URLEncoder
 import scala.collection.immutable.ListMap
 import scala.xml.Node
+
 import org.apache.daffodil.core.dsom.IIUtils._
 import org.apache.daffodil.lib.api.DaffodilSchemaSource
 import org.apache.daffodil.lib.api.URISchemaSource
 import org.apache.daffodil.lib.api.WarnID
 import org.apache.daffodil.lib.util.Delay
 import org.apache.daffodil.lib.util.Misc
-import org.apache.daffodil.lib.xml.{DFDLCatalogResolver, NS}
+import org.apache.daffodil.lib.xml.DFDLCatalogResolver
+import org.apache.daffodil.lib.xml.NS
 
 /**
  * This file along with DFDLSchemaFile are the implementation of import and include
@@ -217,11 +219,13 @@ abstract class IIBase(
 
         // Enhanced to use the DFDLCatalogResolver, because
         // other things than Daffodil's own loading of files need to process
-        // include/imports such as the schematron validator.
+        // include/imports such as the schematron validator
         val r = DFDLCatalogResolver.get
-        val completeURI = enclosingSchemaURI.map { esu =>
-          r.resolveToURI(slText, esu.toString)
-        }.getOrElse(uri)
+        val completeURI = enclosingSchemaURI
+          .map { esu =>
+            r.resolveToURI(slText, esu.toString)
+          }
+          .getOrElse(uri)
         val protocol = {
           if (completeURI.isAbsolute) {
             val completeURL = completeURI.toURL

--- a/daffodil-lib/src/main/scala/org/apache/daffodil/lib/xml/DaffodilXMLLoader.scala
+++ b/daffodil-lib/src/main/scala/org/apache/daffodil/lib/xml/DaffodilXMLLoader.scala
@@ -263,10 +263,11 @@ class DFDLCatalogResolver private ()
         // and the classpath.
         val baseURI = if (baseURIString == null) None else Some(new URI(baseURIString))
         // try it as a direct classpath resolution first, and if that fails,
-        // try removing all the upward path steps (if any).
-        val optURI = Misc.getResourceRelativeOption(sysId, baseURI).orElse(
-          Misc.getResourceRelativeOption(removeInitialUpwardPathSteps(sysId), baseURI)
-        )
+        // try removing all the upward path steps (if any)
+        val optURI = Misc.getResourceRelativeOption(sysId, baseURI)
+          .orElse(
+            Misc.getResourceRelativeOption(removeInitialUpwardPathSteps(sysId), baseURI),
+          )
         optURI match {
           case Some(uri) => Logger.log.debug(s"Found on classpath: ${uri}.")
           case None => {

--- a/daffodil-schematron/src/test/resources/sch/schematron-3.sch
+++ b/daffodil-schematron/src/test/resources/sch/schematron-3.sch
@@ -24,7 +24,11 @@
 
     <!-- Your constraints go here -->
     <sch:pattern>
-        <sch:include href="custom-resolver/title-rules.sch"/>
+        <!--
+        even in schematron we can use either a relative path,
+        or a classpath root relative path
+        -->
+        <sch:include href="../custom-resolver/title-rules.sch"/>
         <sch:rule context="chapter">
             <sch:let name="numOfTitles" value="count(title)"/>
             <sch:assert test="title">A chapter should have a title</sch:assert>

--- a/daffodil-schematron/src/test/resources/xsd/embedded-1.dfdl.xsd
+++ b/daffodil-schematron/src/test/resources/xsd/embedded-1.dfdl.xsd
@@ -18,7 +18,8 @@
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
            xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/">
 
-    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+    <!-- schemaLocation can have upward relative path step, or can be from a classpath root. -->
+    <xs:include schemaLocation="../org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
     <xs:annotation>
         <xs:appinfo source="http://www.ogf.org/dfdl/">
             <dfdl:format ref="GeneralFormat"/>

--- a/daffodil-test/src/test/resources/test space/test 1/multi_base_05_nons.dfdl.xsd
+++ b/daffodil-test/src/test/resources/test space/test 1/multi_base_05_nons.dfdl.xsd
@@ -28,8 +28,9 @@
         alignment="implicit" alignmentUnits="bytes" trailingSkip="0"/>
     </xs:appinfo>
   </xs:annotation>
-   
-  <xs:include schemaLocation="test space/test 2/multi_A_05_nons.dfdl.xsd"/>
+
+  <!-- schemaLocations can either be relative paths, or can be absolute paths -->
+  <xs:include schemaLocation="../../test space/test 2/multi_A_05_nons.dfdl.xsd"/>
   <xs:include schemaLocation="test space/test 3/multi_B_05_nons.dfdl.xsd"/>
   
   <xs:element name="baseSeq">


### PR DESCRIPTION
If schema authors put in relative path up-steps.
Then this enables reuse of DFDL schemas as XSD schemas in tools other than Daffodil itself without having to edit all the include/import schemaLocation attributes which are inter-component references.

DAFFODIL-2828