### PR TITLE
Fixed test test_date_constructor_01 in TestDFDLExpressions

### DIFF
--- a/daffodil-test/src/test/resources/org/apache/daffodil/section23/dfdl_functions/Functions.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section23/dfdl_functions/Functions.tdml
@@ -9106,7 +9106,7 @@
     </tdml:document>
     <tdml:errors>
       <tdml:error>Parse Error</tdml:error>
-      <tdml:error>Invalid date "1991-03-4" (Day must be two digits)</tdml:error>
+      <tdml:error>Failed to parse xs:date from string: 1991-03-4</tdml:error>
     </tdml:errors>
   </tdml:parserTestCase>
   

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section23/dfdl_expressions/TestDFDLExpressions.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section23/dfdl_expressions/TestDFDLExpressions.scala
@@ -1326,7 +1326,7 @@ class TestDFDLExpressions {
   @Test def test_time_constructor_04(): Unit = { runner2.runOneTest("time_constructor_04") }
 
   // DFDL-1124
-  // @Test def test_date_constructor_01() { runner2.runOneTest("date_constructor_01") }
+  @Test def test_date_constructor_01(): Unit = { runner2.runOneTest("date_constructor_01") }
   @Test def test_date_constructor_02(): Unit = { runner2.runOneTest("date_constructor_02") }
   // @Test def test_date_constructor_02a() { runner2.runOneTest("date_constructor_02a") }
   @Test def test_date_constructor_03(): Unit = { runner2.runOneTest("date_constructor_03") }


### PR DESCRIPTION
Fixed test "test_date_constructor_01" in testDFDLExpressions. This involved uncommenting the test and changing the expected error message in date_constructor_01 in Functions.tdml

This test checks that single digit days are not allowed in dates.

This test has been disabled for a long time due to a now fixed bug where single digit days were being allowed in dates. This bug has been fixed and single digit days are no longer allowed, so the test has been renenabled, and the expected error message has been updated

 DAFFODIL-1124