### PR TITLE
Disable constant length facet check for inputValueCalc elements

### DIFF
--- a/daffodil-core/src/main/scala/org/apache/daffodil/core/grammar/ElementBaseGrammarMixin.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/core/grammar/ElementBaseGrammarMixin.scala
@@ -1625,9 +1625,12 @@ trait ElementBaseGrammarMixin
      * Warn if a type respects minLength/maxLength/length facets and we can calculate that the
      * infoset length will be out of range of the facet values. Note that we can only do this in
      * specific cases, like when the length and encoding properties are constant and the
-     * encoding is fixed width characters.
+     * encoding is fixed width characters. Note that IVC ignores explicit length so we only do
+     * this for represented elements.
      */
-    if ((lengthKind eq LengthKind.Explicit) && (hasLength || hasMinLength || hasMaxLength)) {
+    if (
+      isRepresented && (lengthKind eq LengthKind.Explicit) && (hasLength || hasMinLength || hasMaxLength)
+    ) {
       val optInfosetLen = elementLengthInBitsEv.optConstant.flatMap { maybeKnownLenInBits =>
         if (maybeKnownLenInBits.isDefined) {
           val len = maybeKnownLenInBits.get

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section02/validation_errors/Validation.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section02/validation_errors/Validation.tdml
@@ -411,6 +411,18 @@
       </xs:simpleType>
     </xs:element>
 
+    <!--
+      dfdl:lengthKind will be ignored when used by IVC elements, but could
+      potentially be used by non-IVC elements that define dfdl:length
+    -->
+    <xs:simpleType name="str" dfdl:lengthKind="explicit">
+      <xs:restriction base="xs:string">
+        <xs:maxLength value="5" />
+      </xs:restriction>
+    </xs:simpleType>
+
+    <xs:element name="e4" type="ex:str" dfdl:inputValueCalc="{ '123456' }" />
+
   </tdml:defineSchema>
 
     <tdml:defineSchema name="TestFacets">
@@ -2151,6 +2163,22 @@
             <tdml:error>failed facet checks due to: facet length (7)</tdml:error>
         </tdml:validationErrors>
 
+    </tdml:parserTestCase>
+
+    <tdml:parserTestCase name="validation_inputValueCalc_08"
+                         root="e4" model="inputValueCalc"
+                         description="Section 17 - the value created using inputValueCalc is validated using length facets"
+                         validation="on">
+        <tdml:document></tdml:document>
+        <tdml:infoset>
+            <tdml:dfdlInfoset>
+                <e4>123456</e4>
+            </tdml:dfdlInfoset>
+        </tdml:infoset>
+        <tdml:validationErrors>
+            <tdml:error>Validation Error</tdml:error>
+            <tdml:error>failed facet checks due to: facet maxLength (5)</tdml:error>
+        </tdml:validationErrors>
     </tdml:parserTestCase>
 
     <tdml:defineSchema name="TestFacets2">

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section02/validation_errors/TestValidationErr.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section02/validation_errors/TestValidationErr.scala
@@ -180,6 +180,9 @@ class TestValidationErr {
   @Test def test_validation_inputValueCalc_07(): Unit = {
     runner.runOneTest("validation_inputValueCalc_07")
   }
+  @Test def test_validation_inputValueCalc_08(): Unit = {
+    runner.runOneTest("validation_inputValueCalc_08")
+  }
 
   @Test def test_validation_testFacets_01(): Unit = {
     runner.runOneTest("validation_testFacets_01")


### PR DESCRIPTION
It is possible to have dfdl:lengthKind="explicit" defiend for elements with dfdl:inputValueCalc. In that case, ther lengthKidproperty should just be ignored. But the logic for checking if a constant length element is within facet length bounds did not ignore the property for IVC elements, which led to it expecting a dfdl:length and errorer.

To fix this, and addition restriction is added so we only do the check for represented elements, i.e. non-IVC elements.

DAFFODIL-2888