### PR TITLE
Provide diagnosticDebugName for GroupRefFactory

### DIFF
--- a/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/GroupRef.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/GroupRef.scala
@@ -113,6 +113,9 @@ final class GroupRefFactory private (
     }
     gref
   }
+
+  override val diagnosticDebugNameImpl = "group reference " + refQName
+
 }
 
 object SequenceGroupRef {

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section14/sequence_groups/SequenceGroup.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section14/sequence_groups/SequenceGroup.tdml
@@ -369,6 +369,7 @@
       <tdml:error>Schema Definition Error</tdml:error>
       <tdml:error>Referenced group definition not found</tdml:error>
       <tdml:error>doesNotExist</tdml:error>
+      <tdml:error>Schema context: group reference</tdml:error>
     </tdml:errors>
   </tdml:parserTestCase>
 


### PR DESCRIPTION
- currently we don't have one resulting in the class name showing up in diagnostics
- setting the diagnosticDebugNameImpl fixes the issue

DAFFODIL-2948