### PR TITLE
Only validate if a simple element parse succeeds

### DIFF
--- a/daffodil-tdml-lib/src/main/scala/org/apache/daffodil/tdml/TDMLRunner.scala
+++ b/daffodil-tdml-lib/src/main/scala/org/apache/daffodil/tdml/TDMLRunner.scala
@@ -1064,7 +1064,9 @@ case class ParserTestCase(ptc: NodeSeq, parentArg: DFDLTestSuite)
   ): Unit = {
 
     try {
-      processor = processor.withExternalDFDLVariables(externalVarBindings)
+      processor = processor
+        .withExternalDFDLVariables(externalVarBindings)
+        .withValidationMode(validationMode)
     } catch {
       case e: Exception => throw TDMLException(e, implString)
     }

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section02/validation_errors/Validation.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section02/validation_errors/Validation.tdml
@@ -2495,4 +2495,42 @@
     <tdml:validationErrors />
   </tdml:parserTestCase>
 
+  <tdml:defineSchema name="runtimeSdeWithRestriction">
+    <xs:include schemaLocation="/org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd" />
+    <dfdl:format ref="ex:GeneralFormat"
+      representation="binary"
+      bitOrder="mostSignificantBitFirst"
+      lengthKind="explicit"
+      lengthUnits="bits"
+      alignmentUnits="bits"
+      alignment="1"
+      byteOrder="littleEndian" />
+
+    <xs:element name="a" dfdl:lengthKind="implicit">
+      <xs:complexType>
+        <xs:sequence>
+          <xs:element name="x" type="xs:int" dfdl:length="1" />
+          <xs:element name="y" dfdl:length="7" dfdl:encoding="X-DFDL-US-ASCII-7-BIT-PACKED" dfdl:bitOrder="leastSignificantBitFirst"> <!-- causes runtime sde -->
+            <xs:simpleType>
+              <xs:restriction base="xs:string">
+                <xs:pattern value="[a-z]" />
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:element>
+        </xs:sequence>
+      </xs:complexType>
+    </xs:element>
+  </tdml:defineSchema>
+
+  <tdml:parserTestCase name="runtimeSdeWithRestriction_1" root="a"
+    model="runtimeSdeWithRestriction"
+    validation="on">
+    <tdml:document>a</tdml:document>
+    <tdml:errors>
+      <tdml:error>Runtime Schema Definition Error</tdml:error>
+      <tdml:error>dfdl:bitOrder</tdml:error>
+      <tdml:error>byte boundary</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
 </tdml:testSuite>

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section02/validation_errors/TestValidationErr.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section02/validation_errors/TestValidationErr.scala
@@ -223,4 +223,8 @@ class TestValidationErr {
   @Test def test_doubleInclusiveNaN(): Unit = { runner.runOneTest("doubleInclusiveNaN") }
 
   @Test def test_optional_element_1(): Unit = { runner.runOneTest("optional_element_1") }
+
+  @Test def test_runtimeSdeWithRestrictdion_1(): Unit = {
+    runner.runOneTest("runtimeSdeWithRestriction_1")
+  }
 }


### PR DESCRIPTION
Currently, restriction validation logic takes place in a finally block of the ElementParserBase combinator when the parse status is "success". However, if an exception is thrown (e.g. Runtime SDE) then we stil hit this finally block, parse status could still be "success", but we likely won't have any data to validate. This can lead to a confusing exception that hides the original exception.

To fix this, this moves validation to the end of the try block, so that we only ever attempt validation if all aspects of a parse succeed. And if an exception is thrown, then this code is simply skipped.

This also modifies the TDML runner so it correctly sets validationMode even when errors are expected. This allows us to test this case where we expect a Runtime SDE error when validation is enabled.

DAFFODIL-2895