### PR TITLE
Improve diagnostic in TDML Runner

### DIFF
--- a/daffodil-lib/src/main/resources/org/apache/daffodil/xsd/tdml.xsd
+++ b/daffodil-lib/src/main/resources/org/apache/daffodil/xsd/tdml.xsd
@@ -308,7 +308,15 @@
 
   <complexType name="dfdlInfosetType" mixed="true">
     <sequence>
-      <any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+      <!--
+      Can be empty if type is 'file'.
+      Otherwise, can be any single element (maxOccurs unbounded removed),
+      which is the root element of the infoset.
+
+      Mixed="true" because when type='file' the content is just a string
+      that is the file path
+      -->
+      <any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="1"/>
     </sequence>
     <attribute name="type" use="optional" default="infoset">
       <simpleType>

--- a/daffodil-tdml-lib/src/test/scala/org/apache/daffodil/tdml/UnitTestTDMLRunner.scala
+++ b/daffodil-tdml-lib/src/test/scala/org/apache/daffodil/tdml/UnitTestTDMLRunner.scala
@@ -21,6 +21,7 @@ import java.io.File
 
 import org.apache.daffodil.lib.Implicits._
 import org.apache.daffodil.lib.Implicits.using
+import org.apache.daffodil.lib.exceptions.UsageException
 import org.apache.daffodil.lib.util._
 import org.apache.daffodil.lib.xml.XMLUtils
 
@@ -334,6 +335,17 @@ class UnitTestTDMLRunner {
       'd'.toByte
     ).toList
     assertEquals(expected, actual.toList)
+  }
+
+  @Test def testDFDLInfosetEmptyDiagnosticMsg(): Unit = {
+    val xml = <tdml:dfdlInfoset/>
+    val exc = intercept[UsageException] {
+      val di = new DFDLInfoset(xml, null)
+      di.contents
+    }
+    val m = exc.getMessage
+    assertTrue(m.contains("dfdlInfoset"))
+    assertTrue(m.contains("single root element"))
   }
 
   @Test def testLSB1(): Unit = {

--- a/daffodil-tdml-processor/src/test/scala/org/apache/daffodil/processor/tdml/TestTDMLRunner.scala
+++ b/daffodil-tdml-processor/src/test/scala/org/apache/daffodil/processor/tdml/TestTDMLRunner.scala
@@ -18,6 +18,7 @@
 package org.apache.daffodil.processor.tdml
 
 import java.io.File
+import java.io.FileNotFoundException
 
 import org.apache.daffodil.lib.Implicits._
 import org.apache.daffodil.lib.Implicits.using
@@ -1061,4 +1062,32 @@ f0 f1 f2 f3 f4 f5 f6 f7 f8 f9 fa fb fc fd fe ff
     assertTrue(exc.getMessage.contains("Either tdml:infoset or tdml:error"))
     assertTrue(exc.getMessage.contains("must be present in the test"))
   }
+
+  @Test def testInfosetFileNotFound() = {
+    val testSuite =
+      <tdml:testSuite suiteName="theSuiteName" xmlns:tdml={tdml} xmlns:dfdl={dfdl}
+                      xmlns:xs={xsd}>
+        <tdml:defineSchema name="mySchema">
+          <xs:include schemaLocation="/org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+          <dfdl:format ref="GeneralFormat"/>
+          <xs:element name="data" type="xs:int" dfdl:lengthKind="delimited"/>
+        </tdml:defineSchema>
+        <tdml:unparserTestCase name="infosetFileNotFound" root="data" model="mySchema">
+          <tdml:infoset>
+            <tdml:dfdlInfoset type="file">/this/does/not/exist.xml</tdml:dfdlInfoset>
+          </tdml:infoset>
+          <tdml:document/>
+        </tdml:unparserTestCase>
+      </tdml:testSuite>
+
+    val runner = new Runner(testSuite)
+    val e = intercept[FileNotFoundException] {
+      runner.runOneTest("infosetFileNotFound")
+    }
+    runner.reset
+    val msg = e.getMessage()
+    assertTrue(msg.contains("not found"))
+    assertTrue(msg.contains("/this/does/not/exist.xml"))
+  }
+
 }

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section15/choice_groups/HiddenChoices.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section15/choice_groups/HiddenChoices.tdml
@@ -217,7 +217,7 @@
   <tdml:unparserTestCase name="nestedNoOVCinHiddenContext" root="e7"
     model="ChoicesInHiddenContexts.dfdl.xsd" description="hidden group ref">
     <tdml:infoset>
-      <tdml:dfdlInfoset>)
+      <tdml:dfdlInfoset>
         <ex:e7/>
       </tdml:dfdlInfoset>
     </tdml:infoset>


### PR DESCRIPTION
I decided to fix an ancient bug. 

Note that this change enforces the syntax of TDML better. 
The dfdlInfoset element used to tolerate having spurious text in it, so long as it also had a root element.
Two TDML files had to be fixed in Daffodil.

If TDML files in schema projects have these spurious characters that were formerly ignored, this change will break
those tests.

DAFFODIL-533