### PR TITLE
Allow backtracking when parsing prefix length fails with prefixIncludesPrefixLength

### DIFF
--- a/daffodil-test/src/test/resources/org/apache/daffodil/section12/lengthKind/PrefixedTests.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section12/lengthKind/PrefixedTests.tdml
@@ -255,6 +255,15 @@
       </xs:complexType>
     </xs:element>
 
+    <xs:element name="pl_text_string_txt_bytes_includes_backtrack">
+      <xs:complexType>
+        <xs:choice>
+          <xs:element ref="ex:pl_text_string_txt_bytes_includes" />
+          <xs:element name="alldata" type="xs:string" dfdl:lengthKind="delimited" />
+        </xs:choice>
+      </xs:complexType>
+    </xs:element>
+
   </tdml:defineSchema>
 
   <tdml:defineSchema name="lengthKindPrefixed-bin.dfdl.xsd">
@@ -2852,6 +2861,21 @@
       <tdml:error>16 out of range</tdml:error>
       <tdml:error>between 1 and 8</tdml:error>
     </tdml:errors>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="pl_text_string_txt_bytes_not_enough_prefix_data_includes_backtrack"
+    root="pl_text_string_txt_bytes_includes_backtrack"
+    model="lengthKindPrefixed-text.dfdl.xsd">
+    <tdml:document>
+      <tdml:documentPart type="text">01</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <ex:pl_text_string_txt_bytes_includes_backtrack>
+          <alldata>01</alldata>
+        </ex:pl_text_string_txt_bytes_includes_backtrack>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
   </tdml:parserTestCase>
 
 </tdml:testSuite>

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section12/lengthKind/TestLengthKindPrefixed.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section12/lengthKind/TestLengthKindPrefixed.scala
@@ -79,6 +79,9 @@ class TestLengthKindPrefixed {
   @Test def test_pl_text_string_txt_bytes_not_enough_prefix_data() = {
     runner.runOneTest("pl_text_string_txt_bytes_not_enough_prefix_data")
   }
+  @Test def test_pl_text_string_txt_bytes_not_enough_prefix_data_includes_backtrack() = {
+    runner.runOneTest("pl_text_string_txt_bytes_not_enough_prefix_data_includes_backtrack")
+  }
   // DFDL-2030, nested prefixed lengths not supported
   // @Test def test_pl_text_string_pl_txt_bytes() = { runner.runOneTest("pl_text_string_pl_txt_bytes") }
   @Test def test_pl_text_int_txt_bytes() = { runner.runOneTest("pl_text_int_txt_bytes") }


### PR DESCRIPTION
> [!NOTE]  
> This might want to wait until 3.8.0 or a later release where we can fix all the prefix length issues 

If parsing a prefix length fails, we just pretend the value was zero and rely on callers to check the processor status and ignore the zero value if it failed. However, even if the parse fails we still do the negative prefix length SDE checks. And if the prefix has an adjustment due to the prefixIncludesPrefixLength property, that zero is a adjusted to become negative and causes an SDE instead of a PE.

Really, we shouldn't do these SDE checks at all if we failed to parse a prefix length since the zero is meaningless and should be ignored. This rearranges the logic so we only check for negative prefix values if the prefix parse actually succeeded.

This also skips calculating contentLength/valueLength if the parse fails.

DAFFODIL-2688