### PR TITLE
Implement Trace functionality for CLI TDML test

### DIFF
--- a/daffodil-cli/src/test/resources/org/apache/daffodil/cli/debug.txt
+++ b/daffodil-cli/src/test/resources/org/apache/daffodil/cli/debug.txt
@@ -1,0 +1,2 @@
+help display
+continue

--- a/daffodil-cli/src/test/scala/org/apache/daffodil/cli/cliTest/TestCLItdml.scala
+++ b/daffodil-cli/src/test/scala/org/apache/daffodil/cli/cliTest/TestCLItdml.scala
@@ -110,6 +110,46 @@ class TestCLItdml {
     }(ExitCode.Success)
   }
 
+  @Test def test_CLI_Tdml_Trace_singleTest(): Unit = {
+    val tdml = path(
+      "daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/Entities.tdml",
+    )
+
+    runCLI(args"-t test $tdml byte_entities_6_08") { cli =>
+      cli.expect("parser:")
+      cli.expect("bitPosition:")
+      cli.expect("data:")
+      cli.expect("[Pass] byte_entities_6_08")
+    }(ExitCode.Success)
+  }
+
+  @Test def test_CLI_Tdml_Debug_singleTest(): Unit = {
+    val tdml = path(
+      "daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/Entities.tdml",
+    )
+
+    runCLI(args"-d test $tdml byte_entities_6_08") { cli =>
+      cli.expect("(debug)")
+      cli.sendLine("continue")
+      cli.expect("[Pass] byte_entities_6_08")
+    }(ExitCode.Success)
+  }
+
+  @Test def test_CLI_Tdml_DebugFile_singleTest(): Unit = {
+    val tdml = path(
+      "daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/Entities.tdml",
+    )
+    val debugFile = path(
+      "daffodil-cli/src/test/resources/org/apache/daffodil/cli/debug.txt",
+    )
+
+    runCLI(args"-d $debugFile test $tdml byte_entities_6_08") { cli =>
+      cli.expect("(debug)")
+      cli.expect("Usage:")
+      cli.expect("[Pass] byte_entities_6_08")
+    }(ExitCode.Success)
+  }
+
   @Test def test_CLI_catch_TestNotCompatible(): Unit = {
     val tdml = path(
       "daffodil-cli/src/test/resources/org/apache/daffodil/cli/testNonCompatibleImplementation.tdml",

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/DataProcessor.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/DataProcessor.scala
@@ -232,7 +232,7 @@ class DataProcessor(
 
   def withDebugger(dbg: AnyRef): DataProcessor = {
     val optDbg = if (dbg eq null) None else Some(dbg.asInstanceOf[Debugger])
-    copy(optDebugger = optDbg)
+    copy(areDebugging = optDbg.isDefined, optDebugger = optDbg)
   }
 
   def withDebugging(flag: Boolean): DataProcessor = {

--- a/daffodil-tdml-processor/src/main/scala/org/apache/daffodil/processor/tdml/DaffodilTDMLDFDLProcessor.scala
+++ b/daffodil-tdml-processor/src/main/scala/org/apache/daffodil/processor/tdml/DaffodilTDMLDFDLProcessor.scala
@@ -189,9 +189,9 @@ class DaffodilTDMLDFDLProcessor private (private var dp: DataProcessor)
       dp.withDebugging(false)
     }
 
-  override def withDebugger(db: AnyRef): DaffodilTDMLDFDLProcessor = {
-    Assert.usage(dp ne null)
-    val d = dp.asInstanceOf[Debugger]
+  override def withDebugger(debugger: AnyRef): DaffodilTDMLDFDLProcessor = {
+    Assert.usage(debugger ne null)
+    val d = debugger.asInstanceOf[Debugger]
     copy(dp = dp.withDebugger(d))
   }
 

--- a/project/Rat.scala
+++ b/project/Rat.scala
@@ -196,6 +196,7 @@ object Rat {
     ),
     file("test-stdLayout/src/test/resources/org1/test-outer-data1.txt"),
     file("test-stdLayout/src/test/resources/org2/test-data1.txt"),
+    file("daffodil-cli/src/test/resources/org/apache/daffodil/cli/debug.txt"),
   )
 
   lazy val BSD2_LICENSE_NAME = "BSD 2-Clause License"


### PR DESCRIPTION
- fix bug with debugger where we were casting the data processor instead of the debugger

Note, we were unable to test the trace output using CLI tests as the trace output wasn't able to be found using CLI.expect. My guess is it has something to do with output being sent to a PipedOutputStream, which may be different from System.out of the other output.

DAFFODIL-2694