### PR TITLE
Bump version for 4.0.0 development

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -223,7 +223,7 @@ val minSupportedJavaVersion: String =
 
 lazy val commonSettings = Seq(
   organization := "org.apache.daffodil",
-  version := "3.9.0",
+  version := "4.0.0-SNAPSHOT",
   scalaVersion := "2.12.20",
   crossScalaVersions := Seq("2.12.20"),
   scalacOptions ++= buildScalacOptions(scalaVersion.value),


### PR DESCRIPTION
Based on the development roadmap, 4.0.0 is the next milestone 

https://cwiki.apache.org/confluence/display/DAFFODIL/Roadmap+for+Upcoming+Releases