### PR TITLE
Upgrade nodejs in the release candidate container

### DIFF
--- a/containers/release-candidate/Dockerfile
+++ b/containers/release-candidate/Dockerfile
@@ -24,6 +24,11 @@ RUN rm -rf /root/*
 
 # Install dependencies, explicitly not enabling the updates repo so we are
 # pinned at a particular fedora release.
+#
+# Note that the default nodejs package shipped with fedora 40 has a bug that
+# can sometimes lead to SIGILL errors on some architectures. So we also upgrade
+# to the latest nodejs version to fix this. However we only upgrade the one
+# package so we are still mostly pinned to the Fedora 40 release.
 RUN \
   dnf -y --quiet --repo=fedora install \
     clang \
@@ -41,6 +46,8 @@ RUN \
     vim-minimal \
     wine \
     winetricks && \
+  dnf -y --quiet --repo=updates upgrade-minimal \
+    nodejs && \
   dnf clean all
 
 # Enable sbt-pgp plugin


### PR DESCRIPTION
The version of nodejs that ships with Fedora 40 has a bug that causes a SIGILL error when runing npm on some architectures. This installs nodejs/npm from the Fedora "updates" repo which includes a fix.