### PR TITLE
Verify OVC reports data too long error as necessary

### DIFF
--- a/daffodil-test/src/test/resources/org/apache/daffodil/section17/calc_value_properties/outputValueCalc.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section17/calc_value_properties/outputValueCalc.tdml
@@ -362,6 +362,16 @@
       </xs:complexType>
     </xs:element>
 
+    <xs:element name="ovc_too_large_for_element">
+      <xs:complexType>
+        <xs:sequence>
+          <xs:element name="e" type="xs:double" dfdl:lengthKind="explicit"
+                      dfdl:length="{ 4 }"
+                      dfdl:outputValueCalc="{ 0.555 }"/>
+        </xs:sequence>
+      </xs:complexType>
+    </xs:element>
+
 	</tdml:defineSchema>
 
 	<tdml:unparserTestCase name="binaryIntegerBigEndian"
@@ -829,5 +839,22 @@
       </tdml:infoset>
       <tdml:document>1219</tdml:document>
     </tdml:unparserTestCase>
+
+  <tdml:unparserTestCase name="OVCTooLargeForElem"
+                         root="ovc_too_large_for_element" model="outputValueCalc-Embedded.dfdl.xsd"
+                         roundTrip="false">
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <ex:ovc_too_large_for_element>
+          <e/>
+        </ex:ovc_too_large_for_element>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+    <tdml:errors>
+      <tdml:error>Unparse Error</tdml:error>
+      <tdml:error>data too long</tdml:error>
+      <tdml:error>truncate</tdml:error>
+    </tdml:errors>
+  </tdml:unparserTestCase>
 
 </tdml:testSuite>

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section17/calc_value_properties/TestOutputValueCalc.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section17/calc_value_properties/TestOutputValueCalc.scala
@@ -121,4 +121,7 @@ class TestOutputValueCalc {
 
   // DAFFODIL-2167
   @Test def test_arrayWithFollowingOVC(): Unit = { runner.runOneTest("arrayWithFollowingOVC") }
+
+  // DAFFODIL-1595
+  @Test def test_OVCTooLargeForElem(): Unit = { runner.runOneTest("OVCTooLargeForElem") }
 }


### PR DESCRIPTION
- currently we have no tests that try to OVC into a too small element. This PR adds in such a test.

(The ticket is marked verify, this test verifies that the fix is already in)

DAFFODIL-1595