### PR TITLE
Support locally suppressing schema definition warnings

### DIFF
--- a/daffodil-core/src/main/scala/org/apache/daffodil/core/dpath/Expression.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/core/dpath/Expression.scala
@@ -54,6 +54,8 @@ abstract class Expression extends OOLAGHostImpl() with BasicComponent {
   override lazy val tunable: DaffodilTunables = parent.tunable
   override lazy val unqualifiedPathStepPolicy: UnqualifiedPathStepPolicy =
     parent.unqualifiedPathStepPolicy
+  override lazy val localSuppressSchemaDefinitionWarnings: Seq[WarnID] =
+    parent.localSuppressSchemaDefinitionWarnings
 
   /**
    * Override where we traverse/access elements.
@@ -463,6 +465,8 @@ case class WholeExpression(
   final override lazy val tunable: DaffodilTunables = host.tunable
   final override lazy val unqualifiedPathStepPolicy: UnqualifiedPathStepPolicy =
     host.unqualifiedPathStepPolicy
+  final override lazy val localSuppressSchemaDefinitionWarnings: Seq[WarnID] =
+    host.localSuppressSchemaDefinitionWarnings
 
   def init(): Unit = {
     this.setOOLAGContext(

--- a/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/SchemaComponent.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/SchemaComponent.scala
@@ -21,6 +21,7 @@ import scala.xml.Node
 
 import org.apache.daffodil.core.runtime1.SchemaComponentRuntime1Mixin
 import org.apache.daffodil.lib.api.DaffodilTunables
+import org.apache.daffodil.lib.api.WarnID
 import org.apache.daffodil.lib.exceptions.Assert
 import org.apache.daffodil.lib.schema.annotation.props.PropTypes
 import org.apache.daffodil.lib.util.Delay
@@ -66,6 +67,18 @@ trait SchemaComponent
   }
 
   def xml: Node
+
+  final lazy val localSuppressSchemaDefinitionWarnings = {
+    val optAttr =
+      xml.attribute(XMLUtils.EXT_NS_APACHE, "suppressSchemaDefinitionWarnings").map { _.text }
+    val warnStrs: Seq[String] =
+      optAttr.map { _.trim.split("\\s+").toSeq }.getOrElse { Seq.empty }
+    val warnIDs = warnStrs.map { warnStr =>
+      // throws SDE if not valid warnID
+      WarnID.stringToEnum("daf:suppressSchemaDefinitionWarnings", warnStr, this)
+    }
+    warnIDs
+  }
 
   override def oolagContextViaArgs = optLexicalParent
 

--- a/daffodil-core/src/main/scala/org/apache/daffodil/core/grammar/GrammarTerm.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/core/grammar/GrammarTerm.scala
@@ -58,6 +58,8 @@ abstract class Gram(contextArg: SchemaComponent)
   final override def namespaces = context.namespaces
   final override def unqualifiedPathStepPolicy = context.unqualifiedPathStepPolicy
   final override def schemaFileLocation = context.schemaFileLocation
+  final override def localSuppressSchemaDefinitionWarnings =
+    context.localSuppressSchemaDefinitionWarnings
 
   final override def SDE(str: String, args: Any*): Nothing = context.SDE(str, args: _*)
 

--- a/daffodil-core/src/main/scala/org/apache/daffodil/core/runtime1/ElementBaseRuntime1Mixin.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/core/runtime1/ElementBaseRuntime1Mixin.scala
@@ -220,7 +220,8 @@ trait ElementBaseRuntime1Mixin { self: ElementBase =>
       maybeCheckByteAndBitOrderEv,
       maybeCheckBitOrderAndCharsetEv,
       isQuasiElement,
-      runtimeProperties
+      runtimeProperties,
+      localSuppressSchemaDefinitionWarnings
     )
     newERD
   }.value

--- a/daffodil-propgen/src/main/scala/org/apache/daffodil/propGen/TunableGenerator.scala
+++ b/daffodil-propgen/src/main/scala/org/apache/daffodil/propGen/TunableGenerator.scala
@@ -106,10 +106,6 @@ class TunableGenerator(schemaRootConfig: scala.xml.Node, schemaRootExt: scala.xm
     |    }
     |  }
     |
-    |  def notSuppressedWarning(warnID: WarnID) =
-    |    !suppressSchemaDefinitionWarnings.contains(warnID) &&
-    |      !suppressSchemaDefinitionWarnings.contains(WarnID.All)
-    |
     |  private def throwInvalidTunableValue(tunable: String, value: String) = {
     |    throw new IllegalArgumentException("Invalid value for tunable " + tunable + ": " + value)
     |  }

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/debugger/InteractiveDebugger.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/debugger/InteractiveDebugger.scala
@@ -20,6 +20,7 @@ package org.apache.daffodil.runtime1.debugger
 import java.io.File
 
 import org.apache.daffodil.lib.api.DaffodilTunables
+import org.apache.daffodil.lib.api.WarnID
 import org.apache.daffodil.lib.exceptions.Assert
 import org.apache.daffodil.lib.exceptions.UnsuppressableException
 import org.apache.daffodil.lib.oolag.ErrorsNotYetRecorded
@@ -2369,4 +2370,6 @@ class DebuggerHost(override val tunable: DaffodilTunables)
   def unqualifiedPathStepPolicy: org.apache.daffodil.lib.api.UnqualifiedPathStepPolicy = ???
   // Members declared in org.apache.daffodil.lib.exceptions.ThrowsSDE
   def schemaFileLocation: org.apache.daffodil.lib.exceptions.SchemaFileLocation = ???
+
+  override lazy val localSuppressSchemaDefinitionWarnings: Seq[WarnID] = Seq()
 }

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/ProcessorStateBases.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/ProcessorStateBases.scala
@@ -566,8 +566,12 @@ abstract class ParseOrUnparseState protected (
   }
 
   final def SDW(warnID: WarnID, str: String, args: Any*) = {
-    if (tunable.notSuppressedWarning(warnID)) {
-      val ctxt = getContext()
+    val ctxt = getContext()
+    val lssdw = ctxt.localSuppressSchemaDefinitionWarnings
+    val tssdw = tunable.suppressSchemaDefinitionWarnings
+    val suppress = lssdw.contains(warnID) || lssdw.contains(WarnID.All) ||
+      tssdw.contains(warnID) || tssdw.contains(WarnID.All)
+    if (!suppress) {
       val rsdw =
         new RuntimeSchemaDefinitionWarning(warnID, ctxt.schemaFileLocation, this, str, args: _*)
       diagnostics = rsdw :: diagnostics

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/RuntimeData.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/RuntimeData.scala
@@ -24,6 +24,7 @@ import scala.util.matching.Regex
 import scala.xml.NamespaceBinding
 
 import org.apache.daffodil.lib.Implicits.ImplicitsSuppressUnusedImportWarning
+import org.apache.daffodil.lib.api.WarnID
 import org.apache.daffodil.lib.exceptions.Assert
 import org.apache.daffodil.lib.exceptions.HasSchemaFileLocation
 import org.apache.daffodil.lib.exceptions.SchemaFileLocation
@@ -692,7 +693,8 @@ sealed class ElementRuntimeData(
   maybeCheckByteAndBitOrderEvArg: Maybe[CheckByteAndBitOrderEv],
   maybeCheckBitOrderAndCharsetEvArg: Maybe[CheckBitOrderAndCharsetEv],
   val isQuasiElement: Boolean,
-  val runtimeProperties: java.util.Map[String, String]
+  val runtimeProperties: java.util.Map[String, String],
+  val localSuppressSchemaDefinitionWarnings: Seq[WarnID]
 ) extends TermRuntimeData(
     positionArg,
     partialNextElementResolverDelay,
@@ -824,8 +826,9 @@ sealed abstract class ErrorERD(local: String, namespaceURI: String)
     null, // fillByteEvArg => FillByteEv
     Nope, // maybeCheckByteAndBitOrderEvArg: => Maybe[CheckByteAndBitOrderEv],
     Nope, // maybeCheckBitOrderAndCharsetEvArg: => Maybe[CheckBitOrderAndCharsetEv],
-    false, // isQuasiElementArg: => Boolean
-    null // runtimeProperties: java.util.Map[String,String]
+    false, // isQuasiElementArg: => Boolean,
+    null, // runtimeProperties: java.util.Map[String,String],
+    null // localSuppressSchemaDefinitionWarnings: Seq[WarnID]
   ) {
 
   override def toString() =

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section02/schema_definition_errors/SchemaDefinitionErrors.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section02/schema_definition_errors/SchemaDefinitionErrors.tdml
@@ -281,4 +281,31 @@
 
   </tdml:parserTestCase>
 
+  <tdml:defineSchema name="warning_suppressed">
+    <xs:include schemaLocation="/org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+    <dfdl:format ref="ex:GeneralFormat" lengthKind="delimited" encoding="utf-8" representation="text"/>
+    <xs:element name="elem" type="xs:string" daf:suppressSchemaDefinitionWarnings="appinfoDFDLSourceWrong">
+      <xs:annotation>
+        <xs:appinfo source="http://www.ogf.org/dfdl/dfdl-1.0/" />
+      </xs:annotation>
+    </xs:element>
+  </tdml:defineSchema>
+
+<!--
+    Test Name: schema_warning_locally_suppressed
+       Schema: warning
+         Root: elem
+      Purpose: This test demonstrates locally suppressed warnings
+-->
+
+  <tdml:parserTestCase name="schema_warning_locally_suppressed" root="elem"
+    model="warning_suppressed" ignoreUnexpectedWarnings="false">
+    <tdml:document><![CDATA[test]]></tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <elem>test</elem>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
 </tdml:testSuite>

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section02/schema_definition_errors/TestSDE.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section02/schema_definition_errors/TestSDE.scala
@@ -53,4 +53,8 @@ class TestSDE {
   @Test def test_ignoreAttributeFormDefault(): Unit = {
     runner.runOneTest("ignoreAttributeFormDefault")
   }
+
+  @Test def test_schema_warning_locally_suppressed(): Unit = {
+    runner.runOneTest("schema_warning_locally_suppressed")
+  }
 }


### PR DESCRIPTION
We currently only support supressing schema definition warnings globally with the use of tunables. However, some uses of Daffodil may not be able to set tunables. Or in some cases we want to suppress a warning if it is caused by a specific location in a schema, but all others should not be suppressed.

Tos support this, this adds support for a new
"daf:suppressSchemaDefinitionWarnings" attribute, where the value is a whitespace separated list of schema definition warnings to suppress if the schema component it is placed on leads to a schema definition warning. Note that this property does not follow morning DFDL property scoping rules. So for example, you cannot have a default value defined in a DFDL format that applies globally to a schema.

Additionaly, we need to treat the new property similar to how to treat dfdl:ref (i.e. exclude it from certain logic), so logic related to excluding dfdl:ref is made more generic to support the new property, reduce special cases, and make surrounding code more consistent.

DAFFODIL-2638