### PR TITLE
Output diagnosticFile for embedded schemas diagnostics

### DIFF
--- a/daffodil-lib/src/main/scala/org/apache/daffodil/lib/api/DaffodilSchemaSource.scala
+++ b/daffodil-lib/src/main/scala/org/apache/daffodil/lib/api/DaffodilSchemaSource.scala
@@ -213,4 +213,9 @@ case class EmbeddedSchemaSource(node: Node, nameHint: String, optTmpDir: Option[
     XMLUtils.convertNodeToTempFile(node, optTmpDir.orNull, nameHint),
   ) {
   override val blameName = nameHint
+
+  override val diagnosticFile =
+    XMLUtils
+      .getOptTDMLFileFromNode(node)
+      .getOrElse(super.diagnosticFile)
 }

--- a/daffodil-lib/src/main/scala/org/apache/daffodil/lib/util/SchemaUtils.scala
+++ b/daffodil-lib/src/main/scala/org/apache/daffodil/lib/util/SchemaUtils.scala
@@ -100,7 +100,7 @@ object SchemaUtils {
   ): Elem = {
     val fileAttrib =
       if (fileName == "") Null
-      else Attribute(XMLUtils.INT_PREFIX, "file", Text(fileName), Null)
+      else Attribute(XMLUtils.INT_PREFIX, XMLUtils.FILE_ATTRIBUTE_NAME, Text(fileName), Null)
     val targetNamespaceAttrib =
       if (targetNamespace == NoNamespace) Null
       else Attribute(None, "targetNamespace", Text(targetNamespace.uri.toString), Null)
@@ -110,7 +110,7 @@ object SchemaUtils {
         import XMLUtils._
         <ignore xmlns:xsd={xsdURI} xmlns:dfdl={dfdlURI} xmlns:xsi={xsiURI} xmlns:fn={
           fnURI
-        } xmlns:math={mathURI} xmlns:dafint={dafintURI}/>.scope
+        } xmlns:math={mathURI}/>.scope
       }
     scope = XMLUtils.combineScopes("xs", XMLUtils.xsdURI, scope) // always need this one
     if (useDefaultNamespace) {
@@ -120,6 +120,7 @@ object SchemaUtils {
       scope = XMLUtils.combineScopes("tns", targetNamespace, scope)
     scope = XMLUtils.combineScopes("ex", targetNamespace, scope)
     scope = XMLUtils.combineScopes("dfdlx", XMLUtils.DFDLX_NAMESPACE, scope)
+    scope = XMLUtils.combineScopes(XMLUtils.INT_PREFIX, XMLUtils.INT_NS, scope)
 
     val schemaNode =
       <xs:schema elementFormDefault={elementFormDefault}>

--- a/daffodil-lib/src/main/scala/org/apache/daffodil/lib/xml/XMLUtils.scala
+++ b/daffodil-lib/src/main/scala/org/apache/daffodil/lib/xml/XMLUtils.scala
@@ -1216,6 +1216,15 @@ Differences were (path, expected, actual):
   }
 
   /**
+   * Look for the dafint:file attribute that should be set for every embedded schema
+   */
+  def getOptTDMLFileFromNode(node: Node): Option[File] = {
+    node
+      .attribute(XMLUtils.INT_NS, XMLUtils.FILE_ATTRIBUTE_NAME)
+      .map(uriStringNode => new File(uriStringNode.text))
+  }
+
+  /**
    * for quick tests, we use literal scala nodes. However, the underlying
    * infrastructure wants to be all file centric for diagnostic-message
    * reasons (line numbers for errors)

--- a/daffodil-tdml-lib/src/main/scala/org/apache/daffodil/tdml/RunnerFactory.scala
+++ b/daffodil-tdml-lib/src/main/scala/org/apache/daffodil/tdml/RunnerFactory.scala
@@ -20,6 +20,7 @@ package org.apache.daffodil.tdml
 import java.nio.file.Paths
 
 import org.apache.daffodil.lib.api.TDMLImplementation
+import org.apache.daffodil.lib.api.URISchemaSource
 import org.apache.daffodil.lib.util.Misc
 
 /**
@@ -203,13 +204,14 @@ class Runner private (
   // synchronized to ensure we only ever create one per Runner.
   def getTS = this.synchronized {
     if (ts == null) {
-      val elemOrURI: Any = source match {
+      val elemOrURISchemaSource: Any = source match {
         case Left(l) => l
         case Right(r) =>
-          if (r.startsWith("/")) Misc.getRequiredResource(r) else new java.net.URI(r)
+          val uri = if (r.startsWith("/")) Misc.getRequiredResource(r) else new java.net.URI(r)
+          URISchemaSource(new java.io.File(r), uri)
       }
       ts = new DFDLTestSuite(
-        elemOrURI,
+        elemOrURISchemaSource,
         optTDMLImplementation,
         validateTDMLFile,
         validateDFDLSchemas,

--- a/daffodil-tdml-processor/src/test/scala/org/apache/daffodil/processor/tdml/TestTDMLRunner.scala
+++ b/daffodil-tdml-processor/src/test/scala/org/apache/daffodil/processor/tdml/TestTDMLRunner.scala
@@ -21,6 +21,7 @@ import java.io.File
 
 import org.apache.daffodil.lib.Implicits._
 import org.apache.daffodil.lib.Implicits.using
+import org.apache.daffodil.lib.exceptions.UsageException
 import org.apache.daffodil.lib.util._
 import org.apache.daffodil.lib.xml.XMLUtils
 import org.apache.daffodil.tdml.Runner
@@ -950,6 +951,31 @@ f0 f1 f2 f3 f4 f5 f6 f7 f8 f9 fa fb fc fd fe ff
       exc
         .getMessage()
         .contains("Duplicate definitions found for parser or unparser test cases: dupTestCase"),
+    )
+  }
+
+  @Test def testNullTestSuite(): Unit = {
+    val testSuite: scala.xml.Elem = null
+    val runner = new Runner(testSuite)
+    val exc = intercept[UsageException] {
+      runner.runAllTests()
+    }
+    assertTrue(
+      exc.getMessage.contains(
+        "argument was not a scala.xmlNode, File, or URISchemaSource: null",
+      ),
+    )
+  }
+
+  @Test def testEmptyNodeTestSuite(): Unit = {
+    val testSuite: scala.xml.Elem = <node/>
+    val runner = new Runner(testSuite)
+    val exc = intercept[TDMLException] {
+      runner.runAllTests()
+    }
+    assertTrue(
+      exc.getMessage().contains("TDML file") &&
+        exc.getMessage().contains("is not valid"),
     )
   }
 

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section00/general/testElementFormDefault.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section00/general/testElementFormDefault.tdml
@@ -136,7 +136,31 @@
     <tdml:document><![CDATA[1]]></tdml:document>
 
   </tdml:unparserTestCase>
-  
+
+  <tdml:unparserTestCase name="delimOptPresentQualified02_additionalByte" root="r1"
+                         model="qualified" roundTrip="true">
+
+    <tdml:infoset >
+      <tdml:dfdlInfoset>
+        <ex:r1>
+          <ex:opt>12</ex:opt>
+        </ex:r1>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+    <tdml:document><![CDATA[12]]></tdml:document>
+
+    <tdml:errors>
+      <tdml:error>Unparse Error</tdml:error>
+      <tdml:error>Schema context: ex:opt</tdml:error>
+      <tdml:error>org</tdml:error>
+      <tdml:error>apache</tdml:error>
+      <tdml:error>daffodil</tdml:error>
+      <tdml:error>section00</tdml:error>
+      <tdml:error>general</tdml:error>
+      <tdml:error>testElementFormDefault.tdml</tdml:error>
+    </tdml:errors>
+
+  </tdml:unparserTestCase>
 <!--
   Test Name: delimOptPresentQualified03
      Schema: elementFormDefaultQualified.dfdl.xsd

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section00/general/TestElementFormDefaultGeneral.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section00/general/TestElementFormDefaultGeneral.scala
@@ -43,6 +43,9 @@ class TestElementFormDefaultGeneral {
   @Test def test_delimOptPresentQualified02(): Unit = {
     runner.runOneTest("delimOptPresentQualified02")
   }
+  @Test def test_delimOptPresentQualified02_additionalByte(): Unit = {
+    runner.runOneTest("delimOptPresentQualified02_additionalByte")
+  }
   @Test def test_delimOptPresentQualified03(): Unit = {
     runner.runOneTest("delimOptPresentQualified03")
   }


### PR DESCRIPTION
- UnitTestSchemaSource embedded schemas called from Runner(testSuite) don't have the dafint prefix bound so we check if they have it and bind it when the dafint:file info is added. The issue they still use the temp file and don't have an associated TDML file we can set for diagnosticFile/URI
- TDML embedded schemas are given a diagnostic file that is gotten from dafint:file attr. This is set using diagnosticFile provided when the URISchemaSource was created for the embedded schema in the DFDL test suite
- pass around URISchemaSource instead of URI in DFDL Test Suite
- get the DefinedSchema filename from the tsURISchemaSource.diagnosticFile or use the dafint:file attribute
- add tdml test with no path separators for windows
- add unittests to hit usageError when a node, file or URISChemaSource isn't passsed in and to hit when the node passed in is not valid

DAFFODIL-2159