### PR TITLE
Throw TDMLException if Test has neither tdml:infoset nor tdml:errors

### DIFF
--- a/daffodil-tdml-lib/src/main/scala/org/apache/daffodil/tdml/TDMLRunner.scala
+++ b/daffodil-tdml-lib/src/main/scala/org/apache/daffodil/tdml/TDMLRunner.scala
@@ -1043,8 +1043,11 @@ case class ParserTestCase(ptc: NodeSeq, parentArg: DFDLTestSuite)
           }
         }
       }
-
-      case _ => Assert.invariantFailed("Should be Some None, or None Some only.")
+      case _ =>
+        throw TDMLException(
+          "Either tdml:infoset or tdml:errors must be present in the test.",
+          implString,
+        )
     }
   }
 

--- a/daffodil-tdml-processor/src/test/scala/org/apache/daffodil/processor/tdml/TestTDMLRunner.scala
+++ b/daffodil-tdml-processor/src/test/scala/org/apache/daffodil/processor/tdml/TestTDMLRunner.scala
@@ -1034,4 +1034,31 @@ f0 f1 f2 f3 f4 f5 f6 f7 f8 f9 fa fb fc fd fe ff
     runner.reset()
     assertTrue(exc.getMessage.contains("only compatible with Daffodil 300.400.500"))
   }
+
+  @Test def testMissingErrorAndInfosetForParserTestCase(): Unit = {
+    val testSuite =
+      <tdml:testSuite suiteName="theSuiteName"
+                      xmlns:tns={tns}
+                      xmlns:tdml={tdml}
+                      xmlns:dfdl={dfdl}
+                      xmlns:xsd={xsd}
+                      xmlns:xs={xsd}
+                      xmlns:xsi={xsi}>
+        <tdml:defineSchema name="mySchema">
+          <xs:include schemaLocation="/org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+          <dfdl:format ref="tns:GeneralFormat"/>
+          <xsd:element name="data" type="xs:int" dfdl:lengthKind="explicit" dfdl:length="2"/>
+        </tdml:defineSchema>
+        <parserTestCase xmlns={tdml} name="testCase" root="data" model="mySchema">
+          <document>25</document>
+        </parserTestCase>
+      </tdml:testSuite>
+    val runner = new Runner(testSuite)
+    val exc = intercept[TDMLException] {
+      runner.runOneTest("testCase")
+    }
+    runner.reset()
+    assertTrue(exc.getMessage.contains("Either tdml:infoset or tdml:error"))
+    assertTrue(exc.getMessage.contains("must be present in the test"))
+  }
 }


### PR DESCRIPTION
- change Some None, None Some message to something more clear
- attempts to change the tdml.xsd proved tricky since the error produced wasn't specific to only infoset/errors

DAFFODIL-2104