### PR TITLE
Support Java 21

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,7 +39,7 @@ jobs:
       fail-fast: false
       matrix:
         java_distribution: [ temurin ]
-        java_version: [ 8, 11, 17 ]
+        java_version: [ 8, 11, 17, 21 ]
         scala_version: [ 2.12.19 ]
         os: [ ubuntu-22.04, windows-2022, macos-12 ]
         exclude:
@@ -48,6 +48,8 @@ jobs:
             java_version: 8
           - os: macos-12
             java_version: 11
+          - os: macos-12
+            java_version: 21
         include:
           # configure shell/cc/ar for all OSes
           - os: ubuntu-22.04

--- a/daffodil-lib/src/main/scala/org/apache/daffodil/lib/util/Misc.scala
+++ b/daffodil-lib/src/main/scala/org/apache/daffodil/lib/util/Misc.scala
@@ -547,8 +547,8 @@ object Misc {
       .onMalformedInput(CodingErrorAction.REPORT)
     val bb = ByteBuffer.wrap((0 to 255).map { i => i.toByte }.toArray)
     val cb = dec.decode(bb)
-    assert(cb.position == 0)
-    assert(cb.limit == 256)
+    assert(cb.position() == 0)
+    assert(cb.limit() == 256)
     // These 5 are unmapped by Windows-1252 but we want to turn any
     // byte into a legit character. So these We add 0x100
     // to get unicode codepoints.

--- a/daffodil-test-integration/src/test/scala/org/apache/daffodil/cliTest/TestCLIDebugger.scala
+++ b/daffodil-test-integration/src/test/scala/org/apache/daffodil/cliTest/TestCLIDebugger.scala
@@ -58,7 +58,9 @@ class TestCLIDebugger {
     "-Dorg.jline.terminal.provider=dumb",
     "-Dorg.jline.terminal.dumb=true",
     "-Dorg.jline.terminal.dumb.color=false",
-    "-Dfile.encoding=UTF-8"
+    "-Dfile.encoding=UTF-8",
+    "-Dstderr.encoding=UTF-8",
+    "-Dstdout.encoding=UTF-8"
   )
 
   val envs = Map(


### PR DESCRIPTION
DAFFODIL-2898

main.yml: Add Java 21 to CI.

Misc.scala: Disambiguate method references.