### PR TITLE
Control Number of Directories in Diagnostics Ouput

### DIFF
--- a/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/SchemaComponentFactory.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/SchemaComponentFactory.scala
@@ -20,15 +20,18 @@ package org.apache.daffodil.core.dsom
 import scala.xml.NamespaceBinding
 
 import org.apache.daffodil.core.dsom.walker.CommonContextView
+import org.apache.daffodil.lib.api.DaffodilTunables
 import org.apache.daffodil.lib.exceptions.SchemaFileLocatable
 import org.apache.daffodil.lib.xml.NS
 import org.apache.daffodil.lib.xml.XMLUtils
 
-trait SchemaFileLocatableImpl extends SchemaFileLocatable {
+trait SchemaFileLocatableImpl extends SchemaFileLocatable { self: SchemaComponent =>
 
   def xml: scala.xml.Node
   def schemaFile: Option[DFDLSchemaFile]
   def optLexicalParent: Option[SchemaComponent]
+
+  def tunables: DaffodilTunables = self.tunable
 
   /**
    * Annotations can contain expressions, so we need to be able to compile them.

--- a/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/SchemaSet.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/SchemaSet.scala
@@ -97,7 +97,7 @@ final class SchemaSet private (
   val schemaSource: DaffodilSchemaSource,
   val shouldValidateDFDLSchemas: Boolean,
   val checkAllTopLevel: Boolean,
-  val tunables: DaffodilTunables,
+  override val tunables: DaffodilTunables,
 ) extends SchemaComponentImpl(<schemaSet/>, None)
   with SchemaSetIncludesAndImportsMixin
   with SchemaSetGrammarMixin {

--- a/daffodil-lib/src/main/scala/org/apache/daffodil/lib/api/Diagnostic.scala
+++ b/daffodil-lib/src/main/scala/org/apache/daffodil/lib/api/Diagnostic.scala
@@ -257,6 +257,26 @@ trait LocationInSchemaFile {
 
   def locationDescription: String
 
+  def limitMaxParentDirectories(
+    uriString: String,
+    maxParentDirectoriesForDiagnostics: Int,
+  ): String = {
+    // works for both windows and unix
+    val splitter = "/"
+    val tokens = uriString.split(splitter)
+    val reducedTokens = tokens
+      // we want to get just the filename plus the max number of directories
+      // since these paths can get really long. To change how much of the path to see
+      // in diagnostics, one can update the maxParentDirectoriesForDiagnostics tunable
+      .takeRight(maxParentDirectoriesForDiagnostics + 1)
+    // we only want to use the prefix if the new number of directories is
+    // less than the original
+    val prefix = if (reducedTokens.length < tokens.length) s"...${splitter}" else ""
+    val newUriString = reducedTokens
+      .mkString(prefix, splitter, "")
+    newUriString
+  }
+
 }
 
 /**

--- a/daffodil-propgen/src/main/resources/org/apache/daffodil/xsd/dafext.xsd
+++ b/daffodil-propgen/src/main/resources/org/apache/daffodil/xsd/dafext.xsd
@@ -366,6 +366,19 @@
             </xs:restriction>
           </xs:simpleType>
         </xs:element>
+        <xs:element name="maxParentDirectoriesForDiagnostics" default="3" minOccurs="0">
+          <xs:annotation>
+            <xs:documentation>
+              The maximum number of parent directories that show up for a file within a diagnostic
+              message.
+            </xs:documentation>
+          </xs:annotation>
+          <xs:simpleType>
+            <xs:restriction base="xs:int">
+              <xs:minInclusive value="0" />
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
         <xs:element name="maxSkipLengthInBytes" default="1024" minOccurs="0">
           <xs:annotation>
             <xs:documentation>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section02/schema_definition_errors/SchemaDefinitionErrors.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section02/schema_definition_errors/SchemaDefinitionErrors.tdml
@@ -17,9 +17,10 @@
 -->
 
 <tdml:testSuite suiteName="ProcessingErrorTests"
-  description="Section 2.3 - Processing Errors" xmlns:tdml="http://www.ibm.com/xmlns/dfdl/testData"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/"
-  xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:ex="http://example.com" xmlns:tns="http://example.com">
+                description="Section 2.3 - Processing Errors" xmlns:tdml="http://www.ibm.com/xmlns/dfdl/testData"
+                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/"
+                xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:ex="http://example.com" xmlns:tns="http://example.com"
+                xmlns:daf="urn:ogf:dfdl:2013:imp:daffodil.apache.org:2018:ext">
 
   <!-- =====================================================================
     Schemas ======================================================================= -->
@@ -236,13 +237,75 @@
 
   </tdml:parserTestCase>
 
-<!--
-    Test Name: missing_closing_tag
-       Schema: MissingClosingTag.dfdl.xsd
-         Root: e1
-      Purpose: This test demonstrates that an SDE will be displayed in the event of a missing
-               closing tag in the schema file.
--->
+  <tdml:parserTestCase name="schema_file_path" root="e1"
+                       model="lineNumber.dfdl.xsd"
+                       description=""
+                       diagnosticsStripLocationInfo="false">
+    <tdml:document />
+
+    <tdml:errors>
+      <tdml:error>Schema Definition Error</tdml:error>
+      <tdml:error>.../daffodil/section02/schema_definition_errors/lineNumber.dfdl.xsd</tdml:error>
+      <tdml:error>line 65</tdml:error>
+      <tdml:error>column 10</tdml:error>
+    </tdml:errors>
+
+  </tdml:parserTestCase>
+
+  <tdml:defineConfig name="cfg_maxParentDirectoriesForDiagnostics_1">
+    <daf:tunables xmlns="http://www.w3.org/2001/XMLSchema"
+                  xmlns:xs="http://www.w3.org/2001/XMLSchema">
+      <daf:maxParentDirectoriesForDiagnostics>2</daf:maxParentDirectoriesForDiagnostics>
+    </daf:tunables>
+  </tdml:defineConfig>
+
+  <tdml:parserTestCase name="schema_file_path_tunable_1" root="e1"
+                       model="lineNumber.dfdl.xsd"
+                       description=""
+                       config="cfg_maxParentDirectoriesForDiagnostics_1"
+                       diagnosticsStripLocationInfo="false">
+    <tdml:document />
+
+    <tdml:errors>
+      <tdml:error>Schema Definition Error</tdml:error>
+      <tdml:error>.../section02/schema_definition_errors/lineNumber.dfdl.xsd</tdml:error>
+      <tdml:error>line 65</tdml:error>
+      <tdml:error>column 10</tdml:error>
+    </tdml:errors>
+
+  </tdml:parserTestCase>
+
+  <tdml:defineConfig name="cfg_maxParentDirectoriesForDiagnostics_2">
+    <daf:tunables xmlns="http://www.w3.org/2001/XMLSchema"
+                  xmlns:xs="http://www.w3.org/2001/XMLSchema">
+      <daf:maxParentDirectoriesForDiagnostics>0</daf:maxParentDirectoriesForDiagnostics>
+    </daf:tunables>
+  </tdml:defineConfig>
+
+  <tdml:parserTestCase name="schema_file_path_tunable_2" root="e1"
+                       model="lineNumber.dfdl.xsd"
+                       description=""
+                       config="cfg_maxParentDirectoriesForDiagnostics_2"
+                       diagnosticsStripLocationInfo="false">
+    <tdml:document />
+
+    <tdml:errors>
+      <tdml:error>Schema Definition Error</tdml:error>
+      <tdml:error>.../lineNumber.dfdl.xsd</tdml:error>
+      <tdml:error>line 65</tdml:error>
+      <tdml:error>column 10</tdml:error>
+    </tdml:errors>
+
+  </tdml:parserTestCase>
+
+
+  <!--
+      Test Name: missing_closing_tag
+         Schema: MissingClosingTag.dfdl.xsd
+           Root: e1
+        Purpose: This test demonstrates that an SDE will be displayed in the event of a missing
+                 closing tag in the schema file.
+  -->
 
   <tdml:parserTestCase name="missing_closing_tag" root="e1"
     model="MissingClosingTag.dfdl.xsd"

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section02/schema_definition_errors/TestSDE.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section02/schema_definition_errors/TestSDE.scala
@@ -42,6 +42,14 @@ class TestSDE {
   @Test def test_schema_component_err(): Unit = { runner.runOneTest("schema_component_err") }
 
   @Test def test_schema_line_number(): Unit = { runner.runOneTest("schema_line_number") }
+  @Test def test_schema_file_path(): Unit = { runner.runOneTest("schema_file_path") }
+  @Test def test_schema_file_path_tunable_1(): Unit = {
+    runner.runOneTest("schema_file_path_tunable_1")
+  }
+  @Test def test_schema_file_path_tunable_2(): Unit = {
+    runner.runOneTest("schema_file_path_tunable_2")
+  }
+
   @Test def test_schema_warning(): Unit = { runner.runOneTest("schema_warning") }
   @Test def test_missing_appinfo_source(): Unit = {
     runner.runOneTest("missing_appinfo_source")


### PR DESCRIPTION
- make tunables available to SchemaFileLocatable and SchemaFileLocatableImpl
- pass in maxParentDirectoriesForDiagnostics tunable to SchemaFileLocatable and use to control the number of dirs that show up in the diagnostic
- update tests

DAFFODIL-1200