### PR TITLE
Pin github actions to a commit hash

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
       - name: Check out Repository
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
       - name: Submit Dependency Graph
-        uses: scalacenter/sbt-dependency-submission@v2.3.1
+        uses: scalacenter/sbt-dependency-submission@f3c0455a87097de07b66c3dc1b8619b5976c1c89 # v2.3.1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -112,14 +112,14 @@ jobs:
 
       - name: Install Dependencies (Windows)
         if: runner.os == 'Windows'
-        uses: msys2/setup-msys2@v2
+        uses: msys2/setup-msys2@cc11e9188b693c2b100158c3322424c4cc1dadea # v2.22.0
         with:
           install: clang diffutils make pkgconf
           path-type: inherit
 
       - name: Check out mxml source (Windows)
         if: runner.os == 'Windows'
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           repository: michaelrsweet/mxml
           ref: v3.3
@@ -138,13 +138,13 @@ jobs:
           echo "COURSIER_CONFIG_DIR=$temp" >> $GITHUB_ENV
 
       - name: Check out Repository
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         # Disabling shallow clone is recommended for improving sonarcloud reporting
         with:
           fetch-depth: 0
 
       - name: Setup Java
-        uses: actions/setup-java@v4.1.0
+        uses: actions/setup-java@9704b39bf258b59bc04b50fa2dd55e9ed76b47a8 # v4.1.0
         with:
           distribution: ${{ matrix.java_distribution }}
           java-version: ${{ matrix.java_version }}
@@ -190,7 +190,7 @@ jobs:
         run: $SBT coverageAggregate
 
       - name: Upload Coverage Report
-        uses: codecov/codecov-action@v4.1.0
+        uses: codecov/codecov-action@54bcd8715eee62d40e33596ef5e8f0f48dbbccab # v4.1.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 
@@ -202,7 +202,7 @@ jobs:
 
       - name: Run SonarCloud Scan
         if: ${{ env.SONARSCAN == 'true' }}
-        uses: SonarSource/sonarcloud-github-action@v2.1.1
+        uses: SonarSource/sonarcloud-github-action@49e6cd3b187936a73b8280d59ffd9da69df63ec9 # v2.1.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
@@ -230,10 +230,10 @@ jobs:
       ############################################################
 
       - name: Check out Repository
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
       - name: Setup Java
-        uses: actions/setup-java@v4.1.0
+        uses: actions/setup-java@9704b39bf258b59bc04b50fa2dd55e9ed76b47a8 # v4.1.0
         with:
           distribution: ${{ matrix.java_distribution }}
           java-version: ${{ matrix.java_version }}
@@ -263,7 +263,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Check Single Commit
-        uses: actions/github-script@v7.0.1
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           script: |
             const commits = await github.rest.pulls.listCommits({


### PR DESCRIPTION
Pinning to a tag can lead to breaking builds or malicious actors compromising our actions if they are able to rename or delete a tag. Pinning to a commit hash avoids these issues. There is no loss of functionality--dependabot is able to update commit hashs and comments containing the associated tag.

DAFFODIL-2881