### PR TITLE
Fix Incorrect Lengths SDEs on Computed Element with LengthKind Implicit

### DIFF
--- a/daffodil-test/src/test/resources/org/apache/daffodil/section17/calc_value_properties/inputValueCalc.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section17/calc_value_properties/inputValueCalc.tdml
@@ -1407,4 +1407,28 @@
     </tdml:errors>
   </tdml:parserTestCase>
 
+  <tdml:defineSchema name="ignoreLengthKindImplicitLengthChecksOnIVCElements">
+    <xs:include schemaLocation="/org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+    <dfdl:format ref="ex:GeneralFormat"/>
+
+    <xs:simpleType name="valueType">
+      <xs:restriction base="xs:string">
+        <xs:maxLength value="13"/>
+      </xs:restriction>
+    </xs:simpleType>
+
+    <xs:element name="value" type="ex:valueType"
+      dfdl:inputValueCalc="{ 'Hello World' }"/>
+  </tdml:defineSchema>
+
+  <tdml:parserTestCase name="IVC_ignored_length_checks"
+                       root="value" model="ignoreLengthKindImplicitLengthChecksOnIVCElements">
+
+    <tdml:document/>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <ex:value>Hello World</ex:value>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
 </tdml:testSuite>

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section17/calc_value_properties/TestInputValueCalc.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section17/calc_value_properties/TestInputValueCalc.scala
@@ -244,4 +244,9 @@ class TestInputValueCalc {
     runner.runOneTest("InputValueCalc_array_elem")
   }
   // @Test def test_InputValueCalc_global_elem() { runner.runOneTest("InputValueCalc_global_elem") }
+
+  // DFDL-2806
+  @Test def test_IVC_ignored_length_checks(): Unit = {
+    runner.runOneTest("IVC_ignored_length_checks")
+  }
 }


### PR DESCRIPTION
- add condition that checks for IVC before doing the check
- add tests

DAFFODIL-2806