### PR TITLE
De-personalize Diagnostic File URLs in Compiled Schemas

### DIFF
--- a/daffodil-cli/src/main/scala/org/apache/daffodil/cli/Main.scala
+++ b/daffodil-cli/src/main/scala/org/apache/daffodil/cli/Main.scala
@@ -227,7 +227,7 @@ class CLIConf(arguments: Array[String], stdout: PrintStream, stderr: PrintStream
 
   implicit def rootNSConverter = org.rogach.scallop.singleArgConverter[RefQName](qnameConvert _)
 
-  implicit def fileResourceURIConverter = singleArgConverter[URI]((s: String) => {
+  implicit def fileResourceURIConverter = singleArgConverter[URISchemaSource]((s: String) => {
     val optResolved =
       try {
         val uri =
@@ -256,19 +256,22 @@ class CLIConf(arguments: Array[String], stdout: PrintStream, stderr: PrintStream
             }
           }
         // At this point we have a valid URI, which could be absolute or relative, with relative
-        // URIs resolved from the current working directory. We can convert this to a string and
-        // pass it to resolveSchemaLocation to find the actual file or resource
-        val cwd = Paths.get("").toUri
-        XMLUtils.resolveSchemaLocation(uri.toString, Some(cwd))
+        // URIs resolved from the current working directory. We create a fake contextPath that represents
+        // a fake file in the current working directory and pass that as the contextSource to the
+        // resolveSchemaLocation function to find the actual file or resource. This is necessary because
+        // resolveSchemaLocation expects a context that is a file for diagnostic purposes.
+        val contextPath = Paths.get("fakeContext.dfdl.xsd")
+        val contextSource = URISchemaSource(contextPath.toFile, contextPath.toUri)
+        XMLUtils.resolveSchemaLocation(uri.toString, Some(contextSource))
       } catch {
         case _: Exception => throw new Exception(s"Could not find file or resource $s")
       }
     optResolved match {
-      case Some((uri, relToAbs)) => {
+      case Some((uriSchemaSource, relToAbs)) => {
         if (relToAbs) {
           Logger.log.warn(s"Found relative path on classpath absolutely, did you mean /$s")
         }
-        uri
+        uriSchemaSource
       }
       case None => {
         throw new Exception(s"Could not find file or resource $s")
@@ -377,7 +380,11 @@ class CLIConf(arguments: Array[String], stdout: PrintStream, stderr: PrintStream
         "Root element to use. Can be prefixed with {namespace}. Must be a top-level element. Defaults to first top-level element of DFDL schema.",
     )
     val schema =
-      opt[URI]("schema", argName = "file", descr = "DFDL schema to use to create parser")(
+      opt[URISchemaSource](
+        "schema",
+        argName = "file",
+        descr = "DFDL schema to use to create parser",
+      )(
         fileResourceURIConverter,
       )
     val stream = toggle(
@@ -488,7 +495,11 @@ class CLIConf(arguments: Array[String], stdout: PrintStream, stderr: PrintStream
         "Root element to use. Can be prefixed with {namespace}. Must be a top-level element. Defaults to first top-level element of DFDL schema.",
     )
     val schema =
-      opt[URI]("schema", argName = "file", descr = "DFDL schema to use to create parser")(
+      opt[URISchemaSource](
+        "schema",
+        argName = "file",
+        descr = "DFDL schema to use to create parser",
+      )(
         fileResourceURIConverter,
       )
     val stream = toggle(
@@ -576,7 +587,7 @@ class CLIConf(arguments: Array[String], stdout: PrintStream, stderr: PrintStream
       descr =
         "Root element to use. Can be prefixed with {namespace}. Must be a top-level element. Defaults to first top-level element of DFDL schema.",
     )
-    val schema = opt[URI](
+    val schema = opt[URISchemaSource](
       "schema",
       required = true,
       argName = "file",
@@ -685,7 +696,11 @@ class CLIConf(arguments: Array[String], stdout: PrintStream, stderr: PrintStream
         "Root element to use. Can be prefixed with {namespace}. Must be a top-level element. Defaults to first top-level element of DFDL schema.",
     )
     val schema =
-      opt[URI]("schema", argName = "file", descr = "DFDL schema to use to create parser")(
+      opt[URISchemaSource](
+        "schema",
+        argName = "file",
+        descr = "DFDL schema to use to create parser",
+      )(
         fileResourceURIConverter,
       )
     val threads = opt[Int](
@@ -774,7 +789,7 @@ class CLIConf(arguments: Array[String], stdout: PrintStream, stderr: PrintStream
         descr =
           "Root element to use. Can be prefixed with {namespace}. Must be a top-level element. Defaults to first top-level element of DFDL schema.",
       )
-      val schema = opt[URI](
+      val schema = opt[URISchemaSource](
         "schema",
         required = true,
         argName = "file",
@@ -820,7 +835,7 @@ class CLIConf(arguments: Array[String], stdout: PrintStream, stderr: PrintStream
       descr =
         "Output file to write the encoded/decoded file to. If not given or is -, data is written to stdout.",
     )
-    val schema = opt[URI](
+    val schema = opt[URISchemaSource](
       "schema",
       argName = "file",
       descr = "DFDL schema to use for schema aware encoding/decoding.",
@@ -1018,7 +1033,7 @@ class Main(
   }
 
   def createProcessorFromSchema(
-    schema: URI,
+    schemaSource: URISchemaSource,
     rootNS: Option[RefQName],
     path: Option[String],
     tunablesMap: Map[String, String],
@@ -1039,7 +1054,6 @@ class Main(
     // to also include the call to pf.onPath. (which is the last phase
     // of compilation, where it asks for the parser)
     //
-    val schemaSource = URISchemaSource(schema)
     val res = Timer.getResult(
       "compiling", {
         val processorFactory = compiler.compileSource(schemaSource)
@@ -1067,7 +1081,7 @@ class Main(
   }
 
   def createGeneratorFromSchema(
-    schema: URI,
+    schemaSource: URISchemaSource,
     rootNS: Option[RefQName],
     tunables: Map[String, String],
     language: String,
@@ -1081,7 +1095,6 @@ class Main(
       }
     }
 
-    val schemaSource = URISchemaSource(schema)
     val cg = Timer.getResult(
       "compiling", {
         val processorFactory = compiler.compileSource(schemaSource)
@@ -1164,11 +1177,10 @@ class Main(
               case Some(file) => new FileOutputStream(file)
             }
 
-            val infosetType = parseOpts.infosetType.toOption.get
             val infosetHandler = InfosetType.getInfosetHandler(
-              parseOpts.infosetType.toOption.get,
+              parseOpts.infosetType(),
               processor,
-              parseOpts.schema.toOption,
+              parseOpts.schema.map(_.uri).toOption,
               forPerformance = false,
             )
 
@@ -1340,11 +1352,10 @@ class Main(
               }
             }
 
-            val infosetType = performanceOpts.infosetType.toOption.get
             val infosetHandler = InfosetType.getInfosetHandler(
-              infosetType,
+              performanceOpts.infosetType(),
               processor,
-              performanceOpts.schema.toOption,
+              performanceOpts.schema.map(_.uri).toOption,
               forPerformance = true,
             )
 
@@ -1505,11 +1516,10 @@ class Main(
             var keepUnparsing = maybeScanner.isEmpty || maybeScanner.get.hasNext
             var exitCode = ExitCode.Success
 
-            val infosetType = unparseOpts.infosetType.toOption.get
             val infosetHandler = InfosetType.getInfosetHandler(
-              unparseOpts.infosetType.toOption.get,
+              unparseOpts.infosetType(),
               processor,
-              unparseOpts.schema.toOption,
+              unparseOpts.schema.map(_.uri).toOption,
               forPerformance = false,
             )
 
@@ -1806,7 +1816,11 @@ class Main(
 
         val exiFactory: Option[EXIFactory] =
           try {
-            Some(EXIInfosetHandler.createEXIFactory(exiOpts.schema.toOption))
+            Some(
+              EXIInfosetHandler.createEXIFactory(
+                exiOpts.schema.map(_.uri).toOption,
+              ),
+            )
           } catch {
             case e: EXIException => {
               Logger.log.error(

--- a/daffodil-cli/src/test/scala/org/apache/daffodil/cli/cliTest/TestCLISaveParser.scala
+++ b/daffodil-cli/src/test/scala/org/apache/daffodil/cli/cliTest/TestCLISaveParser.scala
@@ -318,4 +318,20 @@ class TestCLISaveParser {
     }
   }
 
+  /**
+   * Attempted to save-parser an invalid schema so we can check the diagnostic error for leaked information
+   */
+  @Test def test_CLI_Saving_SaveParser_error(): Unit = {
+    val schema = path(
+      "daffodil-sapi/src/test/resources/test/sapi/mySchema6.dfdl.xsd",
+    )
+
+    withTempFile { parser =>
+      runCLI(args"save-parser -s $schema $parser") { cli =>
+        cli.expectErr("[error]")
+        cli.expectErr(s"Schema context:  Location line 32 column 74 in ${schema.normalize()}")
+      }(ExitCode.UnableToCreateProcessor)
+    }
+  }
+
 }

--- a/daffodil-core/src/main/scala/org/apache/daffodil/core/compiler/Compiler.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/core/compiler/Compiler.scala
@@ -325,7 +325,7 @@ class Compiler private (
     optRootName: Option[String] = None,
     optRootNamespace: Option[String] = None,
   ): ProcessorFactory = {
-    val source = URISchemaSource(file.toURI)
+    val source = URISchemaSource(file, file.toURI)
     compileSource(source, optRootName, optRootNamespace)
   }
 

--- a/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/Import.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/Import.scala
@@ -25,6 +25,7 @@ import org.apache.daffodil.lib.api.DaffodilSchemaSource
 import org.apache.daffodil.lib.api.URISchemaSource
 import org.apache.daffodil.lib.exceptions.Assert
 import org.apache.daffodil.lib.util.Logger
+import org.apache.daffodil.lib.util.Misc
 import org.apache.daffodil.lib.xml._
 
 /**
@@ -98,10 +99,13 @@ final class Import(importNode: Node, xsd: XMLSchemaDocument, seenArg: IIMap)
         None
       }
       case Some(ns) => {
-        val uri = resolver.resolveURI(ns.toString)
-        if (uri == null) None
+        val uriString = resolver.resolveURI(ns.toString)
+        if (uriString == null) None
         else {
-          val res = URISchemaSource(URI.create(uri))
+          val uri = URI.create(uriString)
+          val dfp = Misc.uriToDiagnosticFile(uri)
+          val res =
+            URISchemaSource(dfp, uri)
           Some(res)
         }
       }

--- a/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/SchemaComponentFactory.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/SchemaComponentFactory.scala
@@ -17,10 +17,10 @@
 
 package org.apache.daffodil.core.dsom
 
+import java.io.File
 import scala.xml.NamespaceBinding
 
 import org.apache.daffodil.core.dsom.walker.CommonContextView
-import org.apache.daffodil.lib.api.DaffodilTunables
 import org.apache.daffodil.lib.exceptions.SchemaFileLocatable
 import org.apache.daffodil.lib.xml.NS
 import org.apache.daffodil.lib.xml.XMLUtils
@@ -30,8 +30,6 @@ trait SchemaFileLocatableImpl extends SchemaFileLocatable { self: SchemaComponen
   def xml: scala.xml.Node
   def schemaFile: Option[DFDLSchemaFile]
   def optLexicalParent: Option[SchemaComponent]
-
-  def tunables: DaffodilTunables = self.tunable
 
   /**
    * Annotations can contain expressions, so we need to be able to compile them.
@@ -76,6 +74,7 @@ trait CommonContextMixin extends NestingLexicalMixin with CommonContextView {
   }
   final def xmlSchemaDocument: XMLSchemaDocument = optXMLSchemaDocument.get
   def uriString: String = optLexicalParent.get.uriString
+  def diagnosticFile: File = optLexicalParent.get.diagnosticFile
 
   def xml: scala.xml.Node
 

--- a/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/SchemaComponentIncludesAndImportsMixin.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/SchemaComponentIncludesAndImportsMixin.scala
@@ -17,6 +17,8 @@
 
 package org.apache.daffodil.core.dsom
 
+import java.io.File
+
 /**
  * Mixin for all SchemaComponents
  */
@@ -34,5 +36,7 @@ trait SchemaComponentIncludesAndImportsMixin extends CommonContextMixin {
   private lazy val uriString_ = LV('fileName) {
     xmlSchemaDocument.uriString
   }.toOption.getOrElse(orElseURL)
+
+  override def diagnosticFile: File = xmlSchemaDocument.diagnosticFile
 
 }

--- a/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/SchemaDocIncludesAndImportsMixin.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/SchemaDocIncludesAndImportsMixin.scala
@@ -22,6 +22,7 @@ import scala.xml.NodeSeq
 
 import org.apache.daffodil.core.dsom.IIUtils._
 import org.apache.daffodil.lib.equality._
+import org.apache.daffodil.lib.exceptions.Assert
 import org.apache.daffodil.lib.xml.NS
 import org.apache.daffodil.lib.xml.NoNamespace
 
@@ -142,6 +143,15 @@ trait SchemaDocIncludesAndImportsMixin { self: XMLSchemaDocument =>
 
   override lazy val uriString = {
     this.uriStringFromAttribute.getOrElse("file:unknown")
+  }
+
+  override lazy val diagnosticFile = if (self.schemaFile.isDefined) {
+    self.schemaFile.get.diagnosticFile
+  } else {
+    // in the case of a boostrap/fake schema document, schemaFile can be None, so we want
+    // to grab the diagnostic of the first schema in the schemaSet
+    Assert.invariant(self.isBootStrapSD)
+    self.schemaSet.diagnosticFile
   }
 
   protected def seenBefore: IIMap

--- a/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/SchemaSet.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/SchemaSet.scala
@@ -96,7 +96,7 @@ final class SchemaSet private (
   val schemaSource: DaffodilSchemaSource,
   val shouldValidateDFDLSchemas: Boolean,
   val checkAllTopLevel: Boolean,
-  override val tunables: DaffodilTunables,
+  val tunables: DaffodilTunables,
 ) extends SchemaComponentImpl(<schemaSet/>, None)
   with SchemaSetIncludesAndImportsMixin
   with SchemaSetGrammarMixin {
@@ -138,6 +138,8 @@ final class SchemaSet private (
    * and as such, doesn't need to be a URL.  Can just be String.
    */
   override lazy val uriString: String = schemaSource.uriForLoading.toString
+
+  override lazy val diagnosticFile: File = schemaSource.diagnosticFile
 
   override def warn(th: Diagnostic) = oolagWarn(th)
 

--- a/daffodil-core/src/test/scala/org/apache/daffodil/core/dsom/TestDsomCompiler.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/core/dsom/TestDsomCompiler.scala
@@ -17,6 +17,7 @@
 
 package org.apache.daffodil.core.dsom
 
+import java.nio.file.Paths
 import scala.xml.Node
 import scala.xml.Utility
 import scala.xml.XML
@@ -225,6 +226,8 @@ class TestDsomCompiler {
     assertTrue(elem.isInstanceOf[LocalElementDecl])
   }
 
+  private val exampleOfMostDFDLConstructsXML = "/test/example-of-most-dfdl-constructs.dfdl.xml"
+
   @Test def test3(): Unit = {
     // Newer versions of the scala-xml library changed the XML.load() function
     // so that it does not ignore comments/processing instructions. This causes
@@ -233,7 +236,8 @@ class TestDsomCompiler {
     // does remove comments and what is normally used by Daffodil) to load the
     // XML to a Scala XML Node.
     val source = URISchemaSource(
-      Misc.getRequiredResource("/test/example-of-most-dfdl-constructs.dfdl.xml"),
+      Paths.get(exampleOfMostDFDLConstructsXML).toFile,
+      Misc.getRequiredResource(exampleOfMostDFDLConstructsXML),
     )
     val loader = new DaffodilXMLLoader(null)
     val testSchema = loader.load(source, None)
@@ -340,7 +344,7 @@ class TestDsomCompiler {
 
   @Test def test4(): Unit = {
     val testSchema =
-      XML.load(Misc.getRequiredResource("/test/example-of-most-dfdl-constructs.dfdl.xml").toURL)
+      XML.load(Misc.getRequiredResource(exampleOfMostDFDLConstructsXML).toURL)
 
     val sset = SchemaSet(testSchema)
     val Seq(sch) = sset.schemas
@@ -450,7 +454,7 @@ class TestDsomCompiler {
 
   @Test def test_simpleType_base_combining(): Unit = {
     val testSchema =
-      XML.load(Misc.getRequiredResource("/test/example-of-most-dfdl-constructs.dfdl.xml").toURL)
+      XML.load(Misc.getRequiredResource(exampleOfMostDFDLConstructsXML).toURL)
 
     val sset = SchemaSet(testSchema)
     val Seq(sch) = sset.schemas
@@ -502,7 +506,7 @@ class TestDsomCompiler {
 
   @Test def test_group_references(): Unit = {
     val testSchema =
-      XML.load(Misc.getRequiredResource("/test/example-of-most-dfdl-constructs.dfdl.xml").toURL)
+      XML.load(Misc.getRequiredResource(exampleOfMostDFDLConstructsXML).toURL)
 
     val sset = SchemaSet(testSchema)
     val Seq(sch) = sset.schemas
@@ -679,7 +683,7 @@ class TestDsomCompiler {
 
   @Test def test_element_references(): Unit = {
     val testSchema =
-      XML.load(Misc.getRequiredResource("/test/example-of-most-dfdl-constructs.dfdl.xml").toURL)
+      XML.load(Misc.getRequiredResource(exampleOfMostDFDLConstructsXML).toURL)
 
     val sset = SchemaSet(testSchema)
     val Seq(sch) = sset.schemas

--- a/daffodil-core/src/test/scala/org/apache/daffodil/core/processor/TestSAXUtils.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/core/processor/TestSAXUtils.scala
@@ -20,6 +20,7 @@ package org.apache.daffodil.core.processor
 import java.io.ByteArrayOutputStream
 import java.io.OutputStream
 import java.io.OutputStreamWriter
+import java.nio.file.Paths
 import scala.xml.Elem
 
 import org.apache.daffodil.core.compiler.Compiler
@@ -58,10 +59,20 @@ object TestSAXUtils {
 
   lazy val loader = new DaffodilXMLLoader()
 
+  lazy val qualifiedWithNestedSchemasFilePath =
+    "/test/example_nested_namespaces_qualified.dfdl.xsd"
   lazy val qualifiedWithNestedSchemasFile =
-    Misc.getRequiredResource("/test/example_nested_namespaces_qualified.dfdl.xsd")
+    Misc.getRequiredResource(qualifiedWithNestedSchemasFilePath)
   lazy val qualifiedWithNestedSchemasElem: Elem =
-    loader.load(URISchemaSource(qualifiedWithNestedSchemasFile), None).asInstanceOf[Elem]
+    loader
+      .load(
+        URISchemaSource(
+          Paths.get(qualifiedWithNestedSchemasFilePath).toFile,
+          qualifiedWithNestedSchemasFile,
+        ),
+        None,
+      )
+      .asInstanceOf[Elem]
   lazy val dpQualifiedWithNestedSchemas: DataProcessor = testDataProcessor(
     qualifiedWithNestedSchemasElem,
   )
@@ -132,10 +143,19 @@ object TestSAXUtils {
   lazy val nillableElementExpectedString: String = nillableElementExpectedInfoset.toString()
   lazy val nillableElementData: String = "^.-3.*4.7"
 
+  private val unqualifiedNoNamespacesFilePath = "/test/example_no_targetnamespace.dfdl.xsd"
   lazy val unqualifiedNoNamespacesFile =
-    Misc.getRequiredResource("/test/example_no_targetnamespace.dfdl.xsd")
+    Misc.getRequiredResource(unqualifiedNoNamespacesFilePath)
   lazy val unqualifiedNoNamespacesElem: Elem =
-    loader.load(URISchemaSource(unqualifiedNoNamespacesFile), None).asInstanceOf[Elem]
+    loader
+      .load(
+        URISchemaSource(
+          Paths.get(unqualifiedNoNamespacesFilePath).toFile,
+          unqualifiedNoNamespacesFile,
+        ),
+        None,
+      )
+      .asInstanceOf[Elem]
 
   /**
    * For an unqualified schemas with no targetnamespace and no default namespace, which means its
@@ -158,10 +178,20 @@ object TestSAXUtils {
     unqualifiedNoNamespacesExpectedInfoset.toString()
   lazy val unqualifiedNoNamespacesData: String = "world.no.^.tea"
 
+  lazy val unqualifiedWithNestedQualifiedFilePath =
+    "/test/example_nested_namespaces_unqualified.dfdl.xsd"
   lazy val unqualifiedWithNestedQualifiedFile =
-    Misc.getRequiredResource("/test/example_nested_namespaces_unqualified.dfdl.xsd")
+    Misc.getRequiredResource(unqualifiedWithNestedQualifiedFilePath)
   lazy val unqualifiedWithNestedQualifiedElem: Elem =
-    loader.load(URISchemaSource(unqualifiedWithNestedQualifiedFile), None).asInstanceOf[Elem]
+    loader
+      .load(
+        URISchemaSource(
+          Paths.get(unqualifiedWithNestedQualifiedFilePath).toFile,
+          unqualifiedWithNestedQualifiedFile,
+        ),
+        None,
+      )
+      .asInstanceOf[Elem]
 
   /**
    * For an unqualified schemas with a targetnamespace and no default namespace, which means its
@@ -197,10 +227,20 @@ object TestSAXUtils {
     unqualifiedWithNestedQualifiedExpectedInfoset.toString()
   lazy val unqualifiedWithNestedQualifiedData: String = "hello.^.bye"
 
+  private val qualifiedWithDefaultNamespaceFilePath =
+    "/test/example_c02_targetnamespace_qualified.dfdl.xsd"
   lazy val qualifiedWithDefaultNamespaceFile =
-    Misc.getRequiredResource("/test/example_c02_targetnamespace_qualified.dfdl.xsd")
+    Misc.getRequiredResource(qualifiedWithDefaultNamespaceFilePath)
   lazy val qualifiedWithDefaultNamespaceElem: Elem =
-    loader.load(URISchemaSource(qualifiedWithDefaultNamespaceFile), None).asInstanceOf[Elem]
+    loader
+      .load(
+        URISchemaSource(
+          Paths.get(qualifiedWithDefaultNamespaceFilePath).toFile,
+          qualifiedWithDefaultNamespaceFile,
+        ),
+        None,
+      )
+      .asInstanceOf[Elem]
   lazy val dpQualifiedWithDefaultNamespaceSchemas: DataProcessor = testDataProcessor(
     qualifiedWithDefaultNamespaceElem,
   )
@@ -213,11 +253,19 @@ object TestSAXUtils {
     qualifiedWithDefaultNamespaceExpectedInfoset.toString()
   lazy val qualifiedWithDefaultNamespaceData: String = "hello"
 
+  private val qualifiedWithDefaultAndNestedSchemasFilePath =
+    "/test/example_nested_namespaces_qualified_with_default.dfdl.xsd"
   lazy val qualifiedWithDefaultAndNestedSchemasFile =
-    Misc.getRequiredResource("/test/example_nested_namespaces_qualified_with_default.dfdl.xsd")
+    Misc.getRequiredResource(qualifiedWithDefaultAndNestedSchemasFilePath)
   lazy val qualifiedWithDefaultAndNestedSchemasElem: Elem =
     loader
-      .load(URISchemaSource(qualifiedWithDefaultAndNestedSchemasFile), None)
+      .load(
+        URISchemaSource(
+          Paths.get(qualifiedWithDefaultAndNestedSchemasFilePath).toFile,
+          qualifiedWithDefaultAndNestedSchemasFile,
+        ),
+        None,
+      )
       .asInstanceOf[Elem]
   lazy val dpQualifiedWithDefaultAndNestedSchemas: DataProcessor = testDataProcessor(
     qualifiedWithDefaultAndNestedSchemasElem,

--- a/daffodil-core/src/test/scala/org/apache/daffodil/core/util/TestUtils.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/core/util/TestUtils.scala
@@ -24,6 +24,7 @@ import java.io.InputStream
 import java.nio.channels.Channels
 import java.nio.channels.ReadableByteChannel
 import java.nio.channels.WritableByteChannel
+import java.nio.file.Paths
 import scala.collection.mutable.ArrayBuffer
 import scala.util.Try
 import scala.xml._
@@ -314,7 +315,7 @@ object TestUtils {
     val nullChannel = java.nio.channels.Channels.newChannel(nos)
     val compiler = Compiler()
     val uri = Misc.getRequiredResource(resourcePathString)
-    val schemaSource = URISchemaSource(uri)
+    val schemaSource = URISchemaSource(Paths.get(resourcePathString).toFile, uri)
     val theTry = Timer.getResult(compileAndSave(compiler, schemaSource, nullChannel))
     theTry.get
   }

--- a/daffodil-core/src/test/scala/org/apache/daffodil/core/xml/TestXMLLoaderWithLocation.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/core/xml/TestXMLLoaderWithLocation.scala
@@ -37,7 +37,9 @@ class TestXMLLoaderWithLocation {
       using(new java.io.FileWriter(tmpXMLFileName)) { fw =>
         fw.write(testXML.toString())
       }
-      val res = URISchemaSource(new File(tmpXMLFileName).toURI)
+      val tmpXMLFile = new File(tmpXMLFileName)
+      val res =
+        URISchemaSource(tmpXMLFile, tmpXMLFile.toURI)
       val eh = new BasicErrorHandler
       val node = (new DaffodilXMLLoader(eh)).load(res, None, addPositionAttributes = true)
       assertTrue(node.toString.toLowerCase.contains("dafint:file"))
@@ -69,7 +71,9 @@ class TestXMLLoaderWithLocation {
       using(new java.io.FileWriter(tmpXMLFileName)) { fw =>
         fw.write(testXML.toString())
       }
-      val res = URISchemaSource(new File(tmpXMLFileName).toURI)
+      val tmpXMLFile = new File(tmpXMLFileName)
+      val res =
+        URISchemaSource(tmpXMLFile, tmpXMLFile.toURI)
       val eh = new BasicErrorHandler
       val node = (new DaffodilXMLLoader(eh)).load(
         res,

--- a/daffodil-japi/src/main/scala/org/apache/daffodil/japi/Daffodil.scala
+++ b/daffodil-japi/src/main/scala/org/apache/daffodil/japi/Daffodil.scala
@@ -38,6 +38,7 @@ import org.apache.daffodil.lib.api.{ DataLocation => SDataLocation }
 import org.apache.daffodil.lib.api.{ Diagnostic => SDiagnostic }
 import org.apache.daffodil.lib.api.{ LocationInSchemaFile => SLocationInSchemaFile }
 import org.apache.daffodil.lib.api.{ WithDiagnostics => SWithDiagnostics }
+import org.apache.daffodil.lib.util.Misc
 import org.apache.daffodil.lib.xml.DFDLCatalogResolver
 import org.apache.daffodil.lib.xml.XMLUtils
 import org.apache.daffodil.runtime1.api.DFDL.{
@@ -165,7 +166,7 @@ class Compiler private[japi] (private var sCompiler: SCompiler) {
    */
   @throws(classOf[java.io.IOException])
   def compileSource(uri: URI, rootName: String, rootNamespace: String): ProcessorFactory = {
-    val source = URISchemaSource(uri)
+    val source = URISchemaSource(Misc.uriToDiagnosticFile(uri), uri)
     val pf = sCompiler.compileSource(source, Option(rootName), Option(rootNamespace))
     new ProcessorFactory(pf)
   }

--- a/daffodil-japi/src/test/java/org/apache/daffodil/example/TestJavaAPI.java
+++ b/daffodil-japi/src/test/java/org/apache/daffodil/example/TestJavaAPI.java
@@ -982,7 +982,6 @@ public class TestJavaAPI {
 
         org.apache.daffodil.japi.Compiler c = Daffodil.compiler();
 
-        java.io.File extVarFile = getResource("/test/japi/external_vars_1.xml");
         java.io.File schemaFile = getResource("/test/japi/mySchemaWithVars.dfdl.xsd");
         ProcessorFactory pf = c.compileFile(schemaFile);
         DataProcessor dp = pf.onPath("/");

--- a/daffodil-lib/src/main/resources/org/apache/daffodil/xsd/tdml.xsd
+++ b/daffodil-lib/src/main/resources/org/apache/daffodil/xsd/tdml.xsd
@@ -184,21 +184,6 @@
     <attribute name="unsupported" type="xs:boolean" use="optional" default="false"/>
     <attribute name="validation" type="tns:validationType" use="optional"/>
     <attribute name="implementations" type="tns:implementationsType" use="optional"/>
-    <attribute name="diagnosticsStripLocationInfo" type="xs:boolean" use="optional" default="true">
-      <annotation>
-        <documentation>We strip the file info from the diagnostics to prevent false
-          positive matches against the test case's error and warning strings
-          coming from file/dir names.
-
-          As there are tests that look for correct file/dir names, those
-          tests will need to NOT strip them and can do so by setting the
-          test flag to false.
-
-          This is only for purposes of comparing error/warning strings
-          to the diagnostic messages. Users would always see, displayed,
-          the full diagnostic messages.</documentation>
-      </annotation>
-    </attribute>
 
   </attributeGroup>
 

--- a/daffodil-lib/src/main/scala/org/apache/daffodil/lib/api/DaffodilConfig.scala
+++ b/daffodil-lib/src/main/scala/org/apache/daffodil/lib/api/DaffodilConfig.scala
@@ -22,6 +22,7 @@ import scala.xml.Elem
 import scala.xml.Node
 
 import org.apache.daffodil.lib.externalvars.Binding
+import org.apache.daffodil.lib.util.Misc
 import org.apache.daffodil.lib.xml.DaffodilXMLLoader
 import org.apache.daffodil.lib.xml.NS
 import org.apache.daffodil.lib.xml.XMLUtils
@@ -66,9 +67,13 @@ object DaffodilConfig {
     }
   }
 
-  def fromURI(uri: URI) = fromSchemaSource(URISchemaSource(uri))
+  def fromURI(uri: URI) = fromSchemaSource(
+    URISchemaSource(Misc.uriToDiagnosticFile(uri), uri),
+  )
 
-  def fromFile(file: File) = fromURI(file.toURI)
+  def fromFile(file: File) = fromSchemaSource(
+    URISchemaSource(file, file.toURI),
+  )
 
 }
 

--- a/daffodil-lib/src/main/scala/org/apache/daffodil/lib/api/Diagnostic.scala
+++ b/daffodil-lib/src/main/scala/org/apache/daffodil/lib/api/Diagnostic.scala
@@ -256,27 +256,6 @@ trait LocationInSchemaFile {
   def fileDescription: String
 
   def locationDescription: String
-
-  def limitMaxParentDirectories(
-    uriString: String,
-    maxParentDirectoriesForDiagnostics: Int,
-  ): String = {
-    // works for both windows and unix
-    val splitter = "/"
-    val tokens = uriString.split(splitter)
-    val reducedTokens = tokens
-      // we want to get just the filename plus the max number of directories
-      // since these paths can get really long. To change how much of the path to see
-      // in diagnostics, one can update the maxParentDirectoriesForDiagnostics tunable
-      .takeRight(maxParentDirectoriesForDiagnostics + 1)
-    // we only want to use the prefix if the new number of directories is
-    // less than the original
-    val prefix = if (reducedTokens.length < tokens.length) s"...${splitter}" else ""
-    val newUriString = reducedTokens
-      .mkString(prefix, splitter, "")
-    newUriString
-  }
-
 }
 
 /**

--- a/daffodil-lib/src/main/scala/org/apache/daffodil/lib/util/Misc.scala
+++ b/daffodil-lib/src/main/scala/org/apache/daffodil/lib/util/Misc.scala
@@ -708,4 +708,16 @@ object Misc {
     }
     Some(res)
   }
+
+  /**
+   * Get the diagnosticFilepath from a uri
+   */
+  def uriToDiagnosticFile(uri: URI): File = {
+    uri.getScheme match {
+      case "jar" => Paths.get(uri.toString.split("\\.jar!").last).toFile
+      case "file" => Paths.get(uri).toFile
+      case _ => Paths.get(uri.getPath).toFile
+    }
+  }
+
 }

--- a/daffodil-propgen/src/main/resources/org/apache/daffodil/xsd/dafext.xsd
+++ b/daffodil-propgen/src/main/resources/org/apache/daffodil/xsd/dafext.xsd
@@ -379,19 +379,6 @@
             </xs:restriction>
           </xs:simpleType>
         </xs:element>
-        <xs:element name="maxParentDirectoriesForDiagnostics" default="3" minOccurs="0">
-          <xs:annotation>
-            <xs:documentation>
-              The maximum number of parent directories that show up for a file within a diagnostic
-              message.
-            </xs:documentation>
-          </xs:annotation>
-          <xs:simpleType>
-            <xs:restriction base="xs:int">
-              <xs:minInclusive value="0" />
-            </xs:restriction>
-          </xs:simpleType>
-        </xs:element>
         <xs:element name="maxSkipLengthInBytes" default="1024" minOccurs="0">
           <xs:annotation>
             <xs:documentation>

--- a/daffodil-propgen/src/main/scala/org/apache/daffodil/propGen/TunableGenerator.scala
+++ b/daffodil-propgen/src/main/scala/org/apache/daffodil/propGen/TunableGenerator.scala
@@ -50,6 +50,8 @@ class TunableGenerator(schemaRootConfig: scala.xml.Node, schemaRootExt: scala.xm
     |//
     |////////////////////////////////////////////////////////////////////////////////////////////
     |
+    |import java.nio.file.Paths
+    |
     |import org.apache.daffodil.lib.exceptions.Assert
     |import org.apache.daffodil.lib.exceptions.ThrowsSDE
     |import org.apache.daffodil.lib.schema.annotation.props.EmptyElementParsePolicy
@@ -70,11 +72,12 @@ class TunableGenerator(schemaRootConfig: scala.xml.Node, schemaRootExt: scala.xm
     |
     |  def apply(): DaffodilTunables = {
     |    // override tunables from the global configuration file on the class path, if it exists
-    |    val (configOpt, _) = Misc.getResourceOption("/daffodil-config.xml")
+    |    val configPath = "/daffodil-config.xml"
+    |    val (configOpt, _) = Misc.getResourceOption(configPath)
     |    val configTunables: Map[String, String] =
     |      if (configOpt.isDefined) {
     |        val loader = new DaffodilXMLLoader()
-    |        val node = loader.load(URISchemaSource(configOpt.get), Some(XMLUtils.dafextURI))
+    |        val node = loader.load(URISchemaSource(Paths.get(configPath).toFile, configOpt.get), Some(XMLUtils.dafextURI))
     |        tunablesMap(node)
     |      } else {
     |        Map.empty

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/externalvars/ExternalVariablesLoader.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/externalvars/ExternalVariablesLoader.scala
@@ -80,7 +80,10 @@ object ExternalVariablesLoader {
     val input = scala.io.Source.fromURI(file.toURI)(enc)
     val ldr = new DaffodilXMLLoader()
     val dafextURI = XMLUtils.dafextURI
-    val node = ldr.load(URISchemaSource(file.toURI), Some(dafextURI))
+    val node = ldr.load(
+      URISchemaSource(file, file.toURI),
+      Some(dafextURI),
+    )
     nodeToBindings(node)
   }
 

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/RuntimeData.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/RuntimeData.scala
@@ -104,7 +104,7 @@ sealed trait RuntimeData
   final override def schemaFileLineColumnNumber: JLong =
     schemaFileLocation.columnNumber.map { JLong.getLong(_) }.orNull
 
-  final override def schemaFileInfo: String = schemaFileLocation.fileURITrimmed
+  final override def schemaFileInfo: String = schemaFileLocation.fileDescription
 }
 
 object TermRuntimeData {

--- a/daffodil-sapi/src/main/scala/org/apache/daffodil/sapi/Daffodil.scala
+++ b/daffodil-sapi/src/main/scala/org/apache/daffodil/sapi/Daffodil.scala
@@ -33,6 +33,7 @@ import org.apache.daffodil.lib.api.{ DataLocation => SDataLocation }
 import org.apache.daffodil.lib.api.{ Diagnostic => SDiagnostic }
 import org.apache.daffodil.lib.api.{ LocationInSchemaFile => SLocationInSchemaFile }
 import org.apache.daffodil.lib.api.{ WithDiagnostics => SWithDiagnostics }
+import org.apache.daffodil.lib.util.Misc
 import org.apache.daffodil.lib.xml.DFDLCatalogResolver
 import org.apache.daffodil.lib.xml.XMLUtils
 import org.apache.daffodil.runtime1.api.DFDL.{
@@ -156,7 +157,7 @@ class Compiler private[sapi] (private var sCompiler: SCompiler) {
     optRootName: Option[String] = None,
     optRootNamespace: Option[String] = None,
   ): ProcessorFactory = {
-    val source = URISchemaSource(uri)
+    val source = URISchemaSource(Misc.uriToDiagnosticFile(uri), uri)
     val pf = sCompiler.compileSource(source, optRootName, optRootNamespace)
     new ProcessorFactory(pf.asInstanceOf[SProcessorFactory])
   }

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section00/general/TestResolver.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section00/general/TestResolver.tdml
@@ -36,7 +36,6 @@
     <tdml:document/>
     <tdml:errors>
       <tdml:error>Schema Definition Error</tdml:error>
-      <tdml:error>SAXParseException</tdml:error>
       <tdml:error>Unable to resolve</tdml:error>
       <tdml:error>this/does/not/exist/schema.dfdl.xsd</tdml:error>
     </tdml:errors>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section00/general/disallowDocTypes.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section00/general/disallowDocTypes.tdml
@@ -59,8 +59,6 @@
     <tdml:document/>
     <tdml:errors>
       <tdml:error>Schema Definition Error</tdml:error>
-      <tdml:error>org.xml.sax.SAXParseException</tdml:error>
-      <tdml:error>hasDocType-include.dfdl.xsd</tdml:error>
       <tdml:error>DOCTYPE is disallowed</tdml:error>
     </tdml:errors>
   </tdml:parserTestCase>
@@ -70,8 +68,6 @@
     <tdml:document/>
     <tdml:errors>
       <tdml:error>Schema Definition Error</tdml:error>
-      <tdml:error>org.xml.sax.SAXParseException</tdml:error>
-      <tdml:error>hasDocType-import.dfdl.xsd</tdml:error>
       <tdml:error>DOCTYPE is disallowed</tdml:error>
     </tdml:errors>
   </tdml:parserTestCase>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section02/schema_definition_errors/SchemaDefinitionErrors.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section02/schema_definition_errors/SchemaDefinitionErrors.tdml
@@ -224,8 +224,7 @@
 
   <tdml:parserTestCase name="schema_line_number" root="e1"
                        model="lineNumber.dfdl.xsd"
-                       description=""
-                       diagnosticsStripLocationInfo="false">
+                       description="">
     <tdml:document />
 
     <tdml:errors>
@@ -236,68 +235,6 @@
     </tdml:errors>
 
   </tdml:parserTestCase>
-
-  <tdml:parserTestCase name="schema_file_path" root="e1"
-                       model="lineNumber.dfdl.xsd"
-                       description=""
-                       diagnosticsStripLocationInfo="false">
-    <tdml:document />
-
-    <tdml:errors>
-      <tdml:error>Schema Definition Error</tdml:error>
-      <tdml:error>.../daffodil/section02/schema_definition_errors/lineNumber.dfdl.xsd</tdml:error>
-      <tdml:error>line 65</tdml:error>
-      <tdml:error>column 10</tdml:error>
-    </tdml:errors>
-
-  </tdml:parserTestCase>
-
-  <tdml:defineConfig name="cfg_maxParentDirectoriesForDiagnostics_1">
-    <daf:tunables xmlns="http://www.w3.org/2001/XMLSchema"
-                  xmlns:xs="http://www.w3.org/2001/XMLSchema">
-      <daf:maxParentDirectoriesForDiagnostics>2</daf:maxParentDirectoriesForDiagnostics>
-    </daf:tunables>
-  </tdml:defineConfig>
-
-  <tdml:parserTestCase name="schema_file_path_tunable_1" root="e1"
-                       model="lineNumber.dfdl.xsd"
-                       description=""
-                       config="cfg_maxParentDirectoriesForDiagnostics_1"
-                       diagnosticsStripLocationInfo="false">
-    <tdml:document />
-
-    <tdml:errors>
-      <tdml:error>Schema Definition Error</tdml:error>
-      <tdml:error>.../section02/schema_definition_errors/lineNumber.dfdl.xsd</tdml:error>
-      <tdml:error>line 65</tdml:error>
-      <tdml:error>column 10</tdml:error>
-    </tdml:errors>
-
-  </tdml:parserTestCase>
-
-  <tdml:defineConfig name="cfg_maxParentDirectoriesForDiagnostics_2">
-    <daf:tunables xmlns="http://www.w3.org/2001/XMLSchema"
-                  xmlns:xs="http://www.w3.org/2001/XMLSchema">
-      <daf:maxParentDirectoriesForDiagnostics>0</daf:maxParentDirectoriesForDiagnostics>
-    </daf:tunables>
-  </tdml:defineConfig>
-
-  <tdml:parserTestCase name="schema_file_path_tunable_2" root="e1"
-                       model="lineNumber.dfdl.xsd"
-                       description=""
-                       config="cfg_maxParentDirectoriesForDiagnostics_2"
-                       diagnosticsStripLocationInfo="false">
-    <tdml:document />
-
-    <tdml:errors>
-      <tdml:error>Schema Definition Error</tdml:error>
-      <tdml:error>.../lineNumber.dfdl.xsd</tdml:error>
-      <tdml:error>line 65</tdml:error>
-      <tdml:error>column 10</tdml:error>
-    </tdml:errors>
-
-  </tdml:parserTestCase>
-
 
   <!--
       Test Name: missing_closing_tag

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section06/namespaces/namespaces.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section06/namespaces/namespaces.tdml
@@ -715,8 +715,7 @@
 
   <tdml:parserTestCase name="long_chain_05" root="rabbitHole5"
                        model="multi_base_03.dfdl.xsd"
-                       description="import a schema - DFDL-6-007R"
-                       diagnosticsStripLocationInfo="false">
+                       description="import a schema - DFDL-6-007R">
     <tdml:document><![CDATA[5632]]></tdml:document>
     <tdml:errors>
       <tdml:error>Schema Definition Error</tdml:error>
@@ -1010,8 +1009,7 @@
         the
         error messages to specifically mention this file, not just show that
         it was included. -->
-      <tdml:error>file:</tdml:error>
-      <tdml:error>subfolder/multi_C_06_nons.dfdl.xsd</tdml:error>
+      <tdml:error>multi_C_06_nons.dfdl.xsd</tdml:error>
     </tdml:errors>
   </tdml:parserTestCase>
 
@@ -2144,8 +2142,7 @@
   -->
   <tdml:parserTestCase name="junkAnnotation01" root="x"
                        model="junk-annotation-01.dfdl.xsd"
-                       description="Diagnostic provides proper line number and file when a junk annotation is found - DFDL-6-007R"
-                       diagnosticsStripLocationInfo="false">
+                       description="Diagnostic provides proper line number and file when a junk annotation is found - DFDL-6-007R">
     <tdml:document />
     <tdml:errors>
       <tdml:error>Schema Definition Error</tdml:error>
@@ -2211,12 +2208,11 @@
 
   <tdml:parserTestCase name="errorLocations_01" root="rabbitHole"
                        model="multi_base_13.dfdl.xsd"
-                       description="import a schema - DFDL-6-007R"
-                       diagnosticsStripLocationInfo="false">
+                       description="import a schema - DFDL-6-007R">
     <tdml:document><![CDATA[temp]]></tdml:document>
       <tdml:errors>
         <tdml:error>nonExistent</tdml:error>
-        <tdml:error>namespaces/multi_C_13.dfdl.xsd</tdml:error>
+        <tdml:error>multi_C_13.dfdl.xsd</tdml:error>
       </tdml:errors>
   </tdml:parserTestCase>
   

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section23/dfdl_expressions/expression_fail.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section23/dfdl_expressions/expression_fail.tdml
@@ -67,7 +67,6 @@
     	<tdml:error>Error</tdml:error>
     	<tdml:error>loading</tdml:error>
     	<tdml:error>schema</tdml:error>
-    	<tdml:error>SAXParseException</tdml:error>
     	<tdml:error>not</tdml:error>
     	<tdml:error>facet-valid</tdml:error>
     	<tdml:error>dfdl:occursCount</tdml:error>

--- a/daffodil-test/src/test/scala/org/apache/daffodil/infoset/TestStringAsXml.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/infoset/TestStringAsXml.scala
@@ -44,7 +44,9 @@ class TestStringAsXml {
 
   private def compileSchema(dfdlSchemaURI: URI) = {
     val c = Compiler()
-    val pf = c.compileSource(URISchemaSource(dfdlSchemaURI))
+    val pf = c.compileSource(
+      URISchemaSource(Misc.uriToDiagnosticFile(dfdlSchemaURI), dfdlSchemaURI),
+    )
     val dp = pf.onPath("/")
     dp.withValidationMode(ValidationMode.Full)
   }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section02/schema_definition_errors/TestSDE.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section02/schema_definition_errors/TestSDE.scala
@@ -42,14 +42,6 @@ class TestSDE {
   @Test def test_schema_component_err(): Unit = { runner.runOneTest("schema_component_err") }
 
   @Test def test_schema_line_number(): Unit = { runner.runOneTest("schema_line_number") }
-  @Test def test_schema_file_path(): Unit = { runner.runOneTest("schema_file_path") }
-  @Test def test_schema_file_path_tunable_1(): Unit = {
-    runner.runOneTest("schema_file_path_tunable_1")
-  }
-  @Test def test_schema_file_path_tunable_2(): Unit = {
-    runner.runOneTest("schema_file_path_tunable_2")
-  }
-
   @Test def test_schema_warning(): Unit = { runner.runOneTest("schema_warning") }
   @Test def test_missing_appinfo_source(): Unit = {
     runner.runOneTest("missing_appinfo_source")


### PR DESCRIPTION
- update DFDLSchemaFile.uriString to remove any prefix from Classpath and replace $HOME with ~ using Misc helper function
- update systemId in SDE/SDW to replace $HOME with ~ using Misc helper function
- update/add tests

DAFFODIL-2195