### PR TITLE
Fix NumberFormatException message in hexCharToValue

### DIFF
--- a/daffodil-lib/src/main/scala/org/apache/daffodil/lib/util/Misc.scala
+++ b/daffodil-lib/src/main/scala/org/apache/daffodil/lib/util/Misc.scala
@@ -279,7 +279,7 @@ object Misc {
         else if (i >= 97 && i <= 102) (i - 97) + 10 // lowercase a-f
         else
           throw new NumberFormatException(
-            "Hex character must be 0-9, a-z, or A-Z, but was '" + c + "'",
+            "Hex character must be 0-9, a-f, or A-F, but was '" + c + "'",
           )
       v
     }

--- a/daffodil-lib/src/test/scala/org/apache/daffodil/lib/util/TestMisc.scala
+++ b/daffodil-lib/src/test/scala/org/apache/daffodil/lib/util/TestMisc.scala
@@ -17,10 +17,43 @@
 
 package org.apache.daffodil.lib.util
 
+import org.apache.daffodil.lib.Implicits.intercept
+
 import org.junit.Assert._
 import org.junit.Test
 
 class TestMisc {
+
+  @Test def testHex2BytesInvalidLower(): Unit = {
+    val e = intercept[NumberFormatException] {
+      Misc.hex2Bytes("0g")
+    }
+    assertTrue(e.getMessage().contains("Hex character must be 0-9, a-f, or A-F"))
+  }
+
+  @Test def testHex2BytesInvalidUpper(): Unit = {
+    val e = intercept[NumberFormatException] {
+      Misc.hex2Bytes("0G")
+    }
+    assertTrue(e.getMessage().contains("Hex character must be 0-9, a-f, or A-F"))
+  }
+
+  @Test def testHex2BytesOdd(): Unit = {
+    val e = intercept[NumberFormatException] {
+      Misc.hex2Bytes("0")
+    }
+    assertTrue(e.getMessage().contains("Hex string must have an even number of characters"))
+  }
+
+  @Test def testHex2BytesValid(): Unit = {
+    assertArrayEquals(Array(0).map(_.toByte), Misc.hex2Bytes("00"))
+    assertArrayEquals(Array(9).map(_.toByte), Misc.hex2Bytes("09"))
+    assertArrayEquals(Array(10).map(_.toByte), Misc.hex2Bytes("0a"))
+    assertArrayEquals(Array(15).map(_.toByte), Misc.hex2Bytes("0F"))
+    assertArrayEquals(Array(10).map(_.toByte), Misc.hex2Bytes("0a"))
+    assertArrayEquals(Array(15).map(_.toByte), Misc.hex2Bytes("0f"))
+    assertArrayEquals(Array(171).map(_.toByte), Misc.hex2Bytes("Ab"))
+  }
 
   @Test def testIsAllUpper(): Unit = {
     assertTrue(Misc.isAllUpper("A", 0))


### PR DESCRIPTION
Update exception message in Misc.hex2Bytes.hexCharToValue function to include correct range of allowed values.

Misc.scala: Update exception message to include correct values.

TestMisc.scala: Add tests for Misc.hex2Bytes function.

DAFFODIL-2834