### PR TITLE
Error if -T and -P options are used together in the CLI

### DIFF
--- a/daffodil-cli/src/main/scala/org/apache/daffodil/cli/Main.scala
+++ b/daffodil-cli/src/main/scala/org/apache/daffodil/cli/Main.scala
@@ -405,9 +405,14 @@ class CLIConf(arguments: Array[String], stdout: PrintStream, stderr: PrintStream
       descr = "Input file to parse. If not specified, or a value of -, reads from stdin.",
     )
 
-    requireOne(schema, parser) // must have one of --schema or --parser
-    conflicts(parser, List(rootNS)) // if --parser is provided, cannot also provide --root
-    validateFileIsFile(config) // --config must be a file that exists
+    // must have one of --schema or --parser
+    requireOne(schema, parser)
+
+    // if --parser is provided, cannot also provide --root or -T
+    conflicts(parser, List(rootNS, tunables))
+
+    // --config must be a file that exists
+    validateFileIsFile(config)
 
     validateOpt(debug, infile) {
       case (Some(_), Some("-")) | (Some(_), None) =>
@@ -510,9 +515,14 @@ class CLIConf(arguments: Array[String], stdout: PrintStream, stderr: PrintStream
       descr = "Input file to unparse. If not specified, or a value of -, reads from stdin.",
     )
 
-    requireOne(schema, parser) // must have one of --schema or --parser
-    conflicts(parser, List(rootNS)) // if --parser is provided, cannot also provide --root
-    validateFileIsFile(config) // --config must be a file that exists
+    // must have one of --schema or --parser
+    requireOne(schema, parser)
+
+    // if --parser is provided, cannot also provide --root or -T
+    conflicts(parser, List(rootNS, tunables))
+
+    // --config must be a file that exists
+    validateFileIsFile(config)
 
     validateOpt(debug, infile) {
       case (Some(_), Some("-")) | (Some(_), None) =>
@@ -706,9 +716,14 @@ class CLIConf(arguments: Array[String], stdout: PrintStream, stderr: PrintStream
       descr = "Input file or directory containing input files to parse or unparse",
     )
 
-    requireOne(schema, parser) // must have one of --schema or --parser
-    conflicts(parser, List(rootNS)) // if --parser is provided, cannot also provide --root
-    validateFileIsFile(config) // --config must be a file that exists
+    // must have one of --schema or --parser
+    requireOne(schema, parser)
+
+    // if --parser is provided, cannot also provide --root or -T
+    conflicts(parser, List(rootNS, tunables))
+
+    // --config must be a file that exists
+    validateFileIsFile(config)
 
     validateOpt(infosetType, schema) {
       case (Some(InfosetType.EXISA), None) =>

--- a/daffodil-cli/src/test/scala/org/apache/daffodil/cli/cliTest/TestCLITunables.scala
+++ b/daffodil-cli/src/test/scala/org/apache/daffodil/cli/cliTest/TestCLITunables.scala
@@ -243,4 +243,18 @@ class TestCLITunables {
     }
   }
 
+  @Test def test_CLI_Parsing_ReloadingWithTunables(): Unit = {
+    val schema = path(
+      "daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/charClassEntities.dfdl.xsd",
+    )
+
+    withTempFile { parser =>
+      runCLI(args"save-parser -s $schema -r matrix $parser") { _ => }(ExitCode.Success)
+
+      runCLI(args"parse --parser $parser -TsuppressSchemaDefinitionWarnings=all") { cli =>
+        cli.expectErr("Option 'parser' conflicts with option 'T'")
+      }(ExitCode.Usage)
+    }
+  }
+
 }


### PR DESCRIPTION
When a parser is created with the CLI "save-parser" command, the values of the tunables are serialized along with the parser. When using the "parse", "unparse", or "performance" commands with the -P option to reload a saved parser, we use the serialized tunable values and ignore the -T option if provided. This can be confusing since there is no indication that the -T option is ignored.

To avoid this, we now error if the -P and -T options are used together. Saved parsers must be rebuilt if you want to change tunable values.

DAFFODIL-2880