### PR TITLE
Better Error Reporting for Library API

### DIFF
--- a/daffodil-core/src/main/scala/org/apache/daffodil/core/compiler/Compiler.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/core/compiler/Compiler.scala
@@ -110,7 +110,7 @@ final class ProcessorFactory private (
   override def onPath(xpath: String): DFDL.DataProcessor = sset.onPath(xpath)
 
   override def forLanguage(language: String): DFDL.CodeGenerator = {
-    Assert.usage(!isError)
+    checkNotError()
 
     // Do a poor man's pluggable code generator implementation - we can replace
     // it after we observe how the validator SPI evolves and wait for our

--- a/daffodil-core/src/main/scala/org/apache/daffodil/core/runtime1/SchemaSetRuntime1Mixin.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/core/runtime1/SchemaSetRuntime1Mixin.scala
@@ -19,7 +19,6 @@ package org.apache.daffodil.core.runtime1
 
 import org.apache.daffodil.core.dsom.SchemaSet
 import org.apache.daffodil.core.grammar.VariableMapFactory
-import org.apache.daffodil.lib.exceptions.Assert
 import org.apache.daffodil.lib.util.Logger
 import org.apache.daffodil.runtime1.api.DFDL
 import org.apache.daffodil.runtime1.processors.DataProcessor
@@ -68,7 +67,7 @@ trait SchemaSetRuntime1Mixin {
   }.value
 
   def onPath(xpath: String): DFDL.DataProcessor = {
-    Assert.usage(!isError)
+    checkNotError()
     if (xpath != "/")
       root.notYetImplemented("""Path must be "/". Other path support is not yet implemented.""")
     val rootERD = root.elementRuntimeData

--- a/daffodil-io/src/test/scala/org/apache/daffodil/io/TestInputSourceDataInputStream2.scala
+++ b/daffodil-io/src/test/scala/org/apache/daffodil/io/TestInputSourceDataInputStream2.scala
@@ -18,7 +18,7 @@
 package org.apache.daffodil.io
 
 import org.apache.daffodil.lib.Implicits._
-import org.apache.daffodil.lib.exceptions.Abort
+import org.apache.daffodil.lib.exceptions.UsageException
 import org.apache.daffodil.lib.util.MaybeULong
 
 import org.junit.Assert._
@@ -107,7 +107,7 @@ class TestInputSourceDataInputStream2 {
     assertEquals(81, dis.bitLimit1b.get)
     assertEquals(10, dis.bytePos0b)
     dis.reset(m1)
-    intercept[Abort] {
+    intercept[UsageException] {
       dis.reset(m2)
     }
   }

--- a/daffodil-japi/src/test/java/org/apache/daffodil/example/TestJavaAPI.java
+++ b/daffodil-japi/src/test/java/org/apache/daffodil/example/TestJavaAPI.java
@@ -1217,6 +1217,22 @@ public class TestJavaAPI {
     }
 
     @Test
+    public void testJavaAPI27() throws IOException {
+        org.apache.daffodil.japi.Compiler c = Daffodil.compiler();
+        java.io.File schemaFile = getResource("/test/japi/mySchema6.dfdl.xsd");
+        ProcessorFactory pf = c.compileFile(schemaFile);
+        assertTrue(pf.isError());
+        try {
+            pf.onPath("/");
+        } catch (Exception e) {
+            Throwable cause = e.getCause();
+            assertTrue(cause.toString().contains("Must call isError"));
+            assertTrue(cause.getCause().toString().contains("Schema Definition Error"));
+            assertTrue(cause.getCause().toString().contains("Cannot resolve the name 'tns:nonExistent'"));
+        }
+    }
+
+    @Test
     public void testJavaAPINullXMLTextEscapeStyle() throws IOException, ClassNotFoundException {
         ByteArrayOutputStream xmlBos = new ByteArrayOutputStream();
         try {

--- a/daffodil-japi/src/test/resources/test/japi/mySchema6.dfdl.xsd
+++ b/daffodil-japi/src/test/resources/test/japi/mySchema6.dfdl.xsd
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<schema xmlns="http://www.w3.org/2001/XMLSchema"
+  targetNamespace="http://example.com" xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/"
+  xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tns="http://example.com">
+  
+  <annotation>
+    <appinfo source="http://www.ogf.org/dfdl/">
+      <dfdl:format ref="tns:GeneralFormat" />
+    </appinfo>
+  </annotation>
+  
+  <include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+  
+  <element name="e2" dfdl:lengthKind="delimited" type="tns:nonExistent"/>
+
+</schema>

--- a/daffodil-lib/src/main/scala/org/apache/daffodil/lib/api/Diagnostic.scala
+++ b/daffodil-lib/src/main/scala/org/apache/daffodil/lib/api/Diagnostic.scala
@@ -308,4 +308,18 @@ trait WithDiagnostics {
    * then one can proceed to run the compiled entity.
    */
   def isError: Boolean
+
+  /**
+   * Helper method to check that isError is false, if not it throws
+   * a usage error caused by illegal state caused by a compilation error
+   */
+  def checkNotError(): Unit = {
+    Assert.usage(
+      !isError,
+      new IllegalStateException(
+        "Must call isError() to ensure there are no errors",
+        getDiagnostics.find(_.isError).get,
+      ),
+    )
+  }
 }

--- a/daffodil-lib/src/main/scala/org/apache/daffodil/lib/exceptions/Assert.scala
+++ b/daffodil-lib/src/main/scala/org/apache/daffodil/lib/exceptions/Assert.scala
@@ -51,7 +51,10 @@ abstract class UnsuppressableException(m: String, th: Throwable) extends Excepti
   def this(th: Throwable) = this(null, th)
 }
 
-class UsageException(m: String) extends UnsuppressableException(m)
+class UsageException(m: String, th: Throwable) extends UnsuppressableException(m, th) {
+  def this(th: Throwable) = this(null, th)
+  def this(m: String) = this(m, null)
+}
 class NotYetImplementedException(m: String)
   extends UnsuppressableException("Not yet implemented: " + m)
 class Abort(m: String, th: Throwable) extends UnsuppressableException(m, th) {
@@ -83,13 +86,18 @@ object Assert extends Assert {
    */
   def usageErrorUnless(testAbortsIfFalse: Boolean, message: String): Unit =
     macro AssertMacros.usageMacro2
+  def usageErrorUnless(testAbortsIfFalse: Boolean, cause: Throwable): Unit =
+    macro AssertMacros.usageMacro2Cause
   def usageErrorUnless(testAbortsIfFalse: Boolean): Unit = macro AssertMacros.usageMacro1
 
   /**
    * Brief form
    */
   def usage(testAbortsIfFalse: Boolean, message: String): Unit = macro AssertMacros.usageMacro2
-  def usage(testAbortsIfFalse: Boolean): Unit = macro AssertMacros.usageMacro1
+  def usage(testAbortsIfFalse: Boolean, cause: Throwable): Unit =
+    macro AssertMacros.usageMacro2Cause
+  def usage(testAbortsIfFalse: Boolean): Unit =
+    macro AssertMacros.usageMacro1
 
   /**
    * test for something that the program is supposed to be ensuring.
@@ -128,7 +136,15 @@ object Assert extends Assert {
   //
 
   def usageError(message: String = "Usage error."): Nothing = {
-    abort(message)
+    toss(new UsageException(message))
+  }
+
+  def usageError(cause: Throwable): Nothing = {
+    toss(new UsageException(cause))
+  }
+
+  def usageError2(message: String = "Usage error.", testAsString: String): Nothing = {
+    usageError(message + " (" + testAsString + ")")
   }
 
   def nyi(info: String): Nothing = {

--- a/daffodil-lib/src/test/scala/org/apache/daffodil/lib/macros/TestAssertMacros.scala
+++ b/daffodil-lib/src/test/scala/org/apache/daffodil/lib/macros/TestAssertMacros.scala
@@ -41,7 +41,7 @@ class TestAssertMacros {
   }
 
   @Test def testUsage1Arg(): Unit = {
-    val e = intercept[Abort] {
+    val e = intercept[UsageException] {
       Assert.usage(if (1 == x) true else false)
     }
     val msg = e.getMessage()
@@ -54,7 +54,7 @@ class TestAssertMacros {
   }
 
   @Test def testUsage2Arg(): Unit = {
-    val e = intercept[Abort] {
+    val e = intercept[UsageException] {
       Assert.usage(if (1 == x) true else false, "foobar")
     }
     val msg = e.getMessage()
@@ -109,5 +109,14 @@ class TestAssertMacros {
     assertTrue(msg.contains("else"))
     assertTrue(msg.contains("false"))
     assertTrue(msg.contains("foobar"))
+  }
+
+  @Test def testUsage2ArgCause(): Unit = {
+    val e = intercept[UsageException] {
+      Assert.usage(if (1 == x) true else false, new Exception("test"))
+    }
+    val cause = e.getCause.toString
+    assertTrue(cause.contains("Exception"))
+    assertTrue(cause.contains("test"))
   }
 }

--- a/daffodil-macro-lib/src/main/scala/org/apache/daffodil/lib/exceptions/AssertMacros.scala
+++ b/daffodil-macro-lib/src/main/scala/org/apache/daffodil/lib/exceptions/AssertMacros.scala
@@ -28,7 +28,17 @@ object AssertMacros {
 
     q"""
     if (!($testAbortsIfFalse)) {
-         Assert.abort2("Usage error: " + $message, $testAsString)
+         Assert.usageError2("Usage error: " + $message, $testAsString)
+    }
+    """
+  }
+
+  def usageMacro2Cause(c: Context)(testAbortsIfFalse: c.Tree, cause: c.Tree): c.Tree = {
+    import c.universe._
+
+    q"""
+    if (!($testAbortsIfFalse)) {
+         Assert.usageError($cause)
     }
     """
   }
@@ -40,7 +50,7 @@ object AssertMacros {
 
     q"""
     if (!($testAbortsIfFalse)) {
-         Assert.abort("Usage error: " + $testAsString)
+         Assert.usageError("Usage error: " + $testAsString)
     }
     """
   }
@@ -100,5 +110,4 @@ object AssertMacros {
     }
     """
   }
-
 }

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/DataProcessor.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/DataProcessor.scala
@@ -340,8 +340,7 @@ class DataProcessor(
    * runtime. Instead we deal with success and failure statuses.
    */
   def parse(input: InputSourceDataInputStream, output: InfosetOutputter): DFDL.ParseResult = {
-    Assert.usage(!this.isError)
-
+    checkNotError()
     // If full validation is enabled, tee all the infoset events to a second
     // infoset outputter that writes the infoset to a byte array, and then
     // we'll validate that byte array upon a successful parse.
@@ -501,7 +500,7 @@ class DataProcessor(
   }
 
   def unparse(inputter: InfosetInputter, output: DFDL.Output): DFDL.UnparseResult = {
-    Assert.usage(!this.isError)
+    checkNotError()
     val outStream = java.nio.channels.Channels.newOutputStream(output)
     unparse(inputter, outStream)
   }

--- a/daffodil-sapi/src/test/resources/test/sapi/mySchema6.dfdl.xsd
+++ b/daffodil-sapi/src/test/resources/test/sapi/mySchema6.dfdl.xsd
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<schema xmlns="http://www.w3.org/2001/XMLSchema"
+  targetNamespace="http://example.com" xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/"
+  xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tns="http://example.com">
+  
+  <annotation>
+    <appinfo source="http://www.ogf.org/dfdl/">
+      <dfdl:format ref="tns:GeneralFormat" />
+    </appinfo>
+  </annotation>
+  
+  <include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+  
+  <element name="e2" dfdl:lengthKind="delimited" type="tns:nonExistent"/>
+
+</schema>

--- a/daffodil-sapi/src/test/scala/org/apache/daffodil/example/TestScalaAPI.scala
+++ b/daffodil-sapi/src/test/scala/org/apache/daffodil/example/TestScalaAPI.scala
@@ -28,7 +28,7 @@ import java.nio.charset.StandardCharsets
 import java.nio.file.Paths
 import javax.xml.XMLConstants
 
-import org.apache.daffodil.lib.exceptions.Abort
+import org.apache.daffodil.lib.exceptions.UsageException
 import org.apache.daffodil.sapi.Daffodil
 import org.apache.daffodil.sapi.DaffodilParseXMLReader
 import org.apache.daffodil.sapi.DaffodilUnhandledSAXException
@@ -887,7 +887,7 @@ class TestScalaAPI {
     try {
       res = dp.parse(input, outputter)
     } catch {
-      case e: Abort => {
+      case e: UsageException => {
         assertTrue(e.getMessage().contains("Usage error"))
         assertTrue(e.getMessage().contains("invalid input source"))
       }
@@ -1205,6 +1205,28 @@ class TestScalaAPI {
     val ur = dp.unparse(inputter, wbc)
     assertFalse(ur.isError)
     assertEquals(expectedData, bos.toString())
+  }
+
+  @Test
+  def testScalaAPI26(): Unit = {
+    val c = Daffodil.compiler()
+    val schemaFile = getResource("/test/sapi/mySchema6.dfdl.xsd")
+    val pf = c.compileFile(schemaFile)
+    assertTrue(pf.isError())
+    try {
+      pf.onPath("/")
+    } catch {
+      case e: UsageException => {
+        val cause = e.getCause
+        assertTrue(cause.toString.contains("Must call isError"))
+        assertTrue(
+          cause.getCause.toString.contains("Schema Definition Error"),
+        )
+        assertTrue(
+          cause.getCause.toString.contains("Cannot resolve the name 'tns:nonExistent'"),
+        )
+      }
+    }
   }
 
   @Test


### PR DESCRIPTION
- replace abort in usageError/usage with IllegalStateException
- Add diagnostics error message to place where usage is called
- add test

DAFFODIL-2072