### PR TITLE
Specify a locale in units tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,6 +58,14 @@ jobs:
             shell: msys2 {0}
             env_cc: clang
             env_ar: llvm-ar
+          # configure different languages for some jobs, defaulting to en_US.UTF-8
+          - env_lang: en_US.UTF-8
+          - os: ubuntu-22.04
+            java_version: 8
+            env_lang: de_DE.UTF-8
+          - os: ubuntu-22.04
+            java_version: 11
+            env_lang: ja_JP.UTF-8
 
     runs-on: ${{ matrix.os }}
     defaults:
@@ -66,6 +74,7 @@ jobs:
     env:
       AR: ${{ matrix.env_ar }}
       CC: ${{ matrix.env_cc }}
+      LANG: ${{ matrix.env_lang }}
       SBT: sbt -J-Xms1024m -J-Xmx5120m -J-XX:ReservedCodeCacheSize=512m -J-XX:MaxMetaspaceSize=1024m ++${{ matrix.scala_version }} coverage
       SONARSCAN: ${{
                      matrix.os == 'ubuntu-22.04' &&
@@ -88,7 +97,9 @@ jobs:
 
       - name: Install Dependencies (Linux)
         if: runner.os == 'Linux'
-        run: sudo apt-get install -y libmxml-dev
+        run: |
+          sudo apt-get install -y libmxml-dev
+          sudo locale-gen $LANG
 
       - name: Install Dependencies (Windows)
         if: runner.os == 'Windows'

--- a/daffodil-core/src/test/scala/org/apache/daffodil/core/grammar/primitives/TestPrimitives.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/core/grammar/primitives/TestPrimitives.scala
@@ -22,6 +22,8 @@ import java.util.regex.PatternSyntaxException
 import org.apache.daffodil.lib.Implicits.intercept
 
 import com.ibm.icu.text.DecimalFormat
+import com.ibm.icu.text.DecimalFormatSymbols
+import com.ibm.icu.util.ULocale
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertTrue
@@ -146,14 +148,16 @@ class TestPrimitives {
     {
       // Note that E is a pattern special character
       val pattern = "'POSITIVE' #.0###;'NEGATIVE' #.0###"
-      val df = new DecimalFormat(pattern)
+      val dfs = new DecimalFormatSymbols(ULocale.US)
+      val df = new DecimalFormat(pattern, dfs)
       val actual = df.format(-6.847)
       assertEquals("NEGATIVE 6.847", actual)
     }
     {
       // here we quote only the E, not the other characters.
       val pattern = "POSITIV'E' #.0###;NEGATIV'E' #.0###"
-      val df = new DecimalFormat(pattern)
+      val dfs = new DecimalFormatSymbols(ULocale.US)
+      val df = new DecimalFormat(pattern, dfs)
       val actual = df.format(6.847)
       assertEquals("POSITIVE 6.847", actual)
     }

--- a/daffodil-runtime1/src/test/scala/org/apache/daffodil/runtime1/processors/input/TestICU.scala
+++ b/daffodil-runtime1/src/test/scala/org/apache/daffodil/runtime1/processors/input/TestICU.scala
@@ -28,6 +28,7 @@ import com.ibm.icu.text.DecimalFormat
 import com.ibm.icu.text.DecimalFormatSymbols
 import com.ibm.icu.text.SimpleDateFormat
 import com.ibm.icu.util.Calendar
+import com.ibm.icu.util.ULocale
 import org.junit.Assert._
 import org.junit.Test
 
@@ -129,7 +130,7 @@ class TestICU {
   // create are commented out to show what used to be broken.
 
   @Test def test_scientific_pos_inf() = {
-    val dfs = new DecimalFormatSymbols()
+    val dfs = new DecimalFormatSymbols(ULocale.US)
     dfs.setInfinity("INF")
     dfs.setNaN("NaN")
     dfs.setExponentSeparator("x10^")
@@ -141,7 +142,7 @@ class TestICU {
   }
 
   @Test def test_scientific_neg_inf() = {
-    val dfs = new DecimalFormatSymbols()
+    val dfs = new DecimalFormatSymbols(ULocale.US)
     dfs.setInfinity("INF")
     dfs.setNaN("NaN")
     dfs.setExponentSeparator("x10^")
@@ -153,7 +154,7 @@ class TestICU {
   }
 
   @Test def test_scientific_nan() = {
-    val dfs = new DecimalFormatSymbols()
+    val dfs = new DecimalFormatSymbols(ULocale.US)
     dfs.setInfinity("INF")
     dfs.setNaN("NaN")
     dfs.setExponentSeparator("x10^")
@@ -192,7 +193,7 @@ class TestICU {
   // scientific notiation with an empty exponent separator. If ICU fixes this
   // bug, this test should fail. See DAFFODIL-1981
   @Test def test_empty_exponent_separator() = {
-    val dfs = new DecimalFormatSymbols()
+    val dfs = new DecimalFormatSymbols(ULocale.US)
     dfs.setExponentSeparator("")
     dfs.setGroupingSeparator(',')
     dfs.setDecimalSeparator('.')
@@ -211,7 +212,7 @@ class TestICU {
   @Test def test_local_side_effect() = {
 
     // Germany's locale has a decimal separator of ','
-    val dfs = new DecimalFormatSymbols(java.util.Locale.GERMANY)
+    val dfs = new DecimalFormatSymbols(ULocale.GERMANY)
 
     // Set the grouping separator to be the same as the decimal separator from
     // the locale. ICU never complains
@@ -243,7 +244,7 @@ class TestICU {
     // defaults to values from the locale. Note that Daffodil does not set
     // inf/nan representations when parsing integers since they should not
     // apply and aren't used according to the DFDL spec
-    val dfs = new DecimalFormatSymbols()
+    val dfs = new DecimalFormatSymbols(ULocale.US)
 
     // Define a pattern that only has a grouping separator--no decimal
     // separator and should only parse integers
@@ -272,7 +273,7 @@ class TestICU {
   // the pattern. Also shows ICU failing to parse infinity/nan when decimalPatternMatchRequired
   // is true and the pattern contains a decimal.
   @Test def test_decimalPatternMatchRequired(): Unit = {
-    val dfs = new DecimalFormatSymbols(java.util.Locale.US)
+    val dfs = new DecimalFormatSymbols(ULocale.US)
 
     val df = new DecimalFormat("", dfs)
     df.setDecimalPatternMatchRequired(true)
@@ -332,7 +333,7 @@ class TestICU {
    * - ICUBigDecimal otherwise
    */
   @Test def test_floatingPointReturnType(): Unit = {
-    val dfs = new DecimalFormatSymbols()
+    val dfs = new DecimalFormatSymbols(ULocale.US)
     val df = new DecimalFormat("", dfs)
     df.applyPattern("###0.0##;-###0.0##")
 


### PR DESCRIPTION
Some unit tests do not specify a locale when creating certain objects, which causes the default system locale to be used. This can cause these tests to fail if run on a system with a different locale. This modifies those tests to specify a locale and ignore the system locale.

This also modifies the GitHub actions so some jobs are run with non-US locales so that we can detect if new tests are added with locale dependent behaviors.

Note that commit 1a0954a7b6 modified integration tests to not be locale dependent--only a small number of unit tests need fixing.

DAFFODIL-2599, DAFFODIL-2612