### PR TITLE
Use macOS-14 for Github Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,14 +41,14 @@ jobs:
         java_distribution: [ temurin ]
         java_version: [ 8, 11, 17, 21 ]
         scala_version: [ 2.12.20 ]
-        os: [ ubuntu-22.04, windows-2022, macos-12 ]
+        os: [ ubuntu-22.04, windows-2022, macos-14 ]
         exclude:
           # only run macos on java 17
-          - os: macos-12
+          - os: macos-14
             java_version: 8
-          - os: macos-12
+          - os: macos-14
             java_version: 11
-          - os: macos-12
+          - os: macos-14
             java_version: 21
         include:
           # configure shell/cc/ar for all OSes
@@ -60,7 +60,7 @@ jobs:
             shell: msys2 {0}
             env_cc: clang
             env_ar: llvm-ar
-          - os: macos-12
+          - os: macos-14
             shell: bash
             env_cc: cc
             env_ar: ar
@@ -104,10 +104,22 @@ jobs:
 
       - name: Install Dependencies (macOS)
         if: runner.os == 'macOS'
+        run: brew install sbt
+
+      - name: Check out mxml source (macOS)
+        if: runner.os == 'macOS'
+        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+        with:
+          repository: michaelrsweet/mxml
+          ref: v3.3.1
+          path: mxml
+
+      - name: Install mxml library (macOS)
+        if: runner.os == 'macOS'
         run: |
-          brew tap-new local/libmxml
-          brew extract --version 3.3.1 libmxml local/libmxml
-          brew install libmxml@3.3.1
+          cd mxml
+          ./configure
+          sudo make install        
 
       - name: Install Dependencies (Linux)
         if: runner.os == 'Linux'


### PR DESCRIPTION
- which is the latest stable version. They only support the last two stable versions, so we should be good for a while
- add step to install sbt since later version of the runner image don't include it
- had to mxml build from source since macos-14 is Apple Silicon mac and by default installs to /opt/homebrew/include, which isn't on the cc search path. Attempts to add the path other ways (-I or CPATH) proved unsuccessful

DAFFODIL-2952