### PR TITLE
Replace Scala Maps with Java Maps to in choice parsers to avoid bad diagnostics

### DIFF
--- a/daffodil-core/src/main/scala/org/apache/daffodil/core/grammar/primitives/ChoiceCombinator.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/core/grammar/primitives/ChoiceCombinator.scala
@@ -31,6 +31,8 @@ import org.apache.daffodil.lib.cookers.IntRangeCooker
 import org.apache.daffodil.lib.exceptions.Assert
 import org.apache.daffodil.lib.schema.annotation.props.gen.ChoiceLengthKind
 import org.apache.daffodil.lib.util.MaybeInt
+import org.apache.daffodil.lib.util.ProperlySerializableMap._
+import org.apache.daffodil.runtime1.infoset.ChoiceBranchEvent
 import org.apache.daffodil.runtime1.processors.RangeBound
 import org.apache.daffodil.runtime1.processors.parsers._
 import org.apache.daffodil.runtime1.processors.unparsers._
@@ -246,7 +248,9 @@ case class ChoiceCombinator(ch: ChoiceTermBase, alternatives: Seq[Gram])
           }
         (parser, isRepresented)
       }
-      val serializableMap: Map[String, (Parser, Boolean)] = dispatchBranchKeyMap.map(identity)
+
+      val serializableMap: ProperlySerializableMap[String, (Parser, Boolean)] =
+        dispatchBranchKeyMap.toProperlySerializableMap
       val serializableKeyRangeMap: Vector[(RangeBound, RangeBound, Parser, Boolean)] =
         dispatchBranchKeyRangeTuples.toVector.map(identity)
 
@@ -319,7 +323,9 @@ case class ChoiceCombinator(ch: ChoiceTermBase, alternatives: Seq[Gram])
         branchForUnparse.get
       }
     } else {
-      val cbm = ChoiceBranchMap(eventUnparserMap, branchForUnparse)
+      val serializableMap: ProperlySerializableMap[ChoiceBranchEvent, Unparser] =
+        eventUnparserMap.toProperlySerializableMap
+      val cbm = ChoiceBranchMap(serializableMap, branchForUnparse)
       new ChoiceCombinatorUnparser(ch.modelGroupRuntimeData, cbm, choiceLengthInBits)
     }
   }

--- a/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/unparsers/runtime1/ChoiceAndOtherVariousUnparsers.scala
+++ b/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/unparsers/runtime1/ChoiceAndOtherVariousUnparsers.scala
@@ -17,23 +17,26 @@
 
 package org.apache.daffodil.unparsers.runtime1
 
+import scala.collection.JavaConverters._
+
 import org.apache.daffodil.lib.util.Maybe
 import org.apache.daffodil.lib.util.Maybe._
 import org.apache.daffodil.lib.util.MaybeInt
+import org.apache.daffodil.lib.util.ProperlySerializableMap._
 import org.apache.daffodil.runtime1.infoset._
 import org.apache.daffodil.runtime1.processors.RuntimeData
 import org.apache.daffodil.runtime1.processors._
 import org.apache.daffodil.runtime1.processors.unparsers._
 
 case class ChoiceBranchMap(
-  lookupTable: Map[ChoiceBranchEvent, Unparser],
+  lookupTable: ProperlySerializableMap[ChoiceBranchEvent, Unparser],
   unmappedDefault: Option[Unparser],
 ) extends Serializable {
 
   def get(cbe: ChoiceBranchEvent): Maybe[Unparser] = {
     val fromTable = lookupTable.get(cbe)
     val res =
-      if (fromTable.isDefined) One(fromTable.get)
+      if (fromTable != null) One(fromTable)
       else {
         //
         // There must be an unmapped default in this case
@@ -49,9 +52,9 @@ case class ChoiceBranchMap(
 
   def defaultUnparser = unmappedDefault
 
-  def childProcessors = lookupTable.values.toSeq ++ unmappedDefault
+  def childProcessors = lookupTable.values.iterator.asScala.toVector ++ unmappedDefault
 
-  def keys = lookupTable.keys
+  def keys = lookupTable.keySet.asScala
 }
 
 /*


### PR DESCRIPTION
When Scala serializes a Map, it uses writeReplace() to actually serialize a HashMap$SerializationProxy object. There appears to be a bug in the deserialization of this proxy object which can lead to very confusing diagnostics if classpaths are not set up correctly when reloading a saved parser.

For example, if a layer transformer is not on the classpath when reloading, you could get an error mentioning only this HashMap$SerializationProxy and the ChoiceCombinator parser. It is not clear at all that the core issue is a layer transformer is not on the classpath.

To fix this, this changes the choice combinator parsers and unparsers to use Java Maps instead. This do not have the deserialization issues that Scala Maps have. Now, if a layer transformer is not on the classpath you get a much more helpful diagnostic stating the saved parser was "created with a different set of dependencies containing a class no longer on the classpath", and includes the actual transformer factory class name, making it much more clear what the problem is.

DAFFODIL-2728