### PR TITLE
Removed argType parameter from FNZeroArgExpr

### DIFF
--- a/daffodil-core/src/main/scala/org/apache/daffodil/core/dpath/Expression.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/core/dpath/Expression.scala
@@ -1508,8 +1508,7 @@ case class FunctionCallExpression(functionQNameString: String, expressions: List
           functionQNameString,
           functionQName,
           NodeInfo.String,
-          NodeInfo.Exists,
-          FNLocalName0(_, _)
+          FNLocalName0
         )
 
       case (RefQName(_, "local-name", FUNC), args) if args.length == 1 =>
@@ -1527,8 +1526,7 @@ case class FunctionCallExpression(functionQNameString: String, expressions: List
           functionQNameString,
           functionQName,
           NodeInfo.String,
-          NodeInfo.Exists,
-          FNNamespaceUri0(_, _)
+          FNNamespaceUri0
         )
 
       case (RefQName(_, "namespace-uri", FUNC), args) if args.length == 1 =>
@@ -2546,18 +2544,26 @@ case class FNZeroArgExpr(
   nameAsParsed: String,
   fnQName: RefQName,
   resultType: NodeInfo.Kind,
-  argType: NodeInfo.Kind,
-  constructor: (CompiledDPath, NodeInfo.Kind) => RecipeOp
+  constructor: () => RecipeOp
 ) extends FunctionCallBase(nameAsParsed, fnQName, Nil) {
 
   override lazy val inherentType = resultType
 
-  override def targetTypeForSubexpression(childExpr: Expression): NodeInfo.Kind = argType
+  /*
+  This function should never be called since FNZeroArgExpr's never have sub expressions.
+  However we still need to overwrite it since it's in the abtract class we are extending.
+  So, we just call Assert.impossible() wrapped with
+  // $COVERAGE-OFF$ and // $COVERAGE-ON$ comments to to disable code coverage.
+   */
+  // $COVERAGE-OFF$
+  override def targetTypeForSubexpression(childExpr: Expression): NodeInfo.Kind =
+    Assert.impossible()
+  // $COVERAGE-ON$
 
   override lazy val compiledDPath = {
     checkArgCount(0)
     val c = conversions
-    val res = new CompiledDPath(constructor(null, null) +: c)
+    val res = new CompiledDPath(constructor() +: c)
     res
   }
 }

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/dpath/FNFunctions.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/dpath/FNFunctions.scala
@@ -743,8 +743,7 @@ case class FNEmpty(recipe: CompiledDPath, argType: NodeInfo.Kind)
  * This function is called when 0 arguments are provided.  We
  * treat this as if the argument passed was "." to denote self.
  */
-case class FNLocalName0(recipe: CompiledDPath, argType: NodeInfo.Kind)
-  extends RecipeOpWithSubRecipes(recipe) {
+case class FNLocalName0() extends RecipeOp {
   override def run(dstate: DState): Unit = {
     // Same as using "." to denote self.
     val localName = dstate.currentElement.name
@@ -805,8 +804,7 @@ case class FNLocalName1(recipe: CompiledDPath, argType: NodeInfo.Kind)
  * This function is called when 0 arguments are provided.  We
  * treat this as if the argument passed was "." to denote self.
  */
-case class FNNamespaceUri0(recipe: CompiledDPath, argType: NodeInfo.Kind)
-  extends RecipeOpWithSubRecipes(recipe) {
+case class FNNamespaceUri0() extends RecipeOp {
   override def run(dstate: DState): Unit = {
     // Insist this is non-constant at compile time (to avoid a NPE)
     if (dstate.isCompile)


### PR DESCRIPTION
argType parameter wasn't needed for FNZeroArgExpr since it's supposed to implement dfdl functions that take no argument those functions are fn:local-name and fn:namespace-uri functions.

argType is used for targetTypeForSubexpression which should never be called in FNZeroArgExpr since their are zero arguments. However, targetTypeForSubexpression still has be implemented in the class since FNZeroArgExpr extends FunctionCallBase, so targetTypeForSubexpression is set to Node.Exists in the FNZeroArgExpr class definition.

In addtion, parameter were removed from FNLocalName0 and FNNamespaceUri0 since these parameters were no longer needed after FNZeroArgExpr was updated. Also, to support this change, both classes now extend RecipeOp instead of RecipeOpWithSubRecipes since RecipeOp needs no parameters and the subRecipes feature wasn't being used in these functions anyways.

 DAFFODIL-2331