### PR TITLE
Optimize BucketingInputSource for performance

### DIFF
--- a/daffodil-io/src/test/scala/org/apache/daffodil/io/TestDaffodilDataInputSource.scala
+++ b/daffodil-io/src/test/scala/org/apache/daffodil/io/TestDaffodilDataInputSource.scala
@@ -133,7 +133,7 @@ class TestBucketingInputSource {
 
   @Test def testBucketingInputSource1(): Unit = {
     val tis = new TestInputStream
-    val bis = new BucketingInputSource(tis, 17)
+    val bis = new BucketingInputSource(tis, 4)
     var i = 0
     while (i < 100) {
       assertEquals(i, bis.position())
@@ -145,7 +145,7 @@ class TestBucketingInputSource {
 
   @Test def testBucketingInputSource2(): Unit = {
     val tis = new TestInputStream
-    val bis = new BucketingInputSource(tis, 7)
+    val bis = new BucketingInputSource(tis, 3)
     val b = new Array[Byte](10)
     assertEquals(true, bis.get(b, 0, 10))
     var i = 0
@@ -164,7 +164,7 @@ class TestBucketingInputSource {
 
   @Test def testBucketingInputSource3(): Unit = {
     val tis = new TestInputStream
-    val bis = new BucketingInputSource(tis, 7)
+    val bis = new BucketingInputSource(tis, 3)
     val b = new Array[Byte](10)
     assertEquals(0, bis.get)
     assertEquals(1, bis.get)
@@ -181,7 +181,7 @@ class TestBucketingInputSource {
 
   @Test def testBucketingInputSource4(): Unit = {
     val tis = new TestInputStream
-    val bis = new BucketingInputSource(tis, 7)
+    val bis = new BucketingInputSource(tis, 3)
     tis.setEOF(4)
     assertEquals(0, bis.get)
     assertEquals(1, bis.get)
@@ -192,7 +192,7 @@ class TestBucketingInputSource {
 
   @Test def testBucketingInputSource5(): Unit = {
     val tis = new TestInputStream
-    val bis = new BucketingInputSource(tis, 7)
+    val bis = new BucketingInputSource(tis, 3)
     val b = new Array[Byte](10)
     tis.setEOF(4)
     assertEquals(false, bis.get(b, 0, 10))
@@ -207,7 +207,7 @@ class TestBucketingInputSource {
 
   @Test def testBucketingInputSource6(): Unit = {
     val tis = new TestInputStream
-    val bis = new BucketingInputSource(tis, 7)
+    val bis = new BucketingInputSource(tis, 3)
     tis.setEOF(17)
     var i = 0
     while (i < 8) {
@@ -226,7 +226,7 @@ class TestBucketingInputSource {
 
   @Test def testBucketingInputSource7(): Unit = {
     val tis = new TestInputStream
-    val bis = new BucketingInputSource(tis, 7)
+    val bis = new BucketingInputSource(tis, 3)
     tis.setEOF(17)
     var i = 0
     while (i < 2) {


### PR DESCRIPTION
The BucketingInputSource has a bytePositionToIndicies function that returns a tuple containing the bucket index and index within that bucket to find a given byte position. This function should be inlined and in theory the tuple allocation could be optimized out since we immediately take it apart into separate variables, but that doesn't seem to be the case, and leads to noticeable Overhead.

This removes the tuple allocation by replacing the one function with two separate functions. This means there is now an extra function call but it avoids the tuple allocation, which appears to be the main overhead.

This also is more careful about which variables are Int's and Long's to minimize the number of toInt calls. This is unlikely to make a performance difference, but does make the code cleaner. This also switches from integer/modular division to shifts and masks which should also be more efficient. This does now require the bucket size to be specified as a power of two.

In basic testing, these changes reduced the overhead of the BucketingInputSource compared to the ByteBufferInputSource from about 15% to 5%.

DAFFODIL-2920