### PR TITLE
Fix Resolve Schema Location for xsi:SchemaLocation in Config files

### DIFF
--- a/daffodil-test/src/test/resources/org/apache/daffodil/section07/external_variables/daffodil_config_cli_test.xml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section07/external_variables/daffodil_config_cli_test.xml
@@ -15,26 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-
-<!--
-  Note: Bug DAFFODIL-2339
-
-  We'd like to have these schemaLocation attributes on daf:dfdlConfig, but this breaks tests because
-  it tries to load the schema from the schemaLocation, and can't resolve org/apache/daffodil/xsd/dafext.xsd.
-
-  Simple things like adding an sbt dependency from daffodil-cli back to daffodil-lib, whether always or "it->test"
-  dependent, don't fix this.
-
-  The CLI is using DaffodilXMLLoader to load this config file, so the resolver should be doing the right thing by
-  finding this dafext.xsd on the class path inside of daffodil-lib's jar.
-
-  The failure seems to happen earlier. A SAX fatal error is invoked when looking up dfdl:anyOther a symbol
-  in the dfdl schema annotation schemas, from the XMLSchema_for_DFDL.
-
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="urn:ogf:dfdl:2013:imp:daffodil.apache.org:2018:ext org/apache/daffodil/xsd/dafext.xsd"
--->
-<daf:dfdlConfig xmlns:daf="urn:ogf:dfdl:2013:imp:daffodil.apache.org:2018:ext">
+<daf:dfdlConfig xmlns:daf="urn:ogf:dfdl:2013:imp:daffodil.apache.org:2018:ext"
+								xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+								xsi:schemaLocation="urn:ogf:dfdl:2013:imp:daffodil.apache.org:2018:ext /org/apache/daffodil/xsd/dafext.xsd"
+>
 	<daf:externalVariableBindings xmlns="http://www.w3.org/2001/XMLSchema"
 		xmlns:ex="http://example.com">
 		<daf:bind name="ex:var1">-9</daf:bind>


### PR DESCRIPTION
- currently we check resolvedUri from namespaces endWith the passed in systemId. With the Xerces bug, the absolutized systemId will never match, so we convert the systemId to a URI and grab its path, and use that for the comparison
- add comment about specific validation error from xerces that requires workaround
- add schema location to config to prove it doesn't cause failure


DAFFODIL-2339