### PR TITLE
Add src/main to daffodil-test-integration for sonarcloud

### DIFF
--- a/daffodil-test-integration/src/main/scala/.keep
+++ b/daffodil-test-integration/src/main/scala/.keep
@@ -1,0 +1,17 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Sonarcloud requires that the src/main directory exist or it errors. This file
+# ensures this directory exists since git doesn't support empty directories.


### PR DESCRIPTION
- without it, sonarcloud errors out. So we add a .keep file in the directory.

(I've verified locally that sonar cloud executes successfully after this change)

DAFFODIL-2949