### PR TITLE
Add use of DAFFODIL_TDML_API_INFOSETS enviroment variable

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -95,6 +95,7 @@ jobs:
                      github.repository == 'apache/daffodil' &&
                      github.ref == 'refs/heads/main'
                   }}
+      DAFFODIL_TDML_API_INFOSETS: all
 
     steps:
 

--- a/daffodil-test-integration/src/test/scala/org/apache/daffodil/cliTest/TestCLITdml.scala
+++ b/daffodil-test-integration/src/test/scala/org/apache/daffodil/cliTest/TestCLITdml.scala
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.daffodil.cliTest
+
+import org.apache.daffodil.cli.Main.ExitCode
+import org.apache.daffodil.cli.cliTest.Util._
+
+import org.junit.Test
+
+class TestCLITdml {
+
+  @Test def test_CLI_Tdml_Trace_singleTest1(): Unit = {
+    val tdml = path(
+      "daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/Entities.tdml"
+    )
+
+    val envs = Map("DAFFODIL_TDML_API_INFOSETS" -> "all")
+
+    runCLI(args"test -i -t $tdml byte_entities_6_08", envs = envs) { cli =>
+      // legacy parse
+      cli.expect("parser: <Element name='e3'>")
+      // sax parse
+      cli.expect("parser: <Element name='e3'>")
+      cli.expect("[Pass] byte_entities_6_08")
+    }(ExitCode.Success)
+  }
+
+  @Test def test_CLI_Tdml_Trace_singleTest2(): Unit = {
+    val tdml = path(
+      "daffodil-test/src/test/resources/org/apache/daffodil/section06/entities/Entities.tdml"
+    )
+
+    val envs = Map("DAFFODIL_TDML_API_INFOSETS" -> "scala")
+
+    runCLI(args"test -i -t $tdml byte_entities_6_08", envs = envs) { cli =>
+      // parse
+      cli.expect("parser: <Element name='e3'>")
+      // unparse
+      cli.expect("parser: not available")
+      cli.expect("[Pass] byte_entities_6_08")
+    }(ExitCode.Success)
+  }
+}


### PR DESCRIPTION
- currently during testing we parse/unparse using both the sax and non-sax API, which leads to issues like trace running outputting twice for the same test which is confusing. We also run the parse for all our infoset outputters. With this enviromental variable, we default to the more efficient single infoset outputter (scalaxml) and single API (non-sax) parse/unparse.
- the DAFFODIL_TDML_API_INFOSETS env has 2 options: 'scala' and 'all'. with scala being the default and 'all' being the current implementation of running both APIs and all infoset outputters
- we convert TDMLInfosetOutputter to a trait so the All and Scala subclasses can extend it as well as TeeInfosetOutputter
- get rid of unused and inaccessible parse function
- set CI mode to all for regression testing
- add cli test showing use of scala and all mode

DAFFODIL-2904