### PR TITLE
Allow inputValueCalc to be defined in a hidden group

### DIFF
--- a/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/Term.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/Term.scala
@@ -527,7 +527,7 @@ trait Term
         e.complexType.group.canUnparseIfHidden
       }
       case e: ElementBase => {
-        e.canBeAbsentFromUnparseInfoset
+        !e.isRepresented || e.canBeAbsentFromUnparseInfoset
       }
     }
     res

--- a/daffodil-core/src/main/scala/org/apache/daffodil/core/grammar/primitives/SequenceCombinator.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/core/grammar/primitives/SequenceCombinator.scala
@@ -97,7 +97,7 @@ class OrderedSequence(sq: SequenceTermBase, sequenceChildrenArg: Seq[SequenceChi
         val nonUnparseableIfHidden = sq.groupMembers.filter(!_.canUnparseIfHidden)
         if (nonUnparseableIfHidden.nonEmpty) {
           SDE(
-            "Element(s) of hidden group must define dfdl:outputValueCalc, be defaultable or be optional:\n%s",
+            "Element(s) of hidden group must define dfdl:outputValueCalc, dfdl:inputValueCalc, be defaultable or be optional:\n%s",
             nonUnparseableIfHidden.mkString("\n")
           )
         }
@@ -189,7 +189,7 @@ class UnorderedSequence(
         val nonUnparseableIfHidden = sq.groupMembers.filter(!_.canUnparseIfHidden)
         if (nonUnparseableIfHidden.nonEmpty) {
           SDE(
-            "Element(s) of hidden group must define dfdl:outputValueCalc, be defaultable or be optional:\n%s",
+            "Element(s) of hidden group must define dfdl:outputValueCalc, dfdl:inputValueCalc, be defaultable or be optional:\n%s",
             nonUnparseableIfHidden.mkString("\n")
           )
         }

--- a/daffodil-core/src/main/scala/org/apache/daffodil/core/runtime1/ChoiceTermRuntime1Mixin.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/core/runtime1/ChoiceTermRuntime1Mixin.scala
@@ -115,7 +115,7 @@ trait ChoiceTermRuntime1Mixin { self: ChoiceTermBase =>
         optOpen.orElse {
           groupMembers.find {
             _.canUnparseIfHidden
-          } // optional, defaultable or OVC
+          } // optional, defaultable, OVC, or IVC
         }
       optDefault
     }

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section14/sequence_groups/SequenceGroup.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section14/sequence_groups/SequenceGroup.tdml
@@ -1501,4 +1501,39 @@
     </tdml:infoset>
   </tdml:parserTestCase>
 
+  <tdml:defineSchema name="hiddenGroupIVC">
+    <xs:include schemaLocation="/org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+    <dfdl:format ref="ex:GeneralFormat" lengthKind="delimited" />
+
+    <xs:group name="hg">
+      <xs:sequence>
+        <xs:element name="original" type="xs:int" dfdl:outputValueCalc="{ (../ex:value - 1) div 2 }" />
+        <xs:element name="transformed" type="xs:int" dfdl:inputValueCalc="{ ../ex:original * 2 }" />
+      </xs:sequence>
+    </xs:group>
+
+    <xs:element name="e" dfdl:lengthKind="delimited">
+      <xs:complexType>
+        <xs:sequence>
+          <xs:sequence dfdl:hiddenGroupRef="ex:hg" />
+          <xs:element name="value" type="xs:int" dfdl:inputValueCalc="{ ../ex:transformed + 1 }" />
+        </xs:sequence>
+      </xs:complexType>
+    </xs:element>
+  </tdml:defineSchema>
+
+  <tdml:parserTestCase name="hiddenGroupIVC" root="e"
+    model="hiddenGroupIVC" description="Section 14 - Groups - DFDL-14-042R">
+    <tdml:document>
+      <tdml:documentPart type="text"><![CDATA[3]]></tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <e>
+          <value>7</value>
+        </e>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
 </tdml:testSuite>

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section14/sequence_groups/TestSequenceGroups.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section14/sequence_groups/TestSequenceGroups.scala
@@ -142,4 +142,6 @@ class TestSequenceGroups {
   @Test def test_delimiterScanning_01(): Unit = { runner_01.runOneTest("delimiterScanning_01") }
   @Test def test_delimiterScanning_02(): Unit = { runner_01.runOneTest("delimiterScanning_02") }
   // @Test def test_delimiterScanning_03() { runner_01.runOneTest("delimiterScanning_03") }
+
+  @Test def test_hiddenGroupIVC(): Unit = { runner_02.runOneTest("hiddenGroupIVC") }
 }


### PR DESCRIPTION
An inputValueCalc inside a hidden group behaves very similar to a variable, but is useful in cases where you don't want to use a variable.

For example, a common pattern is two have groups pairs of elements of original data and transformed value. In a subset of cases we may want to hide the original/transformed pair and use an non-hidden IVC that references the transformed value. By allowing hidden IVC's, we do not need change the pattern to use variables.

Only minimal changes are needed because this does not change parse behavior and IVC elements are already skipped during unparsing.

DAFFODIL-2903