### PR TITLE
Add support for passing exception directly into DaffodilUnhandledSAXException

### DIFF
--- a/daffodil-core/src/test/scala/org/apache/daffodil/core/processor/TestSAXUnparseAPI.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/core/processor/TestSAXUnparseAPI.scala
@@ -23,8 +23,10 @@ import java.io.ByteArrayOutputStream
 import org.apache.daffodil.lib.Implicits.intercept
 import org.apache.daffodil.lib.xml.DaffodilSAXParserFactory
 import org.apache.daffodil.lib.xml.XMLUtils
+import org.apache.daffodil.runtime1.api.DFDL.DaffodilUnhandledSAXException
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.xml.sax.InputSource
@@ -200,4 +202,37 @@ class TestSAXUnparseAPI {
     assertTrue(m.contains("prior to end"))
     assertTrue(m.contains("{http://example.com}list"))
   }
+
+  @Test def testDaffodilUnhandledSAXException_creation_bothMessageAndCause(): Unit = {
+    val message = "Error Message"
+    val expectedException = new IllegalArgumentException("Illegal Argument Message")
+    val actualException = new DaffodilUnhandledSAXException(message, expectedException)
+    assertEquals(message, actualException.getMessage)
+    assertEquals(expectedException, actualException.getCause)
+  }
+
+  @Test def testDaffodilUnhandledSAXException_creation_onlyMessage(): Unit = {
+    val message = "Error Message"
+    val actualException = new DaffodilUnhandledSAXException(message)
+    assertEquals(message, actualException.getMessage)
+    assertNull(actualException.getCause)
+  }
+
+  @Test def testDaffodilUnhandledSAXException_creation_onlyCause(): Unit = {
+    val expectedException = new IllegalArgumentException("Illegal Argument Message")
+    val actualException = new DaffodilUnhandledSAXException(expectedException)
+    // when the detailMessage is null as is the case when no message is passed in,
+    // getMessage returns the detailMessage from the embedded exception
+    assertEquals(expectedException.getMessage, actualException.getMessage)
+    assertEquals(expectedException, actualException.getCause)
+  }
+  @Test def testDaffodilUnhandledSAXException_creation_onlyCauseNoCauseMessage(): Unit = {
+    val expectedException = new IllegalArgumentException()
+    val actualException = new DaffodilUnhandledSAXException(expectedException)
+    // when the detailMessage is null as is the case when no message is passed in,
+    // getMessage returns the detailMessage from the embedded exception
+    assertNull(actualException.getMessage)
+    assertEquals(expectedException, actualException.getCause)
+  }
+
 }

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/api/DFDLParserUnparser.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/api/DFDLParserUnparser.scala
@@ -237,7 +237,11 @@ object DFDL {
    * occurs, this usually represents a bug in Daffodil
    */
   class DaffodilUnhandledSAXException(description: String, cause: Exception)
-    extends SAXException(description, cause)
+    extends SAXException(description, cause) {
+    def this(msg: String) = this(msg, null)
+
+    def this(cause: Exception) = this(null, cause)
+  }
 
   trait ParseResult extends Result with WithDiagnostics {
     def resultState: State

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/DaffodilUnparseContentHandlerImpl.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/DaffodilUnparseContentHandlerImpl.scala
@@ -413,7 +413,7 @@ class DaffodilUnparseContentHandlerImpl(dp: DFDL.DataProcessor, output: DFDL.Out
           case Left(e) => {
             // unparse threw an unexpected exception, this is likely a bug. We don't
             // have an UnparseResult so just rethrow the exception as a SAXException.
-            throw new DaffodilUnhandledSAXException(e.getMessage, e)
+            throw new DaffodilUnhandledSAXException(e)
           }
           // $COVERAGE-ON$
         }


### PR DESCRIPTION
- add constructors for throwable only and message only
- add unit tests that create the DaffodilUnhandledSAXException and compares them to the message, the throwable or both

DAFFODIL-2433