### PR TITLE
Add test that illustrates float text parse bug

### DIFF
--- a/daffodil-test/src/test/resources/org/apache/daffodil/section05/simple_types/SimpleTypes.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section05/simple_types/SimpleTypes.tdml
@@ -139,6 +139,9 @@
       dfdl:textNumberPattern="000000000000000000000" />
     <xs:element name="floatTextFail" type="xs:float"
       dfdl:lengthKind="implicit" />
+    <xs:element name="floatTextDelim" type="xs:float"
+                dfdl:representation="text" dfdl:lengthKind="delimited"
+                dfdl:terminator="%SP;"/>
 
     <xs:element name="nonNegIntBin" type="xs:nonNegativeInteger"
       dfdl:representation="binary" dfdl:lengthKind="explicit" dfdl:length="{ 16 }" />
@@ -3715,6 +3718,17 @@
     <tdml:infoset>
       <tdml:dfdlInfoset>
         <floatText>-2.7</floatText>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="float_text_delim" root="floatTextDelim"
+                       model="SimpleTypes-Embedded.dfdl.xsd" description="Section 5 Simple type-float - DFDL-5-008R">
+
+    <tdml:document><![CDATA[3.4028235E38]]></tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <floatTextDelim>3.4028235E38</floatTextDelim>
       </tdml:dfdlInfoset>
     </tdml:infoset>
   </tdml:parserTestCase>

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section05/simple_types/TestSimpleTypes.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section05/simple_types/TestSimpleTypes.scala
@@ -826,6 +826,10 @@ class TestSimpleTypes {
   @Test def test_float_text(): Unit = { runner.runOneTest("float_text") }
   @Test def test_float_text2(): Unit = { runner.runOneTest("float_text2") }
   @Test def test_float_text3(): Unit = { runner.runOneTest("float_text3") }
+
+  // DAFFODIL-2867
+  // @Test def test_float_text_delim(): Unit = { runner.runOneTest("float_text_delim") }
+
   @Test def test_float_text_fail(): Unit = { runner.runOneTest("float_text_fail") }
   @Test def test_characterDuringValidFloat(): Unit = {
     runner.runOneTest("characterDuringValidFloat")


### PR DESCRIPTION
This is a representation="text" xs:float that is
delimited. Parsing Float.MaxValue i.e., this text string:
```
3.4028235E38
```
I get this error:
```
Parse Error: Value '340282350000000000000000000000000000000' is out of range for type: xs:float
```

No similar issue for type xs:double.

DAFFODIL-2867