### PR TITLE
Make code gen support EmptyGram

### DIFF
--- a/daffodil-codegen-c/src/main/scala/org/apache/daffodil/codegen/c/DaffodilCCodeGenerator.scala
+++ b/daffodil-codegen-c/src/main/scala/org/apache/daffodil/codegen/c/DaffodilCCodeGenerator.scala
@@ -259,6 +259,9 @@ object DaffodilCCodeGenerator
    */
   def generateCode(gram: Gram, cgState: CodeGeneratorState): Unit = {
     gram match {
+      // Skip empty grams
+      case g: Gram if g.isEmpty => noop(g)
+      // Handle non-empty grams
       case g: AlignmentFill => alignmentFillGenerateCode(g, cgState)
       case g: AssertBooleanPrim => noop(g)
       case g: BinaryBoolean => binaryBooleanGenerateCode(g.e, cgState)


### PR DESCRIPTION
Fix the Daffodil C code generator to stop crashing on someone's private DFDL schema.  Their schema is private and too large to include, but somehow it creates an EmptyGram object.  Make sure the code gen recognizes the EmptyGram object instead of crashing when seeing it.

c/DaffodilCCodeGenerator.scala: Add clause to support EmptyGram.

DAFFODIL-2863