### PR TITLE
Check for Unused Properties on Annotated Schema Components

### DIFF
--- a/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/AnnotatedSchemaComponent.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/AnnotatedSchemaComponent.scala
@@ -291,6 +291,7 @@ final class SharedFactory[SharedType] {
 trait AnnotatedSchemaComponent
   extends SchemaComponent
   with AnnotatedMixin
+  with ResolvesLocalProperties
   with OverlapCheckMixin {
 
   protected override def initialize(): Unit = {
@@ -376,6 +377,45 @@ trait AnnotatedSchemaComponent
   final protected lazy val defaultFormatChain: ChainPropProvider = {
     val res = schemaDocument.formatAnnotation.formatChain
     res
+  }
+
+  /**
+   * Used to look for DFDL properties on Annotated Schema Components that
+   * have not been accessed and record it as a warning. This function uses the
+   * property cache state to determine which properties have been accessed, so
+   * this function must only be called after all property accesses are complete
+   * (e.g. schema compilation has finished) and after propagateUsedProperties
+   * has been called on all AnnotatedSchemaComponents, to ensure there are no false
+   * positives/negatives.
+   *
+   * Note: This is not a recursive walk. It identifies and issues warnings about
+   * unaccessed properties on just one AnnotatedSchemaComponent
+   */
+  final lazy val checkUnusedProperties: Unit = {
+    // Get the properties defined on this component and what it refers to
+    val localProps = formatAnnotation.justThisOneProperties
+    val refProps = optReferredToComponent
+      .map { _.formatAnnotation.justThisOneProperties }
+      .getOrElse(Map.empty)
+
+    val usedProperties = propCache
+
+    localProps.foreach { case (prop, (value, _)) =>
+      if (!usedProperties.contains(prop)) {
+        SDW(WarnID.IgnoreDFDLProperty, "DFDL property was ignored: %s=\"%s\"", prop, value)
+      }
+    }
+
+    refProps.foreach { case (prop, (value, _)) =>
+      if (!usedProperties.contains(prop)) {
+        optReferredToComponent.get.SDW(
+          WarnID.IgnoreDFDLProperty,
+          "DFDL property was ignored: %s=\"%s\"",
+          prop,
+          value
+        )
+      }
+    }
   }
 }
 

--- a/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/RestrictionUnion.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/RestrictionUnion.scala
@@ -278,7 +278,7 @@ final class Union private (val xmlArg: Node, simpleTypeDef: SimpleTypeDefBase)
   private lazy val immediateTypeXMLs = xml \ "simpleType"
   private lazy val immediateTypes: Seq[SimpleTypeDefBase] = immediateTypeXMLs.map { node =>
     {
-      LocalSimpleTypeDef(node, schemaDocument)
+      LocalSimpleTypeDef(node, this)
     }
   }
 

--- a/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/SchemaSet.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/SchemaSet.scala
@@ -18,6 +18,7 @@
 package org.apache.daffodil.core.dsom
 
 import java.io.File
+import scala.collection.mutable
 import scala.xml.Node
 
 import org.apache.daffodil.core.compiler.RootSpec
@@ -540,8 +541,127 @@ final class SchemaSet private (
     .flatMap(_.defineVariables)
     .union(predefinedVars)
 
-  private lazy val checkUnusedProperties = LV('hasUnusedProperties) {
-    root.checkUnusedProperties
+  private val doneSimpleTypeDefs: mutable.Set[SimpleTypeDefBase] = mutable.Set()
+
+  /**
+   * Used to propagate used properties through all element/group references, element declarations
+   * and simple types. This is necessary because we can have elements being referenced
+   * by multiple element refs, where the first element gets its propCache populated with
+   * the properties it has used, and the second element doesn't because it shares the parsers
+   * of the first element.
+   *
+   * With this function, we copy used properties from element refs to elements, group refs to groups,
+   * from elements to their simple types, from enclosing elements to their local simple types,
+   * and from simple types to their base types. This function is recursive when processing
+   * simple type definitions that reference simple type defs whose base is a primitive type.
+   *
+   * Note: this is clobbering the property caches, making them subsequently unusable
+   * for their initial property lookup uses. Hence, this must be done in a pass that
+   * happens only after all other schema compilation involving properties is complete.
+   */
+  def propagateUsedPropertiesForThis(asc: AnnotatedSchemaComponent): Unit = {
+    asc match {
+      case ggd: GlobalGroupDef => {
+        val groupRefs = root.refMap.getOrElse(ggd, Seq.empty)
+        groupRefs.foreach { case (_, grs) =>
+          grs.foreach { rs =>
+            val gr = rs.from.asInstanceOf[AnnotatedSchemaComponent]
+            gr.propCache.foreach { kv =>
+              if (ggd.formatAnnotation.justThisOneProperties.contains(kv._1)) {
+                ggd.propCache.put(kv._1, kv._2)
+              }
+            }
+          }
+        }
+      }
+      case ged: GlobalElementDecl => {
+        val elementRefs = root.refMap.getOrElse(ged, Seq.empty)
+        elementRefs.foreach { case (_, ers) =>
+          ers.foreach { rs =>
+            val er = rs.from.asInstanceOf[AnnotatedSchemaComponent]
+            er.propCache.foreach { kv =>
+              if (ged.formatAnnotation.justThisOneProperties.contains(kv._1)) {
+                ged.propCache.put(kv._1, kv._2)
+              }
+            }
+          }
+        }
+      }
+      case gstd: GlobalSimpleTypeDef if gstd.bases.nonEmpty => {
+        val elementsOfType = root.refMap.getOrElse(gstd, Seq.empty)
+        elementsOfType.foreach { case (_, eles) =>
+          eles.foreach { rs =>
+            val er = rs.from.asInstanceOf[AnnotatedSchemaComponent]
+            er.propCache.foreach { kv =>
+              if (gstd.formatAnnotation.justThisOneProperties.contains(kv._1)) {
+                gstd.propCache.put(kv._1, kv._2)
+              }
+            }
+          }
+        }
+        doneSimpleTypeDefs.add(gstd)
+      }
+      case lstd: LocalSimpleTypeDef => {
+        val enclElements = lstd.enclosingElements
+        enclElements.foreach { ee =>
+          ee.propCache.foreach { kv =>
+            if (lstd.formatAnnotation.justThisOneProperties.contains(kv._1)) {
+              lstd.propCache.put(kv._1, kv._2)
+            }
+          }
+        }
+        doneSimpleTypeDefs.add(lstd)
+      }
+      case gstd: GlobalSimpleTypeDef if gstd.bases.isEmpty => {
+        val othersReferencingThis =
+          root.typeBaseChainMap
+            .getOrElse(gstd, Seq.empty) ++ root.refMap.getOrElse(gstd, Seq.empty)
+        othersReferencingThis.foreach { case (_, refs) =>
+          refs.collect {
+            case rs if rs.from.isInstanceOf[SimpleTypeDefBase] =>
+              val std = rs.from.asInstanceOf[SimpleTypeDefBase]
+              if (!doneSimpleTypeDefs.contains(std)) {
+                propagateUsedPropertiesForThis(std)
+              }
+              std.propCache.foreach(kv => gstd.propCache.put(kv._1, kv._2))
+            case rs =>
+              val er = rs.from.asInstanceOf[AnnotatedSchemaComponent]
+              er.propCache.foreach { kv =>
+                if (gstd.formatAnnotation.justThisOneProperties.contains(kv._1)) {
+                  gstd.propCache.put(kv._1, kv._2)
+                }
+              }
+          }
+        }
+        doneSimpleTypeDefs.add(gstd)
+      }
+      case _ => // do nothing
+    }
+  }
+
+  /**
+   * Propagate used properties through AnnotatedSchemaComponent.
+   * This must be done after compilation is complete to ensure all properties
+   * that are used are accounted for.
+   * This is part of the algorithm for identifying properties that are present, but unused.
+   *
+   * Note: This algorithm repurposes propCaches which are no longer usable
+   * for property lookups after this is done.
+   */
+  private lazy val propagateUsedProperties = {
+    root.allComponents.collect { case asc: AnnotatedSchemaComponent =>
+      propagateUsedPropertiesForThis(asc)
+    }
+  }
+
+  /**
+   * check unused properties on annotated schema component, must be done
+   * after compilation is completed and used properties are propagated
+   */
+  private lazy val checkUnusedProperties = LV('checkUnusedProperties) {
+    root.allComponents.collect { case asc: AnnotatedSchemaComponent =>
+      asc.checkUnusedProperties
+    }
   }.value
 
   /**
@@ -563,6 +683,15 @@ final class SchemaSet private (
     else {
       val hasErrors = super.isError
       if (!hasErrors) {
+        // must be called after compilation is done
+        // this is a central part of the algorithm by which we identify properties that are present,
+        // but not used (see checkUnusedProperties).
+        // The overall algorithm is expressed in multiple places.
+        // This part handles the propagation of properties from referencer to referenced object
+        // when property combining occurs.
+        propagateUsedProperties
+        // The rest of the algorithm is then just traversing every AnnotatedSchemaComponent
+        // to see what properties are present on them that do not appear in the propCache.
         // must be last, after all compilation is done.
         // only check this if there are no errors.
         checkUnusedProperties
@@ -679,8 +808,9 @@ class TransitiveClosureSchemaComponents private () extends TransitiveClosure[Sch
         st.bases ++
           st.optRestriction ++
           st.optUnion
-      case r: Restriction => r.optUnion.toSeq
+      case r: Restriction => r.optUnion.toSeq ++ r.enumerations
       case u: Union => u.unionMemberTypes
+      case e: EnumerationDef => Nil
       case c: ComplexTypeBase => Seq(c.modelGroup)
       case gd: GlobalGroupDef => gd.groupMembers
       case stmt: DFDLStatement => Nil

--- a/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/SimpleTypes.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/SimpleTypes.scala
@@ -305,4 +305,5 @@ final class EnumerationDef(xml: Node, parentType: SimpleTypeDefBase)
   protected def isMyFormatAnnotation(a: DFDLAnnotation): Boolean =
     Assert.invariantFailed("Should not be called")
 
+  override val diagnosticDebugNameImpl = "enumeration"
 }

--- a/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/Term.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/Term.scala
@@ -22,7 +22,6 @@ import java.util.UUID
 
 import org.apache.daffodil.core.dsom.walker.TermView
 import org.apache.daffodil.core.grammar.TermGrammarMixin
-import org.apache.daffodil.lib.api.WarnID
 import org.apache.daffodil.lib.exceptions.Assert
 import org.apache.daffodil.lib.schema.annotation.props.Found
 import org.apache.daffodil.lib.schema.annotation.props.NotFound
@@ -104,43 +103,6 @@ trait Term
    * Abbreviation analogous to trd, tci is the compile-time counterpart.
    */
   final def tci = dpathCompileInfo
-
-  /**
-   * Used to recursively go through Terms and look for DFDL properties that
-   * have not been accessed and record it as a warning. This function uses the
-   * property cache state to determine which properties have been access, so
-   * this function must only be called after all property accesses are complete
-   * (e.g. schema compilation has finished) to ensure there are no false
-   * positives.
-   */
-  final lazy val checkUnusedProperties: Unit = {
-    // Get the properties defined on this term and what it refers to
-    val localProps = formatAnnotation.justThisOneProperties
-    val refProps = optReferredToComponent
-      .map { _.formatAnnotation.justThisOneProperties }
-      .getOrElse(Map.empty)
-
-    val usedProperties = propCache
-
-    localProps.foreach { case (prop, (value, _)) =>
-      if (!usedProperties.contains(prop)) {
-        SDW(WarnID.IgnoreDFDLProperty, "DFDL property was ignored: %s=\"%s\"", prop, value)
-      }
-    }
-
-    refProps.foreach { case (prop, (value, _)) =>
-      if (!usedProperties.contains(prop)) {
-        optReferredToComponent.get.SDW(
-          WarnID.IgnoreDFDLProperty,
-          "DFDL property was ignored: %s=\"%s\"",
-          prop,
-          value
-        )
-      }
-    }
-
-    termChildren.foreach { _.checkUnusedProperties }
-  }
 
   def position: Int
 

--- a/daffodil-lib/src/main/scala/org/apache/daffodil/lib/exceptions/SchemaFileLocatable.scala
+++ b/daffodil-lib/src/main/scala/org/apache/daffodil/lib/exceptions/SchemaFileLocatable.scala
@@ -136,11 +136,14 @@ class XercesSchemaFileLocation(
 
   // we have to override equals and hashCode because the OOlag error checks for duplicates in its error list
   override def equals(obj: Any): Boolean = {
-    val xsflObj = obj.asInstanceOf[XercesSchemaFileLocation]
-    xsflObj.xercesError.getLineNumber == this.xercesError.getLineNumber &&
-    xsflObj.xercesError.getColumnNumber == this.xercesError.getColumnNumber &&
-    xsflObj.xercesError.getSystemId == this.xercesError.getSystemId &&
-    xsflObj.schemaFileLocation == this.schemaFileLocation
+    // sometimes what OOlag error/warning is comparing against isn't a XercesSchemaFileLocation, but
+    // is a schemaFileLocation instead, since XercesSchemaFileLocation is a SchemaFileLocation as well,
+    // we just use that for comparison
+    val sflObj = obj.asInstanceOf[SchemaFileLocation]
+    sflObj.lineNumber.getOrElse("") == this.lineNumber.getOrElse("") &&
+    sflObj.columnNumber.getOrElse("") == this.columnNumber.getOrElse("") &&
+    sflObj.diagnosticFile == this.diagnosticFile &&
+    sflObj.diagnosticDebugName == this.diagnosticDebugName
   }
 
   override def hashCode: Int = {

--- a/daffodil-lib/src/main/scala/org/apache/daffodil/lib/schema/annotation/props/PropertyScoping.scala
+++ b/daffodil-lib/src/main/scala/org/apache/daffodil/lib/schema/annotation/props/PropertyScoping.scala
@@ -152,6 +152,13 @@ trait FindPropertyMixin extends PropTypes {
    */
   protected def lookupProperty(pname: String): PropertyLookupResult
 
+  /**
+   * the PropCache plays two roles in different phases of the compilation.
+   * First for property lookups, second for determining which properties are present, but unused.
+   *
+   * These two uses are incompatible as the second does propagation of used properties using propCache.
+   * The first use must therefore be over. Then the caches are repurposed for the second algorithm.
+   */
   val propCache = new scala.collection.mutable.LinkedHashMap[String, PropertyLookupResult]
 
   /**

--- a/daffodil-test/src/test/resources/org/apache/daffodil/extensions/enum/enumInvalid.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/extensions/enum/enumInvalid.tdml
@@ -95,6 +95,20 @@
       </restriction>
     </simpleType>
 
+    <xs:simpleType name="rep" dfdl:lengthKind="explicit" dfdl:length="1">
+      <xs:restriction base="xs:unsignedInt" />
+    </xs:simpleType>
+
+    <xs:simpleType name="value" dfdlx:repType="ex:rep">
+      <xs:restriction base="xs:string">
+        <xs:enumeration value="ZERO" dfdlx:repValue="0" />
+        <xs:enumeration value="ONE" dfdlx:repValue="1" />
+        <xs:enumeration value="TWO" dfdlx:repValue="2" />
+      </xs:restriction>
+    </xs:simpleType>
+
+    <xs:element name="r2" type="ex:value" />
+
   </tdml:defineSchema>
 
   <parserTestCase name="noRepValues" model="s1" root="r1">
@@ -108,6 +122,20 @@
       <error>dfdlx:repValueRanges</error>
       <error>dfdlx:repType</error>
       <error>ex:myByte</error>
+    </errors>
+  </parserTestCase>
+
+  <parserTestCase name="noRepValues2" model="s1" root="r2">
+    <document>
+      <documentPart type="byte">01</documentPart>
+    </document>
+    <errors>
+      <error>Schema Definition Error</error>
+      <error>enumerations must define</error>
+      <error>dfdlx:repValues</error>
+      <error>dfdlx:repValueRanges</error>
+      <error>dfdlx:repType</error>
+      <error>ex:rep</error>
     </errors>
   </parserTestCase>
 

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section07/property_syntax/PropertySyntax.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section07/property_syntax/PropertySyntax.tdml
@@ -146,8 +146,19 @@
         </xs:appinfo>
       </xs:annotation>
     </xs:element>
-    
-</tdml:defineSchema>
+
+
+    <xs:simpleType name="value">
+      <xs:restriction base="xs:string">
+        <xs:enumeration value="ZERO" dfdlx:repValue="0" />
+        <xs:enumeration value="ONE" dfdlx:repValue="1" />
+        <xs:enumeration value="TWO" dfdlx:repValue="2" />
+      </xs:restriction>
+    </xs:simpleType>
+
+    <xs:element name="root8" type="ex:value" />
+
+  </tdml:defineSchema>
     
     <tdml:parserTestCase name="ShortAndLongForm" root="root"
     model="PropertySyntax" description="Negative test for both short and long form on an element- DFDL-7-020R">
@@ -401,4 +412,242 @@
     </tdml:errors>
   </tdml:parserTestCase>
 
+
+  <tdml:parserTestCase name="ignoredPropertiesWarning2" root="root8"
+      model="PropertySyntax" description="warning due to ignored properties"
+      roundTrip="true">
+    <tdml:document><![CDATA[1]]></tdml:document>
+    <tdml:warnings>
+      <tdml:warning>DFDL property was ignored</tdml:warning>
+      <tdml:warning>repValue</tdml:warning>
+    </tdml:warnings>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <root8>1</root8>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:defineSchema name="PropertiesOnTypesOfElements" xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/"
+      xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:ex="http://example.com">
+    <xs:include schemaLocation="/org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd" />
+
+    <dfdl:format ref="GeneralFormat" lengthKind="delimited" />
+
+    <xs:element name="DinnerTime">
+      <xs:complexType>
+        <xs:choice>
+          <xs:element ref="ex:MonthDayTime" />
+          <xs:element ref="ex:DayTime" />
+        </xs:choice>
+      </xs:complexType>
+    </xs:element>
+
+    <xs:element name="MonthDayTime">
+      <xs:complexType>
+        <xs:sequence>
+          <xs:element ref="ex:Month"/>
+          <xs:element ref="ex:Day"/>
+        </xs:sequence>
+      </xs:complexType>
+    </xs:element>
+
+    <xs:element name="DayTime">
+      <xs:complexType>
+        <xs:sequence>
+          <xs:element ref="ex:Day"/>
+        </xs:sequence>
+      </xs:complexType>
+    </xs:element>
+
+    <xs:element name="Month"
+        type="ex:MonthDayType"
+        dfdl:lengthKind="explicit"
+        dfdl:length="2">
+    </xs:element>
+
+    <xs:element name="Day"
+        type="ex:MonthDayType"
+        dfdl:lengthKind="explicit"
+        dfdl:length="2">
+    </xs:element>
+
+    <xs:simpleType name="MonthDayType">
+      <xs:annotation>
+        <xs:appinfo source="http://www.ogf.org/dfdl/">
+          <dfdl:simpleType textNumberRep="standard"
+              textNumberCheckPolicy="strict"
+              textNumberPattern="00"
+              textStandardGroupingSeparator=","
+              textStandardDecimalSeparator="."
+              textStandardBase="10"
+              textNumberRounding="pattern"/>
+        </xs:appinfo>
+      </xs:annotation>
+      <xs:restriction base="xs:unsignedInt"/>
+    </xs:simpleType>
+  </tdml:defineSchema>
+
+  <tdml:parserTestCase name="propertiesOnTypeOfElement1" root="DinnerTime"
+      model="PropertiesOnTypesOfElements"
+      roundTrip="true">
+    <tdml:document><![CDATA[09]]></tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <DinnerTime>
+          <DayTime>
+            <Day>9</Day>
+          </DayTime>
+        </DinnerTime>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:defineSchema name="PropertiesOnSimpleTypeChains" xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/"
+      xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:ex="http://example.com" xmlns:ps="urn:property-syntax">
+    <xs:include schemaLocation="/org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd" />
+    <xs:import namespace="urn:property-syntax" schemaLocation="/org/apache/daffodil/section07/property_syntax/property_syntax2.dfdl.xsd" />
+
+    <dfdl:format ref="ex:GeneralFormat" lengthKind="delimited" />
+
+    <xs:element name="DinnerTime">
+      <xs:complexType>
+        <xs:choice>
+          <xs:element ref="ex:MonthDayTime" />
+          <xs:element ref="ex:DayTime" />
+        </xs:choice>
+      </xs:complexType>
+    </xs:element>
+
+    <xs:element name="MonthDayTime">
+      <xs:complexType>
+        <xs:sequence>
+          <xs:element ref="ex:Month"/>
+          <xs:element ref="ex:Day"/>
+        </xs:sequence>
+      </xs:complexType>
+    </xs:element>
+
+    <xs:element name="DayTime">
+      <xs:complexType>
+        <xs:sequence>
+          <xs:element ref="ex:Day"/>
+        </xs:sequence>
+      </xs:complexType>
+    </xs:element>
+
+    <xs:element name="Month"
+        type="ex:MonthDayType"
+        dfdl:lengthKind="explicit"
+        dfdl:length="2">
+    </xs:element>
+
+    <xs:element name="Day"
+        type="ps:MonthDayTypeBase"
+        dfdl:lengthKind="explicit"
+        dfdl:length="2">
+    </xs:element>
+
+    <xs:simpleType name="MonthDayType">
+      <xs:restriction base="ps:MonthDayTypeBase"/>
+    </xs:simpleType>
+  </tdml:defineSchema>
+
+  <tdml:parserTestCase name="propertiesOnTypeOfElement2" root="DinnerTime"
+      model="PropertiesOnSimpleTypeChains"
+      roundTrip="true">
+    <tdml:document><![CDATA[09]]></tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <DinnerTime>
+          <DayTime>
+            <Day>9</Day>
+          </DayTime>
+        </DinnerTime>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:defineSchema name="PropertiesOnGroups" xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/"
+      xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:ex="http://example.com" xmlns:ps="urn:property-syntax">
+    <xs:include schemaLocation="/org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd" />
+    <xs:import namespace="urn:property-syntax" schemaLocation="/org/apache/daffodil/section07/property_syntax/property_syntax2.dfdl.xsd" />
+
+    <dfdl:format ref="ex:GeneralFormat" lengthKind="delimited" />
+
+    <xs:element name="DinnerTime">
+      <xs:complexType>
+        <xs:group ref="ex:g1"/>
+      </xs:complexType>
+    </xs:element>
+
+    <xs:group name="g1">
+      <xs:choice dfdl:initiator="[" dfdl:terminator="]">
+        <xs:element ref="ex:MonthDayTime" />
+        <xs:element ref="ex:DayTime" />
+      </xs:choice>
+    </xs:group>
+
+    <xs:element name="MonthDayTime">
+      <xs:complexType>
+        <xs:group ref="ex:g2"/>
+      </xs:complexType>
+    </xs:element>
+
+    <xs:group name="g2">
+      <xs:sequence dfdl:separator="/">
+        <xs:element ref="ex:Month"/>
+        <xs:element ref="ex:Day"/>
+      </xs:sequence>
+    </xs:group>
+
+    <xs:element name="DayTime">
+      <xs:complexType>
+        <xs:group ref="ex:g3"/>
+      </xs:complexType>
+    </xs:element>
+
+    <xs:group name="g3">
+      <xs:sequence>
+        <xs:element ref="ex:Day"/>
+      </xs:sequence>
+    </xs:group>
+
+    <xs:element name="Month"
+        type="ex:MonthDayType"
+        dfdl:lengthKind="explicit"
+        dfdl:length="2">
+    </xs:element>
+
+    <xs:element name="Day">
+      <xs:simpleType>
+        <xs:annotation>
+          <xs:appinfo source="http://www.ogf.org/dfdl/">
+            <dfdl:simpleType lengthKind="explicit" length="2"/>
+          </xs:appinfo>
+        </xs:annotation>
+        <xs:restriction base="ps:MonthDayTypeBase"/>
+      </xs:simpleType>
+    </xs:element>
+
+    <xs:simpleType name="MonthDayType">
+      <xs:restriction base="ps:MonthDayTypeBase"/>
+    </xs:simpleType>
+  </tdml:defineSchema>
+
+  <tdml:parserTestCase name="propertiesOnGroups1" root="DinnerTime"
+      model="PropertiesOnGroups"
+      roundTrip="true">
+    <tdml:document><![CDATA[[09/05]]]></tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <DinnerTime>
+          <MonthDayTime>
+            <Month>9</Month>
+            <Day>5</Day>
+          </MonthDayTime>
+        </DinnerTime>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
 </tdml:testSuite>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section07/property_syntax/property_syntax2.dfdl.xsd
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section07/property_syntax/property_syntax2.dfdl.xsd
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/"
+targetNamespace="urn:property-syntax" xmlns:ps="urn:property-syntax">
+
+  <xs:include schemaLocation="/org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+
+  <xs:annotation>
+    <xs:appinfo source="http://www.ogf.org/dfdl/">
+      <dfdl:format ref="ps:GeneralFormat" separator="" initiator="" terminator="" leadingSkip='0' textTrimKind="none" initiatedContent="no"
+        ignoreCase="no" alignment='implicit' alignmentUnits='bytes' trailingSkip='0'
+        lengthKind="delimited"/>
+    </xs:appinfo>
+  </xs:annotation>
+
+  <xs:simpleType name="MonthDayTypeBase">
+    <xs:annotation>
+      <xs:appinfo source="http://www.ogf.org/dfdl/">
+        <dfdl:simpleType textNumberRep="standard"
+            textNumberCheckPolicy="strict"
+            textNumberPattern="00"
+            textStandardGroupingSeparator=","
+            textStandardDecimalSeparator="."
+            textStandardBase="10"
+            textNumberRounding="pattern"/>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:restriction base="ps:uIntBase"/>
+  </xs:simpleType>
+
+  <xs:simpleType name="MonthDayTypeBase2">
+    <xs:annotation>
+      <xs:appinfo source="http://www.ogf.org/dfdl/">
+        <dfdl:simpleType textNumberRep="standard"
+            textNumberCheckPolicy="strict"
+            textNumberPattern="00"
+            textStandardGroupingSeparator=","
+            textStandardDecimalSeparator="."
+            textStandardBase="10"
+            textNumberRounding="pattern"/>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:restriction base="ps:uIntBase"/>
+  </xs:simpleType>
+
+  <xs:simpleType name="uIntBase">
+    <xs:restriction base="xs:unsignedInt"/>
+  </xs:simpleType>
+</xs:schema>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section12/lengthKind/PrefixedTests.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section12/lengthKind/PrefixedTests.tdml
@@ -2575,8 +2575,7 @@
                 dfdl:lengthKind="prefixed"
                 dfdl:prefixLengthType="ex:prefixType"
                 dfdl:prefixIncludesPrefixLength="no"
-                type="xs:nonNegativeInteger"
-                dfdl:lengthUnits="bits"/>
+                type="xs:nonNegativeInteger" dfdl:lengthUnits="bits"/>
   </tdml:defineSchema>
 
   <tdml:parserTestCase name="lengthUnitsBitsForNonNegativeInteger_prefixed" root="r1" model="lengthUnitsBitsForNonNegativeInteger_prefixed"

--- a/daffodil-test/src/test/scala/org/apache/daffodil/extensions/TestEnums.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/extensions/TestEnums.scala
@@ -43,6 +43,8 @@ class TestEnums {
 
   @Test def test_emptyRepValues(): Unit = { runner2.runOneTest("emptyRepValues") }
   @Test def test_noRepValues(): Unit = { runner2.runOneTest("noRepValues") }
+  // DFDL-2798
+  @Test def test_noRepValues2(): Unit = { runner2.runOneTest("noRepValues2") }
   @Test def test_enumRepTypeNonInt(): Unit = { runner2.runOneTest("enumRepTypeNonInt") }
 
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section07/property_syntax/TestPropertySyntax.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section07/property_syntax/TestPropertySyntax.scala
@@ -66,6 +66,20 @@ class TestPropertySyntax {
   @Test def test_ignoredPropertiesWarning(): Unit = {
     runner1.runOneTest("ignoredPropertiesWarning")
   }
+  // DFDL-2798
+  @Test def test_ignoredPropertiesWarning2(): Unit = {
+    runner1.runOneTest("ignoredPropertiesWarning2")
+  }
+  @Test def test_propertiesOnTypeOfElement1(): Unit = {
+    runner1.runOneTest("propertiesOnTypeOfElement1")
+  }
+  @Test def test_propertiesOnTypeOfElement2(): Unit = {
+    runner1.runOneTest("propertiesOnTypeOfElement2")
+  }
+  @Test def test_propertiesOnGroups1(): Unit = {
+    runner1.runOneTest("propertiesOnGroups1")
+  }
+
   // DFDL-1842
   @Test def test_overlappingProperties1(): Unit = {
     runner1.runOneTest("overlappingProperties1")


### PR DESCRIPTION
- currently we check unused properties on terms only, which means unsused properties on non-term schema components can be missed. This will fix that issue, by moving the checks to AnnotatedSchemaComponents instead.
- fix bug with XercesSchemaFileLocation.equals assuming all incoming objects would be XercesSchemaFileLocations as well. We also get just plain SchemaFileLocations, which can break things, so instead we compare against SchemaFileLocation members
- add tests

DAFFODIL-2798