### PR TITLE
Use the correct namespace for the quasi repType element

### DIFF
--- a/daffodil-core/src/main/scala/org/apache/daffodil/core/grammar/RepTypeMixin.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/core/grammar/RepTypeMixin.scala
@@ -61,7 +61,7 @@ trait RepTypeMixin { self: ElementBase =>
     hasRT
   }.value
 
-  private lazy val repTypeGSTD: GlobalSimpleTypeDef = LV('prefixLengthTypeGSTD) {
+  private lazy val repTypeGSTD: GlobalSimpleTypeDef = LV('repTypeGSTD) {
     // throws an SDE if the simple type def is not found or if it is not a simple type (e.g. a
     // primitive type)
     val gstd = schemaSet.getGlobalSimpleTypeDefNoPrim(repType, "dfdlx:repType", this)
@@ -75,11 +75,18 @@ trait RepTypeMixin { self: ElementBase =>
   }.value
 
   lazy val repTypeElementDecl: RepTypeQuasiElementDecl = LV('repTypeElementDecl) {
+    // this quasi element must use the in-scope namespaces from where the repType property was
+    // defined, which isn't necessarily the same as the in-scope namespaces on this element,
+    // since the repType property could be defined on a simpleType in another file with
+    // completely different namesapce prefixes. This information is available on the Found
+    // class, but the generated property code does not make that available for repType, so we
+    // must manually do a lookup here.
+    val repTypeNamespaces = findProperty("repType").location.namespaces
     val xmlElem = Elem(
       null,
       "QuasiElementForRepType",
       new UnprefixedAttribute("type", repType.toString, Null),
-      namespaces,
+      repTypeNamespaces,
       true,
     )
     RepTypeQuasiElementDecl(xmlElem, repTypeGSTD)

--- a/daffodil-test/src/test/resources/org/apache/daffodil/extensions/repType/repType.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/extensions/repType/repType.tdml
@@ -921,4 +921,15 @@
     </tdml:errors>
   </tdml:parserTestCase>
 
+  <tdml:parserTestCase name="repType_different_namespaces_01" model="repType_01_a.dfdl.xsd">
+    <tdml:document>
+      <tdml:documentPart type="byte">01</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <a:value xmlns:a="http://example.com">one</a:value>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
 </tdml:testSuite>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/extensions/repType/repType_01_a.dfdl.xsd
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/extensions/repType/repType_01_a.dfdl.xsd
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<schema
+  xmlns="http://www.w3.org/2001/XMLSchema"
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/"
+  xmlns:a="http://example.com"
+  targetNamespace="http://example.com"
+  elementFormDefault="unqualified">
+
+  <include schemaLocation="/org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd" />
+
+  <include schemaLocation="repType_01_b.dfdl.xsd" />
+
+  <annotation>
+    <appinfo source="http://www.ogf.org/dfdl/">
+      <dfdl:format ref="a:GeneralFormat"/>
+    </appinfo>
+  </annotation>
+
+  <element name="value" type="a:valueType" />
+
+</schema>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/extensions/repType/repType_01_b.dfdl.xsd
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/extensions/repType/repType_01_b.dfdl.xsd
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<schema
+  xmlns="http://www.w3.org/2001/XMLSchema"
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/"
+  xmlns:dfdlx="http://www.ogf.org/dfdl/dfdl-1.0/extensions"
+  xmlns:b="http://example.com"
+  targetNamespace="http://example.com"
+  elementFormDefault="unqualified">
+
+  <include schemaLocation="/org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd" />
+
+  <annotation>
+    <appinfo source="http://www.ogf.org/dfdl/">
+      <dfdl:format ref="b:GeneralFormat" representation="binary" />
+    </appinfo>
+  </annotation>
+
+  <simpleType name="repType" dfdl:lengthKind="explicit" dfdl:length="1">
+    <restriction base="xs:int" />
+  </simpleType>
+
+  <simpleType name="valueType" dfdlx:repType="b:repType">
+    <restriction base="xs:string">
+      <enumeration value="zero" dfdlx:repValues="0"/>
+      <enumeration value="one" dfdlx:repValues="1"/>
+    </restriction>
+  </simpleType>
+
+</schema>

--- a/daffodil-test/src/test/scala/org/apache/daffodil/extensions/TestRepType.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/extensions/TestRepType.scala
@@ -103,4 +103,8 @@ class TestRepType {
   @Test def test_repType_hiddenGroup_01(): Unit = {
     runner.runOneTest("repType_hiddenGroup_01")
   }
+
+  @Test def test_repType_different_namespaces_01(): Unit = {
+    runner.runOneTest("repType_different_namespaces_01")
+  }
 }


### PR DESCRIPTION
When a repType property exists for an element, we create a new quasi schema element that has its type attribute set to the value of the repType attribute. This quasi element is then used to generate a repType parser from.

Currently, the namespace used for this quasi element is the in-scope namespace for the element that has a the repType property. But it is possible that that repType property is defind on a simple type in another file with a completely different namespace. This means this quasi element could use the wrong namspace, which can lead to failure to find the repType and confusing diagnostics.

To fix this, instead of using the in-scope namespace from the element using a repType, we instead use the in-scope namespace from where the repType was actually defined.

DAFFODIL-2857