### PR TITLE
Add support for lengthUnit=bits for any type

### DIFF
--- a/daffodil-propgen/src/main/resources/org/apache/daffodil/xsd/dafext.xsd
+++ b/daffodil-propgen/src/main/resources/org/apache/daffodil/xsd/dafext.xsd
@@ -104,12 +104,8 @@
         <xs:element name="allowBigIntegerBits" type="xs:boolean" default="true" minOccurs="0">
           <xs:annotation>
             <xs:documentation>
-              Previous Daffodil releases let schemas define every type's length using "bits" as the length unit
-              even though the specification allows bit length units only for a specific set of types' binary
-              representations and does not allow bit length units for any other type's binary representation
-              or any type's text representation.  When this tunable is true, a deprecation warning is issued
-              when bit length units are incorrectly used.  When this tunable is false, a schema definition
-              error will be issued instead.
+              Deprecated. This tunable no longer has any affect and is only kept for
+              backwards compatability.
             </xs:documentation>
           </xs:annotation>
         </xs:element>
@@ -703,7 +699,12 @@
           <xs:enumeration value="appinfoNoSource" />
           <xs:enumeration value="choiceInsideHiddenGroup" />
           <xs:enumeration value="codeGenerator" />
-          <xs:enumeration value="deprecatedBigIntegerBits" />
+          <!-- deprecated -->
+          <xs:enumeration value="deprecatedBigIntegerBits">
+            <xs:annotation>
+              <xs:documentation>Deprecated.</xs:documentation>
+            </xs:annotation>
+          </xs:enumeration>
           <xs:enumeration value="deprecatedBuiltInFormats" />
           <xs:enumeration value="deprecatedEncodingNameUSASCII7BitPacked" />
           <xs:enumeration value="deprecatedExpressionResultCoercion" />

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section05/simple_types/SimpleTypes.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section05/simple_types/SimpleTypes.tdml
@@ -276,6 +276,12 @@
       dfdl:binaryCalendarRep="binarySeconds" dfdl:binaryCalendarEpoch="01-01-2000T00:00:00"/>
     <xs:element name="dateTimeBin12" type="xs:dateTime" dfdl:lengthKind="delimited" dfdl:terminator=";"
       dfdl:binaryCalendarRep="binarySeconds" dfdl:binaryCalendarEpoch="1977-01-01T00:00:07"/>
+    <xs:element name="dateTimeBin13" type="xs:dateTime" dfdl:lengthKind="explicit" dfdl:length="{ 32 }"
+                dfdl:lengthUnits="bits" dfdl:binaryCalendarRep="binarySeconds" dfdl:binaryCalendarEpoch="2018-01-01T09:13:42+09:00"/>
+    <xs:element name="dateTimeBin14" type="xs:dateTime" dfdl:lengthKind="explicit" dfdl:length="{ 64 }"
+                dfdl:lengthUnits="bits" dfdl:binaryCalendarRep="binaryMilliseconds" dfdl:binaryCalendarEpoch="2000-06-15T03:25:19"/>
+    <xs:element name="dateTimeBin15" type="xs:date" dfdl:lengthKind="explicit" dfdl:length="{ 64 }"
+                dfdl:lengthUnits="bits" dfdl:binaryCalendarRep="binaryMilliseconds" dfdl:binaryCalendarEpoch="2000-06-15T03:25:19"/>
 
     <xs:element name="dateBinBCD" type="xs:date" dfdl:calendarPattern="MMddyy" dfdl:calendarPatternKind="explicit"
       dfdl:lengthKind="explicit" dfdl:length="{ 3 }" dfdl:lengthUnits="bytes" dfdl:binaryCalendarRep="bcd" />
@@ -338,6 +344,9 @@
       dfdl:lengthKind="explicit" dfdl:length="{ 3 }" dfdl:lengthUnits="bytes" dfdl:binaryCalendarRep="ibm4690Packed" />
     <xs:element name="dateBinIBM4690Packed2" type="xs:date" dfdl:calendarPattern="MMddyy" dfdl:calendarPatternKind="explicit"
       dfdl:lengthKind="explicit" dfdl:length="{ 18 }" dfdl:lengthUnits="bits" dfdl:binaryCalendarRep="ibm4690Packed"/>
+    <xs:element name="dateBinIBM4690Packed3" type="xs:date" dfdl:calendarPattern="MMddyy" dfdl:calendarPatternKind="explicit"
+                dfdl:lengthKind="explicit" dfdl:length="{ 24 }" dfdl:lengthUnits="bits" dfdl:binaryCalendarRep="ibm4690Packed" />
+
 
     <xs:element name="dateTimeBinIBM4690Packed">
       <xs:complexType>
@@ -2410,9 +2419,11 @@
     <tdml:document>
       <tdml:documentPart type="bits">00000000 00000000 00000000 00111101</tdml:documentPart>
     </tdml:document>
-    <tdml:errors>
-      <tdml:error>Schema Definition Error: lengthUnits must be 'bytes' when binaryCalendarRep='binarySeconds'</tdml:error>
-    </tdml:errors>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <ex:dateTimeBin2 xmlns:ex="http://example.com">1970-01-01T00:01:01</ex:dateTimeBin2>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
   </tdml:parserTestCase>
 
   <tdml:parserTestCase name="dateTimeBin3" root="dateTimeBin3"
@@ -2694,6 +2705,48 @@
       <tdml:error>Insufficient bits</tdml:error>
       <tdml:error>Needed 64</tdml:error>
       <tdml:error>63 available</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="dateTimeBin23" root="dateTimeBin13"
+                       model="SimpleTypes-binary" description="binarySeconds with LengthUnits=bits"
+                       roundTrip="true">
+
+    <tdml:document>
+      <tdml:documentPart type="bits">00000000 00000000 00000000 00000001</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <dateTimeBin13>2018-01-01T09:13:43+09:00</dateTimeBin13>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="dateTimeBin24" root="dateTimeBin14"
+                       model="SimpleTypes-binary" description="binaryMilliSeconds with lengthUnits=bits"
+                       roundTrip="true">
+
+    <tdml:document>
+      <tdml:documentPart type="bits">00000000 00000000 00000000 00000000 11111111 11111111 11111111 11111111</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <dateTimeBin14>2000-08-03T20:28:06.295000</dateTimeBin14>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="dateTimeBin25" root="dateTimeBin15"
+                       model="SimpleTypes-binary" description="binaryMilliSeconds with lengthUnits=bits"
+                       roundTrip="true">
+
+    <tdml:document>
+      <tdml:documentPart type="bits">00000000 00000000 00000000 00000000 11111111 11111111 11111111 11111111</tdml:documentPart>
+    </tdml:document>
+    <tdml:errors>
+      <tdml:error>binaryCalendarRep='binaryMilliseconds'</tdml:error>
+      <tdml:error>not allowed</tdml:error>
+      <tdml:error>type date</tdml:error>
     </tdml:errors>
   </tdml:parserTestCase>
 
@@ -2990,6 +3043,20 @@
       <tdml:error>Parse Error</tdml:error>
       <tdml:error>Expected unsigned data but parsed a negative number</tdml:error>
     </tdml:errors>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="dateBinIBM4690Packed4" root="dateBinIBM4690Packed3"
+                       model="SimpleTypes-binary" description="binary packed calendar representation with lengthUnit=bits"
+                       roundTrip="true" ignoreUnexpectedWarnings="false">
+
+    <tdml:document>
+      <tdml:documentPart type="byte">12 14 23</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <dateBinIBM4690Packed3>2023-12-14</dateBinIBM4690Packed3>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
   </tdml:parserTestCase>
 
   <tdml:parserTestCase name="dateTimeBinIBM4690Packed" root="dateTimeBinIBM4690Packed"

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section12/lengthKind/ExplicitTests.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section12/lengthKind/ExplicitTests.tdml
@@ -962,12 +962,12 @@
   </tdml:parserTestCase>
 
 <!--
-     Test Name: invalidLengthUnitsIntegerWarning_explicit
-        Schema: invalidLengthUnitsInteger_explicit
+     Test Name: lengthUnitsBitsForInteger_explicit
+        Schema: lengthUnitsBitsForInteger_explicit
           Root: r1
-       Purpose: This test checks that a warning is emitted when a bigint is used when lengthUnits='bits'.
+       Purpose: This test checks that no warning is emitted when a bigint is used when lengthUnits='bits'.
 -->
-  <tdml:defineSchema name="invalidLengthUnitsInteger_explicit">
+  <tdml:defineSchema name="lengthUnitsBitsForInteger_explicit">
     <xs:include schemaLocation="/org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
     <dfdl:defineFormat name="Binary">
       <dfdl:format ref="ex:GeneralFormat" representation="binary"/>
@@ -977,51 +977,52 @@
     <xs:element name="r1" dfdl:lengthKind="explicit" type="xs:integer" dfdl:lengthUnits="bits" dfdl:length="8"/>
   </tdml:defineSchema>
 
-  <tdml:parserTestCase name="invalidLengthUnitsIntegerWarning_explicit" root="r1" model="invalidLengthUnitsInteger_explicit"
-                       description="lengthKind='explicit' lengthUnits='bits' type='xs:integer'">
+  <tdml:parserTestCase name="lengthUnitsBitsForInteger_explicit" root="r1" model="lengthUnitsBitsForInteger_explicit"
+                       description="lengthKind='explicit' lengthUnits='bits' type='xs:integer'"
+                       ignoreUnexpectedWarnings="false">
     <tdml:document>
       <tdml:documentPart type="byte">
         0f
       </tdml:documentPart>
     </tdml:document>
     <tdml:infoset>
-      <tdml:dfdlInfoset>f
+      <tdml:dfdlInfoset>
         <r1>15</r1>
       </tdml:dfdlInfoset>
     </tdml:infoset>
-    <tdml:warnings>
-      <tdml:warning>lengthUnits='bits'</tdml:warning>
-      <tdml:warning>will only be supported</tdml:warning>
-    </tdml:warnings>
   </tdml:parserTestCase>
 
 <!--
-     Test Name: invalidLengthUnitsIntegerError_explicit
-        Schema: invalidLengthUnitsInteger_explicit
+     Test Name: lengthUnitsBitsForInteger_explicit2
+        Schema: lengthUnitsBitsForInteger_explicit
           Root: r1
-       Purpose: This test checks that an error is raised when a bigint is used when lengthUnits='bits'.
+       Purpose: This test verifies that no error is raised when a bigint is used when lengthUnits='bits'
+       and to show that the allowBigIntegerBits tunable has no effect.
 -->
-  <tdml:parserTestCase name="invalidLengthUnitsIntegerError_explicit" root="r1" model="invalidLengthUnitsInteger_explicit"
+  <tdml:parserTestCase name="lengthUnitsBitsForInteger_explicit2" root="r1" model="lengthUnitsBitsForInteger_explicit"
                        description="lengthKind='explicit' lengthUnits='bits' type='xs:integer' error"
-                       config="enforceBigIntegerBits">
-    <tdml:document>
+                       config="enforceBigIntegerBits"
+                       ignoreUnexpectedWarnings="false">
+
+  <tdml:document>
       <tdml:documentPart type="byte">
         0f
       </tdml:documentPart>
     </tdml:document>
-    <tdml:errors>
-      <tdml:error>lengthUnits='bits'</tdml:error>
-      <tdml:error>is only supported</tdml:error>
-    </tdml:errors>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <r1>15</r1>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
   </tdml:parserTestCase>
 
 <!--
-     Test Name: invalidLengthUnitsDecimalWarning_explicit
-        Schema: invalidLengthUnitsDecimal_explicit
+     Test Name: lengthUnitsBitsForDecimal_explicit
+        Schema: lengthUnitsBitsForDecimal_explicit
           Root: r1
-       Purpose: This test checks that a warning is emitted when a decimal is used when lengthUnits='bits'.
+       Purpose: This test checks that no warning is emitted when a decimal is used when lengthUnits='bits'.
 -->
-  <tdml:defineSchema name="invalidLengthUnitsDecimal_explicit">
+  <tdml:defineSchema name="lengthUnitsBitsForDecimal_explicit">
     <xs:include schemaLocation="/org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
     <dfdl:defineFormat name="Binary">
       <dfdl:format ref="ex:GeneralFormat" representation="binary"/>
@@ -1033,22 +1034,153 @@
                 dfdl:binaryDecimalVirtualPoint="2"/>
   </tdml:defineSchema>
 
-  <tdml:parserTestCase name="invalidLengthUnitsDecimalWarning_explicit" root="r1" model="invalidLengthUnitsDecimal_explicit"
-                       description="lengthKind='explicit' lengthUnits='bits' type='xs:decimal'">
-    <tdml:document>
+  <tdml:parserTestCase name="lengthUnitsBitsForDecimal_explicit" root="r1" model="lengthUnitsBitsForDecimal_explicit"
+                       description="lengthKind='explicit' lengthUnits='bits' type='xs:decimal'"
+                       ignoreUnexpectedWarnings="false">
+
+  <tdml:document>
       <tdml:documentPart type="byte">
         0f
       </tdml:documentPart>
     </tdml:document>
     <tdml:infoset>
-      <tdml:dfdlInfoset>f
+      <tdml:dfdlInfoset>
         <r1>0.15</r1>
       </tdml:dfdlInfoset>
     </tdml:infoset>
-    <tdml:warnings>
-      <tdml:warning>lengthUnits='bits'</tdml:warning>
-      <tdml:warning>will only be supported</tdml:warning>
-    </tdml:warnings>
+  </tdml:parserTestCase>
+
+<!--
+     Test Name: lengthUnitsBitsForFloat_explicit
+        Schema: lengthUnitsBitsForFloat_explicit
+          Root: r1
+       Purpose: This test checks that no warning is emitted when a float/double is used when lengthUnits='bits'.
+-->
+  <tdml:defineSchema name="lengthUnitsBitsForFloatDouble_explicit">
+    <xs:include schemaLocation="/org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+    <dfdl:defineFormat name="Binary">
+      <dfdl:format ref="ex:GeneralFormat" representation="binary"/>
+    </dfdl:defineFormat>
+    <dfdl:format ref="ex:Binary" />
+
+    <xs:element name="r1" dfdl:lengthKind="explicit" type="xs:float"
+                dfdl:lengthUnits="bits" dfdl:length="32"/>
+    <xs:element name="r2" dfdl:lengthKind="explicit" type="xs:double"
+                dfdl:lengthUnits="bits" dfdl:length="64"/>
+    <xs:element name="r3" dfdl:lengthKind="explicit" type="xs:float"
+                dfdl:lengthUnits="bits" dfdl:length="8"/>
+    <xs:element name="r4" dfdl:lengthKind="explicit" type="xs:double"
+                dfdl:lengthUnits="bits" dfdl:length="32"/>
+    <xs:element name="r5">
+      <xs:complexType>
+        <xs:sequence>
+          <xs:element name="len" type="xs:int" dfdl:inputValueCalc="{ 32 }"/>
+          <xs:element name="e1" dfdl:lengthKind="explicit" type="xs:float"
+                      dfdl:lengthUnits="bits" dfdl:length="{ ../ex:len }"/>
+        </xs:sequence>
+      </xs:complexType>
+    </xs:element>
+    <xs:element name="r6">
+      <xs:complexType>
+        <xs:sequence>
+          <xs:element name="len" type="xs:int" dfdl:inputValueCalc="{ 64 }"/>
+          <xs:element name="e1" dfdl:lengthKind="explicit" type="xs:double"
+                      dfdl:lengthUnits="bits" dfdl:length="{ ../ex:len }"/>
+        </xs:sequence>
+      </xs:complexType>
+    </xs:element>
+  </tdml:defineSchema>
+
+  <tdml:parserTestCase name="lengthUnitsBitsForFloat_explicit1" root="r1" model="lengthUnitsBitsForFloatDouble_explicit"
+                       description="lengthKind='explicit' lengthUnits='bits' type='xs:float'"
+                       ignoreUnexpectedWarnings="false">
+
+  <tdml:document>
+      <tdml:documentPart type="byte">
+        42 f6 e9 79
+      </tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <r1>123.456</r1>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="lengthUnitsBitsForFloat_explicit2" root="r3" model="lengthUnitsBitsForFloatDouble_explicit"
+                       description="lengthKind='explicit' lengthUnits='bits' type='xs:float'"
+                       ignoreUnexpectedWarnings="false">
+
+  <tdml:document>
+      <tdml:documentPart type="byte">
+        42 f6 e9 79
+      </tdml:documentPart>
+    </tdml:document>
+    <tdml:errors>
+      <tdml:error>Schema Definition Error</tdml:error>
+      <tdml:error>must be 32 bits</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="lengthUnitsBitsForFloat_explicit3" root="r5" model="lengthUnitsBitsForFloatDouble_explicit"
+                       description="lengthKind='explicit' lengthUnits='bits' type='xs:float'"
+                       ignoreUnexpectedWarnings="false">
+
+  <tdml:document>
+      <tdml:documentPart type="byte">
+        42 f6 e9 79
+      </tdml:documentPart>
+    </tdml:document>
+    <tdml:errors>
+      <tdml:error>floating point binary numbers</tdml:error>
+      <tdml:error>may not have runtime-specified lengths</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="lengthUnitsBitsForDouble_explicit1" root="r2" model="lengthUnitsBitsForFloatDouble_explicit"
+                       description="lengthKind='explicit' lengthUnits='bits' type='xs:double'"
+                       ignoreUnexpectedWarnings="false">
+
+  <tdml:document>
+      <tdml:documentPart type="byte">
+        40 5e dd 2f 1a 9f be 77
+      </tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <r2>123.456</r2>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="lengthUnitsBitsForDouble_explicit2" root="r4" model="lengthUnitsBitsForFloatDouble_explicit"
+                       description="lengthKind='explicit' lengthUnits='bits' type='xs:double'"
+                       ignoreUnexpectedWarnings="false">
+
+  <tdml:document>
+      <tdml:documentPart type="byte">
+        40 5e dd 2f 1a 9f be 77
+      </tdml:documentPart>
+    </tdml:document>
+    <tdml:errors>
+      <tdml:error>Schema Definition Error</tdml:error>
+      <tdml:error>must be 64 bits</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="lengthUnitsBitsForDouble_explicit3" root="r6" model="lengthUnitsBitsForFloatDouble_explicit"
+                       description="lengthKind='explicit' lengthUnits='bits' type='xs:double'"
+                       ignoreUnexpectedWarnings="false">
+
+    <tdml:document>
+      <tdml:documentPart type="byte">
+        40 5e dd 2f 1a 9f be 77
+      </tdml:documentPart>
+    </tdml:document>
+    <tdml:errors>
+      <tdml:error>floating point binary numbers</tdml:error>
+      <tdml:error>may not have runtime-specified lengths</tdml:error>
+    </tdml:errors>
   </tdml:parserTestCase>
 
   <!--

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section12/lengthKind/PrefixedTests.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section12/lengthKind/PrefixedTests.tdml
@@ -2560,7 +2560,7 @@
     </tdml:errors>
   </tdml:parserTestCase>
 
-  <tdml:defineSchema name="invalidLengthUnits_prefixed">
+  <tdml:defineSchema name="lengthUnitsBitsForNonNegativeInteger_prefixed">
     <xs:include schemaLocation="/org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
     <dfdl:defineFormat name="Binary">
       <dfdl:format ref="ex:GeneralFormat" representation="binary"/>
@@ -2579,9 +2579,9 @@
                 dfdl:lengthUnits="bits"/>
   </tdml:defineSchema>
 
-  <tdml:parserTestCase name="invalidLengthUnits_prefixed" root="r1" model="invalidLengthUnits_prefixed"
-                       description="">
-    <tdml:document>
+  <tdml:parserTestCase name="lengthUnitsBitsForNonNegativeInteger_prefixed" root="r1" model="lengthUnitsBitsForNonNegativeInteger_prefixed"
+                       ignoreUnexpectedWarnings="false">
+  <tdml:document>
       <tdml:documentPart type="byte">08 ff</tdml:documentPart>
     </tdml:document>
     <tdml:infoset>
@@ -2589,10 +2589,6 @@
         <r1>255</r1>
       </tdml:dfdlInfoset>
     </tdml:infoset>
-    <tdml:warnings>
-      <tdml:warning>lengthUnits='bits'</tdml:warning>
-      <tdml:warning>will only be supported</tdml:warning>
-    </tdml:warnings>
   </tdml:parserTestCase>
 
   <!--

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section05/simple_types/TestSimpleTypes.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section05/simple_types/TestSimpleTypes.scala
@@ -311,6 +311,9 @@ class TestSimpleTypes {
   @Test def test_dateTimeBin20(): Unit = { runner.runOneTest("dateTimeBin20") }
   @Test def test_dateTimeBin21(): Unit = { runner.runOneTest("dateTimeBin21") }
   @Test def test_dateTimeBin22(): Unit = { runner.runOneTest("dateTimeBin22") }
+  @Test def test_dateTimeBin23(): Unit = { runner.runOneTest("dateTimeBin23") }
+  @Test def test_dateTimeBin24(): Unit = { runner.runOneTest("dateTimeBin24") }
+  @Test def test_dateTimeBin25(): Unit = { runner.runOneTest("dateTimeBin25") }
   @Test def test_dateBinBCD(): Unit = { runner.runOneTest("dateBinBCD") }
   @Test def test_dateBinBCD2(): Unit = { runner.runOneTest("dateBinBCD2") }
   @Test def test_dateBinBCD3(): Unit = { runner.runOneTest("dateBinBCD3") }
@@ -334,6 +337,7 @@ class TestSimpleTypes {
   @Test def test_dateBinIBM4690Packed(): Unit = { runner.runOneTest("dateBinIBM4690Packed") }
   @Test def test_dateBinIBM4690Packed2(): Unit = { runner.runOneTest("dateBinIBM4690Packed2") }
   @Test def test_dateBinIBM4690Packed3(): Unit = { runner.runOneTest("dateBinIBM4690Packed3") }
+  @Test def test_dateBinIBM4690Packed4(): Unit = { runner.runOneTest("dateBinIBM4690Packed4") }
   @Test def test_dateTimeBinIBM4690Packed(): Unit = {
     runner.runOneTest("dateTimeBinIBM4690Packed")
   }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section12/lengthKind/TestLengthKindExplicit.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section12/lengthKind/TestLengthKindExplicit.scala
@@ -98,14 +98,33 @@ class TestLengthKindExplicit {
     runner.runOneTest("denseBit_lengthKind_explicit")
   }
 
-  @Test def test_invalidLengthUnitsIntegerWarning_explicit(): Unit = {
-    runner.runOneTest("invalidLengthUnitsIntegerWarning_explicit")
+  // DFDL-2931
+  @Test def test_lengthUnitsBitsForInteger_explicit(): Unit = {
+    runner.runOneTest("lengthUnitsBitsForInteger_explicit")
   }
-  @Test def test_invalidLengthUnitsIntegerError_explicit(): Unit = {
-    runner.runOneTest("invalidLengthUnitsIntegerError_explicit")
+  @Test def test_lengthUnitsBitsForInteger_explicit2(): Unit = {
+    runner.runOneTest("lengthUnitsBitsForInteger_explicit2")
   }
-  @Test def test_invalidLengthUnitsDecimalWarning_explicit(): Unit = {
-    runner.runOneTest("invalidLengthUnitsDecimalWarning_explicit")
+  @Test def test_lengthUnitsBitsForDecimal_explicit(): Unit = {
+    runner.runOneTest("lengthUnitsBitsForDecimal_explicit")
+  }
+  @Test def test_lengthUnitsBitsForFloat_explicit1(): Unit = {
+    runner.runOneTest("lengthUnitsBitsForFloat_explicit1")
+  }
+  @Test def test_lengthUnitsBitsForFloat_explicit2(): Unit = {
+    runner.runOneTest("lengthUnitsBitsForFloat_explicit2")
+  }
+  @Test def test_lengthUnitsBitsForFloat_explicit3(): Unit = {
+    runner.runOneTest("lengthUnitsBitsForFloat_explicit3")
+  }
+  @Test def test_lengthUnitsBitsForDouble_explicit1(): Unit = {
+    runner.runOneTest("lengthUnitsBitsForDouble_explicit1")
+  }
+  @Test def test_lengthUnitsBitsForDouble_explicit2(): Unit = {
+    runner.runOneTest("lengthUnitsBitsForDouble_explicit2")
+  }
+  @Test def test_lengthUnitsBitsForDouble_explicit3(): Unit = {
+    runner.runOneTest("lengthUnitsBitsForDouble_explicit3")
   }
 
   @Test def test_invalidUnsignedLongBitLength(): Unit = {

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section12/lengthKind/TestLengthKindPrefixed.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section12/lengthKind/TestLengthKindPrefixed.scala
@@ -280,8 +280,8 @@ class TestLengthKindPrefixed {
   @Test def test_pl_complexContentLengthCharacters_utf8_1() = {
     runner.runOneTest("pl_complexContentLengthCharacters_utf8_1")
   }
-  @Test def test_invalidLengthUnits_prefixed(): Unit = {
-    runner.runOneTest("invalidLengthUnits_prefixed")
+  @Test def lengthUnitsBitsForNonNegativeInteger_prefixed(): Unit = {
+    runner.runOneTest("lengthUnitsBitsForNonNegativeInteger_prefixed")
   }
 
   @Test def test_invalidUnsignedLongBitLength(): Unit = {


### PR DESCRIPTION
- we currently report a warning when we use lengthUnit=bits with certain types ex date/time types. Per the discussions on dev (https://lists.apache.org/thread/01sn3fk2wk7jtos2svw4995f7dxxt7g1), we want to open up use of lengthUnit=bits to all types.
- verify test that uses lengthUnit=bits with calendar type no longer produces warning
- verify test that uses lengthUnit=bits with integer type no longer produces warning
- verify test that uses lengthUnit=bits with decimal type no longer produces warning
- deprecate allowBigIntegerBits tunable and the DeprecatedBigIntegerBits WarnID

Deprecation/Compatibility
- allowBigIntegerBits tunable no longer has any effect. All types are allowed to use lengthUnit=bits.
- WarnID DeprecatedBigIntegerBits has been deprecated. It is no longer in use in the codebase.

DAFFODIL-2931