### PR TITLE
fn:count(non-array) must issue SDE

### DIFF
--- a/daffodil-core/src/main/scala/org/apache/daffodil/core/dpath/Expression.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/core/dpath/Expression.scala
@@ -2295,6 +2295,18 @@ abstract class FunctionCallBase(
     res
   }
 
+  final def checkArgArray(): Unit = {
+    lazy val isArray = expressions.head match {
+      case rpe: RelativePathExpression => rpe.steps.last.isArray
+      case rpe: RootPathExpression => rpe.steps.last.isArray
+      case _ => true
+    }
+    if (!isArray) argArrayErr()
+  }
+  final def argArrayErr() = {
+    SDE("The %s function requires an array.", functionQName.toPrettyString)
+  }
+
   final def checkArgCount(n: Int): Unit = {
     if (expressions.length != n) argCountErr(n)
   }
@@ -2369,6 +2381,7 @@ case class FNCountExpr(nameAsParsed: String, fnQName: RefQName, args: List[Expre
 
   override lazy val compiledDPath = {
     checkArgCount(1)
+    checkArgArray()
     val arg0Recipe = args(0).compiledDPath
     val arg0Type = args(0).inherentType
     val c = conversions

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/dpath/DState.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/dpath/DState.scala
@@ -41,7 +41,6 @@ import java.math.{ BigInteger => JBigInt }
 
 import org.apache.daffodil.lib.api.DaffodilTunables
 import org.apache.daffodil.lib.api.DataLocation
-import org.apache.daffodil.lib.api.WarnID
 import org.apache.daffodil.runtime1.dsom.DPathCompileInfo
 import org.apache.daffodil.runtime1.infoset.DataValue.DataValuePrimitiveNullable
 
@@ -118,6 +117,7 @@ case class DState(
   tunable: DaffodilTunables,
   val parseOrUnparseState: Maybe[ParseOrUnparseState],
 ) {
+
   import org.apache.daffodil.lib.util.Numbers._
 
   var isCompile = false
@@ -140,6 +140,7 @@ case class DState(
   def setMode(m: EvalMode): Unit = {
     _mode = m
   }
+
   def mode = _mode
 
   //
@@ -203,10 +204,12 @@ case class DState(
     _currentValue = v
     _currentNode = null
   }
+
   def setCurrentValue(v: Long): Unit = {
     _currentValue = v
     _currentNode = null
   }
+
   def setCurrentValue(v: Boolean): Unit = {
     _currentValue = v
     _currentNode = null
@@ -215,45 +218,26 @@ case class DState(
   def booleanValue: Boolean = currentValue.getBoolean
 
   def longValue: Long = asLong(currentValue.getAnyRef)
+
   def intValue: Int = longValue.toInt
+
   def doubleValue: Double = asDouble(currentValue.getAnyRef)
 
   def integerValue: JBigInt = asBigInt(currentValue.getAnyRef)
+
   def decimalValue: JBigDecimal = asBigDecimal(currentValue.getAnyRef)
+
   def stringValue: String = currentValue.getString
 
   def isNilled: Boolean = currentElement.isNilled
 
-  private def isAnArray(): Boolean = {
-    if (!currentNode.isInstanceOf[DIArray]) {
-      Assert.invariant(errorOrWarn.isDefined)
-      if (currentNode.isInstanceOf[DIElement]) {
-        errorOrWarn.get.SDW(
-          WarnID.PathNotToArray,
-          "The specified path to element %s is not to an array. Suggest using fn:exists instead.",
-          currentElement.name,
-        )
-      } else {
-        errorOrWarn.get.SDW(
-          WarnID.PathNotToArray,
-          "The specified path is not to an array. Suggest using fn:exists instead.",
-        )
-      }
-      false
-    } else {
-      true
-    }
-  }
-
   def arrayLength: Long =
-    if (isAnArray()) currentArray.length
-    else 1L
+    currentArray.length
 
-  def finalArrayLength: Long =
-    if (isAnArray()) {
-      currentArray.requireFinal
-      currentArray.length
-    } else 1L
+  def finalArrayLength: Long = {
+    currentArray.requireFinal()
+    currentArray.length
+  }
 
   def exists: Boolean = true // we're at a node, so it must exist.
 

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/dpath/FNFunctions.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/dpath/FNFunctions.scala
@@ -634,7 +634,7 @@ trait ExistsKind {
     Assert.invariant(dstate.currentNode ne null)
     val res = dstate.mode match {
       case UnparserNonBlocking => {
-        // we are evaluating an expresion while unparsing in non blocking mode.
+        // we are evaluating an expression while unparsing in non blocking mode.
         // This means this throwable must have come from an evaluatable using
         // only backwards references. Backwards references are known to be
         // final (even if isFinal isn't set yet), so because an exception was

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/dpath/NodeInfo.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/dpath/NodeInfo.scala
@@ -651,11 +651,17 @@ object NodeInfo extends Enum {
     trait PrimNumericFloat extends PrimNumeric { self: Numeric.Kind =>
       def min: Double
       def max: Double
-      private lazy val minBD = new JBigDecimal(min)
-      private lazy val maxBD = new JBigDecimal(max)
+      def minStr: String
+      def maxStr: String
+      private lazy val minBD = new JBigDecimal(minStr)
+      private lazy val maxBD = new JBigDecimal(maxStr)
 
       def isValid(n: java.lang.Number): Boolean = n match {
         case bd: JBigDecimal => {
+          bd.compareTo(minBD) >= 0 && bd.compareTo(maxBD) <= 0
+        }
+        case bi: JBigInt => {
+          val bd = new JBigDecimal(bi)
           bd.compareTo(minBD) >= 0 && bd.compareTo(maxBD) <= 0
         }
         case _ => {
@@ -681,6 +687,10 @@ object NodeInfo extends Enum {
       protected override def fromNumberNoCheck(n: Number): DataValueFloat = n.floatValue
       override val min = -JFloat.MAX_VALUE.doubleValue
       override val max = JFloat.MAX_VALUE.doubleValue
+      // we cannot use min/max.toString for minStr/maxStr because min/max are doubles so
+      // toString would have a precision different than Float.MaxValue.toString
+      override val minStr = "-" + JFloat.MAX_VALUE.toString
+      override val maxStr = JFloat.MAX_VALUE.toString
       override val width: MaybeInt = MaybeInt(32)
     }
 
@@ -698,6 +708,8 @@ object NodeInfo extends Enum {
       protected override def fromNumberNoCheck(n: Number): DataValueDouble = n.doubleValue
       override val min = -JDouble.MAX_VALUE
       override val max = JDouble.MAX_VALUE
+      override val minStr = "-" + JDouble.MAX_VALUE.toString
+      override val maxStr = JDouble.MAX_VALUE.toString
       override val width: MaybeInt = MaybeInt(64)
     }
 

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/PaddingRuntimeMixin.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/PaddingRuntimeMixin.scala
@@ -17,6 +17,7 @@
 
 package org.apache.daffodil.runtime1.processors.parsers
 
+import org.apache.daffodil.lib.exceptions.Assert
 import org.apache.daffodil.lib.util.MaybeChar
 import org.apache.daffodil.runtime1.processors.TextJustificationType
 
@@ -24,11 +25,28 @@ trait PaddingRuntimeMixin {
   protected def justificationTrim: TextJustificationType.Type
   protected def parsingPadChar: MaybeChar
 
-  private def removeRightPadding(str: String): String =
-    if (parsingPadChar.isEmpty) str
-    else str.reverse.dropWhile(c => c == parsingPadChar.get).reverse
-  private def removeLeftPadding(str: String): String =
-    if (parsingPadChar.isEmpty) str else str.dropWhile(c => c == parsingPadChar.get)
+  private def removeRightPadding(str: String): String = {
+    // must have a pad character if we are removing padding
+    Assert.invariant(parsingPadChar.isDefined)
+    val padChar = parsingPadChar.get
+    var index = str.length - 1
+    while (index >= 0 && str(index) == padChar) {
+      index -= 1
+    }
+    str.substring(0, index + 1)
+  }
+
+  private def removeLeftPadding(str: String): String = {
+    // must have a pad character if we are removing padding
+    Assert.invariant(parsingPadChar.isDefined)
+    val padChar = parsingPadChar.get
+    var index = 0
+    while (index < str.length && str(index) == padChar) {
+      index += 1
+    }
+    str.substring(index)
+  }
+
   private def removePadding(str: String): String = removeRightPadding(removeLeftPadding(str))
 
   def trimByJustification(str: String): String = {

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section05/simple_types/SimpleTypes.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section05/simple_types/SimpleTypes.tdml
@@ -139,6 +139,8 @@
       dfdl:textNumberPattern="000000000000000000000" />
     <xs:element name="floatTextFail" type="xs:float"
       dfdl:lengthKind="implicit" />
+    <xs:element name="floatTextDelim" type="xs:float"
+                dfdl:representation="text" dfdl:lengthKind="delimited" />
 
     <xs:element name="nonNegIntBin" type="xs:nonNegativeInteger"
       dfdl:representation="binary" dfdl:lengthKind="explicit" dfdl:length="{ 16 }" />
@@ -3715,6 +3717,21 @@
     <tdml:infoset>
       <tdml:dfdlInfoset>
         <floatText>-2.7</floatText>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="float_text_max" root="floatTextDelim"
+                       model="SimpleTypes-Embedded.dfdl.xsd" description="Section 5 Simple type-float - DFDL-5-008R">
+    <!--
+      We would really prefer to use "3.4028235E38" as the document data (wich would parse exactly the same),
+      but textNumberPattern is "#,##0.###" so this unparses with all 39 digits plus commas instead of using
+      an exponent. In order to round trip correctly, we set the document to the more verbose form
+    -->
+    <tdml:document><![CDATA[340,282,350,000,000,000,000,000,000,000,000,000,000]]></tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <floatTextDelim>3.4028235E38</floatTextDelim>
       </tdml:dfdlInfoset>
     </tdml:infoset>
   </tdml:parserTestCase>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section12/lengthKind/PrefixedTests.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section12/lengthKind/PrefixedTests.tdml
@@ -448,7 +448,7 @@
       <xs:restriction base="xs:integer" /> 
     </xs:simpleType>
 
-    <xs:simpleType name="prefixExpression" dfdl:lengthKind="explicit" dfdl:length="{ fn:count(.) }">
+    <xs:simpleType name="prefixExpression" dfdl:lengthKind="explicit" dfdl:length="{ fn:exists(.) }">
       <xs:restriction base="xs:integer" /> 
     </xs:simpleType>
 

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section23/dfdl_expressions/expressions.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section23/dfdl_expressions/expressions.tdml
@@ -213,7 +213,7 @@
           <xs:element name="a" type="xs:int" />
           <xs:element name="a" type="xs:int" />
           <xs:element name="a" type="xs:int" />
-          <xs:element name="ivc" type="xs:int" dfdl:inputValueCalc="{ fn:count(../ex:a) }"/>
+          <xs:element name="ivc" type="xs:int" dfdl:inputValueCalc="{ fn:exists(../ex:a) }"/>
         </xs:sequence>
       </xs:complexType>
     </xs:element>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section23/dfdl_functions/Functions.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section23/dfdl_functions/Functions.tdml
@@ -167,7 +167,7 @@
         <xs:appinfo source="http://www.ogf.org/dfdl/">
           <dfdl:assert test="{ fn:count( /ex:more_count1 ) eq 3 }"
             message="Assertion 
-            failed for fn:count( /ex:more_count ) eq 3" />
+            failed for fn:count( /ex:more_count1 ) eq 3" />
         </xs:appinfo>
       </xs:annotation>
       <xs:complexType>
@@ -182,7 +182,7 @@
         <xs:appinfo source="http://www.ogf.org/dfdl/">
           <dfdl:assert test="{ fn:count( /ex:more_count1b ) eq 1 }"
             message="Assertion 
-            failed for fn:count( /ex:more_count ) eq 1" />
+            failed for fn:count( /ex:more_count1b ) eq 1" />
         </xs:appinfo>
       </xs:annotation>
       <xs:complexType>
@@ -3323,14 +3323,11 @@
     <tdml:document>
       <tdml:documentPart type="text"><![CDATA[#:1]]></tdml:documentPart>
     </tdml:document>
-    <tdml:infoset>
-      <tdml:dfdlInfoset xmlns:xs="http://www.w3.org/2001/XMLSchema"
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-        <more_count1b>
-          <i1>1</i1>
-        </more_count1b>
-      </tdml:dfdlInfoset>
-    </tdml:infoset>
+    <tdml:errors>
+      <tdml:error>Schema Definition Error</tdml:error>
+      <tdml:error>fn:count</tdml:error>
+      <tdml:error>array</tdml:error>
+    </tdml:errors>
   </tdml:parserTestCase>
 
 <!--
@@ -5150,6 +5147,51 @@
       </xs:complexType>
     </xs:element>
 
+    <xs:element name="count07">
+      <xs:complexType>
+        <xs:sequence>
+          <xs:element name="int" type="xs:int" minOccurs="2" maxOccurs="2" dfdl:representation="binary" />
+          <xs:element name="count" type="xs:int" dfdl:representation="binary" dfdl:inputValueCalc="{ fn:count(../ex:int) }" />
+        </xs:sequence>
+      </xs:complexType>
+    </xs:element>
+
+    <xs:element name="count08">
+      <xs:complexType>
+        <xs:sequence>
+          <xs:element name="int" type="xs:int" dfdl:representation="binary" />
+          <xs:element name="count" type="xs:int" dfdl:representation="binary" dfdl:inputValueCalc="{ fn:count(../ex:int) }" />
+        </xs:sequence>
+      </xs:complexType>
+    </xs:element>
+
+    <xs:element name="count09">
+      <xs:complexType>
+        <xs:sequence>
+          <xs:element name="int" type="xs:int" minOccurs="0" maxOccurs="1" dfdl:representation="binary" />
+          <xs:element name="count" type="xs:int" dfdl:representation="binary" dfdl:inputValueCalc="{ fn:count(../ex:int) }" />
+        </xs:sequence>
+      </xs:complexType>
+    </xs:element>
+
+    <xs:element name="count10">
+      <xs:complexType>
+        <xs:sequence>
+          <xs:element name="int" type="xs:int" dfdl:representation="binary" />
+          <xs:element name="count" type="xs:int" dfdl:representation="binary" dfdl:outputValueCalc="{ fn:count(../ex:int) }" />
+        </xs:sequence>
+      </xs:complexType>
+    </xs:element>
+
+    <xs:element name="count11">
+      <xs:complexType>
+        <xs:sequence>
+          <xs:element name="int" type="xs:int" dfdl:representation="binary" />
+          <xs:element name="count" type="xs:int" dfdl:representation="binary" dfdl:occursCountKind="expression" dfdl:occursCount="{ fn:count(../ex:int) }" />
+        </xs:sequence>
+      </xs:complexType>
+    </xs:element>
+
     <xs:element name="local-name01">
       <xs:complexType>
         <xs:sequence dfdl:separator=",">
@@ -6333,8 +6375,7 @@
 -->
 
   <tdml:parserTestCase name="xPathFunc_round_hte_02" root="round-hte"
-    model="XPathFunctions" description="Section 23.5.2 - Standard XPath Functions - round-half-to-even - DFDL-23-098R"
-    roundTrip="twoPass">
+    model="XPathFunctions" description="Section 23.5.2 - Standard XPath Functions - round-half-to-even - DFDL-23-098R">
 
     <tdml:document>
       <tdml:documentPart type="text">3.455,2</tdml:documentPart>
@@ -6360,8 +6401,7 @@
 -->
 
   <tdml:parserTestCase name="xPathFunc_round_hte_03" root="round-hte"
-    model="XPathFunctions" description="Section 23.5.2 - Standard XPath Functions - round-half-to-even - DFDL-23-098R"
-    roundTrip="twoPass">
+    model="XPathFunctions" description="Section 23.5.2 - Standard XPath Functions - round-half-to-even - DFDL-23-098R">
 
     <tdml:document>
       <tdml:documentPart type="text">3.00865,4</tdml:documentPart>
@@ -6386,8 +6426,7 @@
 -->
 
   <tdml:parserTestCase name="xPathFunc_round_hte_04" root="round-hte"
-    model="XPathFunctions" description="Section 23.5.2 - Standard XPath Functions - round-half-to-even - DFDL-23-098R"
-    roundTrip="twoPass">
+    model="XPathFunctions" description="Section 23.5.2 - Standard XPath Functions - round-half-to-even - DFDL-23-098R">
 
     <tdml:document>
       <tdml:documentPart type="text">3.00065,4</tdml:documentPart>
@@ -6412,8 +6451,7 @@
 -->
 
   <tdml:parserTestCase name="xPathFunc_round_hte_05" root="round-hte"
-    model="XPathFunctions" description="Section 23.5.2 - Standard XPath Functions - round-half-to-even - DFDL-23-098R"
-    roundTrip="twoPass">
+    model="XPathFunctions" description="Section 23.5.2 - Standard XPath Functions - round-half-to-even - DFDL-23-098R">
 
     <tdml:document>
       <tdml:documentPart type="text">3.000065,5</tdml:documentPart>
@@ -11049,18 +11087,11 @@
     <tdml:document>
       <tdml:documentPart type="text"></tdml:documentPart>
     </tdml:document>
-    <tdml:infoset>
-      <tdml:dfdlInfoset>
-        <count02>
-          <calced>calculated string</calced>
-          <count>1</count>
-        </count02>
-      </tdml:dfdlInfoset>
-    </tdml:infoset>
-    <tdml:warnings>
-      <tdml:warning>Runtime Schema Definition Warning</tdml:warning>
-      <tdml:warning>fn:exists</tdml:warning>
-    </tdml:warnings>
+    <tdml:errors>
+      <tdml:error>Schema Definition Error</tdml:error>
+      <tdml:error>fn:count</tdml:error>
+      <tdml:error>array</tdml:error>
+    </tdml:errors>
   </tdml:parserTestCase>
 
 <!--
@@ -11076,19 +11107,11 @@
     <tdml:document>
       <tdml:documentPart type="text"></tdml:documentPart>
     </tdml:document>
-    <tdml:infoset>
-      <tdml:dfdlInfoset>
-        <count02b>
-          <str>calculated string</str>
-          <calced>calculated string</calced>
-          <count>1</count>
-        </count02b>
-      </tdml:dfdlInfoset>
-    </tdml:infoset>
-    <tdml:warnings>
-      <tdml:warning>Runtime Schema Definition Warning</tdml:warning>
-      <tdml:warning>fn:exists</tdml:warning>
-    </tdml:warnings>
+    <tdml:errors>
+      <tdml:error>Schema Definition Error</tdml:error>
+      <tdml:error>fn:count</tdml:error>
+      <tdml:error>array</tdml:error>
+    </tdml:errors>
   </tdml:parserTestCase>
 
 <!--
@@ -11393,6 +11416,110 @@
       </tdml:dfdlInfoset>
     </tdml:infoset>
   </tdml:unparserTestCase>
+
+  <!--
+      Test Name: count_12
+         Schema: XPathFunctions
+           Root: count07
+           Purpose: This test demonstrates the count() function works as expected
+                    when parsing an array of scalars
+  -->
+
+  <tdml:parserTestCase name="count_12" root="count07"
+    model="XPathFunctions" description="Section 23 - Functions - fn:count - DFDL-23-122R">
+    <tdml:document>
+      <tdml:documentPart type="byte">00 00 00 01 00 00 00 02</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <ex:count07 xmlns:ex="http://example.com">
+          <ex:int>1</ex:int>
+          <ex:int>2</ex:int>
+          <ex:count>2</ex:count>
+        </ex:count07>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <!--
+      Test Name: count_13
+         Schema: XPathFunctions
+           Root: count08
+           Purpose: This test demonstrates the count() function works as expected
+                    when parsing a unique scalar element
+  -->
+
+  <tdml:parserTestCase name="count_13" root="count08" roundTrip="true"
+                       model="XPathFunctions" description="Section 23 - Functions - fn:count - DFDL-23-122R">
+    <tdml:document>
+      <tdml:documentPart type="byte">00 00 00 01</tdml:documentPart>
+    </tdml:document>
+    <tdml:errors>
+      <tdml:error>Schema Definition Error</tdml:error>
+      <tdml:error>fn:count</tdml:error>
+      <tdml:error>array</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+  <!--
+      Test Name: count_14
+         Schema: XPathFunctions
+           Root: count09
+           Purpose: This test demonstrates the count() function works as expected
+                    when parsing an optional element
+  -->
+
+  <tdml:parserTestCase name="count_14" root="count09" roundTrip="true"
+                       model="XPathFunctions" description="Section 23 - Functions - fn:count - DFDL-23-122R">
+    <tdml:document>
+      <tdml:documentPart type="byte">00 00 00 01</tdml:documentPart>
+    </tdml:document>
+    <tdml:errors>
+      <tdml:error>Schema Definition Error</tdml:error>
+      <tdml:error>fn:count</tdml:error>
+      <tdml:error>array</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+  <!--
+      Test Name: count_15
+         Schema: XPathFunctions
+           Root: count10
+           Purpose: This test demonstrates the count() function works as expected
+                    when parsing a unique scalar element using outputValueCalc
+  -->
+
+  <tdml:parserTestCase name="count_15" root="count10" roundTrip="true"
+                       model="XPathFunctions" description="Section 23 - Functions - fn:count - DFDL-23-122R">
+    <tdml:document>
+      <tdml:documentPart type="byte">00 00 00 01</tdml:documentPart>
+    </tdml:document>
+    <tdml:errors>
+      <tdml:error>Schema Definition Error</tdml:error>
+      <tdml:error>fn:count</tdml:error>
+      <tdml:error>array</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+  <!--
+      Test Name: count_16
+         Schema: XPathFunctions
+           Root: count11
+           Purpose: This test demonstrates the count() function works as expected
+                    when parsing a unique scalar element using an occursCount expression
+  -->
+
+  <tdml:parserTestCase name="count_16" root="count11" roundTrip="true"
+                       model="XPathFunctions" description="Section 23 - Functions - fn:count - DFDL-23-122R">
+    <tdml:document>
+      <tdml:documentPart type="byte">00 00 00 01</tdml:documentPart>
+    </tdml:document>
+    <tdml:errors>
+      <tdml:error>Schema Definition Error</tdml:error>
+      <tdml:error>fn:count</tdml:error>
+      <tdml:error>array</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
 
 <!--
     Test Name: local_name_01

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section05/simple_types/TestSimpleTypes.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section05/simple_types/TestSimpleTypes.scala
@@ -826,6 +826,8 @@ class TestSimpleTypes {
   @Test def test_float_text(): Unit = { runner.runOneTest("float_text") }
   @Test def test_float_text2(): Unit = { runner.runOneTest("float_text2") }
   @Test def test_float_text3(): Unit = { runner.runOneTest("float_text3") }
+  @Test def test_float_text_max(): Unit = { runner.runOneTest("float_text_max") }
+
   @Test def test_float_text_fail(): Unit = { runner.runOneTest("float_text_fail") }
   @Test def test_characterDuringValidFloat(): Unit = {
     runner.runOneTest("characterDuringValidFloat")

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section23/dfdl_expressions/TestDFDLExpressions.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section23/dfdl_expressions/TestDFDLExpressions.scala
@@ -769,6 +769,12 @@ class TestDFDLExpressions {
   @Test def test_count_10(): Unit = { runner2.runOneTest("count_10") }
   @Test def test_count_11(): Unit = { runner2.runOneTest("count_11") }
 
+  @Test def test_count_12(): Unit = { runner2.runOneTest("count_12") }
+  @Test def test_count_13(): Unit = { runner2.runOneTest("count_13") }
+  @Test def test_count_14(): Unit = { runner2.runOneTest("count_14") }
+  @Test def test_count_15(): Unit = { runner2.runOneTest("count_15") }
+  @Test def test_count_16(): Unit = { runner2.runOneTest("count_16") }
+
   @Test def test_local_name_01(): Unit = { runner2.runOneTest("local_name_01") }
   @Test def test_local_name_02(): Unit = { runner2.runOneTest("local_name_02") }
   @Test def test_local_name_03(): Unit = { runner2.runOneTest("local_name_03") }


### PR DESCRIPTION
Throw a SDE during compilation if the fn:count function is called on a path expression that ends with a unique scalar element.

DAFFODIL-2711

Expression.scala: Add checkArgArray function to check for an array element and call for fn:count expression.

DState.scala: Remove isAnArray function since it is now redundant.

FNFunctions.scala: Fix typo.

PrefixedTests.tdml: Update element to use fn:exists instead of fn:count.

expressions.tdml: Update element to use fn:exists instead of fn:count.

Functions.tdml: Add test cases using fn:count on arrays of length 1 and 2 using inputValueCalc, outputValueCalc, and occursCount expressions. Fix assertion messages. Update tests that now result in errors.

TestDFDLExpressions.scala: Add new test cases for Functions.tdml.