### PR TITLE
Improve performance of xml and json infoset outputters

### DIFF
--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/infoset/JsonInfosetOutputter.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/infoset/JsonInfosetOutputter.scala
@@ -29,12 +29,16 @@ import org.apache.daffodil.runtime1.api.InfosetSimpleElement
 
 import com.fasterxml.jackson.core.io.JsonStringEncoder
 
-class JsonInfosetOutputter private (writer: java.io.Writer, pretty: Boolean)
+class JsonInfosetOutputter private (writer: java.io.BufferedWriter, pretty: Boolean)
   extends InfosetOutputter
   with Indentable {
 
   def this(os: java.io.OutputStream, pretty: Boolean) = {
-    this(new java.io.OutputStreamWriter(os, StandardCharsets.UTF_8), pretty)
+    // using a BufferedWriter provides significant performance improvements
+    this(
+      new java.io.BufferedWriter(new java.io.OutputStreamWriter(os, StandardCharsets.UTF_8)),
+      pretty,
+    )
   }
 
   // Keeps track of if the next element we see is the first child or not of a
@@ -63,7 +67,7 @@ class JsonInfosetOutputter private (writer: java.io.Writer, pretty: Boolean)
     } else {
       writer.write(',')
     }
-    if (pretty) writer.write(System.lineSeparator())
+    if (pretty) writer.newLine()
     if (pretty) outputIndentation(writer)
   }
 
@@ -91,7 +95,7 @@ class JsonInfosetOutputter private (writer: java.io.Writer, pretty: Boolean)
   // complex/array/document at the right indentation level
   private def endNodeWithChildren(): Unit = {
     isFirstChildStack.pop()
-    if (pretty) writer.write(System.lineSeparator())
+    if (pretty) writer.newLine()
     decrementIndentation()
     if (pretty) outputIndentation(writer)
   }
@@ -163,7 +167,7 @@ class JsonInfosetOutputter private (writer: java.io.Writer, pretty: Boolean)
   override def endDocument(): Unit = {
     endNodeWithChildren()
     writer.write('}')
-    if (pretty) writer.write(System.lineSeparator())
+    if (pretty) writer.newLine()
     writer.flush()
   }
 }


### PR DESCRIPTION
The XMLTextInfosetOutputter and JSONInfosetOutputter do not use any buffering when writing data. Modifying these to wrap a BufferedWriter around the existing OutputStreamWriter gives significant performance improvements. Using a BufferedWriter also allows us to use its built-in newLine() function for pretty printing.

This also modifies the "Standard" XML escape style in the xml infoset outputter so that it first checks if there are any characters that need to be escaped, similar to what we do for CDATA escape style. In most cases, there will not be any characters that need escaping, so we can avoid Scala XML's escape utility, which has noticeable overhead, even if nothing needs escaping.

With these changes tested on a large file with lots of strings, this saw total parse + infoset output time drop from about 125 seconds to 93 seconds, about a 25% decrease. Note that parsing with the null infoset outputter takes about 78 seconds, so the xml infoset outputter overhead went from about 37% of the total parse time down to about 20%.

DAFFODIL-2872