### PR TITLE
Fix Ignored RootNS

### DIFF
--- a/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/SchemaComponent.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/SchemaComponent.scala
@@ -334,7 +334,7 @@ final class Schema private (
    *
    * This just scans each schema document in the schema, checking each one.
    */
-  def getGlobalElementDecl(name: String) = {
+  def getGlobalElementDecl(name: String): Option[GlobalElementDecl] = {
     val sds = schemaDocuments
     val res = sds.flatMap { sd =>
       {

--- a/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/SchemaSet.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/SchemaSet.scala
@@ -315,12 +315,12 @@ final class SchemaSet private (
    * root element name, then this searches for a single element having that name, and if it is
    * unambiguous, it is used as the root.
    */
-  private def findRootElement(name: String) = {
+  private def findRootElement(name: String): GlobalElementDecl = {
     val candidates = schemas.flatMap {
       _.getGlobalElementDecl(name)
     }
     schemaDefinitionUnless(
-      candidates.length != 0,
+      candidates.nonEmpty,
       "No root element found for %s in any available namespace",
       name
     )
@@ -337,7 +337,7 @@ final class SchemaSet private (
       }
     )
     Assert.invariant(candidates.length == 1)
-    val ge = candidates(0)
+    val ge = candidates.head
     ge
   }
 

--- a/daffodil-tdml-lib/src/main/scala/org/apache/daffodil/tdml/TDMLRunner.scala
+++ b/daffodil-tdml-lib/src/main/scala/org/apache/daffodil/tdml/TDMLRunner.scala
@@ -673,7 +673,14 @@ abstract class TestCase(testCaseXML: NodeSeq, val parent: DFDLTestSuite) {
   lazy val tcID = (testCaseXML \ "@ID").text
   lazy val id = tcName + (if (tcID != "") "(" + tcID + ")" else "")
   lazy val rootAttrib = (testCaseXML \ "@root").text
-  lazy val rootNSAttrib = (testCaseXML \ "@rootNS").text
+  lazy val optRootNSAttrib: Option[String] = {
+    val attr = testCaseXML.asInstanceOf[Elem].attribute("rootNS")
+    if (attr.isDefined) {
+      Some(testCaseXML \@ "rootNS")
+    } else {
+      None
+    }
+  }
 
   lazy val (infosetRootName, infosetRootNamespaceString) =
     if (this.optExpectedOrInputInfoset.isDefined) {
@@ -695,12 +702,12 @@ abstract class TestCase(testCaseXML: NodeSeq, val parent: DFDLTestSuite) {
   }
 
   def getRootNamespaceString() = {
-    if (optExpectedOrInputInfoset.isDefined)
+    if (this.optRootNSAttrib.isDefined) {
+      optRootNSAttrib.get
+    } else if (optExpectedOrInputInfoset.isDefined)
       infosetRootNamespaceString
     else if (optEmbeddedSchema.isDefined)
       XMLUtils.EXAMPLE_NAMESPACE.toString
-    else if (this.rootNSAttrib != "")
-      rootNSAttrib
     else {
       // For some TDML Processors, we have to provide
       // the root namespace. They don't provide a way to search

--- a/daffodil-tdml-processor/src/test/resources/test/tdml/chameleon-schema1.dfdl.xsd
+++ b/daffodil-tdml-processor/src/test/resources/test/tdml/chameleon-schema1.dfdl.xsd
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/">
+  <xs:include schemaLocation="/org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+  <xs:import namespace="urn:schema:namespace" schemaLocation="/test/tdml/generic-schema1.dfdl.xsd"/>
+
+  <xs:annotation>
+    <xs:appinfo source="http://www.ogf.org/dfdl/">
+      <dfdl:format ref="GeneralFormat"/>
+    </xs:appinfo>
+  </xs:annotation>
+
+  <xs:element name="data" type="xs:int" dfdl:lengthKind="explicit" dfdl:length="{ 2 }"/>
+</xs:schema>

--- a/daffodil-tdml-processor/src/test/resources/test/tdml/generic-schema1.dfdl.xsd
+++ b/daffodil-tdml-processor/src/test/resources/test/tdml/generic-schema1.dfdl.xsd
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<xs:schema xmlns="http://www.w3.org/2001/XMLSchema" xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns:ex="http://example.com" xmlns:s="urn:schema:namespace" targetNamespace="urn:schema:namespace" xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/">
+  <xs:include schemaLocation="/org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+  <xs:annotation>
+    <xs:appinfo source="http://www.ogf.org/dfdl/">
+      <dfdl:format ref="s:GeneralFormat"/>
+    </xs:appinfo>
+  </xs:annotation>
+
+  <xs:element name="data" type="xs:string" dfdl:lengthKind="explicit" dfdl:length="{ 3 }"/>
+</xs:schema>

--- a/daffodil-tdml-processor/src/test/scala/org/apache/daffodil/processor/tdml/TestTDMLRunner2.scala
+++ b/daffodil-tdml-processor/src/test/scala/org/apache/daffodil/processor/tdml/TestTDMLRunner2.scala
@@ -677,4 +677,81 @@ abc # a comment
     runner.reset
   }
 
+  // DFDL-2947
+  @Test def test_rootNSSpecifiesNoNamespaceRoot(): Unit = {
+    val tdmlTestSuite =
+      <tdml:testSuite suiteName="theSuiteName" xmlns:ex={example} xmlns:tdml={tdml} xmlns:dfdl={
+        dfdl
+      } xmlns:xsd={xsd} xmlns:xs={xsd} xmlns:xsi={xsi}>
+        <tdml:parserTestCase name="test1" root="data" rootNS="" model="/test/tdml/chameleon-schema1.dfdl.xsd">
+          <tdml:document>37</tdml:document>
+          <tdml:infoset>
+            <tdml:dfdlInfoset>
+              <data>37</data>
+            </tdml:dfdlInfoset>
+          </tdml:infoset>
+        </tdml:parserTestCase>
+      </tdml:testSuite>
+
+    val runner = new Runner(tdmlTestSuite)
+    runner.runOneTest("test1")
+  }
+
+  @Test def test_rootNSSpecifiesNamespaceRoot(): Unit = {
+    val tdmlTestSuite =
+      <tdml:testSuite suiteName="theSuiteName" xmlns:ex={example} xmlns:tdml={tdml} xmlns:dfdl={
+        dfdl
+      } xmlns:xsd={xsd} xmlns:xs={xsd} xmlns:xsi={xsi}>
+        <tdml:parserTestCase name="test1" root="data" rootNS="urn:schema:namespace" model="/test/tdml/chameleon-schema1.dfdl.xsd">
+          <tdml:document>boy</tdml:document>
+          <tdml:infoset>
+            <tdml:dfdlInfoset>
+              <data>boy</data>
+            </tdml:dfdlInfoset>
+          </tdml:infoset>
+        </tdml:parserTestCase>
+      </tdml:testSuite>
+
+    val runner = new Runner(tdmlTestSuite)
+    runner.runOneTest("test1")
+  }
+
+  @Test def test_noRootCandidates1(): Unit = {
+    val tdmlTestSuite =
+      <tdml:testSuite suiteName="theSuiteName" xmlns:ex={example} xmlns:tdml={tdml} xmlns:dfdl={
+        dfdl
+      } xmlns:xsd={xsd} xmlns:xs={xsd} xmlns:xsi={xsi}>
+        <tdml:parserTestCase name="test1" root="data1" model="/test/tdml/chameleon-schema1.dfdl.xsd">
+          <tdml:document>37</tdml:document>
+          <tdml:errors>
+          <tdml:error>Schema Definition Error</tdml:error>
+          <tdml:error>no root element found</tdml:error>
+          <tdml:error>data1</tdml:error>
+          </tdml:errors>
+        </tdml:parserTestCase>
+      </tdml:testSuite>
+
+    val runner = new Runner(tdmlTestSuite)
+    runner.runOneTest("test1")
+  }
+
+  @Test def test_noRootCandidates2(): Unit = {
+    val tdmlTestSuite =
+      <tdml:testSuite suiteName="theSuiteName" xmlns:ex={example} xmlns:tdml={tdml} xmlns:dfdl={
+        dfdl
+      } xmlns:xsd={xsd} xmlns:xs={xsd} xmlns:xsi={xsi}>
+        <tdml:parserTestCase name="test1" root="data" rootNS="doesNotExist" model="/test/tdml/chameleon-schema1.dfdl.xsd">
+          <tdml:document>37</tdml:document>
+          <tdml:errors>
+          <tdml:error>Schema Definition Error</tdml:error>
+          <tdml:error>no global element found</tdml:error>
+            <!-- extra brace is there escape the inner brace -->
+          <tdml:error>{{doesNotExist}}data</tdml:error>
+          </tdml:errors>
+        </tdml:parserTestCase>
+      </tdml:testSuite>
+
+    val runner = new Runner(tdmlTestSuite)
+    runner.runOneTest("test1")
+  }
 }

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section06/namespaces/namespaces.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section06/namespaces/namespaces.tdml
@@ -910,7 +910,7 @@
     <tdml:document><![CDATA[333]]></tdml:document>
     <tdml:errors>
       <tdml:error>Schema Definition Error</tdml:error>
-      <tdml:error>More than one definition for name: vagueEle</tdml:error>
+      <tdml:error>More than one definition for name: vagueElem</tdml:error>
     </tdml:errors>
   </tdml:parserTestCase>
 


### PR DESCRIPTION
- currently we find the root element using only the local name of an element, this can result in ambiguous roots and an error if you have an element with no namespace and one with a namespace. This PR fixes that by searching using the qname instead
- add search for qname option if no namespace is specified, because there might still be an unambiguous root element within a namespace, the user just opted not to specify it

DAFFODIL-2947