### PR TITLE
Set SOURCE_DATE_EPOCH for build reproducability when creating release candidates

### DIFF
--- a/containers/release-candidate/src/daffodil-release-candidate
+++ b/containers/release-candidate/src/daffodil-release-candidate
@@ -234,6 +234,8 @@ DAFFODIL_TUTORIALS_DIR=$DAFFODIL_SITE_DIR/site/tutorials
 DAFFODIL_DIST_DIR=$REPO_ROOT/$DAFFODIL_DIST
 DAFFODIL_RELEASE_DIR=$DAFFODIL_DIST_DIR/$VERSION-$PRE_RELEASE
 
+export SOURCE_DATE_EPOCH=$(git show --no-patch --format=%ct HEAD)
+
 if [ -d "$DAFFODIL_RELEASE_DIR" ]; then echo -e "\n!!! $PROJECT_NAME release directory already exists: $DAFFODIL_RELEASE_DIR !!! "; exit; fi
 
 git -C $DAFFODIL_CODE_DIR config --local user.name  "$GIT_COMMIT_NAME"


### PR DESCRIPTION
A common source of differences in our release artifacts are embedded timestamps. The latest version of sbt-native-packager, used to create these artifacts now supports the SOURCE_DATE_EPOCH environment variable which provides control over these embedded timestamps.

When building the release candidate, we now set the SOURCE_DATE_EPOCH to the UNIX timestamp of when the commit being built was merged (i.e. the git "committer" time), allowing for reproducible builds. There are some caveats:

* The MSI installer includes one UUID and timestamp that cannot be changed. Fortunately, msidiff shows this is the only difference so is straightforward to verify
* The RPM created by the release candidate script embeds a GPG signature which has a timestamp of when the signature was created, which cannot be changed. To verify RPM reproducibility, the signature must removed with rpmsign --delsign
* Zip files still include a timestamp in an extended header. I'll report to sbt-native-packager and see if a fix can be included in the next release.

DAFFODIL-2890