### PR TITLE
Bump SonarSource/sonarcloud-github-action from v1.9 to v2.1.1

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -200,7 +200,7 @@ jobs:
 
       - name: Run SonarCloud Scan
         if: ${{ env.SONARSCAN == 'true' }}
-        uses: sonarsource/sonarcloud-github-action@v1.9
+        uses: SonarSource/sonarcloud-github-action@v2.1.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
This updates the docker container used to do the scan and should use the support Java 17 version.

Also uses correct capitalization of "SonarSource", maybe this is why dependabot never updated this for us?

This also enables the scan on pull requests. I'm not sure why we enabled it only when merged to main, but the documentation claims it works on PRs too, so lets do that.

DAFFODIL-2856