### PR TITLE
Fix DPath conversion from double to unsigned long

### DIFF
--- a/daffodil-core/src/main/scala/org/apache/daffodil/core/dpath/Conversions.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/core/dpath/Conversions.scala
@@ -105,7 +105,7 @@ object Conversion {
       case (Double, NonNegativeInteger) =>
         DoubleToDecimal +: conversionOps(Decimal, tt, context)
       case (Double, Long) => List(DoubleToLong)
-      case (Double, UnsignedLong) => DoubleToUnsignedLong +: conversionOps(Long, tt, context)
+      case (Double, UnsignedLong) => List(DoubleToUnsignedLong)
       case (Double, i: Int.Kind) => DoubleToLong +: conversionOps(Long, tt, context)
       case (Double, ui: UnsignedInt.Kind) =>
         DoubleToUnsignedLong +: UnsignedLongToLong +: conversionOps(Long, tt, context)

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section17/calc_value_properties/inputValueCalc.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section17/calc_value_properties/inputValueCalc.tdml
@@ -464,6 +464,15 @@
         </xs:sequence>
       </xs:complexType>
     </xs:element>
+
+    <xs:element name="ivc_17_4">
+      <xs:complexType>
+        <xs:sequence>
+          <xs:element name="double" type="xs:double" />
+          <xs:element name="ivc_ulong_from_double" type="xs:unsignedLong" dfdl:inputValueCalc="{ ../ex:double }"/>
+        </xs:sequence>
+      </xs:complexType>
+    </xs:element>
     
     <xs:element name="ivc_18_1_a">
       <xs:complexType>
@@ -1073,6 +1082,20 @@
           <num>7</num>
           <ivc_ulong_range_max>18446744073709551615</ivc_ulong_range_max>
         </ivc_17_3>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="InputValueCalc_UnsignedLong_From_Double"
+    root="ivc_17_4" model="inputValueCalc-Embedded.dfdl.xsd">
+
+    <tdml:document>9.223372036854775808E18</tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <ivc_17_4>
+          <double>9.223372036854776E18</double>
+          <ivc_ulong_from_double>9223372036854775808</ivc_ulong_from_double>
+        </ivc_17_4>
       </tdml:dfdlInfoset>
     </tdml:infoset>
   </tdml:parserTestCase>

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section17/calc_value_properties/TestInputValueCalc.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section17/calc_value_properties/TestInputValueCalc.scala
@@ -113,6 +113,10 @@ class TestInputValueCalc {
     runner.runOneTest("InputValueCalc_UnsignedLong_Range_Max_Pass")
   }
 
+  @Test def test_InputValueCalc_UnsignedLong_From_Double(): Unit = {
+    runner.runOneTest("InputValueCalc_UnsignedLong_From_Double")
+  }
+
   // NOTE: These tests were modified to test both the CompileTime and RunTime side of expressions
   // when dealing with InputValueCalc.  Essentially, constant expressions are evaluated at compile time.
   // Non constant expressions are evaluated at run time.


### PR DESCRIPTION
A conversion from a source type of xs:double to a target type of xs:unsignedLong correctly inserts a DoubleToUnsignedLong converter, but follows that with an additional LongToUnsignedLong converter. This leads to an exception because LongToUnsignedLong expects to get a Long, but the DoubleToUnsignedLong converter has converted the value to a BigInt (the representation for an UnsignedLong).

The additional converter is not needed and is likely a copy/paste error. This removes the unneeded converter and allows the conversion to succeed.

DAFFODIL-2839