### PR TITLE
mmap files when possible to improve CLI parse performance

### DIFF
--- a/daffodil-japi/src/main/scala/org/apache/daffodil/japi/io/InputSourceDataInputStream.scala
+++ b/daffodil-japi/src/main/scala/org/apache/daffodil/japi/io/InputSourceDataInputStream.scala
@@ -26,7 +26,30 @@ import org.apache.daffodil.io.{ InputSourceDataInputStream => SInputSourceDataIn
  * Provides Daffodil with byte data from an InputStream, ByteBuffer, or byte
  * Array.
  *
- * @param dis the underlying Scala InputSourceDataInputStream
+ * Note that the InputStream variant has potential overhead due to streaming capabilities and
+ * support for files greater than 2GB. In some cases, better performance might come from using
+ * the byte array or ByteBuffer variants instead. For example, if your data is already in a byte
+ * array, one should use the Array[Byte] or ByteBuffer variants instead of wrapping it in a
+ * ByteArrayInputStream. As another example, instead of using a FileInputStream like this:
+ *
+ * {{{
+ * Path path = Paths.get(file);
+ * FileInputStream fis = Files.newInputStream(path);
+ * InputSourceDataInputStream input = InputSourceDataInputStream(fis);
+ * }}}
+ *
+ * You might consider mapping the file to a MappedByteBuffer like below, keeping in mind that
+ * MappedByteBuffers have size limitations and potentially different performance characteristics
+ * depending on the file size and system--it maybe not always be faster than above.
+ *
+ * {{{
+ * Path path = Paths.get(file);
+ * long size = Files.size(path);
+ * FileChannel fc = FileChannel.open(path, StandardOpenOption.READ);
+ * ByteBuffer bb = fc.map(FileChannel.MapMode.READ_ONLY, 0, size);
+ * fc.close();
+ * InputSourceDataInputStream input = new InputSourceDataInputStream(bb);
+ * }}}
  */
 class InputSourceDataInputStream private[japi] (
   private[japi] val dis: SInputSourceDataInputStream

--- a/daffodil-sapi/src/main/scala/org/apache/daffodil/sapi/io/InputSourceDataInputStream.scala
+++ b/daffodil-sapi/src/main/scala/org/apache/daffodil/sapi/io/InputSourceDataInputStream.scala
@@ -26,6 +26,31 @@ import org.apache.daffodil.io.{ InputSourceDataInputStream => SInputSourceDataIn
  * Provides Daffodil with byte data from an InputStream, ByteBuffer, or byte
  * Array.
  *
+ * Note that the InputStream variant has potential overhead due to streaming capabilities and
+ * support for files greater than 2GB. In some cases, better performance might come from using
+ * the byte array or ByteBuffer variants instead. For example, if your data is already in a byte
+ * array, one should use the Array[Byte] or ByteBuffer variants instead of wrapping it in a
+ * ByteArrayInputStream. As another example, instead of using a FileInputStream like this:
+ *
+ * {{{
+ * val path = Paths.get(file)
+ * val fis = Files.newInputStream(path)
+ * val input = InputSourceDataInputStream(fis)
+ * }}}
+ *
+ * You might consider mapping the file to a MappedByteBuffer like below, keeping in mind that
+ * MappedByteBuffers have size limitations and potentially different performance characteristics
+ * depending on the file size and system--it maybe not always be faster than above.
+ *
+ * {{{
+ * val path = Paths.get(file)
+ * val size = Files.size(path)
+ * val fc = FileChannel.open(path, StandardOpenOption.READ)
+ * val bb = fc.map(FileChannel.MapMode.READ_ONLY, 0, size)
+ * fc.close()
+ * val input = InputSourceDataInputStream(bb)
+ * }}}
+ *
  * @param dis the underlying Scala InputSourceDataInputStream
  */
 class InputSourceDataInputStream private[sapi] (


### PR DESCRIPTION
Daffodil currently supports two different input sources: a BucketingInputSource backed by an InputStream and ByteBufferInputSource backed by a ByteBuffer. The CLI currntly always uses the BucketingInputSource because the ByteBufferInputSource does not support stdin or files larger than 2GB. Although the gap is closing due to other optimizations, the BucketingInputSource still has overhead compared to ByteBufferInputSource due to added complexity.

This changes the CLI logic to use a ByteBufferInputSource where possible (parsing files <= 2GB) using mmap and a MappedByteBuffer to efficiently create a ByteBuffer.

Basic testing shows about a 5% increase over the BucketingInputSource for a large file with many small reads.

DAFFODIL-2921