### PR TITLE
Prepare for 3.8.0 release

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -223,7 +223,7 @@ val minSupportedJavaVersion: String =
 
 lazy val commonSettings = Seq(
   organization := "org.apache.daffodil",
-  version := "3.8.0-SNAPSHOT",
+  version := "3.8.0",
   scalaVersion := "2.12.19",
   crossScalaVersions := Seq("2.12.19"),
   scalacOptions ++= buildScalacOptions(scalaVersion.value),

--- a/containers/release-candidate/Dockerfile
+++ b/containers/release-candidate/Dockerfile
@@ -46,11 +46,24 @@ RUN \
 # Enable sbt-pgp plugin
 COPY src/plugins.sbt /root/.sbt/1.0/plugins/
 
+# WIX is a Microsoft Windows Installer creation tool kit.
+#
 # Install wix, including changes to allow WiX to run in wine on Linux. See
 # src/wix_wine.sh for more details on why we need to do this and how it works
+#
+# Updating WIX should be done only if there is a specific need (for security, or other compelling reason)
+# because it is likely things will break and the release scripts/process will have to adapt.
+# The WIX version 3.11.2 is hard coded into these script lines as tokens wix3112rtm and wix311.
+#
+# In order to ensure we are downloading and using the exact WIX binary we have tested and trust
+# we verify the sha512 is the same as the one expected. This protects us from if someone
+# was to get github credentials allowing them to change the wix binaries on github.
+# If WIX is updated to a newer version, this sha512 will need to be recomputed.
+ARG WIXSHA=6fd961c85e1e6adafb99ef50c9659e3eb83c84ecaf49f523e556788845b206e1857aba2c39409405d4cda1df9b30a552ce5aab808be5f8368a37a447d78d1a05
+#
 RUN \
   curl -sS -L https://github.com/wixtoolset/wix3/releases/download/wix3112rtm/wix311-binaries.zip -o wix311-binaries.zip && \
-  echo "6fd961c85e1e6adafb99ef50c9659e3eb83c84ecaf49f523e556788845b206e1857aba2c39409405d4cda1df9b30a552ce5aab808be5f8368a37a447d78d1a05 wix311-binaries.zip" | sha512sum --quiet -c - && \
+  echo "$WIXSHA wix311-binaries.zip" | sha512sum --quiet -c - && \
   mkdir /opt/wix311 && \
   unzip -q wix311-binaries.zip -d /opt/wix311/ && \
   rm wix311-binaries.zip
@@ -59,15 +72,15 @@ RUN mv /opt/wix311/{light.exe,real-light.exe}
 COPY src/wix_wine.sh /opt/wix311/candle.exe
 COPY src/wix_wine.sh /opt/wix311/light.exe
 
-# Install a pinned version of sbt, needed because the spt-rpm repository
-# frequently adds new versions.
+# Install a pinned version of sbt. This is used only as a bootstrap so does not need to be updated.
+# This version of sbt is not used to build any Daffodil project parts, as they specify their own sbt versions.
 RUN \
   dnf -y --quiet --repofrompath=sbt-rpm,https://repo.scala-sbt.org/scalasbt/rpm --repo=sbt-rpm --nogpgcheck install \
     sbt-1.7.1 && \
   dnf clean all
 
-# Install a pinned version of yarn, needed because the npm repository
-# frequently adds new versions.
+# Install a pinned version of yarn. This is used only as a bootstrap so does not need to be updated.
+# This version of yarn is not used to build any Daffodil project parts, as they specify their own yarn versions.
 RUN \
   npm --no-update-notifier install --global yarn@1.22.19
 

--- a/containers/release-candidate/src/plugins.sbt
+++ b/containers/release-candidate/src/plugins.sbt
@@ -13,4 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//
+// The sbt-pgp plugin version should not be updated unless there is a compelling reason.
+// The release process scripts will likely break and need to be adapted if it is changed.
 addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.1.2")


### PR DESCRIPTION
Removed "-SNAPSHOT" from Daffodil version number

Added comments to release scripts about not updating specific versions. No functional changes.
(Goes along with updates to the Wiki release process page.)

DAFFODIL-2908