### PR TITLE
Add SBT task to generate tunables doc

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -169,7 +169,7 @@ jobs:
         run: $SBT compile Test/compile daffodil-test-integration/Test/compile
 
       - name: Build Documentation
-        run: $SBT unidoc
+        run: $SBT unidoc genTunablesDoc
 
       - name: Package Zip & Tar
         run: $SBT daffodil-cli/Universal/packageBin daffodil-cli/Universal/packageZipTarball

--- a/containers/release-candidate/src/daffodil-release-candidate
+++ b/containers/release-candidate/src/daffodil-release-candidate
@@ -298,6 +298,7 @@ case $PROJECT_REPO in
       "daffodil-cli/Universal/packageBin" \
       "daffodil-cli/Universal/packageZipTarball" \
       "unidoc" \
+      "genTunablesDoc" \
 
     echo "Installing Convenience Binaries..."
     mkdir -p $DAFFODIL_RELEASE_DIR/bin/
@@ -316,6 +317,7 @@ case $PROJECT_REPO in
     mkdir -p $DAFFODIL_DOCS_DIR/{javadoc,scaladoc}/
     cp -R target/javaunidoc/* $DAFFODIL_DOCS_DIR/javadoc/
     cp -R target/scala-2.12/unidoc/* $DAFFODIL_DOCS_DIR/scaladoc/
+    cp target/tunables.md $DAFFODIL_SITE_DIR/site/
 
     echo "Installing Site Tutorials..."
     rm -rf $DAFFODIL_TUTORIALS_DIR
@@ -405,6 +407,7 @@ if [ "$PROJECT_REPO" = "daffodil" ]
 then
   echo "- Files in $DAFFODIL_DOCS_DIR"
   echo "- Files in $DAFFODIL_TUTORIALS_DIR"
+  echo "- File at $DAFFODIL_SITE_DIR/site/tunables.md"
   echo "- Staged published files at https://repository.apache.org/"
 fi
 echo


### PR DESCRIPTION
- currently we hardcode the description of tunables on daffodil-site. This list is out of date. Instead, the fix uses an sbt task 'genTunablesDoc' to generate a markdown document from the dafext.xsd and outputs it to target/tunables.md
- related daffodil-site PR https://github.com/apache/daffodil-site/pull/148

DAFFODIL-2758