### PR TITLE
Include the crossVersion in daffodil jars packaged in tar/zip/RPM

### DIFF
--- a/daffodil-cli/build.sbt
+++ b/daffodil-cli/build.sbt
@@ -36,6 +36,22 @@ Universal / mappings ++= Seq(
   baseDirectory.value / "README.md" -> "README.md",
 )
 
+// When the sbt-native-packger plugin creates a tar/zip/RPM/etc, it does not include the
+// crossVersion in mapping of jars built from this project (i.e. org.apache.daffodil jars only).
+// There are cases where this crossVersion would be useful (e.g. consistency with Ivy jar names
+// that do include the crossVersion), so this modifies the mapping to include that. Note that
+// the name of the path already has what we need, we just need to prepend "lib/" and our
+// organization.
+Universal / mappings := (Universal / mappings).value.map { case (path, mapping) =>
+  val thisProjectJarPrefix = "lib/" + organization.value + "."
+  val newMapping =
+    if (mapping.startsWith(thisProjectJarPrefix))
+      thisProjectJarPrefix + path.getName
+    else
+      mapping
+  (path, newMapping)
+}
+
 maintainer := "Apache Daffodil <dev@daffodil.apache.org>"
 
 //


### PR DESCRIPTION
The sbt-native-packager plugin does not include the crossVersion in the Daffodil jars that it packages in tar/zip/RPM/etc. This could be useful for more easily comparing jars from maven (which do include the crossVersion) or creating a local Ivy/maven repo.

The plugin does not have an configuration option to set this, so this directly modifies the mappings that the plugin creates to include the crossVersion for Daffodil jars only.

For example, a package mapping that was previously this:

    lib/org.apache.daffodil.daffodil-lib-3.7.0.jar

is now changed to this:

    lib/org.apache.daffodil.daffodil-lib_2.12-3.7.0.jar

DAFFODIL-2849