### PR TITLE
Only provide valid line/col info from Xerces

### DIFF
--- a/daffodil-cli/src/test/scala/org/apache/daffodil/cli/cliTest/TestCLISaveParser.scala
+++ b/daffodil-cli/src/test/scala/org/apache/daffodil/cli/cliTest/TestCLISaveParser.scala
@@ -327,7 +327,7 @@ class TestCLISaveParser {
     withTempFile { parser =>
       runCLI(args"save-parser -s $schema $parser") { cli =>
         cli.expectErr("[error]")
-        cli.expectErr(s"Schema context:  Location line 32 column 74 in ${schema.normalize()}")
+        cli.expectErr(s"Schema context: Location line 32 column 74 in ${schema.normalize()}")
       }(ExitCode.UnableToCreateProcessor)
     }
   }

--- a/daffodil-lib/src/main/scala/org/apache/daffodil/lib/api/Diagnostic.scala
+++ b/daffodil-lib/src/main/scala/org/apache/daffodil/lib/api/Diagnostic.scala
@@ -178,8 +178,9 @@ abstract class Diagnostic protected (
   protected def schemaContextString =
     if (schemaContext.isEmpty) ""
     else {
-      val pn = schemaContext.get.diagnosticDebugName
-      "\nSchema context: %s%s".format(pn, schemaLocationsString)
+      val ddn = schemaContext.get.diagnosticDebugName
+      val pn = if (ddn.nonEmpty) " " + ddn else ""
+      "\nSchema context:%s%s".format(pn, schemaLocationsString)
     }
 
   private def dataLocationString =

--- a/daffodil-lib/src/main/scala/org/apache/daffodil/lib/exceptions/SchemaFileLocatable.scala
+++ b/daffodil-lib/src/main/scala/org/apache/daffodil/lib/exceptions/SchemaFileLocatable.scala
@@ -123,8 +123,8 @@ class XercesSchemaFileLocation(
   val xercesError: SAXParseException,
   val schemaFileLocation: SchemaFileLocation
 ) extends SchemaFileLocation(
-    Option(xercesError.getLineNumber.toString),
-    Option(xercesError.getColumnNumber.toString),
+    (if (xercesError.getLineNumber > 0) Some(xercesError.getLineNumber.toString) else None),
+    (if (xercesError.getColumnNumber > 0) Some(xercesError.getColumnNumber.toString) else None),
     schemaFileLocation.diagnosticFile,
     schemaFileLocation.toString,
     schemaFileLocation.diagnosticDebugName

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section00/general/TestResolver.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section00/general/TestResolver.tdml
@@ -38,6 +38,7 @@
       <tdml:error>Schema Definition Error</tdml:error>
       <tdml:error>Unable to resolve</tdml:error>
       <tdml:error>this/does/not/exist/schema.dfdl.xsd</tdml:error>
+      <tdml:error>Schema context: Location in</tdml:error>
     </tdml:errors>
   </tdml:parserTestCase>
 


### PR DESCRIPTION
- currently we output the line/col info directly from Xerces even if it's -1. We update the code to provide none if line/col <= 0 with test
- we also fix the doublespace when there is no diagnosticDebugName provided for schema context
- we looked into implementing a locator, and it was more trouble than it was worth since Xerces doesn't provide it to us

DAFFODIL-2953