### PR TITLE
Fix always lenient calendar parsing/unparsing

### DIFF
--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/EvCalendarLanguage.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/EvCalendarLanguage.scala
@@ -120,7 +120,7 @@ class DateTimeFormatterEv(
       override def initialValue = {
         val formatter = new SimpleDateFormat(pattern, locale)
         formatter.setCalendar(calendar)
-        formatter.setLenient(true) // TODO: should this use calendarCheckPolicy?
+        formatter.setLenient(calendar.isLenient)
         formatter
       }
     }

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section05/simple_types/SimpleTypes.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section05/simple_types/SimpleTypes.tdml
@@ -325,7 +325,7 @@
     <xs:element name="dateTimeBinBCD2" type="xs:dateTime" dfdl:calendarPattern="MMddyyyyhhmmss" dfdl:calendarPatternKind="explicit"
       dfdl:lengthKind="implicit" dfdl:lengthUnits="bytes" dfdl:binaryCalendarRep="bcd"/>
     <xs:element name="dateTimeBinBCD3" type="xs:dateTime" dfdl:calendarPattern="MMddyyyyhhmmss" dfdl:calendarPatternKind="explicit"
-      dfdl:lengthKind="explicit" dfdl:length="{ 7 }" dfdl:lengthUnits="bytes" dfdl:binaryCalendarRep="bcd"/>
+      dfdl:lengthKind="explicit" dfdl:length="{ 7 }" dfdl:lengthUnits="bytes" dfdl:binaryCalendarRep="bcd" dfdl:calendarCheckPolicy="lax"/>
 
     <xs:element name="dateTimeBinBCD4">
       <xs:complexType>
@@ -5102,7 +5102,7 @@
                 dfdl:textCalendarJustification="right" dfdl:textCalendarPadCharacter="d" dfdl:lengthKind="delimited" />
 
     <xs:element name="date12" type="ex:explicDate" dfdl:calendarPattern="dd MM yyyy, HH:mm:ss"/>
-    <xs:element name="date13" type="ex:explicDate" dfdl:calendarPattern="MM-dd-yyyy G"/>
+    <xs:element name="date13" type="ex:explicDate" dfdl:calendarPattern="MM-dd-yyyy G" dfdl:calendarCheckPolicy="lax"/>
     <xs:element name="date14" type="ex:explicDate" dfdl:calendarPattern="Q yyyy"/>
     <xs:element name="date15" type="ex:explicDate" dfdl:calendarPattern="D yyyy"/>
     <xs:element name="date16" type="ex:explicDate" dfdl:calendarPattern="F MM yyyy"/>
@@ -5145,7 +5145,9 @@
         </xs:sequence>
       </xs:complexType>
     </xs:element>
-    
+
+    <xs:element name="date35" type="xs:date" dfdl:calendarCheckPolicy="strict" dfdl:calendarPatternKind="explicit" dfdl:calendarPattern="MMM dd yyyy" dfdl:lengthKind="explicit" dfdl:length="12" />
+
     <xs:simpleType name="explicDate" dfdl:calendarPatternKind="explicit" dfdl:lengthKind="delimited">
       <xs:restriction base="xs:date"/>
     </xs:simpleType>
@@ -5216,7 +5218,7 @@
       </xs:complexType>
     </xs:element>
 
-    <xs:element name="dateTimeImp" type="xs:dateTime" dfdl:calendarPatternKind="implicit" dfdl:lengthKind="delimited" />
+    <xs:element name="dateTimeImp" type="xs:dateTime" dfdl:calendarPatternKind="implicit" dfdl:lengthKind="delimited" dfdl:calendarCheckPolicy="lax"/>
     <xs:element name="dateTime01" type="xs:dateTime" dfdl:calendarPatternKind="explicit" dfdl:calendarPattern="'It is 'hh:mmaa' on the 'dd'st of 'MMM', year 'yyyy"
                 dfdl:lengthKind="explicit" dfdl:length="44" 
                 dfdl:textPadKind="padChar" dfdl:textTrimKind="padChar"/>
@@ -6283,7 +6285,19 @@
 
     <tdml:document><![CDATA[2001-03-35]]></tdml:document>
     <tdml:errors>
-      <tdml:error/>
+      <tdml:error>Unable to parse</tdml:error>
+      <tdml:error>2001-03-35</tdml:error>
+      <tdml:error>valid range</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="dateStrictCheckPolicy02" root="date35"
+    model="dateTimeSchema" description="Section 13 Simple Types - calendarCheckPolicy - DFDL-13-139R">
+
+    <tdml:document><![CDATA[Mar. 31 2001]]></tdml:document>
+    <tdml:errors>
+      <tdml:error>Unable to parse</tdml:error>
+      <tdml:error>Mar. 31 2001</tdml:error>
     </tdml:errors>
   </tdml:parserTestCase>
 
@@ -6299,7 +6313,9 @@
 
     <tdml:document><![CDATA[13:99:50-0800]]></tdml:document>
     <tdml:errors>
-      <tdml:error/>
+      <tdml:error>Unable to parse</tdml:error>
+      <tdml:error>13:99:50-0800</tdml:error>
+      <tdml:error>valid range</tdml:error>
     </tdml:errors>
   </tdml:parserTestCase>
 
@@ -6315,7 +6331,9 @@
 
     <tdml:document><![CDATA[13:30:70GMT]]></tdml:document>
     <tdml:errors>
-      <tdml:error>Failed to parse '13:30:70GMT'</tdml:error>
+      <tdml:error>Unable to parse</tdml:error>
+      <tdml:error>13:30:70GMT</tdml:error>
+      <tdml:error>valid range</tdml:error>
     </tdml:errors>
   </tdml:parserTestCase>
 

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section23/dfdl_functions/Functions.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section23/dfdl_functions/Functions.tdml
@@ -702,7 +702,7 @@
     <xs:element name="e_yearfromdatetime2">
       <xs:complexType>
         <xs:sequence>
-          <xs:element name="date" type="xs:dateTime" dfdl:lengthKind="delimited" />
+          <xs:element name="date" type="xs:dateTime" dfdl:lengthKind="delimited" dfdl:calendarCheckPolicy="lax"/>
           <xs:element name="year" type="xs:int" dfdl:inputValueCalc="{ fn:year-from-dateTime(../ex:date) }"/>
         </xs:sequence>
       </xs:complexType>
@@ -819,7 +819,7 @@
     <xs:element name="e_yearfromdate2">
       <xs:complexType>
         <xs:sequence>
-          <xs:element name="date" type="xs:date" dfdl:lengthKind="delimited" />
+          <xs:element name="date" type="xs:date" dfdl:lengthKind="delimited" dfdl:calendarCheckPolicy="lax" />
           <xs:element name="year" type="xs:int" dfdl:inputValueCalc="{ fn:year-from-date(../ex:date) }"/>
         </xs:sequence>
       </xs:complexType>
@@ -904,7 +904,7 @@
     <xs:element name="e_xfromtime1">
       <xs:complexType>
         <xs:sequence>
-          <xs:element name="time" type="xs:time" dfdl:lengthKind="delimited" />
+          <xs:element name="time" type="xs:time" dfdl:lengthKind="delimited" dfdl:calendarCheckPolicy="lax"/>
           <xs:element name="hours" type="xs:int" dfdl:inputValueCalc="{ fn:hours-from-time(../ex:time) }"/>
           <xs:element name="minutes" type="xs:int" dfdl:inputValueCalc="{ fn:minutes-from-time(../ex:time) }"/>
           <xs:element name="seconds" type="xs:decimal" dfdl:inputValueCalc="{ fn:seconds-from-time(../ex:time) }"/>
@@ -913,11 +913,11 @@
       </xs:complexType>
     </xs:element>
 
-    <xs:element name="e_xfromtime2">
+    <xs:element name="e_xfromtime2" dfdl:calendarCheckPolicy="lax">
       <xs:complexType>
         <xs:sequence>
           <xs:element name="time" type="xs:time" dfdl:lengthKind="delimited" dfdl:calendarPatternKind="explicit"
-            dfdl:calendarPattern="HH:mm:ss.SSSz"  />
+            dfdl:calendarPattern="HH:mm:ss.SSSz" dfdl:calendarCheckPolicy="lax" />
           <xs:element name="hours" type="xs:int" dfdl:inputValueCalc="{ fn:hours-from-time(../ex:time) }"/>
           <xs:element name="minutes" type="xs:int" dfdl:inputValueCalc="{ fn:minutes-from-time(../ex:time) }"/>
           <xs:element name="seconds" type="xs:decimal" dfdl:inputValueCalc="{ fn:seconds-from-time(../ex:time) }"/>

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section05/simple_types/TestSimpleTypes.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section05/simple_types/TestSimpleTypes.scala
@@ -398,11 +398,20 @@ class TestSimpleTypes {
   @Test def test_dateLaxCheckPolicy04(): Unit = { runner.runOneTest("dateLaxCheckPolicy04") }
   @Test def test_dateLaxCheckPolicy05(): Unit = { runner.runOneTest("dateLaxCheckPolicy05") }
 
-  // DFDL-1042 - not very strict
-  // @Test def test_dateStrictCheckPolicy01() { runner.runOneTest("dateStrictCheckPolicy01") }
-  // @Test def test_timeStrictCheckPolicy01() { runner.runOneTest("timeStrictCheckPolicy01") }
-  // @Test def test_timeStrictCheckPolicy02() { runner.runOneTest("timeStrictCheckPolicy02") }
-  // @Test def test_timeFormatting5() { runner.runOneTest("timeFormatting5") }
+  // DFDL-1042/DFDL-2951
+  @Test def test_dateStrictCheckPolicy01(): Unit = {
+    runner.runOneTest("dateStrictCheckPolicy01")
+  }
+  @Test def test_dateStrictCheckPolicy02(): Unit = {
+    runner.runOneTest("dateStrictCheckPolicy02")
+  }
+  @Test def test_timeStrictCheckPolicy01(): Unit = {
+    runner.runOneTest("timeStrictCheckPolicy01")
+  }
+  @Test def test_timeStrictCheckPolicy02(): Unit = {
+    runner.runOneTest("timeStrictCheckPolicy02")
+  }
+  @Test def test_timeFormatting5(): Unit = { runner.runOneTest("timeFormatting5") }
 
   @Test def test_Long1(): Unit = { runner.runOneTest("Long1") }
   @Test def test_BigInteger1(): Unit = { runner.runOneTest("BigInteger1") }


### PR DESCRIPTION
- we used to override the leniency regardless of what the calendar check policy was, now this ticket fixes that by setting it based on the isLenient value of calendar.
- uncomment previously failing tests
- make newly failing tests lax
- add additional test

DAFFODIL-2951, DAFFODIL-1042