### PR TITLE
Fix Missing File Exception

### DIFF
--- a/daffodil-cli/src/main/scala/org/apache/daffodil/cli/Main.scala
+++ b/daffodil-cli/src/main/scala/org/apache/daffodil/cli/Main.scala
@@ -2005,6 +2005,10 @@ class Main(
           Logger.log.error(Misc.getSomeMessage(e).get)
           ExitCode.FileNotFound
         }
+        case e: java.nio.file.NoSuchFileException => {
+          Logger.log.error(Misc.getSomeMessage(e).get + " (No such file or directory)")
+          ExitCode.FileNotFound
+        }
         case e: ExternalVariableException => {
           Logger.log.error(Misc.getSomeMessage(e).get)
           ExitCode.BadExternalVariable

--- a/daffodil-cli/src/test/scala/org/apache/daffodil/cli/cliTest/TestCLIParsing.scala
+++ b/daffodil-cli/src/test/scala/org/apache/daffodil/cli/cliTest/TestCLIParsing.scala
@@ -271,6 +271,17 @@ class TestCLIParsing {
     }(ExitCode.Success)
   }
 
+  @Test def test_CLI_Parsing_SimpleParse_inFileDoesNotExist(): Unit = {
+    val schema = path(
+      "daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/charClassEntities.dfdl.xsd"
+    )
+    val input = path("/does/not/exist/input.txt")
+
+    runCLI(args"parse -s $schema -r matrix $input") { cli =>
+      cli.expectErr(s"[error] $input (No such file or directory)")
+    }(ExitCode.FileNotFound)
+  }
+
   @Test def test_CLI_Parsing_SimpleParse_stOutDash(): Unit = {
     val schema = path(
       "daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/charClassEntities.dfdl.xsd"


### PR DESCRIPTION
- currently we don't capture NoSuchFileException from Paths.get in our run try/catch, which results in a "This is a bug" exception. With this fix, we capture the exception and add a bit more detail to make it clear what is happening (missing file or directory), since the exception only reports the file name.
- add cli test

DAFFODIL-2944