### PR TITLE
[RFC] Add special case for textNumberPattern with a '0' pad character

### DIFF
--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/EvTextNumber.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/EvTextNumber.scala
@@ -186,6 +186,31 @@ class TextNumberFormatEv(
       }
     }
 
+    // If textNumberPattern specifies a pad character before the number pattern and without a
+    // positive prefix, then ICU defaults to a pad position of PAD_BEFORE_PREFIX with no way to
+    // change it with just the pattern. This is reasonable for most cases, like when the pad
+    // character is a space. However, if the pad character in textNumberPattern is '0', then
+    // negative numbers are padded with a '0' before the negative sign. For example, a pattern
+    // of "*0####0" unparses -123 to "0-123". This is very unlikely to be what the user wants
+    // with this pattern.
+    //
+    // So in this very specific case, we change the pad position to PAD_AFTER_PREFIX so the zero
+    // pad character appears after the negative sign, e.g. "-0123". Note that the check for
+    // format width > 0 is used to test if padding is enabled at all--there is no specific API
+    // for this, and this is how ICU determines to add padding or not.
+    //
+    // If a user really wants '0' characters to the left of the negative sign, they can use
+    // textPadKind/textTrimKind and textNumberPadCharacter to uses Daffodils padding logic
+    // instead of ICUs.
+    if (
+      df.getFormatWidth > 0 &&
+      df.getPadCharacter == '0' &&
+      df.getPositivePrefix == "" &&
+      df.getPadPosition == DecimalFormat.PAD_BEFORE_PREFIX
+    ) {
+      df.setPadPosition(DecimalFormat.PAD_AFTER_PREFIX)
+    }
+
     df
   }
 

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section13/text_number_props/TextNumberProps.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section13/text_number_props/TextNumberProps.tdml
@@ -321,6 +321,13 @@
     <xs:element name="tnp103" type="xs:integer" dfdl:textNumberPattern="###0.0##"
       dfdl:textNumberCheckPolicy="strict" />
 
+    <!--
+      Daffodil configures ICU so that a textNumberPattern with a leading pad
+      character of '0' and no positive prefix pads to the right of the negative sign
+    -->
+    <xs:element name="tnp104" type="xs:integer" dfdl:textNumberPattern="*0####0"
+      dfdl:textNumberCheckPolicy="strict" />
+
   </tdml:defineSchema>
   
   <tdml:defineSchema name="textNumberPattern2"  elementFormDefault="qualified">
@@ -4502,6 +4509,28 @@
       <tdml:error>Inf</tdml:error>
       <tdml:error>xs:integer</tdml:error>
     </tdml:errors>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="textNumberZeroPad01" root="tnp104" model="textNumberPattern">
+    <tdml:document>
+      <tdml:documentPart type="text">00012</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <tnp104>12</tnp104>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="textNumberZeroPad02" root="tnp104" model="textNumberPattern">
+    <tdml:document>
+      <tdml:documentPart type="text">-0012</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <tnp104>-12</tnp104>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
   </tdml:parserTestCase>
 
 </tdml:testSuite>

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section13/text_number_props/TestTextNumberProps.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section13/text_number_props/TestTextNumberProps.scala
@@ -523,4 +523,7 @@ class TestTextNumberProps {
   @Test def test_textNumberIntegerWithDecimal04(): Unit = {
     runner.runOneTest("textNumberIntegerWithDecimal04")
   }
+
+  @Test def test_textNumberZeroPad01(): Unit = { runner.runOneTest("textNumberZeroPad01") }
+  @Test def test_textNumberZeroPad02(): Unit = { runner.runOneTest("textNumberZeroPad02") }
 }


### PR DESCRIPTION
> [!NOTE]
> I've marked this as a RFC/Draft--although I think this changes the behavior to what a user would expect with this specific type of textNumberPattern, it is behavior that is not specified by the DFDL specification

If textNumberPattern specifies a pad character before the number pattern and without a positive prefix, then ICU defaults to a pad position of PAD_BEFORE_PREFIX with no way to change it with just the pattern. This is reasonable for most cases, like when the pad character is a space. However, if the pad character in textNumberPattern is '0', then negative numbers are padded with a '0' before the negative sign. For example, a pattern of "*0####0" unparses -123 to "0-123". This is very unlikely to be what the user wants with this pattern.

So in this very specific case, we change the pad position to PAD_AFTER_PREFIX so the zero pad character appears after the negative sign, e.g. "-0123".

If a user really wants '0' characters to the left of the negative sign, they can use textPadKind/textTrimKind and textNumberPadCharacter to uses Daffodils padding logic.