### PR TITLE
Add support for escalating SDWs to Errors

### DIFF
--- a/daffodil-propgen/src/main/resources/org/apache/daffodil/xsd/dafext.xsd
+++ b/daffodil-propgen/src/main/resources/org/apache/daffodil/xsd/dafext.xsd
@@ -185,6 +185,13 @@
             </xs:documentation>
           </xs:annotation>
         </xs:element>
+        <xs:element name="escalateWarningsToErrors" type="xs:boolean" default="false" minOccurs="0">
+          <xs:annotation>
+            <xs:documentation>
+              This tunable allows the escalation of Schema Definition Warnings to Errors.
+            </xs:documentation>
+          </xs:annotation>
+        </xs:element>
         <xs:element name="generatedNamespacePrefixStem" type="xs:string" default="tns" minOccurs="0">
           <xs:annotation>
             <xs:documentation>

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/debugger/InteractiveDebugger.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/debugger/InteractiveDebugger.scala
@@ -355,8 +355,8 @@ class InteractiveDebugger(
         // Most errors are coming back here as RSDE because that's what they get upconverted into.
         // Most expression problems are considered SDE.
         //
-        case _: RuntimeSchemaDefinitionError => {
-          state.setSuccess()
+        case e: RuntimeSchemaDefinitionError => {
+          state.suppressDiagnosticAndSucceed(e)
           false
         }
       }

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/dpath/DPath.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/dpath/DPath.scala
@@ -394,7 +394,6 @@ final class RuntimeExpressionDPath[T <: AnyRef](
             if (value.asInstanceOf[String].length == 0) {
               val e = new RuntimeSchemaDefinitionError(
                 ci.schemaFileLocation,
-                state,
                 "Non-empty string required."
               )
               doSDE(e, state)

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/DataProcessor.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/DataProcessor.scala
@@ -513,9 +513,9 @@ class DataProcessor(
         state.dataInputStream.inputSource.setInvalid
         state.setFailed(sde)
       }
-      case rsde: RuntimeSchemaDefinitionError => {
+      case sdefw: SchemaDefinitionErrorFromWarning => {
         state.dataInputStream.inputSource.setInvalid
-        state.setFailed(rsde)
+        state.setFailed(sdefw)
       }
       case e: ErrorAlreadyHandled => {
         state.setFailed(e.th)
@@ -574,8 +574,8 @@ class DataProcessor(
           unparserState.setFailed(sde)
           unparserState.unparseResult
         }
-        case rsde: RuntimeSchemaDefinitionError => {
-          unparserState.setFailed(rsde)
+        case sdefw: SchemaDefinitionErrorFromWarning => {
+          unparserState.setFailed(sdefw)
           unparserState.unparseResult
         }
         case e: ErrorAlreadyHandled => {

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/SuspensionTracker.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/SuspensionTracker.scala
@@ -120,7 +120,14 @@ class SuspensionTracker(suspensionWaitYoung: Int, suspensionWaitOld: Int) {
 class SuspensionDeadlockException(suspExprs: Seq[Suspension])
   extends RuntimeSchemaDefinitionError(
     suspExprs(0).rd.schemaFileLocation,
-    suspExprs(0).savedUstate,
     "Expressions/Unparsers are circularly deadlocked (mutually defined):\n%s",
-    suspExprs.groupBy { _.rd }.mapValues { _(0) }.values.mkString(" - ", "\n - ", "")
+    suspExprs
+      .groupBy {
+        _.rd
+      }
+      .mapValues {
+        _(0)
+      }
+      .values
+      .mkString(" - ", "\n - ", "")
   )

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/ParseErrors.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/ParseErrors.scala
@@ -140,12 +140,12 @@ trait DoSDEMixin {
         throw sde
       }
       case other => {
-        val sde = new RuntimeSchemaDefinitionError(
-          state.getContext().schemaFileLocation,
-          state,
-          e,
-          null
-        )
+        val sde =
+          new RuntimeSchemaDefinitionError(
+            state.getContext().schemaFileLocation,
+            e,
+            e.getMessage
+          )
         state.setFailed(sde)
         state.toss(sde)
       }

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/Parser.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/Parser.scala
@@ -342,7 +342,6 @@ case class NotParsableParser(context: ElementRuntimeData) extends PrimParserNoDa
     // create an SDE and toss it
     val rsde = new RuntimeSchemaDefinitionError(
       context.schemaFileLocation,
-      state,
       "This schema was compiled without parse support. Check the parseUnparsePolicy tunable or dfdlx:parseUnparsePolicy property."
     )
     context.toss(rsde)

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/unparsers/Unparser.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/unparsers/Unparser.scala
@@ -201,7 +201,6 @@ case class NotUnparsableUnparser(override val context: ElementRuntimeData)
     // create an SDE and toss it
     val rsde = new RuntimeSchemaDefinitionError(
       context.schemaFileLocation,
-      state,
       "This schema was compiled without unparse support. Check the parseUnparsePolicy tunable or dfdlx:parseUnparsePolicy property."
     )
     context.toss(rsde)

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section02/schema_definition_errors/SchemaDefinitionErrors.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section02/schema_definition_errors/SchemaDefinitionErrors.tdml
@@ -308,4 +308,67 @@
     </tdml:infoset>
   </tdml:parserTestCase>
 
+
+  <tdml:defineSchema name="warning_escalated">
+    <xs:include schemaLocation="/org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+    <dfdl:format ref="ex:GeneralFormat" lengthKind="delimited" encoding="utf-8" representation="text"/>
+    <xs:element name="elem" type="xs:string">
+      <xs:annotation>
+        <xs:appinfo source="http://www.ogf.org/dfdl/dfdl-1.0/" />
+      </xs:annotation>
+    </xs:element>
+
+    <xs:element name="elem2" type="xs:string" daf:suppressSchemaDefinitionWarnings="appinfoDFDLSourceWrong">
+      <xs:annotation>
+        <xs:appinfo source="http://www.ogf.org/dfdl/dfdl-1.0/" />
+      </xs:annotation>
+    </xs:element>
+  </tdml:defineSchema>
+
+
+  <tdml:defineConfig name="escalateWarnings">
+    <daf:tunables>
+      <daf:escalateWarningsToErrors>true</daf:escalateWarningsToErrors>
+    </daf:tunables>
+  </tdml:defineConfig>
+
+  <!--
+      Test Name: schema_warning_escalated_to_error
+         Schema: warning_escalated
+           Root: elem
+        Purpose: This test demonstrates escalating warnings to errors
+  -->
+
+  <tdml:parserTestCase name="schema_warning_escalated_to_error" root="elem"
+                       model="warning_escalated"
+                       ignoreUnexpectedWarnings="false"
+                       config="escalateWarnings">
+    <tdml:document><![CDATA[test]]></tdml:document>
+    <tdml:errors>
+      <tdml:error>Schema Definition Warning Escalated Error</tdml:error>
+      <tdml:error>appinfoDFDLSourceWrong</tdml:error>
+      <tdml:error>xs:appinfo source attribute</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+<!--
+      Test Name: schema_warning_escalated_to_error2
+         Schema: warning_escalated
+           Root: elem2
+        Purpose: This test demonstrates escalating warnings to errors doesn't happen when
+        warning is suppressed
+  -->
+
+  <tdml:parserTestCase name="schema_warning_escalated_to_error2" root="elem2"
+                       model="warning_escalated"
+                       ignoreUnexpectedWarnings="false"
+                       config="escalateWarnings">
+    <tdml:document><![CDATA[test]]></tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <elem2>test</elem2>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
 </tdml:testSuite>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section07/variables/variables.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section07/variables/variables.tdml
@@ -23,6 +23,7 @@
   xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:ct="http://w3.ibm.com/xmlns/dfdl/ctInfoset"
   xmlns:fn="http://www.w3.org/2005/xpath-functions"
   xmlns:ex="http://example.com"
+  xmlns:daf="urn:ogf:dfdl:2013:imp:daffodil.apache.org:2018:ext"
   defaultRoundTrip="true">
 
   <tdml:defineSchema name="v">
@@ -2218,6 +2219,26 @@
         </root>
       </tdml:dfdlInfoset>
     </tdml:infoset>
+  </tdml:parserTestCase>
+
+
+  <tdml:defineConfig name="escalateWarnings">
+    <daf:tunables>
+      <daf:escalateWarningsToErrors>true</daf:escalateWarningsToErrors>
+    </daf:tunables>
+  </tdml:defineConfig>
+
+  <tdml:parserTestCase name="defineVariable_nonConstantExpression_setVar_err2" root="root"
+    model="defineVariable_nonConstantExpression_setVar" description="escalate warning"
+    config="escalateWarnings">
+    <tdml:document/>
+    <tdml:errors>
+      <tdml:error>Schema Definition Warning Escalated Error</tdml:error>
+      <tdml:error>variableSet</tdml:error>
+      <tdml:error>Cannot set variable</tdml:error>
+      <tdml:error>after reading the default value</tdml:error>
+      <tdml:error>State was: VariableRead</tdml:error>
+    </tdml:errors>
   </tdml:parserTestCase>
 
 

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section02/schema_definition_errors/TestSDE.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section02/schema_definition_errors/TestSDE.scala
@@ -57,4 +57,12 @@ class TestSDE {
   @Test def test_schema_warning_locally_suppressed(): Unit = {
     runner.runOneTest("schema_warning_locally_suppressed")
   }
+
+  @Test def test_schema_warning_escalated_to_error(): Unit = {
+    runner.runOneTest("schema_warning_escalated_to_error")
+  }
+
+  @Test def test_schema_warning_escalated_to_error2(): Unit = {
+    runner.runOneTest("schema_warning_escalated_to_error2")
+  }
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section07/variables/TestVariables.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section07/variables/TestVariables.scala
@@ -90,6 +90,9 @@ class TestVariables {
   @Test def test_defineVariable_nonConstantExpression_setVar_err(): Unit = {
     runner.runOneTest("defineVariable_nonConstantExpression_setVar_err")
   }
+  @Test def test_defineVariable_nonConstantExpression_setVar_err2(): Unit = {
+    runner.runOneTest("defineVariable_nonConstantExpression_setVar_err2")
+  }
 
   // DAFFODIL-2444 - This test triggers an unhandled NoSuchElement exception, which if handled then runs into an Assert.invariant
   // @Test def test_defineVariable_ref_infoset_err(): Unit = { runner.runOneTest("defineVariable_ref_infoset_err") }


### PR DESCRIPTION
- add tunable 'escalateWarningsToErrors' to control escalation of all warnings to errors
- add test to demonstrate tunable

DAFFODIL-2810