### PR TITLE
Fix mapping from separatorPolicy to separatorSuppressionPolicy

### DIFF
--- a/daffodil-lib/src/main/scala/org/apache/daffodil/lib/schema/annotation/props/ByHandMixins.scala
+++ b/daffodil-lib/src/main/scala/org/apache/daffodil/lib/schema/annotation/props/ByHandMixins.scala
@@ -197,8 +197,8 @@ trait SeparatorSuppressionPolicyMixin extends PropertyMixin {
         spString match {
           case "required" => SeparatorSuppressionPolicy.Never
           case "suppressed" => SeparatorSuppressionPolicy.AnyEmpty
-          case "suppressedAtEndStrict" => SeparatorSuppressionPolicy.TrailingEmpty
-          case "suppressedAtEndLax" => SeparatorSuppressionPolicy.TrailingEmptyStrict
+          case "suppressedAtEndLax" => SeparatorSuppressionPolicy.TrailingEmpty
+          case "suppressedAtEndStrict" => SeparatorSuppressionPolicy.TrailingEmptyStrict
           case _ => Assert.invariantFailed("illegal string for separatorPolicy")
         }
       }


### PR DESCRIPTION
Daffodil allows use of the deprecated separatorPolicy property and internally maps it to the new separatorSuppressionPolicy property. Unfortunately, according to the OGF Errata document our mapping is wrong, which means suppressedAtEndLax behaves like trailingEmptyStrict and suppressedAtEndStrict behaves like trailingEmpty. This is reversed from how it should be. This fixes that mapping so they have the correct behavior.

Deprecation/Compatibility:

The deprecated separatorPolicy property values of "suppressedAtEndLax" and "suppressedAtEndStrict" had incorrect behaviors, with each property behaving like the other. Schemas using one value should be updated to use the other. Alternatively, schemas should be updated to use the new separatorSuppressionPolicy property with the following mappings from the deprecated property:

* required -> never
* suppressed -> anyEmpty
* suppressedAtEndLax -> trailingEmpty
* suppressedAtEndStrict -> trailingEmptyStrict

DAFFODIL-2882