### PR TITLE
Add support for validation of length facet

### DIFF
--- a/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/RestrictionUnion.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/RestrictionUnion.scala
@@ -118,6 +118,9 @@ final class Restriction private (xmlArg: Node, val simpleTypeDef: SimpleTypeDefB
   lazy val localBaseFacets: ElemFacets = {
     val myFacets: Queue[FacetValue] = Queue.empty // val not var - it's a mutable collection
     if (localPatternValue.length > 0) { myFacets.enqueue((Facet.pattern, localPatternValue)) }
+    if (localLengthValue.length > 0) {
+      myFacets.enqueue((Facet.length, localLengthValue))
+    }
     if (localMinLengthValue.length > 0) {
       myFacets.enqueue((Facet.minLength, localMinLengthValue))
     }
@@ -162,6 +165,10 @@ final class Restriction private (xmlArg: Node, val simpleTypeDef: SimpleTypeDefB
       val rPattern = remoteBaseFacets.filter { case (f, v) => f == Facet.pattern }
       val cPattern = lPattern.union(rPattern)
       cPattern.foreach(x => combined.enqueue(x))
+    }
+    if (hasLength) {
+      val cValue = getCombinedValue(Facet.length)
+      combined.enqueue((Facet.length, cValue.toString()))
     }
     if (hasMinLength) {
       val cValue = getCombinedValue(Facet.minLength)

--- a/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/SimpleTypes.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/SimpleTypes.scala
@@ -147,7 +147,7 @@ abstract class SimpleTypeDefBase(xml: Node, lexicalParent: SchemaComponent)
     optRestriction
       .map { r =>
         if (
-          r.hasPattern || r.hasEnumeration || r.hasMinLength || r.hasMaxLength ||
+          r.hasPattern || r.hasEnumeration || r.hasLength || r.hasMinLength || r.hasMaxLength ||
           r.hasMinInclusive || r.hasMaxInclusive || r.hasMinExclusive || r.hasMaxExclusive ||
           r.hasTotalDigits || r.hasFractionDigits
         ) false

--- a/daffodil-core/src/main/scala/org/apache/daffodil/core/runtime1/SimpleTypeRuntime1Mixin.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/core/runtime1/SimpleTypeRuntime1Mixin.scala
@@ -34,6 +34,7 @@ trait SimpleTypeRuntime1Mixin { self: SimpleTypeDefBase =>
         noFacetChecks,
         optRestriction.toSeq.flatMap { r => if (r.hasPattern) r.patternValues else Nil },
         optRestriction.flatMap { r => toOpt(r.hasEnumeration, r.enumerationValues.get) },
+        optRestriction.flatMap { r => toOpt(r.hasLength, r.lengthValue) },
         optRestriction.flatMap { r => toOpt(r.hasMinLength, r.minLengthValue) },
         optRestriction.flatMap { r => toOpt(r.hasMaxLength, r.maxLengthValue) },
         optRestriction.flatMap { r => toOpt(r.hasMinInclusive, r.minInclusiveValue) },

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/dsom/Facets1.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/dsom/Facets1.scala
@@ -24,6 +24,7 @@ object Facet extends Enum {
   sealed abstract trait Type extends EnumValueType
   case object enumeration extends Type
   case object fractionDigits extends Type
+  case object length extends Type
   case object maxExclusive extends Type
   case object maxInclusive extends Type
   case object maxLength extends Type

--- a/daffodil-test/src/test/resources/org/apache/daffodil/extensions/repType/repType.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/extensions/repType/repType.tdml
@@ -758,7 +758,7 @@
           <xs:element name="field" dfdlx:repType="tns:rep">
             <xs:simpleType>
               <xs:restriction base="xs:string">
-                <!-- "t" is actually the only valid value due to min/maxLength -->
+                <!-- "one" is actually the only valid value due to min/maxLength -->
                 <xs:enumeration value="one" dfdlx:repValues="1" />
                 <xs:enumeration value="t" dfdlx:repValues="2" />
                 <xs:enumeration value="three" dfdlx:repValues="3" />
@@ -771,9 +771,29 @@
       </xs:complexType>
     </xs:element>
 
+    <xs:element name="root2">
+      <xs:complexType>
+        <xs:sequence>
+          <xs:element name="field" dfdlx:repType="tns:rep">
+            <xs:simpleType>
+              <xs:restriction base="xs:string">
+                <!-- "t" is actually the only valid value due to length -->
+                <xs:enumeration value="one" dfdlx:repValues="1" />
+                <xs:enumeration value="t" dfdlx:repValues="2" />
+                <xs:enumeration value="three" dfdlx:repValues="3" />
+                <xs:length value="1" />
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:element>
+        </xs:sequence>
+      </xs:complexType>
+    </xs:element>
+
   </tdml:defineSchema>
 
-  <tdml:parserTestCase name="repType_length_facet_01" model="repType-LengthFacets.dfdl.xsd" validation="limited">
+  <tdml:parserTestCase name="repType_length_facet_01"
+                       root="root1"
+                       model="repType-LengthFacets.dfdl.xsd" validation="limited">
     <tdml:document>
       <tdml:documentPart type="byte">01</tdml:documentPart>
     </tdml:document>
@@ -786,7 +806,9 @@
     </tdml:infoset>
   </tdml:parserTestCase>
 
-  <tdml:parserTestCase name="repType_length_facet_02" model="repType-LengthFacets.dfdl.xsd" validation="limited">
+  <tdml:parserTestCase name="repType_length_facet_02"
+                       root="root1"
+                       model="repType-LengthFacets.dfdl.xsd" validation="limited">
     <tdml:document>
       <tdml:documentPart type="byte">02</tdml:documentPart>
     </tdml:document>
@@ -804,7 +826,9 @@
     </tdml:validationErrors>
   </tdml:parserTestCase>
 
-  <tdml:parserTestCase name="repType_length_facet_03" model="repType-LengthFacets.dfdl.xsd" validation="limited">
+  <tdml:parserTestCase name="repType_length_facet_03"
+                       root="root1"
+                       model="repType-LengthFacets.dfdl.xsd" validation="limited">
     <tdml:document>
       <tdml:documentPart type="byte">03</tdml:documentPart>
     </tdml:document>
@@ -819,6 +843,59 @@
       <tdml:error>ex:field</tdml:error>
       <tdml:error>maxLength</tdml:error>
       <tdml:error>3</tdml:error>
+    </tdml:validationErrors>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="repType_length_facet_04"
+                       root="root2"
+                       model="repType-LengthFacets.dfdl.xsd" validation="limited">
+    <tdml:document>
+      <tdml:documentPart type="byte">01</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <root2>
+          <field>one</field>
+        </root2>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+    <tdml:validationErrors>
+      <tdml:error>ex:field</tdml:error>
+      <tdml:error>facet length (1)</tdml:error>
+    </tdml:validationErrors>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="repType_length_facet_05"
+                       root="root2"
+                       model="repType-LengthFacets.dfdl.xsd" validation="limited">
+    <tdml:document>
+      <tdml:documentPart type="byte">02</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <root2>
+          <field>t</field>
+        </root2>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="repType_length_facet_06"
+                       root="root2"
+                       model="repType-LengthFacets.dfdl.xsd" validation="limited">
+    <tdml:document>
+      <tdml:documentPart type="byte">03</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <root2>
+          <field>three</field>
+        </root2>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+    <tdml:validationErrors>
+      <tdml:error>ex:field</tdml:error>
+      <tdml:error>facet length (1)</tdml:error>
     </tdml:validationErrors>
   </tdml:parserTestCase>
 

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section02/validation_errors/Validation.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section02/validation_errors/Validation.tdml
@@ -385,7 +385,24 @@
         </xs:restriction>
       </xs:simpleType>
     </xs:element>
-    
+
+    <xs:element name="eString_minMaxLen7" dfdl:lengthKind="implicit" dfdl:inputValueCalc="{ 'string' }">
+      <xs:simpleType>
+          <xs:restriction base="xs:string">
+              <xs:minLength value="7"/>
+              <xs:maxLength value="7"/>
+          </xs:restriction>
+      </xs:simpleType>
+    </xs:element>
+
+    <xs:element name="eString_len7" dfdl:lengthKind="implicit" dfdl:inputValueCalc="{ 'string' }">
+      <xs:simpleType>
+          <xs:restriction base="xs:string">
+              <xs:length value="7"/>
+          </xs:restriction>
+      </xs:simpleType>
+    </xs:element>
+
     <xs:element name="e3" dfdl:lengthKind="delimited" dfdl:inputValueCalc="{ 'string' }">
       <xs:simpleType>
         <xs:restriction base="xs:string">
@@ -396,7 +413,7 @@
 
   </tdml:defineSchema>
 
-  <tdml:defineSchema name="TestFacets">
+    <tdml:defineSchema name="TestFacets">
     <xs:include schemaLocation="/org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
     <dfdl:format ref="ex:GeneralFormat" />
 
@@ -407,8 +424,47 @@
         </xs:restriction>
       </xs:simpleType>
     </xs:element>
-    
-    <xs:element name="e3_2" dfdl:lengthKind="delimited">
+
+    <xs:element name="eHexBinary_minMaxLen7" dfdl:lengthKind="delimited" dfdl:encoding="iso-8859-1">
+        <xs:simpleType>
+            <xs:restriction base="xs:hexBinary">
+                <xs:minLength value="7"/>
+                <xs:maxLength value="7"/>
+            </xs:restriction>
+        </xs:simpleType>
+    </xs:element>
+
+    <xs:element name="eHexBinary_len7" dfdl:lengthKind="delimited" dfdl:encoding="iso-8859-1">
+        <xs:simpleType>
+            <xs:restriction base="xs:hexBinary">
+                <xs:length value="7"/>
+            </xs:restriction>
+        </xs:simpleType>
+    </xs:element>
+
+    <xs:element name="eHexBinary_len0" dfdl:lengthKind="delimited" dfdl:encoding="iso-8859-1">
+        <xs:simpleType>
+            <xs:restriction base="xs:hexBinary">
+                <xs:length value="0"/>
+            </xs:restriction>
+        </xs:simpleType>
+    </xs:element>
+
+     <xs:element name="eString_localLen2" dfdl:lengthKind="implicit">
+        <xs:simpleType>
+            <xs:restriction base="ex:stringBaseLen2">
+                <xs:length value="2"/>
+            </xs:restriction>
+        </xs:simpleType>
+    </xs:element>
+
+    <xs:simpleType name="stringBaseLen2">
+        <xs:restriction base="xs:string">
+            <xs:length value="2"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+      <xs:element name="e3_2" dfdl:lengthKind="delimited">
       <xs:simpleType>
         <xs:restriction base="ex:stMaxLength_2">
           <xs:maxLength value="1" />
@@ -643,7 +699,111 @@
 
 		</tdml:validationErrors>
   </tdml:parserTestCase>
-  
+
+    <tdml:parserTestCase name="validation_testFacets_01"
+                         root="eHexBinary_minMaxLen7" model="TestFacets"
+                         description="validates hexBinary against min/maxLength facet"
+                         validation="limited">
+
+    <tdml:document>
+        <tdml:documentPart type="byte">deadbeefdafada</tdml:documentPart>
+    </tdml:document>
+
+        <tdml:infoset>
+            <tdml:dfdlInfoset>
+                <ex:eHexBinary_minMaxLen7>DEADBEEFDAFADA</ex:eHexBinary_minMaxLen7>
+            </tdml:dfdlInfoset>
+        </tdml:infoset>
+
+    </tdml:parserTestCase>
+
+    <tdml:parserTestCase name="validation_testFacets_02"
+                         root="eHexBinary_len7" model="TestFacets"
+                         description="validates hexBinary against length facet"
+                         validation="limited">
+
+    <tdml:document>
+        <tdml:documentPart type="byte">deadbeefdafada</tdml:documentPart>
+    </tdml:document>
+
+        <tdml:infoset>
+            <tdml:dfdlInfoset>
+                <ex:eHexBinary_len7>DEADBEEFDAFADA</ex:eHexBinary_len7>
+            </tdml:dfdlInfoset>
+        </tdml:infoset>
+    </tdml:parserTestCase>
+
+    <tdml:parserTestCase name="validation_testFacets_03"
+                         root="eHexBinary_len0" model="TestFacets"
+                         description="validates against length facet"
+                         validation="limited">
+
+        <tdml:document>
+            <tdml:documentPart type="byte">deadbeefdafada</tdml:documentPart>
+        </tdml:document>
+
+        <tdml:infoset>
+            <tdml:dfdlInfoset>
+                <ex:eHexBinary_len0>DEADBEEFDAFADA</ex:eHexBinary_len0>
+            </tdml:dfdlInfoset>
+        </tdml:infoset>
+
+        <tdml:validationErrors>
+
+            <tdml:error>eHexBinary_len0</tdml:error>
+            <tdml:error>failed facet checks</tdml:error>
+            <tdml:error>facet length (0)</tdml:error>
+
+        </tdml:validationErrors>
+    </tdml:parserTestCase>
+
+    <tdml:parserTestCase name="validation_testFacets_04"
+                         root="eString_localLen2" model="TestFacets"
+                         description="verify local length must be equal to base length"
+                         validation="limited">
+
+        <tdml:document>12</tdml:document>
+        <tdml:infoset>
+            <tdml:dfdlInfoset>
+                <eString_localLen2>12</eString_localLen2>
+            </tdml:dfdlInfoset>
+        </tdml:infoset>
+    </tdml:parserTestCase>
+
+    <tdml:defineSchema name="TestFacets3">
+        <xs:include schemaLocation="/org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+        <dfdl:format ref="ex:GeneralFormat" />
+        <xs:element name="eString_localLen1" dfdl:lengthKind="implicit">
+            <xs:simpleType>
+                <xs:restriction base="ex:stringBaseLen2">
+                    <xs:length value="1"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:element>
+
+        <xs:simpleType name="stringBaseLen2">
+            <xs:restriction base="xs:string">
+                <xs:length value="2"/>
+            </xs:restriction>
+        </xs:simpleType>
+    </tdml:defineSchema>
+
+    <tdml:parserTestCase name="validation_testFacets3_01"
+                         root="eString_localLen1" model="TestFacets3"
+                         description="verify local length must be equal to base length"
+                         validation="limited">
+
+        <tdml:document>12</tdml:document>
+
+        <tdml:errors>
+            <tdml:error>Schema Definition Error</tdml:error>
+            <tdml:error>length-valid-restriction</tdml:error>
+            <tdml:error>value of length</tdml:error>
+            <tdml:error>must be = the value of that of the base type</tdml:error>
+        </tdml:errors>
+    </tdml:parserTestCase>
+
+
 <!--
     Test name: checkEnumeration_Pass_limited
        Schema: TestFacets
@@ -1921,7 +2081,139 @@
 
   </tdml:parserTestCase>
 
-  <tdml:parserTestCase name="floatExclusiveValid"
+    <tdml:parserTestCase name="validation_inputValueCalc_04"
+                         root="eString_minMaxLen7" model="inputValueCalc"
+                         description="Section 17 - the value created using inputValueCalc is validated using minLength/maxLength facets"
+                         validation="limited">
+
+        <tdml:document></tdml:document>
+
+        <tdml:infoset>
+            <tdml:dfdlInfoset>
+                <eString_minMaxLen7>string</eString_minMaxLen7>
+            </tdml:dfdlInfoset>
+        </tdml:infoset>
+
+        <tdml:validationErrors>
+            <tdml:error>Validation Error</tdml:error>
+            <tdml:error>failed facet checks due to: facet minLength (7)</tdml:error>
+        </tdml:validationErrors>
+
+    </tdml:parserTestCase>
+
+    <tdml:parserTestCase name="validation_inputValueCalc_05"
+                         root="eString_len7" model="inputValueCalc"
+                         description="Section 17 - the value created using inputValueCalc is validated using length facets"
+                         validation="limited">
+
+        <tdml:document></tdml:document>
+
+        <tdml:infoset>
+            <tdml:dfdlInfoset>
+                <eString_len7>string</eString_len7>
+            </tdml:dfdlInfoset>
+        </tdml:infoset>
+
+        <tdml:validationErrors>
+            <tdml:error>Validation Error</tdml:error>
+            <tdml:error>failed facet checks due to: facet length (7)</tdml:error>
+        </tdml:validationErrors>
+
+    </tdml:parserTestCase>
+
+    <tdml:parserTestCase name="validation_inputValueCalc_06"
+                         root="eString_minMaxLen7" model="inputValueCalc"
+                         description="Section 17 - the value created using inputValueCalc is validated using minLength/maxLength facets"
+                         validation="on">
+
+        <tdml:document></tdml:document>
+
+        <tdml:infoset>
+            <tdml:dfdlInfoset>
+                <eString_minMaxLen7>string</eString_minMaxLen7>
+            </tdml:dfdlInfoset>
+        </tdml:infoset>
+
+        <tdml:validationErrors>
+            <tdml:error>Validation Error</tdml:error>
+            <tdml:error>failed facet checks due to: facet minLength (7)</tdml:error>
+        </tdml:validationErrors>
+
+    </tdml:parserTestCase>
+
+    <tdml:parserTestCase name="validation_inputValueCalc_07"
+                         root="eString_len7" model="inputValueCalc"
+                         description="Section 17 - the value created using inputValueCalc is validated using length facets"
+                         validation="on">
+
+        <tdml:document></tdml:document>
+
+        <tdml:infoset>
+            <tdml:dfdlInfoset>
+                <eString_len7>string</eString_len7>
+            </tdml:dfdlInfoset>
+        </tdml:infoset>
+
+        <tdml:validationErrors>
+            <tdml:error>Validation Error</tdml:error>
+            <tdml:error>failed facet checks due to: facet length (7)</tdml:error>
+        </tdml:validationErrors>
+
+    </tdml:parserTestCase>
+
+    <tdml:defineSchema name="TestFacets2">
+        <xs:include schemaLocation="/org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+        <dfdl:format ref="ex:GeneralFormat" />
+        <xs:element name="eHexBinary_lenMinMaxLen7" dfdl:lengthKind="delimited" dfdl:encoding="ISO-8859-1">
+            <xs:simpleType>
+                <xs:restriction base="xs:hexBinary">
+                    <xs:length value="7"/>
+                    <xs:minLength value="7"/>
+                    <xs:maxLength value="7"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:element>
+    </tdml:defineSchema>
+
+    <tdml:parserTestCase name="validation_testFacets2_01"
+                         root="eHexBinary_lenMinMaxLen7" model="TestFacets2"
+                         description="checks that length cannot be used with min/maxLength"
+                         validation="limited">
+
+        <tdml:document>
+            <tdml:documentPart type="byte">deadbeef</tdml:documentPart>
+        </tdml:document>
+
+        <!-- this is a Xerces Error -->
+        <tdml:errors>
+            <tdml:error>Schema Definition Error</tdml:error>
+            <tdml:error>due to length-minLength-maxLength</tdml:error>
+            <tdml:error>not have a minLength facet if the current restriction has the minLength facet</tdml:error>
+            <tdml:error>and the current restriction or base has the length facet</tdml:error>
+        </tdml:errors>
+
+    </tdml:parserTestCase>
+
+    <tdml:parserTestCase name="validation_testFacets2_02"
+                         root="eHexBinary_lenMinMaxLen7" model="TestFacets2"
+                         description="checks that length cannot be used with min/maxLength"
+                         validation="on">
+
+        <tdml:document>
+            <tdml:documentPart type="byte">deadbeef</tdml:documentPart>
+        </tdml:document>
+
+        <!-- this is a Xerces Error -->
+        <tdml:errors>
+            <tdml:error>Schema Definition Error</tdml:error>
+            <tdml:error>due to length-minLength-maxLength</tdml:error>
+            <tdml:error>not have a minLength facet if the current restriction has the minLength facet</tdml:error>
+            <tdml:error>and the current restriction or base has the length facet</tdml:error>
+        </tdml:errors>
+
+    </tdml:parserTestCase>
+
+    <tdml:parserTestCase name="floatExclusiveValid"
     root="floatExclusive" model="TestFacets"
     validation="on">
 

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section13/text_number_props/TextNumberPropsUnparse.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section13/text_number_props/TextNumberPropsUnparse.tdml
@@ -96,6 +96,12 @@
           <xs:minLength value="10" />
         </xs:restriction>
       </xs:simpleType>
+
+      <xs:simpleType name="stLen10">
+        <xs:restriction base="xs:string">
+          <xs:length value="10" />
+        </xs:restriction>
+      </xs:simpleType>
       
       <xs:simpleType name="st3to10">
         <xs:restriction base="xs:string">
@@ -117,7 +123,9 @@
       <xs:element name="e11" type="ex:st10" dfdl:lengthKind="explicit" dfdl:length="2" dfdl:textStringPadCharacter="#" dfdl:textPadKind="padChar" dfdl:textTrimKind="padChar" dfdl:textStringJustification="left" />
       
       <xs:element name="e12" type="ex:st10" dfdl:lengthKind="explicit" dfdl:length="{ 2 }" dfdl:textStringPadCharacter="#" dfdl:textPadKind="padChar" dfdl:textTrimKind="padChar" dfdl:textStringJustification="left" />
-      
+
+      <xs:element name="e12_dfdlLength2" type="ex:stLen10" dfdl:lengthKind="explicit" dfdl:length="{ 2 }" dfdl:textStringPadCharacter="#" dfdl:textPadKind="padChar" dfdl:textTrimKind="padChar" dfdl:textStringJustification="left" />
+
       <xs:element name="e13" dfdl:lengthKind="implicit">
         <xs:complexType>
           <xs:sequence  dfdl:separator="," >
@@ -437,6 +445,23 @@
       <tdml:warning>Explicit dfdl:length</tdml:warning>
       <tdml:warning>out of range</tdml:warning>
       <tdml:warning>facet minLength</tdml:warning>
+    </tdml:warnings>
+    <tdml:document>O#</tdml:document>
+  </tdml:unparserTestCase>
+
+  <tdml:unparserTestCase name="unparsePaddedString11" model="delimitedStringsPadding" root="e12_dfdlLength2"
+                         description="ensure length facet results in a similar warning to min/maxLength facets"
+   roundTrip="false">
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <ex:e12_dfdlLength2 xmlns:ex="http://example.com">O</ex:e12_dfdlLength2>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+    <tdml:warnings>
+      <tdml:warning>Schema Definition Warning</tdml:warning>
+      <tdml:warning>Explicit dfdl:length</tdml:warning>
+      <tdml:warning>out of range</tdml:warning>
+      <tdml:warning>facet length</tdml:warning>
     </tdml:warnings>
     <tdml:document>O#</tdml:document>
   </tdml:unparserTestCase>

--- a/daffodil-test/src/test/scala/org/apache/daffodil/extensions/TestRepType.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/extensions/TestRepType.scala
@@ -94,6 +94,15 @@ class TestRepType {
   @Test def test_repType_length_facet_03(): Unit = {
     runner.runOneTest("repType_length_facet_03")
   }
+  @Test def test_repType_length_facet_04(): Unit = {
+    runner.runOneTest("repType_length_facet_04")
+  }
+  @Test def test_repType_length_facet_05(): Unit = {
+    runner.runOneTest("repType_length_facet_05")
+  }
+  @Test def test_repType_length_facet_06(): Unit = {
+    runner.runOneTest("repType_length_facet_06")
+  }
 
   @Test def test_repType_negative_01(): Unit = { runner.runOneTest("repType_negative_01") }
   @Test def test_repType_negative_02(): Unit = { runner.runOneTest("repType_negative_02") }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section02/validation_errors/TestValidationErr.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section02/validation_errors/TestValidationErr.scala
@@ -168,6 +168,41 @@ class TestValidationErr {
   @Test def test_validation_inputValueCalc_03(): Unit = {
     runner.runOneTest("validation_inputValueCalc_03")
   }
+  @Test def test_validation_inputValueCalc_04(): Unit = {
+    runner.runOneTest("validation_inputValueCalc_04")
+  }
+  @Test def test_validation_inputValueCalc_05(): Unit = {
+    runner.runOneTest("validation_inputValueCalc_05")
+  }
+  @Test def test_validation_inputValueCalc_06(): Unit = {
+    runner.runOneTest("validation_inputValueCalc_06")
+  }
+  @Test def test_validation_inputValueCalc_07(): Unit = {
+    runner.runOneTest("validation_inputValueCalc_07")
+  }
+
+  @Test def test_validation_testFacets_01(): Unit = {
+    runner.runOneTest("validation_testFacets_01")
+  }
+  @Test def test_validation_testFacets_02(): Unit = {
+    runner.runOneTest("validation_testFacets_02")
+  }
+  @Test def test_validation_testFacets_03(): Unit = {
+    runner.runOneTest("validation_testFacets_03")
+  }
+  @Test def test_validation_testFacets_04(): Unit = {
+    runner.runOneTest("validation_testFacets_04")
+  }
+  @Test def test_validation_testFacets2_01(): Unit = {
+    runner.runOneTest("validation_testFacets2_01")
+  }
+  @Test def test_validation_testFacets2_02(): Unit = {
+    runner.runOneTest("validation_testFacets2_02")
+  }
+
+  @Test def test_validation_testFacets3_01(): Unit = {
+    runner.runOneTest("validation_testFacets3_01")
+  }
 
   @Test def test_floatExclusiveValid(): Unit = { runner.runOneTest("floatExclusiveValid") }
   @Test def test_floatExclusiveInf(): Unit = { runner.runOneTest("floatExclusiveInf") }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section13/text_number_props/TestTextNumberPropsUnparse.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section13/text_number_props/TestTextNumberPropsUnparse.scala
@@ -76,6 +76,7 @@ class TestTextNumberPropsUnparse {
   }
 
   @Test def test_unparsePaddedString10(): Unit = { runner.runOneTest("unparsePaddedString10") }
+  @Test def test_unparsePaddedString11(): Unit = { runner.runOneTest("unparsePaddedString11") }
 
   @Test def test_unparsePaddedStringTruncate01(): Unit = {
     runner.runOneTest("unparsePaddedStringTruncate01")


### PR DESCRIPTION
- add support for length, also set minLength and maxLength with the value of length, when hasLength is true, and those variables are queried
- ensure length and minLength and maxLength facets are not declared together (Xerces Error, but we have asserts incase Xerces validation is turned off)
- add tests for validation=limited and validation=on

DAFFODIL-2842