### PR TITLE
Remove numbers from CLI integration test names

### DIFF
--- a/daffodil-cli/src/test/scala/org/apache/daffodil/cli/cliTest/TestCLIParsing.scala
+++ b/daffodil-cli/src/test/scala/org/apache/daffodil/cli/cliTest/TestCLIParsing.scala
@@ -34,7 +34,7 @@ class TestCLIParsing {
     }(ExitCode.Success)
   }
 
-  @Test def test_3677_CLI_Parsing_elementFormDefault_qualified(): Unit = {
+  @Test def test_CLI_Parsing_elementFormDefault_qualified(): Unit = {
     val schema = path(
       "daffodil-test/src/test/resources/org/apache/daffodil/section00/general/elementFormDefaultQualified.dfdl.xsd",
     )
@@ -45,7 +45,7 @@ class TestCLIParsing {
     }(ExitCode.LeftOverData)
   }
 
-  @Test def test_3678_CLI_Parsing_elementFormDefault_unqualified(): Unit = {
+  @Test def test_CLI_Parsing_elementFormDefault_unqualified(): Unit = {
     val schema = path(
       "daffodil-test/src/test/resources/org/apache/daffodil/section00/general/elementFormDefaultUnqualified.dfdl.xsd",
     )
@@ -56,7 +56,7 @@ class TestCLIParsing {
     }(ExitCode.LeftOverData)
   }
 
-  @Test def test_2358_CLI_Parsing_SimpleParse_stdOut_extVars(): Unit = {
+  @Test def test_CLI_Parsing_SimpleParse_stdOut_extVars(): Unit = {
     val schema = path(
       "daffodil-test/src/test/resources/org/apache/daffodil/section07/external_variables/external_variables.dfdl.xsd",
     )
@@ -71,7 +71,7 @@ class TestCLIParsing {
     }(ExitCode.Success)
   }
 
-  @Test def test_3507_CLI_Parsing_SimpleParse_SaveParser_extVars(): Unit = {
+  @Test def test_CLI_Parsing_SimpleParse_SaveParser_extVars(): Unit = {
     withTempFile { parser =>
       val schema = path(
         "daffodil-test/src/test/resources/org/apache/daffodil/section07/external_variables/external_variables.dfdl.xsd",
@@ -98,7 +98,7 @@ class TestCLIParsing {
     }
   }
 
-  @Test def test_2360_CLI_Parsing_SimpleParse_stdOut_extVars2(): Unit = {
+  @Test def test_CLI_Parsing_SimpleParse_stdOut_extVars2(): Unit = {
     val schema = path(
       "daffodil-test/src/test/resources/org/apache/daffodil/section07/external_variables/external_variables.dfdl.xsd",
     )
@@ -114,7 +114,7 @@ class TestCLIParsing {
     }(ExitCode.LeftOverData)
   }
 
-  @Test def test_3506_CLI_Parsing_SimpleParse_extVars2(): Unit = {
+  @Test def test_CLI_Parsing_SimpleParse_extVars2(): Unit = {
     withTempFile { parser =>
       val schema = path(
         "daffodil-test/src/test/resources/org/apache/daffodil/section07/external_variables/external_variables.dfdl.xsd",
@@ -150,7 +150,7 @@ class TestCLIParsing {
     }(ExitCode.BadExternalVariable)
   }
 
-  @Test def test_3227_CLI_Parsing_SimpleParse_DFDL1197_fix(): Unit = {
+  @Test def test_CLI_Parsing_SimpleParse_DFDL1197_fix(): Unit = {
     val schema = path(
       "daffodil-test/src/test/resources/org/apache/daffodil/section12/delimiter_properties/testOptionalInfix.dfdl.xsd",
     )
@@ -161,7 +161,7 @@ class TestCLIParsing {
     }(ExitCode.LeftOverData)
   }
 
-  @Test def test_1593_CLI_Parsing_MultifileSchema_noGlobalElem(): Unit = {
+  @Test def test_CLI_Parsing_MultifileSchema_noGlobalElem(): Unit = {
     val schema = path(
       "daffodil-test/src/test/resources/org/apache/daffodil/section06/namespaces/multi_base_21.dfdl.xsd",
     )
@@ -181,7 +181,7 @@ class TestCLIParsing {
   //  TDML tests do not verify this part of expected infosets. This is one test
   //  verifies the expected output. If this test fails, it likely means we've
   //  broken our attempts to create consistent prefix mappings.
-  @Test def test_1585_CLI_Parsing_MultifileSchema_methodImportSameDir(): Unit = {
+  @Test def test_CLI_Parsing_MultifileSchema_methodImportSameDir(): Unit = {
     val schema = path(
       "daffodil-test/src/test/resources/org/apache/daffodil/section06/namespaces/multi_base_14.dfdl.xsd",
     )
@@ -196,7 +196,7 @@ class TestCLIParsing {
     }(ExitCode.Success)
   }
 
-  @Test def test_1586_CLI_Parsing_MultifileSchema_methodIncludeSameDir(): Unit = {
+  @Test def test_CLI_Parsing_MultifileSchema_methodIncludeSameDir(): Unit = {
     val schema = path(
       "daffodil-test/src/test/resources/org/apache/daffodil/section06/namespaces/multi_base_15.dfdl.xsd",
     )
@@ -208,7 +208,7 @@ class TestCLIParsing {
     }(ExitCode.Success)
   }
 
-  @Test def test_1587_CLI_Parsing_MultifileSchema_methodImportSameDir2(): Unit = {
+  @Test def test_CLI_Parsing_MultifileSchema_methodImportSameDir2(): Unit = {
     val schema = path(
       "daffodil-test/src/test/resources/org/apache/daffodil/section06/namespaces/multi_base_16.dfdl.xsd",
     )
@@ -220,7 +220,7 @@ class TestCLIParsing {
     }(ExitCode.Success)
   }
 
-  @Test def test_1317_IBMCompatibility_ABC_test_ibm_abc_cli(): Unit = {
+  @Test def test_CLI_IBMCompatibility_ABC_test_ibm_abc(): Unit = {
     val schema = path(
       "daffodil-test/src/test/resources/org/apache/daffodil/section06/namespaces/ABC_IBM.dfdl.xsd",
     )
@@ -232,7 +232,7 @@ class TestCLIParsing {
     }(ExitCode.Success)
   }
 
-  @Test def test_977_CLI_Parsing_SimpleParse_stdOut(): Unit = {
+  @Test def test_CLI_Parsing_SimpleParse_stdOut(): Unit = {
     val schema = path(
       "daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/charClassEntities.dfdl.xsd",
     )
@@ -243,7 +243,7 @@ class TestCLIParsing {
     }(ExitCode.LeftOverData)
   }
 
-  @Test def test_978_CLI_Parsing_SimpleParse_outFile(): Unit = {
+  @Test def test_CLI_Parsing_SimpleParse_outFile(): Unit = {
     withTempFile { output =>
       val schema = path(
         "daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/charClassEntities.dfdl.xsd",
@@ -258,7 +258,7 @@ class TestCLIParsing {
     }
   }
 
-  @Test def test_979_CLI_Parsing_SimpleParse_inFile(): Unit = {
+  @Test def test_CLI_Parsing_SimpleParse_inFile(): Unit = {
     val schema = path(
       "daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/charClassEntities.dfdl.xsd",
     )
@@ -269,7 +269,7 @@ class TestCLIParsing {
     }(ExitCode.Success)
   }
 
-  @Test def test_980_CLI_Parsing_SimpleParse_stOutDash(): Unit = {
+  @Test def test_CLI_Parsing_SimpleParse_stOutDash(): Unit = {
     val schema = path(
       "daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/charClassEntities.dfdl.xsd",
     )
@@ -280,7 +280,7 @@ class TestCLIParsing {
     }(ExitCode.Success)
   }
 
-  @Test def test_981_CLI_Parsing_SimpleParse_stdInDash(): Unit = {
+  @Test def test_CLI_Parsing_SimpleParse_stdInDash(): Unit = {
     val schema = path(
       "daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/charClassEntities.dfdl.xsd",
     )
@@ -291,7 +291,7 @@ class TestCLIParsing {
     }(ExitCode.LeftOverData)
   }
 
-  @Test def test_983_CLI_Parsing_SimpleParse_verboseMode(): Unit = {
+  @Test def test_CLI_Parsing_SimpleParse_verboseMode(): Unit = {
     val schema = path(
       "daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/charClassEntities.dfdl.xsd",
     )
@@ -307,14 +307,14 @@ class TestCLIParsing {
     }(ExitCode.LeftOverData)
   }
 
-  @Test def test_984_CLI_Parsing_negativeTest(): Unit = {
+  @Test def test_CLI_Parsing_negativeTest(): Unit = {
     runCLI(args"parse") { cli =>
       cli.sendLine("0,1,2,3", inputDone = true)
       cli.expectErr("There should be exactly one of the following options: schema, parser")
     }(ExitCode.Usage)
   }
 
-  @Test def test_985_CLI_Parsing_SimpleParse_defaultRoot(): Unit = {
+  @Test def test_CLI_Parsing_SimpleParse_defaultRoot(): Unit = {
     val schema = path(
       "daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/charClassEntities.dfdl.xsd",
     )
@@ -325,7 +325,7 @@ class TestCLIParsing {
     }(ExitCode.LeftOverData)
   }
 
-  @Test def test_988_CLI_Parsing_SimpleParse_specifiedRoot(): Unit = {
+  @Test def test_CLI_Parsing_SimpleParse_specifiedRoot(): Unit = {
     val schema = path(
       "daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/charClassEntities.dfdl.xsd",
     )
@@ -338,7 +338,7 @@ class TestCLIParsing {
     }(ExitCode.LeftOverData)
   }
 
-  @Test def test_996_CLI_Parsing_negativeTest04(): Unit = {
+  @Test def test_CLI_Parsing_negativeTest04(): Unit = {
     val schema = path(
       "daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/charClassEntities.dfdl.xsd",
     )
@@ -349,7 +349,7 @@ class TestCLIParsing {
     }(ExitCode.UnableToCreateProcessor)
   }
 
-  @Test def test_997_CLI_Parsing_multSchemas(): Unit = {
+  @Test def test_CLI_Parsing_multSchemas(): Unit = {
     val schema1 = path(
       "daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/charClassEntities.dfdl.xsd",
     )
@@ -363,7 +363,7 @@ class TestCLIParsing {
     }(ExitCode.Usage)
   }
 
-  @Test def test_3661_CLI_Parsing_badSchemaPath(): Unit = {
+  @Test def test_CLI_Parsing_badSchemaPath(): Unit = {
     val schema = path(
       "daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/doesnotexist.dfdl.xsd",
     )
@@ -375,7 +375,7 @@ class TestCLIParsing {
     }(ExitCode.Usage)
   }
 
-  @Test def test_1002_CLI_Parsing_negativeTest03(): Unit = {
+  @Test def test_CLI_Parsing_negativeTest03(): Unit = {
 
     runCLI(args"parse -P parserThatDoesNotExist") { cli =>
       cli.sendLine("0,1,2", inputDone = true)
@@ -383,7 +383,7 @@ class TestCLIParsing {
     }(ExitCode.FileNotFound)
   }
 
-  @Test def test_1003_CLI_Parsing_SimpleParse_emptyNamespace(): Unit = {
+  @Test def test_CLI_Parsing_SimpleParse_emptyNamespace(): Unit = {
     val schema = path(
       "daffodil-test/src/test/resources/org/apache/daffodil/section07/defineFormat/defineFormat.dfdl.xsd",
     )
@@ -394,7 +394,7 @@ class TestCLIParsing {
     }(ExitCode.Success)
   }
 
-  @Test def test_1004_CLI_Parsing_SimpleParse_namespaceUsed(): Unit = {
+  @Test def test_CLI_Parsing_SimpleParse_namespaceUsed(): Unit = {
     val schema = path(
       "daffodil-cli/src/test/resources/org/apache/daffodil/cli/charClassEntities.dfdl.xsd",
     )
@@ -406,7 +406,7 @@ class TestCLIParsing {
     }(ExitCode.Success)
   }
 
-  @Test def test_2615_CLI_Parsing_SimpleParse_namespaceUsedLongOpt(): Unit = {
+  @Test def test_CLI_Parsing_SimpleParse_namespaceUsedLongOpt(): Unit = {
     val schema = path(
       "daffodil-cli/src/test/resources/org/apache/daffodil/cli/charClassEntities.dfdl.xsd",
     )
@@ -418,7 +418,7 @@ class TestCLIParsing {
     }(ExitCode.Success)
   }
 
-  @Test def test_1005_CLI_Parsing_SimpleParse_rootPath(): Unit = {
+  @Test def test_CLI_Parsing_SimpleParse_rootPath(): Unit = {
     val schema = path(
       "daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/charClassEntities.dfdl.xsd",
     )
@@ -431,7 +431,7 @@ class TestCLIParsing {
     }(ExitCode.Success)
   }
 
-  @Test def test_1015_CLI_Parsing_SimpleParse_defaultRootMultSchema(): Unit = {
+  @Test def test_CLI_Parsing_SimpleParse_defaultRootMultSchema(): Unit = {
     val schema = path(
       "daffodil-test/src/test/resources/org/apache/daffodil/section07/defineFormat/defineFormat.dfdl.xsd",
     )
@@ -442,7 +442,7 @@ class TestCLIParsing {
     }(ExitCode.Success)
   }
 
-  @Test def test_XXX_CLI_Parsing_SimpleSchema_basicTest_validationOn(): Unit = {
+  @Test def test_CLI_Parsing_SimpleSchema_basicTest_validationOn(): Unit = {
     val schema = path(
       "daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/charClassEntities.dfdl.xsd",
     )
@@ -453,7 +453,7 @@ class TestCLIParsing {
     }(ExitCode.LeftOverData)
   }
 
-  @Test def test_XXX_CLI_Parsing_SimpleSchema_basicTest_validation_missing_mode(): Unit = {
+  @Test def test_CLI_Parsing_SimpleSchema_basicTest_validation_missing_mode(): Unit = {
     val schema = path(
       "daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/charClassEntities.dfdl.xsd",
     )
@@ -466,7 +466,7 @@ class TestCLIParsing {
     }(ExitCode.Usage)
   }
 
-  @Test def test_XXX_CLI_Parsing_SimpleSchema_basicTest_validationLimited(): Unit = {
+  @Test def test_CLI_Parsing_SimpleSchema_basicTest_validationLimited(): Unit = {
     val schema = path(
       "daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/charClassEntities.dfdl.xsd",
     )
@@ -477,7 +477,7 @@ class TestCLIParsing {
     }(ExitCode.LeftOverData)
   }
 
-  @Test def test_XXX_CLI_Parsing_SimpleSchema_basicTest_validationOff(): Unit = {
+  @Test def test_CLI_Parsing_SimpleSchema_basicTest_validationOff(): Unit = {
     val schema = path(
       "daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/charClassEntities.dfdl.xsd",
     )
@@ -488,7 +488,7 @@ class TestCLIParsing {
     }(ExitCode.LeftOverData)
   }
 
-  @Test def test_XXX_CLI_Parsing_SimpleSchema_basicTest_validationFooBar(): Unit = {
+  @Test def test_CLI_Parsing_SimpleSchema_basicTest_validationFooBar(): Unit = {
     val schema = path(
       "daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/charClassEntities.dfdl.xsd",
     )
@@ -499,7 +499,7 @@ class TestCLIParsing {
     }(ExitCode.Usage)
   }
 
-  @Test def test_1319_CLI_Parsing_invalidElementSDE(): Unit = {
+  @Test def test_CLI_Parsing_invalidElementSDE(): Unit = {
     val schema = path(
       "daffodil-cli/src/test/resources/org/apache/daffodil/cli/ABC_IBM_invalid.dfdl.xsd",
     )
@@ -510,7 +510,7 @@ class TestCLIParsing {
     }(ExitCode.UnableToCreateProcessor)
   }
 
-  @Test def test_1346_CLI_Parsing_SimpleParse_defaultRootMultSchemaMultiple(): Unit = {
+  @Test def test_CLI_Parsing_SimpleParse_defaultRootMultSchemaMultiple(): Unit = {
     val schema = path(
       "daffodil-test/src/test/resources/org/apache/daffodil/section07/defineFormat/defineFormat.dfdl.xsd",
     )
@@ -522,14 +522,14 @@ class TestCLIParsing {
     }
   }
 
-  @Test def test_1386_CLI_Parsing_negativeTest05(): Unit = {
+  @Test def test_CLI_Parsing_negativeTest05(): Unit = {
     runCLI(args"") { cli =>
       cli.sendLine("12", inputDone = true)
       cli.expectErr("Subcommand required")
     }(ExitCode.Usage)
   }
 
-  @Test def test_1971_CLI_Parsing_traceMode01(): Unit = {
+  @Test def test_CLI_Parsing_traceMode01(): Unit = {
     val schema = path(
       "daffodil-test/src/test/resources/org/apache/daffodil/section06/namespaces/multi_base_15.dfdl.xsd",
     )
@@ -540,7 +540,7 @@ class TestCLIParsing {
     }(ExitCode.Success)
   }
 
-  @Test def test_1973_CLI_Parsing_traceMode03(): Unit = {
+  @Test def test_CLI_Parsing_traceMode03(): Unit = {
     val schema = path(
       "daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/charClassEntities.dfdl.xsd",
     )
@@ -553,7 +553,7 @@ class TestCLIParsing {
     }(ExitCode.LeftOverData)
   }
 
-  @Test def test_1941_CLI_Parsing_SimpleParse_leftOverData(): Unit = {
+  @Test def test_CLI_Parsing_SimpleParse_leftOverData(): Unit = {
     val schema = path(
       "daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/charClassEntities.dfdl.xsd",
     )
@@ -689,7 +689,7 @@ class TestCLIParsing {
     }(ExitCode.Success)
   }
 
-  @Test def test_3606_CLI_Parsing_SimpleParse_largeInfoset(): Unit = {
+  @Test def test_CLI_Parsing_SimpleParse_largeInfoset(): Unit = {
     val schema = path(
       "daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/charClassEntities.dfdl.xsd",
     )
@@ -740,7 +740,7 @@ class TestCLIParsing {
     }
   }
 
-  @Test def test_XXX_CLI_Parsing_Stream_01(): Unit = {
+  @Test def test_CLI_Parsing_Stream_01(): Unit = {
     val schema = path(
       "daffodil-cli/src/test/resources/org/apache/daffodil/cli/cli_schema_02.dfdl.xsd",
     )
@@ -753,7 +753,7 @@ class TestCLIParsing {
     }(ExitCode.Success)
   }
 
-  @Test def test_XXX_CLI_Parsing_Stream_02(): Unit = {
+  @Test def test_CLI_Parsing_Stream_02(): Unit = {
     val schema = path(
       "daffodil-cli/src/test/resources/org/apache/daffodil/cli/cli_schema_02.dfdl.xsd",
     )
@@ -768,7 +768,7 @@ class TestCLIParsing {
     }(ExitCode.LeftOverData)
   }
 
-  @Test def test_XXX_CLI_Parsing_Stream_03(): Unit = {
+  @Test def test_CLI_Parsing_Stream_03(): Unit = {
     val schema = path(
       "daffodil-cli/src/test/resources/org/apache/daffodil/cli/cli_schema_02.dfdl.xsd",
     )
@@ -800,7 +800,7 @@ class TestCLIParsing {
     }
   }
 
-  @Test def test_XXX_CLI_Parsing_SimpleParse_w3cdom(): Unit = {
+  @Test def test_CLI_Parsing_SimpleParse_w3cdom(): Unit = {
     val schema = path(
       "daffodil-test/src/test/resources/org/apache/daffodil/section00/general/generalSchema.dfdl.xsd",
     )
@@ -811,7 +811,7 @@ class TestCLIParsing {
     }(ExitCode.Success)
   }
 
-  @Test def test_XXX_CLI_Parsing_SimpleParse_jdom(): Unit = {
+  @Test def test_CLI_Parsing_SimpleParse_jdom(): Unit = {
     val schema = path(
       "daffodil-test/src/test/resources/org/apache/daffodil/section00/general/generalSchema.dfdl.xsd",
     )
@@ -822,7 +822,7 @@ class TestCLIParsing {
     }(ExitCode.Success)
   }
 
-  @Test def test_XXX_CLI_Parsing_SimpleParse_scala_xml(): Unit = {
+  @Test def test_CLI_Parsing_SimpleParse_scala_xml(): Unit = {
     val schema = path(
       "daffodil-test/src/test/resources/org/apache/daffodil/section00/general/generalSchema.dfdl.xsd",
     )
@@ -833,7 +833,7 @@ class TestCLIParsing {
     }(ExitCode.Success)
   }
 
-  @Test def test_XXX_CLI_Parsing_SimpleParse_json(): Unit = {
+  @Test def test_CLI_Parsing_SimpleParse_json(): Unit = {
     val schema = path(
       "daffodil-test/src/test/resources/org/apache/daffodil/section00/general/generalSchema.dfdl.xsd",
     )
@@ -844,7 +844,7 @@ class TestCLIParsing {
     }(ExitCode.Success)
   }
 
-  @Test def test_XXX_CLI_Parsing_SimpleParse_null(): Unit = {
+  @Test def test_CLI_Parsing_SimpleParse_null(): Unit = {
     val schema = path(
       "daffodil-test/src/test/resources/org/apache/daffodil/section00/general/generalSchema.dfdl.xsd",
     )
@@ -859,7 +859,7 @@ class TestCLIParsing {
     }
   }
 
-  @Test def test_XXX_CLI_Parsing_SimpleParse_sax(): Unit = {
+  @Test def test_CLI_Parsing_SimpleParse_sax(): Unit = {
     val schema = path(
       "daffodil-test/src/test/resources/org/apache/daffodil/section00/general/generalSchema.dfdl.xsd",
     )
@@ -870,7 +870,7 @@ class TestCLIParsing {
     }(ExitCode.Success)
   }
 
-  @Test def test_XXX_CLI_Parsing_SimpleParse_exi(): Unit = {
+  @Test def test_CLI_Parsing_SimpleParse_exi(): Unit = {
     val schema = path(
       "daffodil-test/src/test/resources/org/apache/daffodil/section00/general/generalSchema.dfdl.xsd",
     )
@@ -880,7 +880,7 @@ class TestCLIParsing {
     }(ExitCode.Success)
   }
 
-  @Test def test_XXX_CLI_Parsing_SimpleParse_exisa(): Unit = {
+  @Test def test_CLI_Parsing_SimpleParse_exisa(): Unit = {
     val schema = path(
       "daffodil-test/src/test/resources/org/apache/daffodil/section00/general/generalSchema.dfdl.xsd",
     )
@@ -898,7 +898,7 @@ class TestCLIParsing {
     }(ExitCode.Usage)
   }
 
-  @Test def test_2575_DFDLX_Trace_output(): Unit = {
+  @Test def test_DFDLX_Trace_output(): Unit = {
     val schema = path(
       "daffodil-cli/src/test/resources/org/apache/daffodil/cli/trace_input.dfdl.xsd",
     )

--- a/daffodil-cli/src/test/scala/org/apache/daffodil/cli/cliTest/TestCLIPerformance.scala
+++ b/daffodil-cli/src/test/scala/org/apache/daffodil/cli/cliTest/TestCLIPerformance.scala
@@ -24,7 +24,7 @@ import org.junit.Test
 
 class TestCLIPerformance {
 
-  @Test def test_3393_CLI_Performance_2_Threads_2_Times(): Unit = {
+  @Test def test_CLI_Performance_2_Threads_2_Times(): Unit = {
     val schema = path(
       "daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/charClassEntities.dfdl.xsd",
     )
@@ -36,7 +36,7 @@ class TestCLIPerformance {
     }(ExitCode.Success)
   }
 
-  @Test def test_XXX_CLI_Performance_2_Threads_2_Times_sax(): Unit = {
+  @Test def test_CLI_Performance_2_Threads_2_Times_sax(): Unit = {
     val schema = path(
       "daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/charClassEntities.dfdl.xsd",
     )
@@ -48,7 +48,7 @@ class TestCLIPerformance {
     }(ExitCode.Success)
   }
 
-  @Test def test_XXX_CLI_Performance_2_Threads_2_Times_exi(): Unit = {
+  @Test def test_CLI_Performance_2_Threads_2_Times_exi(): Unit = {
     val schema = path(
       "daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/charClassEntities.dfdl.xsd",
     )
@@ -60,7 +60,7 @@ class TestCLIPerformance {
     }(ExitCode.Success)
   }
 
-  @Test def test_XXX_CLI_Performance_2_Threads_2_Times_exisa(): Unit = {
+  @Test def test_CLI_Performance_2_Threads_2_Times_exisa(): Unit = {
     val schema = path(
       "daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/charClassEntities.dfdl.xsd",
     )
@@ -72,7 +72,7 @@ class TestCLIPerformance {
     }(ExitCode.Success)
   }
 
-  @Test def test_3394_CLI_Performance_3_Threads_20_Times(): Unit = {
+  @Test def test_CLI_Performance_3_Threads_20_Times(): Unit = {
     val schema = path(
       "daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/charClassEntities.dfdl.xsd",
     )
@@ -84,7 +84,7 @@ class TestCLIPerformance {
     }(ExitCode.Success)
   }
 
-  @Test def test_3395_CLI_Performance_5_Threads_50_Times(): Unit = {
+  @Test def test_CLI_Performance_5_Threads_50_Times(): Unit = {
     val schema = path(
       "daffodil-cli/src/test/resources/org/apache/daffodil/cli/cli_schema.dfdl.xsd",
     )
@@ -96,7 +96,7 @@ class TestCLIPerformance {
     }(ExitCode.Success)
   }
 
-  @Test def test_3396_CLI_Performance_2_Threads_2_Times_Negative(): Unit = {
+  @Test def test_CLI_Performance_2_Threads_2_Times_Negative(): Unit = {
     val schema = path(
       "daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/charClassEntities.dfdl.xsd",
     )
@@ -109,7 +109,7 @@ class TestCLIPerformance {
     }(ExitCode.PerformanceTestError)
   }
 
-  @Test def test_3641_CLI_Performance_Unparse_2_Threads_2_Times(): Unit = {
+  @Test def test_CLI_Performance_Unparse_2_Threads_2_Times(): Unit = {
     val schema = path(
       "daffodil-test/src/test/resources/org/apache/daffodil/section00/general/generalSchema.dfdl.xsd",
     )
@@ -123,7 +123,7 @@ class TestCLIPerformance {
     }(ExitCode.Success)
   }
 
-  @Test def test_XXX_CLI_Performance_Unparse_2_Threads_2_Times_sax(): Unit = {
+  @Test def test_CLI_Performance_Unparse_2_Threads_2_Times_sax(): Unit = {
     val schema = path(
       "daffodil-test/src/test/resources/org/apache/daffodil/section00/general/generalSchema.dfdl.xsd",
     )
@@ -137,7 +137,7 @@ class TestCLIPerformance {
     }(ExitCode.Success)
   }
 
-  @Test def test_XXX_CLI_Performance_Unparse_2_Threads_2_Times_exi(): Unit = {
+  @Test def test_CLI_Performance_Unparse_2_Threads_2_Times_exi(): Unit = {
     val schema = path(
       "daffodil-test/src/test/resources/org/apache/daffodil/section00/general/generalSchema.dfdl.xsd",
     )
@@ -151,7 +151,7 @@ class TestCLIPerformance {
     }(ExitCode.Success)
   }
 
-  @Test def test_XXX_CLI_Performance_Unparse_2_Threads_2_Times_exisa(): Unit = {
+  @Test def test_CLI_Performance_Unparse_2_Threads_2_Times_exisa(): Unit = {
     val schema = path(
       "daffodil-test/src/test/resources/org/apache/daffodil/section00/general/generalSchema.dfdl.xsd",
     )
@@ -165,7 +165,7 @@ class TestCLIPerformance {
     }(ExitCode.Success)
   }
 
-  @Test def test_XXX_CLI_Performance_Unparse_2_Threads_2_Times_null(): Unit = {
+  @Test def test_CLI_Performance_Unparse_2_Threads_2_Times_null(): Unit = {
     val schema = path(
       "daffodil-test/src/test/resources/org/apache/daffodil/section00/general/generalSchema.dfdl.xsd",
     )
@@ -179,7 +179,7 @@ class TestCLIPerformance {
     }(ExitCode.Success)
   }
 
-  @Test def test_3643_CLI_Performance_Unparse_3_Threads_20_Times(): Unit = {
+  @Test def test_CLI_Performance_Unparse_3_Threads_20_Times(): Unit = {
     val schema = path(
       "daffodil-test/src/test/resources/org/apache/daffodil/section00/general/generalSchema.dfdl.xsd",
     )
@@ -193,7 +193,7 @@ class TestCLIPerformance {
     }(ExitCode.Success)
   }
 
-  @Test def test_3644_CLI_Performance_Unparse_5_Threads_50_Times(): Unit = {
+  @Test def test_CLI_Performance_Unparse_5_Threads_50_Times(): Unit = {
     val schema = path(
       "daffodil-test/src/test/resources/org/apache/daffodil/section00/general/generalSchema.dfdl.xsd",
     )
@@ -207,7 +207,7 @@ class TestCLIPerformance {
     }(ExitCode.Success)
   }
 
-  @Test def test_3642_CLI_Performance_Unparse_2_Threads_2_Times_Negative(): Unit = {
+  @Test def test_CLI_Performance_Unparse_2_Threads_2_Times_Negative(): Unit = {
     val schema = path(
       "daffodil-test/src/test/resources/org/apache/daffodil/section00/general/generalSchema.dfdl.xsd",
     )

--- a/daffodil-cli/src/test/scala/org/apache/daffodil/cli/cliTest/TestCLISaveParser.scala
+++ b/daffodil-cli/src/test/scala/org/apache/daffodil/cli/cliTest/TestCLISaveParser.scala
@@ -24,7 +24,7 @@ import org.junit.Test
 
 class TestCLISaveParser {
 
-  @Test def test_3017_CLI_Saving_SaveParser_simple(): Unit = {
+  @Test def test_CLI_Saving_SaveParser_simple(): Unit = {
     val schema = path(
       "daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/charClassEntities.dfdl.xsd",
     )
@@ -39,7 +39,7 @@ class TestCLISaveParser {
     }
   }
 
-  @Test def test_3018_CLI_Saving_SaveParser_stdout(): Unit = {
+  @Test def test_CLI_Saving_SaveParser_stdout(): Unit = {
     val schema = path(
       "daffodil-test/src/test/resources/org/apache/daffodil/section07/external_variables/external_variables.dfdl.xsd",
     )
@@ -50,7 +50,7 @@ class TestCLISaveParser {
     }(ExitCode.Success)
   }
 
-  @Test def test_3019_CLI_Saving_SaveParser_withConfig(): Unit = {
+  @Test def test_CLI_Saving_SaveParser_withConfig(): Unit = {
     val schema = path(
       "daffodil-test/src/test/resources/org/apache/daffodil/section07/external_variables/external_variables.dfdl.xsd",
     )
@@ -72,7 +72,7 @@ class TestCLISaveParser {
     }
   }
 
-  @Test def test_3020_CLI_Saving_SaveParser_namespaceUsed(): Unit = {
+  @Test def test_CLI_Saving_SaveParser_namespaceUsed(): Unit = {
     val schema = path(
       "daffodil-cli/src/test/resources/org/apache/daffodil/cli/charClassEntities.dfdl.xsd",
     )
@@ -89,7 +89,7 @@ class TestCLISaveParser {
     }
   }
 
-  @Test def test_3021_CLI_Saving_SaveParser_path(): Unit = {
+  @Test def test_CLI_Saving_SaveParser_path(): Unit = {
     val schema = path(
       "daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/charClassEntities.dfdl.xsd",
     )
@@ -104,7 +104,7 @@ class TestCLISaveParser {
     }
   }
 
-  @Test def test_3022_CLI_Saving_SaveParser_MultSchema(): Unit = {
+  @Test def test_CLI_Saving_SaveParser_MultSchema(): Unit = {
     val schema1 = path(
       "daffodil-test/src/test/resources/org/apache/daffodil/section07/defineFormat/defineFormat.dfdl.xsd",
     )
@@ -119,7 +119,7 @@ class TestCLISaveParser {
     }
   }
 
-  @Test def test_3023_CLI_Saving_SaveParser_verboseMode(): Unit = {
+  @Test def test_CLI_Saving_SaveParser_verboseMode(): Unit = {
     val schema = path(
       "daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/charClassEntities.dfdl.xsd",
     )
@@ -135,7 +135,7 @@ class TestCLISaveParser {
     }
   }
 
-  @Test def test_3038_CLI_Saving_SaveParser_namespaceNoRoot(): Unit = {
+  @Test def test_CLI_Saving_SaveParser_namespaceNoRoot(): Unit = {
     val schema = path(
       "daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/charClassEntities.dfdl.xsd",
     )
@@ -149,7 +149,7 @@ class TestCLISaveParser {
     }
   }
 
-  @Test def test_3039_CLI_Saving_SaveParser_emptyNamespace(): Unit = {
+  @Test def test_CLI_Saving_SaveParser_emptyNamespace(): Unit = {
     val schema = path(
       "daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/charClassEntities.dfdl.xsd",
     )
@@ -164,7 +164,7 @@ class TestCLISaveParser {
     }
   }
 
-  @Test def test_DFDL_1205_CLI_FullValidation_SavedParser_Incompatible(): Unit = {
+  @Test def test_CLI_DFDL_1205_FullValidation_SavedParser_Incompatible(): Unit = {
     val schema = path(
       "daffodil-cli/src/test/resources/org/apache/daffodil/cli/charClassEntities.dfdl.xsd",
     )
@@ -188,7 +188,7 @@ class TestCLISaveParser {
    * Note that in Daffodil 2.6.0 behavior of external variables changed. They are not saved as part of binary
    * compiling. They are a runtime-thing only.
    */
-  @Test def test_3508_CLI_Saving_SaveParser_extVars(): Unit = {
+  @Test def test_CLI_Saving_SaveParser_extVars(): Unit = {
     val schema = path(
       "daffodil-test/src/test/resources/org/apache/daffodil/section07/external_variables/external_variables.dfdl.xsd",
     )
@@ -207,7 +207,7 @@ class TestCLISaveParser {
     }
   }
 
-  @Test def test_3063_CLI_Saving_SaveParser_validate(): Unit = {
+  @Test def test_CLI_Saving_SaveParser_validate(): Unit = {
     val schema = path(
       "daffodil-cli/src/test/resources/org/apache/daffodil/cli/cli_schema.dfdl.xsd",
     )
@@ -237,7 +237,7 @@ class TestCLISaveParser {
 
   // DAFFODIL-1141
   /*@Test*/
-  def test_3036_CLI_Saving_SaveParser_debug(): Unit = {
+  def test_CLI_Saving_SaveParser_debug(): Unit = {
     val schema = path(
       "daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/charClassEntities.dfdl.xsd",
     )
@@ -251,7 +251,7 @@ class TestCLISaveParser {
 
   // DAFFODIL-1141
   /*@Test*/
-  def test_3037_CLI_Saving_SaveParser_trace(): Unit = {
+  def test_CLI_Saving_SaveParser_trace(): Unit = {
     val schema = path(
       "daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/charClassEntities.dfdl.xsd",
     )
@@ -263,7 +263,7 @@ class TestCLISaveParser {
     }
   }
 
-  @Test def test_3572_CLI_Saving_SaveParser_unparse(): Unit = {
+  @Test def test_CLI_Saving_SaveParser_unparse(): Unit = {
     val schema = path(
       "daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/charClassEntities.dfdl.xsd",
     )
@@ -280,7 +280,7 @@ class TestCLISaveParser {
     }
   }
 
-  @Test def test_3573_CLI_Saving_SaveParser_unparse2(): Unit = {
+  @Test def test_CLI_Saving_SaveParser_unparse2(): Unit = {
     val schema = path(
       "daffodil-test/src/test/resources/org/apache/daffodil/section00/general/generalSchema.dfdl.xsd",
     )
@@ -297,7 +297,7 @@ class TestCLISaveParser {
     }
   }
 
-  @Test def test_3941_CLI_Saving_SaveParser_tunables(): Unit = {
+  @Test def test_CLI_Saving_SaveParser_tunables(): Unit = {
     val schema = path(
       "daffodil-test/src/test/resources/org/apache/daffodil/section00/general/generalSchema.dfdl.xsd",
     )

--- a/daffodil-cli/src/test/scala/org/apache/daffodil/cli/cliTest/TestCLIUnparsing.scala
+++ b/daffodil-cli/src/test/scala/org/apache/daffodil/cli/cliTest/TestCLIUnparsing.scala
@@ -28,7 +28,7 @@ import org.junit.Test
 
 class TestCLIUnparsing {
 
-  @Test def test_3525_CLI_Unparsing_SimpleUnparse_inFile(): Unit = {
+  @Test def test_CLI_Unparsing_SimpleUnparse_inFile(): Unit = {
     val schema = path(
       "daffodil-test/src/test/resources/org/apache/daffodil/section00/general/generalSchema.dfdl.xsd",
     )
@@ -41,7 +41,7 @@ class TestCLIUnparsing {
     }(ExitCode.Success)
   }
 
-  @Test def test_3526_CLI_Unparsing_SimpleUnparse_inFile2(): Unit = {
+  @Test def test_CLI_Unparsing_SimpleUnparse_inFile2(): Unit = {
     val schema = path(
       "daffodil-test/src/test/resources/org/apache/daffodil/section00/general/generalSchema.dfdl.xsd",
     )
@@ -54,7 +54,7 @@ class TestCLIUnparsing {
     }(ExitCode.Success)
   }
 
-  @Test def test_3527_CLI_Unparsing_SimpleUnparse_stdin(): Unit = {
+  @Test def test_CLI_Unparsing_SimpleUnparse_stdin(): Unit = {
     val schema = path(
       "daffodil-test/src/test/resources/org/apache/daffodil/section00/general/generalSchema.dfdl.xsd",
     )
@@ -68,7 +68,7 @@ class TestCLIUnparsing {
     }(ExitCode.Success)
   }
 
-  @Test def test_3528_CLI_Unparsing_SimpleUnparse_stdin2(): Unit = {
+  @Test def test_CLI_Unparsing_SimpleUnparse_stdin2(): Unit = {
     val schema = path(
       "daffodil-test/src/test/resources/org/apache/daffodil/section00/general/generalSchema.dfdl.xsd",
     )
@@ -79,7 +79,7 @@ class TestCLIUnparsing {
     }(ExitCode.Success)
   }
 
-  @Test def test_3529_CLI_Unparsing_SimpleUnparse_stdin3(): Unit = {
+  @Test def test_CLI_Unparsing_SimpleUnparse_stdin3(): Unit = {
     val schema = path(
       "daffodil-test/src/test/resources/org/apache/daffodil/section00/general/generalSchema.dfdl.xsd",
     )
@@ -90,7 +90,7 @@ class TestCLIUnparsing {
     }(ExitCode.Success)
   }
 
-  @Test def test_3584_CLI_Unparsing_SimpleUnparse_stdin4(): Unit = {
+  @Test def test_CLI_Unparsing_SimpleUnparse_stdin4(): Unit = {
     val schema = path(
       "daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/charClassEntities.dfdl.xsd",
     )
@@ -104,7 +104,7 @@ class TestCLIUnparsing {
     }(ExitCode.Success)
   }
 
-  @Test def test_3574_CLI_Unparsing_SimpleUnparse_extVars(): Unit = {
+  @Test def test_CLI_Unparsing_SimpleUnparse_extVars(): Unit = {
     val schema = path(
       "daffodil-test/src/test/resources/org/apache/daffodil/section07/external_variables/external_variables.dfdl.xsd",
     )
@@ -121,7 +121,7 @@ class TestCLIUnparsing {
     }(ExitCode.Success)
   }
 
-  @Test def test_3575_CLI_Unparsing_SimpleUnparse_extVars2(): Unit = {
+  @Test def test_CLI_Unparsing_SimpleUnparse_extVars2(): Unit = {
     val schema = path(
       "daffodil-test/src/test/resources/org/apache/daffodil/section07/external_variables/external_variables.dfdl.xsd",
     )
@@ -137,7 +137,7 @@ class TestCLIUnparsing {
     }(ExitCode.Success)
   }
 
-  @Test def test_3582_CLI_Unparsing_SimpleUnparse_outFile(): Unit = {
+  @Test def test_CLI_Unparsing_SimpleUnparse_outFile(): Unit = {
     val schema = path(
       "daffodil-test/src/test/resources/org/apache/daffodil/section00/general/generalSchema.dfdl.xsd",
     )
@@ -153,7 +153,7 @@ class TestCLIUnparsing {
     }
   }
 
-  @Test def test_3581_CLI_Unparsing_SimpleUnparse_stOutDash(): Unit = {
+  @Test def test_CLI_Unparsing_SimpleUnparse_stOutDash(): Unit = {
     val schema = path(
       "daffodil-test/src/test/resources/org/apache/daffodil/section00/general/generalSchema.dfdl.xsd",
     )
@@ -166,7 +166,7 @@ class TestCLIUnparsing {
     }(ExitCode.Success)
   }
 
-  @Test def test_3580_CLI_Unparsing_SimpleUnparse_verboseMode(): Unit = {
+  @Test def test_CLI_Unparsing_SimpleUnparse_verboseMode(): Unit = {
     val schema = path(
       "daffodil-test/src/test/resources/org/apache/daffodil/section00/general/generalSchema.dfdl.xsd",
     )
@@ -182,14 +182,14 @@ class TestCLIUnparsing {
     }(ExitCode.Success)
   }
 
-  @Test def test_3579_CLI_Unparsing_negativeTest(): Unit = {
+  @Test def test_CLI_Unparsing_negativeTest(): Unit = {
     runCLI(args"unparse") { cli =>
       cli.send("<tns:e1 xmlns:tns='http://example.com'>Hello</tns:e1>", inputDone = true)
       cli.expectErr("There should be exactly one of the following options: schema, parser")
     }(ExitCode.Usage)
   }
 
-  @Test def test_3578_CLI_Unparsing_SimpleUnparse_defaultRoot(): Unit = {
+  @Test def test_CLI_Unparsing_SimpleUnparse_defaultRoot(): Unit = {
     val schema = path(
       "daffodil-test/src/test/resources/org/apache/daffodil/section00/general/generalSchema.dfdl.xsd",
     )
@@ -200,7 +200,7 @@ class TestCLIUnparsing {
     }(ExitCode.Success)
   }
 
-  @Test def test_3583_CLI_Unparsing_SimpleUnparse_rootPath(): Unit = {
+  @Test def test_CLI_Unparsing_SimpleUnparse_rootPath(): Unit = {
     val schema = path(
       "daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/charClassEntities.dfdl.xsd",
     )
@@ -216,7 +216,7 @@ class TestCLIUnparsing {
 
   // DAFFODIL-1346
   /*@Test*/
-  def test_3576_CLI_Unparsing_validate(): Unit = {
+  def test_CLI_Unparsing_validate(): Unit = {
     val schema = path(
       "daffodil-cli/src/test/resources/org/apache/daffodil/cli/cli_schema.dfdl.xsd",
     )
@@ -257,7 +257,7 @@ class TestCLIUnparsing {
 
   // DAFFODIL-2709
   /*@Test*/
-  def test_3577_CLI_Unparsing_traceMode(): Unit = {
+  def test_CLI_Unparsing_traceMode(): Unit = {
     val schema = path(
       "daffodil-test/src/test/resources/org/apache/daffodil/section06/namespaces/multi_base_15.dfdl.xsd",
     )
@@ -273,7 +273,7 @@ class TestCLIUnparsing {
     }(ExitCode.Success)
   }
 
-  @Test def test_3662_CLI_Unparsing_badSchemaPath(): Unit = {
+  @Test def test_CLI_Unparsing_badSchemaPath(): Unit = {
     val schema = path(
       "daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/doesnotexist.dfdl.xsd",
     )
@@ -285,7 +285,7 @@ class TestCLIUnparsing {
     }(ExitCode.Usage)
   }
 
-  @Test def test_xxxx_CLI_Unparsing_SimpleUnparse_w3cdom(): Unit = {
+  @Test def test_CLI_Unparsing_SimpleUnparse_w3cdom(): Unit = {
     val schema = path(
       "daffodil-test/src/test/resources/org/apache/daffodil/section00/general/generalSchema.dfdl.xsd",
     )
@@ -298,7 +298,7 @@ class TestCLIUnparsing {
     }(ExitCode.Success)
   }
 
-  @Test def test_xxxx_CLI_Unparsing_SimpleUnparse_jdom(): Unit = {
+  @Test def test_CLI_Unparsing_SimpleUnparse_jdom(): Unit = {
     val schema = path(
       "daffodil-test/src/test/resources/org/apache/daffodil/section00/general/generalSchema.dfdl.xsd",
     )
@@ -311,7 +311,7 @@ class TestCLIUnparsing {
     }(ExitCode.Success)
   }
 
-  @Test def test_xxxx_CLI_Unparsing_SimpleUnparse_scala_xml(): Unit = {
+  @Test def test_CLI_Unparsing_SimpleUnparse_scala_xml(): Unit = {
     val schema = path(
       "daffodil-test/src/test/resources/org/apache/daffodil/section00/general/generalSchema.dfdl.xsd",
     )
@@ -324,7 +324,7 @@ class TestCLIUnparsing {
     }(ExitCode.Success)
   }
 
-  @Test def test_xxxx_CLI_Unparsing_SimpleUnparse_json(): Unit = {
+  @Test def test_CLI_Unparsing_SimpleUnparse_json(): Unit = {
     val schema = path(
       "daffodil-test/src/test/resources/org/apache/daffodil/section00/general/generalSchema.dfdl.xsd",
     )
@@ -337,7 +337,7 @@ class TestCLIUnparsing {
     }(ExitCode.Success)
   }
 
-  @Test def test_xxxx_CLI_Unparsing_SimpleUnparse_w3cdom_stream(): Unit = {
+  @Test def test_CLI_Unparsing_SimpleUnparse_w3cdom_stream(): Unit = {
     val schema = path(
       "daffodil-test/src/test/resources/org/apache/daffodil/section00/general/generalSchema.dfdl.xsd",
     )
@@ -350,7 +350,7 @@ class TestCLIUnparsing {
     }(ExitCode.Success)
   }
 
-  @Test def test_xxxx_CLI_Unparsing_SimpleUnparse_jdom_stream(): Unit = {
+  @Test def test_CLI_Unparsing_SimpleUnparse_jdom_stream(): Unit = {
     val schema = path(
       "daffodil-test/src/test/resources/org/apache/daffodil/section00/general/generalSchema.dfdl.xsd",
     )
@@ -363,7 +363,7 @@ class TestCLIUnparsing {
     }(ExitCode.Success)
   }
 
-  @Test def test_xxxx_CLI_Unparsing_SimpleUnparse_scala_xml_stream(): Unit = {
+  @Test def test_CLI_Unparsing_SimpleUnparse_scala_xml_stream(): Unit = {
     val schema = path(
       "daffodil-test/src/test/resources/org/apache/daffodil/section00/general/generalSchema.dfdl.xsd",
     )
@@ -376,7 +376,7 @@ class TestCLIUnparsing {
     }(ExitCode.Success)
   }
 
-  @Test def test_xxxx_CLI_Unparsing_SimpleUnparse_json_stream(): Unit = {
+  @Test def test_CLI_Unparsing_SimpleUnparse_json_stream(): Unit = {
     val schema = path(
       "daffodil-test/src/test/resources/org/apache/daffodil/section00/general/generalSchema.dfdl.xsd",
     )
@@ -389,7 +389,7 @@ class TestCLIUnparsing {
     }(ExitCode.Success)
   }
 
-  @Test def test_xxxx_CLI_Unparsing_SimpleUnparse_sax(): Unit = {
+  @Test def test_CLI_Unparsing_SimpleUnparse_sax(): Unit = {
     val schema = path(
       "daffodil-test/src/test/resources/org/apache/daffodil/section00/general/generalSchema.dfdl.xsd",
     )
@@ -402,7 +402,7 @@ class TestCLIUnparsing {
     }(ExitCode.Success)
   }
 
-  @Test def test_xxxx_CLI_Unparsing_SimpleUnparse_exi(): Unit = {
+  @Test def test_CLI_Unparsing_SimpleUnparse_exi(): Unit = {
     val schema = path(
       "daffodil-test/src/test/resources/org/apache/daffodil/section00/general/generalSchema.dfdl.xsd",
     )
@@ -415,7 +415,7 @@ class TestCLIUnparsing {
     }(ExitCode.Success)
   }
 
-  @Test def test_xxxx_CLI_Unparsing_SimpleUnparse_exisa(): Unit = {
+  @Test def test_CLI_Unparsing_SimpleUnparse_exisa(): Unit = {
     val schema = path(
       "daffodil-test/src/test/resources/org/apache/daffodil/section00/general/generalSchema.dfdl.xsd",
     )
@@ -428,7 +428,7 @@ class TestCLIUnparsing {
     }(ExitCode.Success)
   }
 
-  @Test def test_xxxx_CLI_Unparsing_SimpleUnparse_null(): Unit = {
+  @Test def test_CLI_Unparsing_SimpleUnparse_null(): Unit = {
     val schema = path(
       "daffodil-test/src/test/resources/org/apache/daffodil/section00/general/generalSchema.dfdl.xsd",
     )
@@ -441,7 +441,7 @@ class TestCLIUnparsing {
     }(ExitCode.Success)
   }
 
-  @Test def test_XXX_CLI_Unparsing_Stream_01(): Unit = {
+  @Test def test_CLI_Unparsing_Stream_01(): Unit = {
     val schema = path(
       "daffodil-cli/src/test/resources/org/apache/daffodil/cli/cli_schema_02.dfdl.xsd",
     )
@@ -454,7 +454,7 @@ class TestCLIUnparsing {
     }(ExitCode.Success)
   }
 
-  @Test def test_XXX_CLI_Unparsing_Stream_sax(): Unit = {
+  @Test def test_CLI_Unparsing_Stream_sax(): Unit = {
     val schema = path(
       "daffodil-cli/src/test/resources/org/apache/daffodil/cli/cli_schema_02.dfdl.xsd",
     )

--- a/daffodil-cli/src/test/scala/org/apache/daffodil/cli/cliTest/TestCLItdml.scala
+++ b/daffodil-cli/src/test/scala/org/apache/daffodil/cli/cliTest/TestCLItdml.scala
@@ -24,7 +24,7 @@ import org.junit.Test
 
 class TestCLItdml {
 
-  @Test def test_995_CLI_Tdml_Listing_negativeTest01(): Unit = {
+  @Test def test_CLI_Tdml_Listing_negativeTest01(): Unit = {
     val tdml = path(
       "daffodil-test/src/test/resources/org/apache/daffodil/section31/escape_characters/Escapes.tdml",
     )
@@ -35,7 +35,7 @@ class TestCLItdml {
     }(ExitCode.Success)
   }
 
-  @Test def test_1001_CLI_Tdml_Listing_execRegex01(): Unit = {
+  @Test def test_CLI_Tdml_Listing_execRegex01(): Unit = {
     val tdml = path(
       "daffodil-test/src/test/resources/org/apache/daffodil/section31/escape_characters/Escapes.tdml",
     )
@@ -45,7 +45,7 @@ class TestCLItdml {
     }(ExitCode.Success)
   }
 
-  @Test def test_1000_CLI_Tdml_Listing_listRegex02(): Unit = {
+  @Test def test_CLI_Tdml_Listing_listRegex02(): Unit = {
     val tdml = path(
       "daffodil-test/src/test/resources/org/apache/daffodil/section31/escape_characters/Escapes.tdml",
     )
@@ -53,7 +53,7 @@ class TestCLItdml {
     runCLI(args"test -l --regex $tdml escape_entryb-\d+") { _ => }(ExitCode.Success)
   }
 
-  @Test def test_999_CLI_Tdml_Listing_listRegex01(): Unit = {
+  @Test def test_CLI_Tdml_Listing_listRegex01(): Unit = {
     val tdml = path(
       "daffodil-test/src/test/resources/org/apache/daffodil/section31/escape_characters/Escapes.tdml",
     )
@@ -66,7 +66,7 @@ class TestCLItdml {
     }(ExitCode.Success)
   }
 
-  @Test def test_994_CLI_Tdml_Listing_execAll(): Unit = {
+  @Test def test_CLI_Tdml_Listing_execAll(): Unit = {
     val tdml = path(
       "daffodil-test/src/test/resources/org/apache/daffodil/section31/escape_characters/Escapes.tdml",
     )
@@ -76,7 +76,7 @@ class TestCLItdml {
     }(ExitCode.Success)
   }
 
-  @Test def test_993_CLI_Tdml_Listing_listAll(): Unit = {
+  @Test def test_CLI_Tdml_Listing_listAll(): Unit = {
     val tdml = path(
       "daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/Entities.tdml",
     )
@@ -90,7 +90,7 @@ class TestCLItdml {
     }(ExitCode.Success)
   }
 
-  @Test def test_992_CLI_Tdml_Listing_singleTestList(): Unit = {
+  @Test def test_CLI_Tdml_Listing_singleTestList(): Unit = {
     val tdml = path(
       "daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/Entities.tdml",
     )
@@ -100,7 +100,7 @@ class TestCLItdml {
     }(ExitCode.Success)
   }
 
-  @Test def test_990_CLI_Tdml_Listing_singleTest(): Unit = {
+  @Test def test_CLI_Tdml_Listing_singleTest(): Unit = {
     val tdml = path(
       "daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/Entities.tdml",
     )
@@ -170,7 +170,7 @@ class TestCLItdml {
     }(ExitCode.Success)
   }
 
-  @Test def test_1016_CLI_Tdml_Listing_listVerbose(): Unit = {
+  @Test def test_CLI_Tdml_Listing_listVerbose(): Unit = {
     val tdml = path(
       "daffodil-test/src/test/resources/org/apache/daffodil/section07/assertions/assert.tdml",
     )

--- a/daffodil-test-integration/src/test/scala/org/apache/daffodil/cliTest/TestCLIDebugger.scala
+++ b/daffodil-test-integration/src/test/scala/org/apache/daffodil/cliTest/TestCLIDebugger.scala
@@ -86,7 +86,7 @@ class TestCLIDebugger {
     }
   }
 
-  @Test def test_3385_CLI_Debugger_invalidExpressions(): Unit = {
+  @Test def test_CLI_Debugger_invalidExpressions(): Unit = {
     val schema = path(
       "daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/charClassEntities.dfdl.xsd",
     )
@@ -121,7 +121,7 @@ class TestCLIDebugger {
     }(ExitCode.Failure)
   }
 
-  @Test def test_1591_CLI_Debugger_invalidCommandError(): Unit = {
+  @Test def test_CLI_Debugger_invalidCommandError(): Unit = {
     val schema = path(
       "daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/charClassEntities.dfdl.xsd",
     )
@@ -135,7 +135,7 @@ class TestCLIDebugger {
     }(ExitCode.Failure)
   }
 
-  @Test def test_1335_CLI_Debugger_dataAndWrapLength(): Unit = {
+  @Test def test_CLI_Debugger_dataAndWrapLength(): Unit = {
     val schema = path(
       "daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/charClassEntities.dfdl.xsd",
     )
@@ -156,7 +156,7 @@ class TestCLIDebugger {
     }(ExitCode.Success)
   }
 
-  @Test def test_982_CLI_Debugger_simpleDebugger(): Unit = {
+  @Test def test_CLI_Debugger_simpleDebugger(): Unit = {
     val schema = path(
       "daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/charClassEntities.dfdl.xsd",
     )
@@ -169,7 +169,7 @@ class TestCLIDebugger {
     }(ExitCode.Success)
   }
 
-  @Test def test_1326_CLI_Debugger_displaysTesting(): Unit = {
+  @Test def test_CLI_Debugger_displaysTesting(): Unit = {
     val schema = path(
       "daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/charClassEntities.dfdl.xsd",
     )
@@ -206,7 +206,7 @@ class TestCLIDebugger {
     }(ExitCode.Success)
   }
 
-  @Test def test_1339_CLI_Debugger_removeHidden(): Unit = {
+  @Test def test_CLI_Debugger_removeHidden(): Unit = {
     val schema = path(
       "daffodil-cli/src/test/resources/org/apache/daffodil/cli/cli_schema.dfdl.xsd",
     )
@@ -228,7 +228,7 @@ class TestCLIDebugger {
     }(ExitCode.Failure)
   }
 
-  @Test def test_3268_CLI_Debugger_removeHidden2(): Unit = {
+  @Test def test_CLI_Debugger_removeHidden2(): Unit = {
     val schema = path(
       "daffodil-cli/src/test/resources/org/apache/daffodil/cli/cli_schema.dfdl.xsd",
     )
@@ -248,7 +248,7 @@ class TestCLIDebugger {
     }(ExitCode.Success)
   }
 
-  @Test def test_1331_CLI_Debugger_breakpointTesting4(): Unit = {
+  @Test def test_CLI_Debugger_breakpointTesting4(): Unit = {
     val schema = path(
       "daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/charClassEntities.dfdl.xsd",
     )
@@ -299,7 +299,7 @@ class TestCLIDebugger {
     }(ExitCode.Success)
   }
 
-  @Test def test_1463_CLI_Debugger_breakOnValueOfElement(): Unit = {
+  @Test def test_CLI_Debugger_breakOnValueOfElement(): Unit = {
     val schema = path(
       "daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/charClassEntities.dfdl.xsd",
     )
@@ -351,7 +351,7 @@ class TestCLIDebugger {
     }(ExitCode.Failure)
   }
 
-  @Test def test_1338_CLI_Debugger_pointsOfUncertaintyInfo(): Unit = {
+  @Test def test_CLI_Debugger_pointsOfUncertaintyInfo(): Unit = {
     val schema = path(
       "daffodil-cli/src/test/resources/org/apache/daffodil/cli/cli_schema.dfdl.xsd",
     )
@@ -378,7 +378,7 @@ class TestCLIDebugger {
     }(ExitCode.Failure)
   }
 
-  @Test def test_1328_CLI_Debugger_breakpointTesting(): Unit = {
+  @Test def test_CLI_Debugger_breakpointTesting(): Unit = {
     val schema = path(
       "daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/charClassEntities.dfdl.xsd",
     )
@@ -414,7 +414,7 @@ class TestCLIDebugger {
     }(ExitCode.Success)
   }
 
-  @Test def test_1329_CLI_Debugger_breakpointTesting2(): Unit = {
+  @Test def test_CLI_Debugger_breakpointTesting2(): Unit = {
     val schema = path(
       "daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/charClassEntities.dfdl.xsd",
     )
@@ -468,7 +468,7 @@ class TestCLIDebugger {
     }(ExitCode.Success)
   }
 
-  @Test def test_1330_CLI_Debugger_breakpointTesting3(): Unit = {
+  @Test def test_CLI_Debugger_breakpointTesting3(): Unit = {
     val schema = path(
       "daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/charClassEntities.dfdl.xsd",
     )
@@ -503,7 +503,7 @@ class TestCLIDebugger {
     }(ExitCode.Success)
   }
 
-  @Test def test_1333_CLI_Debugger_settingInfosetLines(): Unit = {
+  @Test def test_CLI_Debugger_settingInfosetLines(): Unit = {
     val schema = path(
       "daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/charClassEntities.dfdl.xsd",
     )
@@ -541,7 +541,7 @@ class TestCLIDebugger {
     }(ExitCode.Success)
   }
 
-  @Test def test_1334_CLI_Debugger_infoBitPosition(): Unit = {
+  @Test def test_CLI_Debugger_infoBitPosition(): Unit = {
     val schema = path(
       "daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/charClassEntities.dfdl.xsd",
     )
@@ -568,7 +568,7 @@ class TestCLIDebugger {
     }(ExitCode.Success)
   }
 
-  @Test def test_1337_CLI_Debugger_childIndex(): Unit = {
+  @Test def test_CLI_Debugger_childIndex(): Unit = {
     val schema = path(
       "daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/charClassEntities.dfdl.xsd",
     )
@@ -596,7 +596,7 @@ class TestCLIDebugger {
     }(ExitCode.Success)
   }
 
-  @Test def test_1340_CLI_Debugger_infoPath(): Unit = {
+  @Test def test_CLI_Debugger_infoPath(): Unit = {
     val schema = path(
       "daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/charClassEntities.dfdl.xsd",
     )
@@ -621,7 +621,7 @@ class TestCLIDebugger {
     }(ExitCode.Success)
   }
 
-  @Test def test_1382_CLI_Debugger_dataAndWrapLength2(): Unit = {
+  @Test def test_CLI_Debugger_dataAndWrapLength2(): Unit = {
     val schema = path(
       "daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/charClassEntities.dfdl.xsd",
     )
@@ -645,7 +645,7 @@ class TestCLIDebugger {
     }(ExitCode.Success)
   }
 
-  @Test def test_1863_CLI_Debugger_groupIndex01(): Unit = {
+  @Test def test_CLI_Debugger_groupIndex01(): Unit = {
     val schema = path(
       "daffodil-cli/src/test/resources/org/apache/daffodil/cli/cli_schema_03.dfdl.xsd",
     )
@@ -673,7 +673,7 @@ class TestCLIDebugger {
     }(ExitCode.Success)
   }
 
-  @Test def test_1029_CLI_Debugger_validation1(): Unit = {
+  @Test def test_CLI_Debugger_validation1(): Unit = {
     val schema = path(
       "daffodil-cli/src/test/resources/org/apache/daffodil/cli/cli_schema_03.dfdl.xsd",
     )
@@ -692,7 +692,7 @@ class TestCLIDebugger {
     }(ExitCode.Failure)
   }
 
-  @Test def test_3258_CLI_Debugger_infodata(): Unit = {
+  @Test def test_CLI_Debugger_infodata(): Unit = {
     val schema = path(
       "daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/charClassEntities.dfdl.xsd",
     )
@@ -721,7 +721,7 @@ class TestCLIDebugger {
     }(ExitCode.Success)
   }
 
-  @Test def test_3264_CLI_Debugger_undefined_command(): Unit = {
+  @Test def test_CLI_Debugger_undefined_command(): Unit = {
     val schema = path(
       "daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/charClassEntities.dfdl.xsd",
     )
@@ -792,7 +792,7 @@ class TestCLIDebugger {
     }(ExitCode.Failure)
   }
 
-  @Test def test_1337_CLI_Debugger_info_infoset(): Unit = {
+  @Test def test_CLI_Debugger_info_infoset(): Unit = {
     val schema = path(
       "daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/charClassEntities.dfdl.xsd",
     )
@@ -986,7 +986,7 @@ class TestCLIDebugger {
     }
   }
 
-  @Test def test_3585_CLI_Debugger_simpleDebugger_unparse(): Unit = {
+  @Test def test_CLI_Debugger_simpleDebugger_unparse(): Unit = {
     val schema = path(
       "daffodil-test/src/test/resources/org/apache/daffodil/section00/general/generalSchema.dfdl.xsd",
     )
@@ -1006,7 +1006,7 @@ class TestCLIDebugger {
     }(ExitCode.Failure)
   }
 
-  @Test def test_3585_CLI_Debugger_prefixLength(): Unit = {
+  @Test def test_CLI_Debugger_prefixLength(): Unit = {
     val schema = path(
       "daffodil-cli/src/test/resources/org/apache/daffodil/cli/prefixed_length.dfdl.xsd",
     )


### PR DESCRIPTION
Remove numbers from CLI integration test names

TestCLIDebugger.scala: remove numbers from test names.

TestCLIParsing.scala: remove numbers from test names.

TestCLIPerformance.scala: remove numbers from test names.

TestCLISaveParser.scala: remove numbers from test names.

TestCLItdml.scala: remove numbers from test names.

TestCLIUnparsing.scala: remove numbers from test names.

DAFFODIL-2753