### PR TITLE
Trim ErrorWarningBase Messages

### DIFF
--- a/daffodil-tdml-lib/src/main/scala/org/apache/daffodil/tdml/TDMLRunner.scala
+++ b/daffodil-tdml-lib/src/main/scala/org/apache/daffodil/tdml/TDMLRunner.scala
@@ -2852,8 +2852,8 @@ abstract class ErrorWarningBase(n: NodeSeq, parent: TestCase) {
 
   protected def diagnosticNodes: Seq[Node]
 
-  lazy val messages = diagnosticNodes.map {
-    _.text
+  lazy val messages: Seq[String] = diagnosticNodes.map {
+    _.text.trim
   }
 
   def hasDiagnostics: Boolean = diagnosticNodes.nonEmpty

--- a/daffodil-tdml-processor/src/test/scala/org/apache/daffodil/processor/tdml/TestTDMLRunner2.scala
+++ b/daffodil-tdml-processor/src/test/scala/org/apache/daffodil/processor/tdml/TestTDMLRunner2.scala
@@ -608,4 +608,32 @@ abc # a comment
   @Test def test_apos_test1(): Unit = { runner.runOneTest("apos_test1") }
   @Test def test_apos_test2(): Unit = { runner.runOneTest("apos_test2") }
 
+  // DFDL-2955
+  @Test def test_whitespaceSurroundingErrorMessages() = {
+    val testSuite =
+      <tdml:testSuite suiteName="theSuiteName" xmlns:tns={tns} xmlns:tdml={tdml} xmlns:dfdl={
+        dfdl
+      } xmlns:xs={xsd}>
+        <!-- This embedded schema has validation errors. -->
+        <tdml:defineSchema name="mySchema">
+          <xs:include schemaLocation="/org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+          <xs:format ref="tns:GeneralFormat" />
+          <xs:element name="data" type="fn:string" dfdl:lengthKind="delimited" />
+        </tdml:defineSchema>
+        <tdml:parserTestCase name="test1" root="data" model="mySchema">
+          <tdml:document>
+            <tdml:documentPart type="text"><![CDATA[abcdef]]></tdml:documentPart>
+          </tdml:document>
+          <tdml:errors>
+            <tdml:error>   cannot resolve   </tdml:error>
+            <tdml:error>  fn:string </tdml:error>
+          </tdml:errors>
+        </tdml:parserTestCase>
+      </tdml:testSuite>
+
+    val runner = Runner(testSuite, validateTDMLFile = false)
+    runner.runOneTest("test1")
+    runner.reset
+  }
+
 }


### PR DESCRIPTION
- so all errors, validation errors and warning messages are stripped of leading and trailing whitespace
- currently the above are sensitive to pretty printing of the TDML, this commit aims to fix that

DAFFODIL-2955