### PR TITLE
JSON output no longer quotes all values

### DIFF
--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/infoset/JsonInfosetInputter.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/infoset/JsonInfosetInputter.scala
@@ -85,7 +85,9 @@ class JsonInfosetInputter(input: java.io.InputStream) extends InfosetInputter {
       jsp.getCurrentToken() match {
         case JsonToken.START_OBJECT => if (objectDepth == 1) StartDocument else StartElement
         case JsonToken.END_OBJECT => EndElement
-        case JsonToken.VALUE_STRING | JsonToken.VALUE_NULL => {
+        case JsonToken.VALUE_STRING | JsonToken.VALUE_NUMBER_INT |
+            JsonToken.VALUE_NUMBER_FLOAT | JsonToken.VALUE_TRUE | JsonToken.VALUE_FALSE |
+            JsonToken.VALUE_NULL => {
           // we don't want to start faking element end yet, but signify that
           // after a call to next(), we will want to fake it
           nextEventShouldBeFakeEnd = true
@@ -118,10 +120,15 @@ class JsonInfosetInputter(input: java.io.InputStream) extends InfosetInputter {
     primType: NodeInfo.Kind,
     runtimeProperties: java.util.Map[String, String]
   ): String = {
-    if (jsp.getCurrentToken() == JsonToken.VALUE_NULL) {
+    if (!jsp.getCurrentToken().isScalarValue()) {
+      throw new NonTextFoundInSimpleContentException(
+        "Unexpected array or object '" + getLocalName + "' on line " + jsp
+          .getTokenLocation()
+          .getLineNr()
+      )
+    } else if (jsp.getCurrentToken() == JsonToken.VALUE_NULL) {
       null
     } else {
-      Assert.invariant(jsp.getCurrentToken() == JsonToken.VALUE_STRING)
       // this handles unescaping any escaped characters
       jsp.getText()
     }
@@ -172,7 +179,7 @@ class JsonInfosetInputter(input: java.io.InputStream) extends InfosetInputter {
             objectDepth -= 1; exitNow = true
 
           // start of a simple type or null
-          case JsonToken.VALUE_STRING | JsonToken.VALUE_NULL => exitNow = true
+          case token if token.isScalarValue() => exitNow = true
 
           // skip field names, jackson makes these available via
           // getCurrentName(), except for array elements

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/infoset/JsonInfosetOutputter.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/infoset/JsonInfosetOutputter.scala
@@ -112,11 +112,37 @@ class JsonInfosetOutputter private (writer: java.io.BufferedWriter, pretty: Bool
         } else {
           simple.getText
         }
-      writer.write('"')
-      writer.write(text)
-      writer.write('"')
+      if (needsQuote(simple)) {
+        writer.write('"')
+        writer.write(text)
+        writer.write('"')
+      } else {
+        writer.write(text)
+      }
     } else {
       writer.write("null")
+    }
+  }
+
+  private def needsQuote(simple: InfosetSimpleElement): Boolean = {
+    simple.metadata.dfdlType match {
+      case DFDLPrimType.String => true
+      case DFDLPrimType.HexBinary => true
+      case DFDLPrimType.AnyURI => true
+      case DFDLPrimType.DateTime => true
+      case DFDLPrimType.Date => true
+      case DFDLPrimType.Time => true
+
+      // json does not support inf/nan double/float so they must be quoted
+      case DFDLPrimType.Double => {
+        val d = simple.getDouble
+        d.isInfinite || d.isNaN
+      }
+      case DFDLPrimType.Float => {
+        val f = simple.getFloat
+        f.isInfinite || f.isNaN
+      }
+      case _ => false
     }
   }
 


### PR DESCRIPTION
JSONInfosetInputter and Outputter were treating all values as strings. This meant everyhing was quoted and was messier for the user to read. In addition, not all json comes from dfdl, so it makes sense to support numbers.

As of the time of this commit 156 tests fail as the changes cause some issues with dates and NaN, INF, and -INF values as well as numbers with a large amount of decimals such as 0.1234567898765432123456789 from test decimal_constructor_06.

 DAFFODIL-2362