### PR TITLE
Allow changing blob attributes when full/custom validation is enabled

### DIFF
--- a/daffodil-japi/src/test/java/org/apache/daffodil/example/TestJavaAPI.java
+++ b/daffodil-japi/src/test/java/org/apache/daffodil/example/TestJavaAPI.java
@@ -35,7 +35,9 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
+import scala.collection.JavaConverters;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
@@ -1307,5 +1309,41 @@ public class TestJavaAPI {
 
         assertFalse(err);
         assertEquals(expect, value);
+    }
+
+    @Test
+    public void testJavaAPIBlob1() throws IOException, ClassNotFoundException, InvalidUsageException {
+        org.apache.daffodil.japi.Compiler c = Daffodil.compiler();
+        java.io.File schemaFile = getResource("/test/japi/blob.dfdl.xsd");
+        ProcessorFactory pf = c.compileFile(schemaFile);
+        DataProcessor dp = pf.onPath("/");
+        dp = dp.withValidationMode(ValidationMode.Full);
+
+        byte[] data = new byte[] { 0x00, 0x00, 0x00, 0x04, 0x01, 0x02, 0x03, 0x04 };
+        ByteArrayInputStream bis = new ByteArrayInputStream(data);
+        InputSourceDataInputStream input = new InputSourceDataInputStream(data);
+
+        Path blobRoot = Paths.get(System.getProperty("java.io.tmpdir"), "daffodil", "japi");
+        Files.createDirectories(blobRoot);
+        Path blobDir = Files.createTempDirectory(blobRoot, "blob-");
+
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        XMLTextInfosetOutputter output = new XMLTextInfosetOutputter(bos, true);
+        output.setBlobAttributes(blobDir, "pre-", ".suf");
+
+        ParseResult res = dp.parse(input, output);
+        List<Path> blobPaths = JavaConverters.seqAsJavaList(output.getBlobPaths());
+
+        try {
+            assertFalse(res.isError());
+            assertTrue(blobPaths.size() == 1);
+            assertTrue(blobPaths.get(0).toString().contains("blob-"));
+            assertTrue(blobPaths.get(0).toString().contains("pre-"));
+            assertTrue(blobPaths.get(0).toString().contains(".suf"));
+        } finally {
+            Iterator<Path> pathIter = blobPaths.iterator();
+            while (pathIter.hasNext()) Files.delete(pathIter.next());
+            Files.delete(blobDir);
+        }
     }
 }

--- a/daffodil-japi/src/test/resources/test/japi/blob.dfdl.xsd
+++ b/daffodil-japi/src/test/resources/test/japi/blob.dfdl.xsd
@@ -27,25 +27,17 @@
   <annotation>
     <appinfo source="http://www.ogf.org/dfdl/">
       <dfdl:format ref="tns:GeneralFormat"
-        representation="binary"
-        encodingErrorPolicy="replace" />
+        representation="binary" />
     </appinfo>
   </annotation>
 
   <xs:element name="root">
     <xs:complexType>
-      <xs:choice>
-        <xs:sequence>
-          <xs:element name="b" type="xs:anyURI"
-            dfdl:lengthKind="explicit" dfdl:length="2098176008"
-            dfdlx:objectKind="bytes" />
-          <xs:element name="a" type="xs:string"
-            dfdl:lengthKind="explicit" dfdl:length="1" />
-        </xs:sequence>
-        <xs:element name="oneGigBlob" type="xs:anyURI"
-          dfdl:lengthKind="explicit" dfdl:length="2098176008"
-          dfdlx:objectKind="bytes" />
-      </xs:choice>
+      <xs:sequence>
+        <xs:element name="length" type="xs:int" />
+        <xs:element name="blob" type="xs:anyURI" dfdlx:objectKind="bytes"
+          dfdl:lengthKind="explicit" dfdl:length="{ ../length }" />
+      </xs:sequence>
     </xs:complexType>
   </xs:element>
 

--- a/daffodil-sapi/src/test/resources/test/sapi/blob.dfdl.xsd
+++ b/daffodil-sapi/src/test/resources/test/sapi/blob.dfdl.xsd
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<schema xmlns="http://www.w3.org/2001/XMLSchema"
+  targetNamespace="http://www.example.org/example1/" xmlns:tns="http://www.example.org/example1/"
+  xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/" xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns:dfdlx="http://www.ogf.org/dfdl/dfdl-1.0/extensions"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+
+  <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormatPortable.dfdl.xsd"/>
+
+  <annotation>
+    <appinfo source="http://www.ogf.org/dfdl/">
+      <dfdl:format ref="tns:GeneralFormat"
+        representation="binary" />
+    </appinfo>
+  </annotation>
+
+  <xs:element name="root">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="length" type="xs:int" />
+        <xs:element name="blob" type="xs:anyURI" dfdlx:objectKind="bytes"
+          dfdl:lengthKind="explicit" dfdl:length="{ ../length }" />
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+
+</schema>
+


### PR DESCRIPTION
When full or custom validation is enabled, Daffodil creates a new TeeInfosetOutputter which proxies infoset events to the user provided InfosetOutputter and another one used for validation. This means that calls to getBlobDirectory, getBlobSuffix, setBlobPath, etc. go to the TeeInfosetOutputter, and ignore any values that a user may have set on their provided InfosetOutputter. This essentially means you cannot change the directory, suffix, or prefix of blobs if full or custom validation is enabled. It also means that if calling getBlobPaths on the user provided InfosetOutputter never returns anything, even if blobs were created.

To fix this, if full or custom validation is enabled, we copy the blob attributes to the TeeInfosetOutputter used for parsing. We also ensure that at the end of parsing, we call setBlobPaths on the InfosetOutputter the user passed in instead of the TeeInfosetOutputter.

DAFFODIL-2837