### PR TITLE
Update testHex2BytesValid test

### DIFF
--- a/daffodil-lib/src/test/scala/org/apache/daffodil/lib/util/TestMisc.scala
+++ b/daffodil-lib/src/test/scala/org/apache/daffodil/lib/util/TestMisc.scala
@@ -48,7 +48,7 @@ class TestMisc {
   @Test def testHex2BytesValid(): Unit = {
     assertArrayEquals(Array(0).map(_.toByte), Misc.hex2Bytes("00"))
     assertArrayEquals(Array(9).map(_.toByte), Misc.hex2Bytes("09"))
-    assertArrayEquals(Array(10).map(_.toByte), Misc.hex2Bytes("0a"))
+    assertArrayEquals(Array(10).map(_.toByte), Misc.hex2Bytes("0A"))
     assertArrayEquals(Array(15).map(_.toByte), Misc.hex2Bytes("0F"))
     assertArrayEquals(Array(10).map(_.toByte), Misc.hex2Bytes("0a"))
     assertArrayEquals(Array(15).map(_.toByte), Misc.hex2Bytes("0f"))


### PR DESCRIPTION
Update textHex2BytesValid test to remove duplicate case.

TestMisc.scala: Update tests for Misc.hex2Bytes function.

[DAFFODIL-2834](https://issues.apache.org/jira/browse/DAFFODIL-2834)