### PR TITLE
Restrict what TDML Runner Searches

### DIFF
--- a/daffodil-lib/src/main/resources/org/apache/daffodil/xsd/tdml.xsd
+++ b/daffodil-lib/src/main/resources/org/apache/daffodil/xsd/tdml.xsd
@@ -184,6 +184,21 @@
     <attribute name="unsupported" type="xs:boolean" use="optional" default="false"/>
     <attribute name="validation" type="tns:validationType" use="optional"/>
     <attribute name="implementations" type="tns:implementationsType" use="optional"/>
+    <attribute name="diagnosticsStripLocationInfo" type="xs:boolean" use="optional" default="true">
+      <annotation>
+        <documentation>We strip the file info from the diagnostics to prevent false
+          positive matches against the test case's error and warning strings
+          coming from file/dir names.
+
+          As there are tests that look for correct file/dir names, those
+          tests will need to NOT strip them and can do so by setting the
+          test flag to false.
+
+          This is only for purposes of comparing error/warning strings
+          to the diagnostic messages. Users would always see, displayed,
+          the full diagnostic messages.</documentation>
+      </annotation>
+    </attribute>
 
   </attributeGroup>
 

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section02/schema_definition_errors/SchemaDefinitionErrors.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section02/schema_definition_errors/SchemaDefinitionErrors.tdml
@@ -222,8 +222,9 @@
 -->
 
   <tdml:parserTestCase name="schema_line_number" root="e1"
-    model="lineNumber.dfdl.xsd"
-    description="">
+                       model="lineNumber.dfdl.xsd"
+                       description=""
+                       diagnosticsStripLocationInfo="false">
     <tdml:document />
 
     <tdml:errors>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section06/namespaces/namespaces.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section06/namespaces/namespaces.tdml
@@ -714,7 +714,9 @@
   -->
 
   <tdml:parserTestCase name="long_chain_05" root="rabbitHole5"
-    model="multi_base_03.dfdl.xsd" description="import a schema - DFDL-6-007R">
+                       model="multi_base_03.dfdl.xsd"
+                       description="import a schema - DFDL-6-007R"
+                       diagnosticsStripLocationInfo="false">
     <tdml:document><![CDATA[5632]]></tdml:document>
     <tdml:errors>
       <tdml:error>Schema Definition Error</tdml:error>
@@ -2141,11 +2143,13 @@
     This test shows we get a diagnostic pointing at right file and line number.
   -->
   <tdml:parserTestCase name="junkAnnotation01" root="x"
-    model="junk-annotation-01.dfdl.xsd"
-    description="Diagnostic provides proper line number and file when a junk annotation is found - DFDL-6-007R">
+                       model="junk-annotation-01.dfdl.xsd"
+                       description="Diagnostic provides proper line number and file when a junk annotation is found - DFDL-6-007R"
+                       diagnosticsStripLocationInfo="false">
     <tdml:document />
     <tdml:errors>
       <tdml:error>Schema Definition Error</tdml:error>
+      <tdml:error>Invalid dfdl annotation</tdml:error>
       <tdml:error>junk-annotation-01.dfdl.xsd</tdml:error>
     </tdml:errors>
   </tdml:parserTestCase>
@@ -2177,8 +2181,6 @@
         <tdml:error>Schema Definition Error</tdml:error>
         <tdml:error>Invalid dfdl annotation</tdml:error>
         <tdml:error>xs:format</tdml:error>
-        <tdml:error>Schema context:</tdml:error>
-        <tdml:error>section06/namespaces/multi_base_04_invalid.dfdl.xsd</tdml:error>
       </tdml:errors>
   </tdml:parserTestCase>
   
@@ -2197,8 +2199,6 @@
         <tdml:error>Schema Definition Error</tdml:error>
         <tdml:error>Invalid dfdl annotation</tdml:error>
         <tdml:error>xs:format</tdml:error>
-        <tdml:error>Schema context:</tdml:error>
-        <tdml:error>section06/namespaces/multi_B_04_invalid.dfdl.xsd</tdml:error>
       </tdml:errors>
   </tdml:parserTestCase>
   
@@ -2210,7 +2210,9 @@
   -->
 
   <tdml:parserTestCase name="errorLocations_01" root="rabbitHole"
-    model="multi_base_13.dfdl.xsd" description="import a schema - DFDL-6-007R">
+                       model="multi_base_13.dfdl.xsd"
+                       description="import a schema - DFDL-6-007R"
+                       diagnosticsStripLocationInfo="false">
     <tdml:document><![CDATA[temp]]></tdml:document>
       <tdml:errors>
         <tdml:error>nonExistent</tdml:error>


### PR DESCRIPTION
- exclude location information
- update failing tests
- add diagnosticsStripLocationInfo test flag that is set to true as a default, and add as false to tests that need to check the location info
- pass in diagnosticStripFileInfo to verifyAllDiagnosticsFound function

DAFFODIL-541