### PR TITLE
Add ability to specify errors that should not occur

### DIFF
--- a/daffodil-lib/src/main/resources/org/apache/daffodil/xsd/tdml.xsd
+++ b/daffodil-lib/src/main/resources/org/apache/daffodil/xsd/tdml.xsd
@@ -75,6 +75,7 @@
       <attribute name="defaultValidation" type="tns:validationType" use="optional"/>
       <attribute name="defaultConfig" type="xs:string" use="optional"/>
       <attribute name="defaultImplementations" type="tns:implementationsType" use="optional"/>
+      <attribute name="defaultIgnoreUnexpectedWarnings" type="xs:boolean" use="optional"/>
     </complexType>
     <unique name="unique-parserTestCase-name">
       <selector xpath="parserTestCase"/>
@@ -184,6 +185,7 @@
     <attribute name="unsupported" type="xs:boolean" use="optional" default="false"/>
     <attribute name="validation" type="tns:validationType" use="optional"/>
     <attribute name="implementations" type="tns:implementationsType" use="optional"/>
+    <attribute name="ignoreUnexpectedWarnings" type="xs:boolean" use="optional"/>
 
   </attributeGroup>
 
@@ -348,7 +350,7 @@
       <xs:simpleType>
         <xs:restriction base="xs:string">
           <xs:enumeration value="all"/>
-          <xs:enumeration value="any"/>
+          <xs:enumeration value="none"/>
         </xs:restriction>
       </xs:simpleType>
     </xs:attribute>

--- a/daffodil-tdml-lib/src/main/scala/org/apache/daffodil/tdml/RunnerFactory.scala
+++ b/daffodil-tdml-lib/src/main/scala/org/apache/daffodil/tdml/RunnerFactory.scala
@@ -149,7 +149,8 @@ class Runner private (
   compileAllTopLevel: Boolean = false,
   defaultRoundTripDefault: RoundTrip = Runner.defaultRoundTripDefaultDefault,
   defaultValidationDefault: String = Runner.defaultValidationDefaultDefault,
-  defaultImplementationsDefault: Seq[String] = Runner.defaultImplementationsDefaultDefault
+  defaultImplementationsDefault: Seq[String] = Runner.defaultImplementationsDefaultDefault,
+  defaultIgnoreUnexpectedWarningsDefault: Boolean = true
 ) {
 
   /**
@@ -220,7 +221,8 @@ class Runner private (
         defaultValidationDefault,
         defaultImplementationsDefault,
         Runner.defaultShouldDoErrorComparisonOnCrossTests,
-        Runner.defaultShouldDoWarningComparisonOnCrossTests
+        Runner.defaultShouldDoWarningComparisonOnCrossTests,
+        defaultIgnoreUnexpectedWarningsDefault
       )
     }
     ts

--- a/daffodil-tdml-processor/src/test/java/org/apache/daffodil/processor/tdml/TestRunnerFactory.java
+++ b/daffodil-tdml-processor/src/test/java/org/apache/daffodil/processor/tdml/TestRunnerFactory.java
@@ -50,7 +50,8 @@ public class TestRunnerFactory {
       false,
       NoRoundTrip$.MODULE$,
       "off",
-      JavaConverters.asScalaBufferConverter(Arrays.asList("daffodil", "ibm")).asScala());
+      JavaConverters.asScalaBufferConverter(Arrays.asList("daffodil", "ibm")).asScala(),
+      false);
     runner.runOneTest("testPass");
     runner.reset();
   }

--- a/daffodil-tdml-processor/src/test/resources/test/tdml/testTDMLErrorsWarningsMatchAttribute.tdml
+++ b/daffodil-tdml-processor/src/test/resources/test/tdml/testTDMLErrorsWarningsMatchAttribute.tdml
@@ -1,0 +1,188 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<tdml:testSuite 
+  suiteName="tdml errors/warnings match attribute"
+  description="Tests for TDML Runner errors/warnings match attribute any, all and none"
+  xmlns:tdml="http://www.ibm.com/xmlns/dfdl/testData"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+  xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/" 
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns:ex="http://example.com" 
+  xmlns:fn="http://www.w3.org/2005/xpath-functions"
+  defaultRoundTrip="false">
+
+  <tdml:defineSchema name="noWarnings">
+    <xs:include schemaLocation="/org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+    <dfdl:format ref="ex:GeneralFormat" lengthKind="delimited" encoding="utf-8" representation="text"/>
+    <xs:element name="elem" type="xs:string">
+      <xs:annotation>
+        <xs:appinfo source="http://www.ogf.org/dfdl/" />
+      </xs:annotation>
+    </xs:element>
+  </tdml:defineSchema>
+
+  <tdml:defineSchema name="causesWarnings">
+    <xs:include schemaLocation="/org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+    <dfdl:format ref="ex:GeneralFormat" lengthKind="delimited" encoding="utf-8" representation="text"/>
+    <xs:element name="elem" type="xs:string">
+      <xs:annotation>
+        <xs:appinfo source="http://www.ogf.org/dfdl/dfdl-1.0/" />
+      </xs:annotation>
+    </xs:element>
+  </tdml:defineSchema>
+
+  <tdml:parserTestCase name="getsWarningExpectsWarnings" root="elem"
+                       model="causesWarnings"
+                       description="">
+    <tdml:document><![CDATA[test]]></tdml:document>
+
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <elem>test</elem>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+
+    <tdml:warnings match="none">
+      <tdml:warning>THIS WILL NOT MATCH</tdml:warning>
+    </tdml:warnings>
+
+    <tdml:warnings>
+      <tdml:warning>Schema Definition Warning</tdml:warning>
+      <tdml:warning>The xs:appinfo source attribute value 'http://www.ogf.org/dfdl/dfdl-1.0/' should be 'http://www.ogf.org/dfdl/'.</tdml:warning>
+    </tdml:warnings>
+
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase
+      name="getsWarningExpectsNoWarnings" root="elem"
+      model="causesWarnings"
+      description=""
+      ignoreUnexpectedWarnings="false">
+    <tdml:document><![CDATA[test]]></tdml:document>
+
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <elem>test</elem>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase
+      name="noWarningExpectsNoWarnings" root="elem"
+      model="noWarnings"
+      description=""
+      ignoreUnexpectedWarnings="false">
+    <tdml:document><![CDATA[test]]></tdml:document>
+
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <elem>test</elem>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:defineSchema name="causesErrors" elementFormDefault="unqualified">
+
+    <xs:include schemaLocation="/org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+    <dfdl:format ref="ex:GeneralFormat" lengthKind="explicit" occursCountKind="implicit"/>
+
+    <xs:element name="causesUnparseError" dfdl:lengthKind="implicit">
+      <xs:complexType>
+        <xs:sequence>
+          <xs:element name="A" type="xs:string" dfdl:length="1"/>
+          <xs:element name="AmbigElt" type="xs:string" dfdl:length="1"/>
+          <xs:element name="B" type="xs:string" dfdl:length="1"/>
+          <xs:element name="AmbigElt" type="xs:string" dfdl:length="1" minOccurs="0"/>
+          <xs:element name="UnparseFails" type="xs:string" dfdl:length="1"
+                      dfdl:outputValueCalc="{ ../AmbigElt }"/>
+        </xs:sequence>
+      </xs:complexType>
+    </xs:element>
+
+    <xs:element name="causesValidationError" dfdl:lengthKind="implicit">
+      <xs:complexType>
+        <xs:sequence>
+          <xs:element name="A" dfdl:length="1" dfdl:inputValueCalc="{ 'A' }">
+            <xs:simpleType>
+              <xs:restriction base="xs:string">
+                <xs:pattern value="[^A-FH-OQ-Z]"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:element>
+        </xs:sequence>
+      </xs:complexType>
+    </xs:element>
+
+  </tdml:defineSchema>
+
+  <tdml:unparserTestCase name="getUnparserWarningWhenExpectingError"
+                         root="causesUnparseError" model="causesErrors">
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <ex:causesUnparseError>
+          <A>1</A>
+          <AmbigElt>2</AmbigElt>
+          <B>3</B>
+          <AmbigElt>4</AmbigElt>
+        </ex:causesUnparseError>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+
+    <tdml:document><![CDATA[12344]]></tdml:document>
+
+    <tdml:errors>
+      <tdml:error>Schema Definition Error</tdml:error>
+    </tdml:errors>
+    <tdml:errors match="none">
+      <tdml:error>WILL NOT MATCH ON THIS</tdml:error>
+    </tdml:errors>
+
+    <tdml:warnings match="none">
+      <tdml:warning>WILL NOT MATCH ON THIS</tdml:warning>
+    </tdml:warnings>
+    <tdml:warnings>
+      <tdml:warning>Schema Definition Warning</tdml:warning>
+      <tdml:warning>AmbigElt</tdml:warning>
+      <tdml:warning>query-style</tdml:warning>
+    </tdml:warnings>
+  </tdml:unparserTestCase>
+
+
+  <tdml:parserTestCase name="expectsAnyValidationError" root="causesValidationError"
+                       model="causesErrors" validation="on">
+
+    <tdml:document/>
+
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <ex:causesValidationError>
+          <A>A</A>
+        </ex:causesValidationError>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+
+    <tdml:validationErrors>
+      <tdml:error>value 'A' of element 'A' is not valid</tdml:error>
+    </tdml:validationErrors>
+    <tdml:validationErrors match="none">
+      <tdml:error>WILL NOT MATCH ON THIS</tdml:error>
+    </tdml:validationErrors>
+  </tdml:parserTestCase>
+
+</tdml:testSuite>

--- a/daffodil-tdml-processor/src/test/scala/org/apache/daffodil/processor/tdml/TestTDMLRunner2.scala
+++ b/daffodil-tdml-processor/src/test/scala/org/apache/daffodil/processor/tdml/TestTDMLRunner2.scala
@@ -259,6 +259,7 @@ class TestTDMLRunner2 {
               </tns:array>
             </tdml:dfdlInfoset>
           </tdml:infoset>
+          <tdml:validationErrors/>
         </tdml:parserTestCase>
       </tdml:testSuite>
 
@@ -268,7 +269,11 @@ class TestTDMLRunner2 {
     }
     runner.reset
     val msg = e.getMessage()
-    assertTrue(msg.contains("Validation errors found where none were expected"))
+    assertTrue(
+      msg.contains(
+        "ignoreUnexpectedDiags = false and test does not expect ValidationError diagnostics"
+      )
+    )
   }
 
   /**

--- a/daffodil-tdml-processor/src/test/scala/org/apache/daffodil/processor/tdml/TestTDMLRunnerMatchAttributes.scala
+++ b/daffodil-tdml-processor/src/test/scala/org/apache/daffodil/processor/tdml/TestTDMLRunnerMatchAttributes.scala
@@ -1,0 +1,169 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.daffodil.processor.tdml
+
+import org.apache.daffodil.lib.Implicits.intercept
+import org.apache.daffodil.lib.xml.XMLUtils
+import org.apache.daffodil.tdml.Runner
+import org.apache.daffodil.tdml.TDMLException
+
+import org.junit.AfterClass
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+object TestTDMLRunnerMatchAttributes {
+  val runner = Runner("/test/tdml/", "testTDMLErrorsWarningsMatchAttribute.tdml")
+
+  @AfterClass def shutDown(): Unit = {
+    runner.reset
+  }
+}
+
+class TestTDMLRunnerMatchAttributes {
+  import TestTDMLRunnerMatchAttributes._
+
+  // DAFFODIL-1583
+  @Test def test_getsWarningExpectsWarnings(): Unit = {
+    runner.runOneTest("getsWarningExpectsWarnings")
+  }
+  @Test def test_getUnparserWarningWhenExpectingError(): Unit = {
+    runner.runOneTest("getUnparserWarningWhenExpectingError")
+  }
+  @Test def test_expectsAnyValidationError() = {
+    runner.runOneTest("expectsAnyValidationError")
+  }
+
+  @Test def test_noWarningExpectsNoWarnings() = {
+    runner.runOneTest("noWarningExpectsNoWarnings")
+  }
+
+  @Test def test_getsWarningExpectsNoWarnings() = {
+    val e = intercept[TDMLException] {
+      runner.runOneTest("getsWarningExpectsNoWarnings")
+    }
+    val errMsg = e.getMessage()
+    assertTrue(
+      errMsg.contains(
+        "ignoreUnexpectedDiags = false and test does not expect Warning diagnostics"
+      )
+    )
+  }
+
+  lazy val testSuite =
+    <ts:testSuite xmlns:dfdl={XMLUtils.DFDL_NAMESPACE} xmlns:xs={
+      XMLUtils.XSD_NAMESPACE
+    } xmlns:ex={XMLUtils.EXAMPLE_NAMESPACE} xmlns:ts={
+      XMLUtils.TDML_NAMESPACE
+    } suiteName="theSuiteName"
+      defaultIgnoreUnexpectedWarnings="false">
+      <ts:defineSchema name="causesWarnings">
+        <xs:include schemaLocation="/org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+        <dfdl:format ref="ex:GeneralFormat"/>
+        <xs:element name="r" type="xs:string" dfdl:lengthKind="delimited">
+          <xs:annotation>
+            <xs:appinfo source="http://www.ogf.org/dfdl/dfdl-1.0/" />
+          </xs:annotation>
+        </xs:element>
+      </ts:defineSchema>
+      <ts:defineSchema name="noWarnings">
+        <xs:include schemaLocation="/org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+        <dfdl:format ref="ex:GeneralFormat"/>
+        <xs:element name="r" type="xs:string" dfdl:lengthKind="delimited">
+          <xs:annotation>
+            <xs:appinfo source="http://www.ogf.org/dfdl/" />
+          </xs:annotation>
+        </xs:element>
+      </ts:defineSchema>
+
+      <ts:parserTestCase name="expectsNoWarningGetsWarnings" root="r" model="causesWarnings" roundTrip="onePass">
+        <ts:infoset>
+          <ts:dfdlInfoset>
+            <ex:r>foo</ex:r>
+          </ts:dfdlInfoset>
+        </ts:infoset>
+        <ts:document>foo</ts:document>
+      </ts:parserTestCase>
+
+      <ts:parserTestCase name="expectsWarningGetsNoWarnings" root="r" model="noWarnings" roundTrip="onePass">
+        <ts:infoset>
+          <ts:dfdlInfoset>
+            <ex:r>foo</ex:r>
+          </ts:dfdlInfoset>
+        </ts:infoset>
+        <ts:document>foo</ts:document>
+
+        <ts:warnings>
+          <ts:warning>Schema Definition Warning</ts:warning>
+          <ts:warning>The xs:appinfo source attribute value 'http://www.ogf.org/dfdl/dfdl-1.0/' should be 'http://www.ogf.org/dfdl/'.</ts:warning>
+        </ts:warnings>
+      </ts:parserTestCase>
+
+      <ts:parserTestCase name="expectsWarningGetsWarning" root="r" model="causesWarnings" roundTrip="onePass">
+        <ts:infoset>
+          <ts:dfdlInfoset>
+            <ex:r>foo</ex:r>
+          </ts:dfdlInfoset>
+        </ts:infoset>
+        <ts:document>foo</ts:document>
+
+        <ts:warnings>
+          <ts:warning>Schema Definition Warning</ts:warning>
+          <ts:warning>The xs:appinfo source attribute value 'http://www.ogf.org/dfdl/dfdl-1.0/' should be 'http://www.ogf.org/dfdl/'.</ts:warning>
+        </ts:warnings>
+      </ts:parserTestCase>
+
+      <ts:parserTestCase name="expectsNoWarningGetsNoWarnings" root="r" model="noWarnings" roundTrip="onePass">
+        <ts:infoset>
+          <ts:dfdlInfoset>
+            <ex:r>foo</ex:r>
+          </ts:dfdlInfoset>
+        </ts:infoset>
+        <ts:document>foo</ts:document>
+      </ts:parserTestCase>
+    </ts:testSuite>
+
+  @Test def test_expectsNoWarningGetsWarnings(): Unit = {
+    val runner = new Runner(testSuite)
+    val e = intercept[TDMLException] {
+      runner.runOneTest("expectsNoWarningGetsWarnings")
+    }
+    runner.reset
+    val msg = e.getMessage()
+    assertTrue(
+      msg.contains("ignoreUnexpectedDiags = false and test does not expect Warning diagnostics")
+    )
+  }
+
+  @Test def test_expectsWarningGetsNoWarnings(): Unit = {
+    val runner = new Runner(testSuite)
+    val e = intercept[TDMLException] {
+      runner.runOneTest("expectsWarningGetsNoWarnings")
+    }
+    runner.reset
+    val msg = e.getMessage()
+    assertTrue(msg.contains("Diagnostic message(s) were expected but not found"))
+  }
+  @Test def test_expectsWarningGetsWarning(): Unit = {
+    val runner = new Runner(testSuite)
+    runner.runOneTest("expectsWarningGetsWarning")
+  }
+  @Test def test_expectsNoWarningGetsNoWarnings(): Unit = {
+    val runner = new Runner(testSuite)
+    runner.runOneTest("expectsNoWarningGetsNoWarnings")
+  }
+}

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section02/validation_errors/Validation.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section02/validation_errors/Validation.tdml
@@ -1898,14 +1898,6 @@
       <tdml:error>Initiator 'C' not found</tdml:error>
     </tdml:errors>
 
-    <tdml:validationErrors>
-        
-      <!-- Validation error for branch1:e1  -->
-      <tdml:error>Validation Error</tdml:error>
-      <tdml:error>nonNegA failed facet checks due to: facet minInclusive (30)</tdml:error>
-
-    </tdml:validationErrors>
-
   </tdml:parserTestCase>
   
   <!--

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section13/text_number_props/TextNumberProps.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section13/text_number_props/TextNumberProps.tdml
@@ -4089,13 +4089,12 @@
 
   <tdml:parserTestCase name="nanInvalidType" root="nanInvalidType"
     model="textprops"
+    ignoreUnexpectedWarnings="false"
     description="Attempt to read nan for an invalid type.">
 
     <tdml:document>
       <tdml:documentPart type="text"><![CDATA[NOTANUMBER]]]></tdml:documentPart>
     </tdml:document>
-
-    <tdml:warnings />
 
     <tdml:errors>
       <tdml:error>Parse Error</tdml:error>
@@ -4108,13 +4107,12 @@
 
   <tdml:parserTestCase name="infInvalidType" root="infInvalidType"
     model="textprops"
+    ignoreUnexpectedWarnings="false"
     description="Attempt to read inf for an invalid type.">
 
     <tdml:document>
       <tdml:documentPart type="text"><![CDATA[INFINITY]]]></tdml:documentPart>
     </tdml:document>
-
-    <tdml:warnings />
 
     <tdml:errors>
       <tdml:error>Parse Error</tdml:error>


### PR DESCRIPTION
- using warnings/errors match attribute, specify whether all/any/none of the messages should match
- add verifyAnyOfDiagnosticsFound and verifyNoneOfDiagnosticsFound for any/none match attributes
- add tdml tests

DAFFODIL-864