### PR TITLE
Allow DataProcessors to be garbage collected in TDML tests

### DIFF
--- a/daffodil-tdml-lib/src/main/scala/org/apache/daffodil/tdml/TDMLRunner.scala
+++ b/daffodil-tdml-lib/src/main/scala/org/apache/daffodil/tdml/TDMLRunner.scala
@@ -934,18 +934,29 @@ abstract class TestCase(testCaseXML: NodeSeq, val parent: DFDLTestSuite) {
             }
           (diags, newNewProc)
       }
-      runProcessor(
-        newCompileResult,
-        optInputOrExpectedData,
-        nBits,
-        optExpectedErrors,
-        optExpectedWarnings,
-        optExpectedValidationErrors,
-        validationMode,
-        roundTrip,
-        implString
-      )
-
+      try {
+        runProcessor(
+          newCompileResult,
+          optInputOrExpectedData,
+          nBits,
+          optExpectedErrors,
+          optExpectedWarnings,
+          optExpectedValidationErrors,
+          validationMode,
+          roundTrip,
+          implString
+        )
+      } finally {
+        // runProcessor may have set the "processor" variable to the DataProcessor used for the
+        // test. This variable only exists as an easy way to avoid having to pass the
+        // DataProcessor around to a bunch of functions. At this point this TestCase is done
+        // with the DataProcessor, so we set it to null so it can be garbage collected if
+        // nothing else uses it. This is common if a test case calls withXYZ to create a
+        // temporary copy of a cached DataProcessor but with different variables, tunables,
+        // validation mode, etc. used only for this specific test. This is especially important
+        // if a DataProcessor stores any large information like a Xerces validator.
+        processor = null
+      }
     }
   }
 


### PR DESCRIPTION
DataProcessors are currently stored in a "processor" variable in each TestCase for easy access while a TestCase is running. However, once a TestCase finishes running, it really shouldn't hold on to this DataProcessor anymore so that it can be garbage collected. We now set that variable to null when finished to allow this. Note that this does not remove DataProcessors from the compile cache--it only allows garbage collection of DataProcessor created with one of the withXYZ functions to tweak the cached processor for a specific test.

Allowing garbage collection of DataProcessors is especially important when Xerces validation is enabled, since each DataProcessor hold a unique instance of a possibly very large Xerces validator. We likely need to change how we store Xerces validators so that they can be shared, but in the meantime this change at least allows a large number of TDML tests to run with validation enabled without running into OutOfMemory errors.

DAFFODIL-2901