### PR TITLE
Update Sonarcloud Properties

### DIFF
--- a/.sonar-project.properties
+++ b/.sonar-project.properties
@@ -16,9 +16,9 @@
 sonar.organization=apache
 sonar.projectKey=apache-daffodil
 
-sonar.modules=daffodil-cli,daffodil-codegen-c,daffodil-core,daffodil-io,daffodil-japi,daffodil-lib,daffodil-macro-lib,daffodil-propgen,daffodil-runtime1,daffodil-runtime1-layers,daffodil-runtime1-unparser,daffodil-sapi,daffodil-tdml-lib,daffodil-tdml-processor,daffodil-test,daffodil-test-ibm1,daffodil-udf
+sonar.modules=daffodil-cli,daffodil-codegen-c,daffodil-core,daffodil-io,daffodil-japi,daffodil-lib,daffodil-macro-lib,daffodil-propgen,daffodil-runtime1,daffodil-runtime1-layers,daffodil-runtime1-unparser,daffodil-sapi,daffodil-schematron,daffodil-sl4j-logger,daffodil-tdml-lib,daffodil-tdml-processor,daffodil-test,daffodil-test-ibm1,daffodil-test-integration,daffodil-udf
 sonar.sources=src/main
-sonar.tests=src/it,src/test
+sonar.tests=src/test
 sonar.c.file.suffixes=-
 sonar.cpp.file.suffixes=-
 sonar.objc.file.suffixes=-
@@ -28,7 +28,7 @@ sonar.objc.file.suffixes=-
 #  the ticket above is fixed
 # TODO DAFFODIL-1958 Main.scala already has a ticket to reduce duplication. 
 #  It can be excluded until that is resolved
-sonar.cpd.exclusions=daffodil-sapi/src/main/scala/org/apache/daffodil/sapi/**/*,daffodil-japi/src/main/scala/org/apache/daffodil/japi/**/*,daffodil-cli/src/main/scala/org/apache/daffodil/Main.scala
+sonar.cpd.exclusions=daffodil-sapi/src/main/scala/org/apache/daffodil/sapi/**/*,daffodil-japi/src/main/scala/org/apache/daffodil/japi/**/*,daffodil-cli/src/main/scala/org/apache/daffodil/cli/Main.scala
 
 sonar.java.binaries=target/**/classes
 sonar.java.test.binaries=target/**/test-classes


### PR DESCRIPTION
- currently we check Main.scala for duplicate code, which is a problem due to DAFFODIL-1958. So we update the path to Main.scala so we can continue to exclude it.
- we no longer have src/it in our codebase, so we remove that from tests
- Added in 3 newest modules since their absence seems to be an oversight

DAFFODIL-2949