### PR TITLE
Use an empty sequence for the xml of implied choice branch sequences

### DIFF
--- a/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/SequenceGroup.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/SequenceGroup.scala
@@ -346,7 +346,7 @@ object ChoiceBranchImpliedSequence {
  * handled as a degenerate sequence having only one element decl within it.
  */
 final class ChoiceBranchImpliedSequence private (rawGM: Term)
-  extends SequenceTermBase(rawGM.xml, rawGM.optLexicalParent, rawGM.position)
+  extends SequenceTermBase(<sequence />, rawGM.optLexicalParent, rawGM.position)
   with SequenceDefMixin
   with ChoiceBranchImpliedSequenceRuntime1Mixin {
 

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section07/discriminators/discriminator.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section07/discriminators/discriminator.tdml
@@ -1131,4 +1131,59 @@
     </tdml:errors>
   </tdml:parserTestCase>
 
+  <tdml:defineSchema name="discrimOnChoiceArray">
+    <xs:include schemaLocation="/org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+    <dfdl:format ref="ex:GeneralFormat" lengthKind="explicit" length="1" />
+
+    <xs:element name="r1" dfdl:lengthKind="implicit">
+      <xs:complexType>
+        <xs:sequence>
+          <xs:element name="type" type="xs:string" />
+          <xs:element name="max" type="xs:int" />
+          <xs:element name="values" dfdl:lengthKind="implicit">
+            <xs:complexType>
+              <xs:choice dfdl:choiceDispatchKey="{ ../ex:type }">
+                <xs:element name="a" dfdl:choiceBranchKey="a" type="xs:int" maxOccurs="unbounded">
+                  <xs:annotation>
+                    <xs:appinfo source="http://www.ogf.org/dfdl/">
+                      <dfdl:discriminator test="{ . lt ../../ex:max }" />
+                    </xs:appinfo>
+                  </xs:annotation>
+                </xs:element>
+                <xs:element name="b" dfdl:choiceBranchKey="b" type="xs:int" maxOccurs="unbounded">
+                  <xs:annotation>
+                    <xs:appinfo source="http://www.ogf.org/dfdl/">
+                      <dfdl:discriminator test="{ . lt ../../ex:max }" />
+                    </xs:appinfo>
+                  </xs:annotation>
+                </xs:element>
+              </xs:choice>
+            </xs:complexType>
+          </xs:element>
+          <xs:element name="remaining" type="xs:string" dfdl:lengthKind="delimited" />
+        </xs:sequence>
+      </xs:complexType>
+    </xs:element>
+
+  </tdml:defineSchema>
+
+  <tdml:parserTestCase name="discrimOnChoiceArray_01" model="discrimOnChoiceArray" root="r1">
+    <tdml:document>b51234567890</tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <ex:r1>
+          <type>b</type>
+          <max>5</max>
+          <values>
+            <b>1</b>
+            <b>2</b>
+            <b>3</b>
+            <b>4</b>
+          </values>
+          <remaining>567890</remaining>
+        </ex:r1>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
 </tdml:testSuite>

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section07/discriminators/TestDiscriminators.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section07/discriminators/TestDiscriminators.scala
@@ -91,6 +91,9 @@ class TestDiscriminators {
   @Test def test_discrimPEvalueLengthEnclosingParent1(): Unit = {
     runner.runOneTest("discrimPEvalueLengthEnclosingParent1")
   }
+  @Test def test_discrimOnChoiceArray_01(): Unit = {
+    runner.runOneTest("discrimOnChoiceArray_01")
+  }
 
   @Test def test_multipleDiscriminators1(): Unit = {
     runner2.runOneTest("multipleDiscriminators1")


### PR DESCRIPTION
When we need to add an implied sequence for a choice branch (like when the branch is an array), we wrap the branch Term in a ChoiceBranchImpliedSequence, which is essentially a Sequence that passes logic through to the underlying Term. This allows us to use existing sequence logic such as creating repetition parsers for arrays.

However, when we create this ChoiceBranchImpliedSequence we set its xml parameter to the xml of the Term it wraps. And because it extends Sequence, it does all the normal sequence logic of parsing that xml, even though much of it is never used because most logic passes through to the underlying Term.

In most cases, this works fine (although its wasted effort) since all that extra work is simply ignored. But, if that XML contains any expressions, things can quickly go off the rails as it tries to compile expressions with the context of this implied sequence.

To fix this, instead of passing in the XML of the underlying Term, we just pass in an empty sequence XML. This means there is no longer any real work for the ChoiceBranchImpliedSequence to do, except for be a tool to create the necessary repetition parsers to wrap around the Term. Not only does this avoid issues with incorrect contexts, but it avoids unnecessary work that is just ignored.

DAFFODIL-2887