### PR TITLE
Update scala-xml to 2.2.0

### DIFF
--- a/daffodil-lib/src/main/scala/org/apache/daffodil/lib/xml/DaffodilConstructingLoader.scala
+++ b/daffodil-lib/src/main/scala/org/apache/daffodil/lib/xml/DaffodilConstructingLoader.scala
@@ -172,16 +172,6 @@ class DaffodilConstructingLoader private[xml] (
   override def reportSyntaxError(pos: Int, msg: String): Unit = {
     val exc = makeSAXParseException(pos, msg)
     errorHandler.fatalError(exc)
-    if (msg == "'<' not allowed in attrib value") {
-      // DAFFODIL-2586
-      // There is a bug in scala-xml which causes an infinite loop when
-      // this error condition is reached. The loop expects the scanner
-      // to advance but in this case it does not. When this error is
-      // seen, an exception needs to be thrown to stop processing.
-      //
-      // See: https://github.com/scala/scala-xml/blob/v2.1.0/shared/src/main/scala/scala/xml/parsing/MarkupParserCommon.scala#L67-L72
-      throw exc
-    }
   }
 
   /*

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -23,7 +23,7 @@ object Dependencies {
 
   lazy val core = Seq(
     "com.lihaoyi" %% "os-lib" % "0.9.1", // for writing/compiling C source files
-    "org.scala-lang.modules" %% "scala-xml" % "2.1.0",
+    "org.scala-lang.modules" %% "scala-xml" % "2.2.0",
     "org.scala-lang.modules" %% "scala-parser-combinators" % "2.3.0",
     "com.ibm.icu" % "icu4j" % "73.2",
     "xerces" % "xercesImpl" % "2.12.2",


### PR DESCRIPTION
Update code to work with changes to the scala-xml library. This also includes removing a workaround for an infinite loop bug in reportSyntaxError.

Note that scala-steward deleted the branch associated with PR https://github.com/apache/daffodil/pull/1049 when the PR was closed, so I can't reop/update that PR. The scala-xml devs suggested an approach to resolve the issues mention in that, which is implemented in this new PR.