### PR TITLE
Remove support for dfdlx:repType/Values from unions

### DIFF
--- a/daffodil-test/src/test/resources/org/apache/daffodil/extensions/type_calc/inputTypeCalc.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/extensions/type_calc/inputTypeCalc.tdml
@@ -63,55 +63,11 @@
       </xs:restriction>
     </xs:simpleType>
 
-    <xs:simpleType name="_1_to_string" dfdlx:repType="tns:uint8">
-      <xs:restriction base="xs:string">
-        <xs:enumeration value="one" dfdlx:repValues="1"/>
-      </xs:restriction>
-    </xs:simpleType>
-
-    <xs:simpleType name="_2through100_to_string" dfdlx:repType="tns:uint8">
-      <xs:restriction base="xs:string">
-        <xs:enumeration value="2-100" dfdlx:repValueRanges="2 100"/>
-      </xs:restriction>
-    </xs:simpleType>
-
-    <xs:simpleType name="_1through100_union_to_string" >
-      <xs:union memberTypes="tns:_1_to_string tns:_2through100_to_string tns:unreachableRepTypeuint8" />
-    </xs:simpleType>
-
-    <xs:simpleType name="_2through100_to_int" dfdlx:repType="tns:uint8">
-      <xs:restriction base="xs:unsignedInt">
-        <xs:minInclusive value="2"/>
-        <xs:maxInclusive value="100"/>
-      </xs:restriction>
-    </xs:simpleType>
-
-    <!-- Used to verify that a branch of a choice statement is not considered. -->
-    <xs:simpleType name="unreachableRepTypeuint8" dfdlx:repType="tns:uint8">
-      <xs:annotation>
-        <xs:appinfo source="http://www.ogf.org/dfdl/">
-          <dfdl:discriminator>{ fn:true() }</dfdl:discriminator>
-        </xs:appinfo>
-      </xs:annotation>
-      <xs:restriction base="xs:string">
-        <xs:enumeration value="unreachable" dfdlx:repValues="-1"/>
-      </xs:restriction>
-    </xs:simpleType>
-
     <xs:simpleType name="complexSet_to_string" dfdlx:repType="tns:uint8">
       <xs:restriction base="xs:string">
         <xs:enumeration value="101 103-110 115 120-125" dfdlx:repValues="101 115" dfdlx:repValueRanges="103 110 120 125"/>
       </xs:restriction>
     </xs:simpleType>
-
-
-    <xs:element name="inputTypeCalc_unionOfKeysetValueCalcs_01">
-      <xs:complexType>
-        <xs:sequence>
-          <xs:element name="byte" type="tns:_1through100_union_to_string" maxOccurs="unbounded" dfdl:occursCountKind="parsed"/>
-        </xs:sequence>
-      </xs:complexType>
-    </xs:element>
 
   </tdml:defineSchema>
 
@@ -232,46 +188,6 @@
           <byte>2-100</byte>
           <byte>101 103-110 115 120-125</byte>
         </keysetValue_02>
-      </tdml:dfdlInfoset>
-    </tdml:infoset>
-  </tdml:unparserTestCase>
-
-  <tdml:parserTestCase name="InputTypeCalc_unionOfKeysetValueCalcs_01"
-    root="inputTypeCalc_unionOfKeysetValueCalcs_01" model="inputTypeCalc-Embedded.dfdl.xsd" description="Extensions - repType with union of keysetValue types">
-
-    <tdml:document>
-    <tdml:documentPart type="byte">
-    01 02 03 64
-    </tdml:documentPart>
-    </tdml:document>
-    <tdml:infoset>
-      <tdml:dfdlInfoset xmlns:xs="http://www.w3.org/2001/XMLSchema"
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-        <inputTypeCalc_unionOfKeysetValueCalcs_01>
-          <byte>one</byte>
-          <byte>2-100</byte>
-          <byte>2-100</byte>
-          <byte>2-100</byte>
-        </inputTypeCalc_unionOfKeysetValueCalcs_01>
-      </tdml:dfdlInfoset>
-    </tdml:infoset>
-  </tdml:parserTestCase>
-
-  <tdml:unparserTestCase name="InputTypeCalc_unparse_unionOfKeysetValueCalcs_01"
-    root="inputTypeCalc_unionOfKeysetValueCalcs_01" model="inputTypeCalc-Embedded.dfdl.xsd" description="Extensions - repType with union of keysetValue types">
-
-    <tdml:document>
-    <tdml:documentPart type="byte">
-    01 02
-    </tdml:documentPart>
-    </tdml:document>
-    <tdml:infoset>
-      <tdml:dfdlInfoset xmlns:xs="http://www.w3.org/2001/XMLSchema"
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-        <inputTypeCalc_unionOfKeysetValueCalcs_01>
-          <byte>one</byte>
-          <byte>2-100</byte>
-        </inputTypeCalc_unionOfKeysetValueCalcs_01>
       </tdml:dfdlInfoset>
     </tdml:infoset>
   </tdml:unparserTestCase>

--- a/daffodil-test/src/test/scala/org/apache/daffodil/extensions/TestInputTypeValueCalc.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/extensions/TestInputTypeValueCalc.scala
@@ -55,13 +55,6 @@ class TestInputTypeValueCalc {
     runner.runOneTest("InputTypeCalc_unparse_keysetValue_02")
   }
 
-  @Test def test_InputTypeCalc_unionOfKeysetValueCalcs_01(): Unit = {
-    runner.runOneTest("InputTypeCalc_unionOfKeysetValueCalcs_01")
-  }
-  @Test def test_InputTypeCalc_unparse_unionOfKeysetValueCalcs_01(): Unit = {
-    runner.runOneTest("InputTypeCalc_unparse_unionOfKeysetValueCalcs_01")
-  }
-
   @Test def test_inherited_LengthKind(): Unit = { runner.runOneTest("inherited_LengthKind") }
 
   @Test def test_valueNotFound_1(): Unit = { runner.runOneTest("valueNotFound_1") }


### PR DESCRIPTION
dfdlx:repTypex on simpleTypes references from unions are now ignored. Likewise, dfdlx:repValues and dfdlx:repValueRanges are also ignored. Unions are now only used for combining restrictions from their simple types.

Deprecation/Compatibility:

dfdlx:repType, dfdlx:repValues, and dfdlx:repValueRanges are now ignored if references on xs:simpleTypes that are referenced from xs:unions. Instead, unions should be combined into a single simple type with the combined representation type and values properties.

DAFFODIL-2211