### PR TITLE
Add test showing optional elements cannot have predicates in expressions

### DIFF
--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/dsom/SDE.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/dsom/SDE.scala
@@ -279,7 +279,7 @@ trait ImplementsThrowsOrSavesSDE extends ImplementsThrowsSDE with SavesErrorsAnd
 
   def subsetError(msg: String, args: Any*) = {
     val msgTxt = msg.format(args: _*)
-    SDE("Subset " + msgTxt)
+    SDE("Subset: " + msgTxt)
   }
 
 }

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section14/unordered_sequences/UnorderedSequences.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section14/unordered_sequences/UnorderedSequences.tdml
@@ -627,7 +627,7 @@
     <tdml:document><![CDATA[a1,b2,cy99:x20:z10]]></tdml:document>
     <tdml:errors>
       <tdml:error>Schema Definition Error</tdml:error>
-      <tdml:error>Subset Indexing is only allowed on arrays</tdml:error>
+      <tdml:error>Subset: Indexing is only allowed on arrays</tdml:error>
     </tdml:errors>
   </tdml:parserTestCase>
 

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section23/dfdl_expressions/expressions.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section23/dfdl_expressions/expressions.tdml
@@ -4322,6 +4322,16 @@ blastoff
       </xs:complexType>
     </xs:element>
 
+    <xs:element name="e6">
+      <xs:complexType>
+        <xs:sequence dfdl:separator=",">
+          <xs:element name="index" type="xs:int" />
+          <xs:element name="item" type="xs:string" minOccurs="0" maxOccurs="1"/>
+          <xs:element name="p" type="xs:string" dfdl:inputValueCalc="{ /ex:e6/ex:item[1] }"/>
+        </xs:sequence>
+      </xs:complexType>
+    </xs:element>
+
   </tdml:defineSchema>
 
   <!--
@@ -4426,7 +4436,24 @@ blastoff
     <tdml:document>2,one,two,three</tdml:document>
     <tdml:errors>
       <tdml:error>Schema Definition Error</tdml:error>
-      <tdml:error>Subset Indexing is only allowed on arrays.</tdml:error>
+      <tdml:error>Subset: Indexing is only allowed on arrays.</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+  <!--
+     Test Name: predicate_06
+        Schema: predicates
+          Root: e6
+       Purpose: This test demonstrates that subset indexing is not allowed on optionals
+  -->
+
+  <tdml:parserTestCase name="predicate_06" root="e6"
+    model="predicates" description="Section 23 - DFDL Expressions - DFDL-23-067R">
+
+    <tdml:document>2,one</tdml:document>
+    <tdml:errors>
+      <tdml:error>Schema Definition Error</tdml:error>
+      <tdml:error>Subset: Indexing is only allowed on arrays.</tdml:error>
     </tdml:errors>
   </tdml:parserTestCase>
 
@@ -7270,7 +7297,7 @@ blastoff
     <tdml:document>1,2,3</tdml:document>
     <tdml:errors>
       <tdml:error>Schema Definition Error</tdml:error>
-      <tdml:error>Subset Indexing is only allowed on arrays</tdml:error>
+      <tdml:error>Subset: Indexing is only allowed on arrays</tdml:error>
       <tdml:error>ex:a</tdml:error>
     </tdml:errors>
   </tdml:parserTestCase>

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section23/dfdl_expressions/TestDFDLExpressions.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section23/dfdl_expressions/TestDFDLExpressions.scala
@@ -529,6 +529,7 @@ class TestDFDLExpressions {
   // @Test def test_predicate_03() { runner.runOneTest("predicate_03") }
   @Test def test_predicate_04(): Unit = { runner.runOneTest("predicate_04") }
   @Test def test_predicate_05(): Unit = { runner.runOneTest("predicate_05") }
+  @Test def test_predicate_06(): Unit = { runner.runOneTest("predicate_06") }
 
   @Test def test_sequential_and_01(): Unit = { runner.runOneTest("sequential_and_01") }
   @Test def test_sequential_and_02(): Unit = { runner.runOneTest("sequential_and_02") }


### PR DESCRIPTION
Optional elements used to be implemented as arrays with a max size of one. A side effect of this was that accessing these elements in an expression required a predicate (e.g. /path/to/optional[1]).

However, at some point we changed the implementation so optional elements were no longer arrays and were added to the infoset just like scalars. This change also meant they no longer needed, or were allowed to have, predicates in expressions. This adds a test to confirm that behavior.

This also adds a colon to "subset" error messages to make the actual error message more clear.

DAFFODIL-2013