### PR TITLE
Reorder DFDL statement processing to match spec

### DIFF
--- a/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/DFDLStatementMixin.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/DFDLStatementMixin.scala
@@ -216,7 +216,8 @@ trait ProvidesDFDLStatementMixin extends ThrowsSDE with HasTermCheck {
 
   final lazy val patternStatements: Seq[DFDLStatement] = patternAsserts ++ patternDiscrims
 
-  final lazy val nonPatternStatements: Seq[DFDLStatement] = nonPatternAsserts ++ nonPatternDiscrims
+  final lazy val nonPatternStatements: Seq[DFDLStatement] =
+    nonPatternAsserts ++ nonPatternDiscrims
 
   final protected lazy val localStatements = this.annotationObjs.collect {
     case st: DFDLStatement => st

--- a/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/DFDLStatementMixin.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/DFDLStatementMixin.scala
@@ -216,8 +216,7 @@ trait ProvidesDFDLStatementMixin extends ThrowsSDE with HasTermCheck {
 
   final lazy val patternStatements: Seq[DFDLStatement] = patternAsserts ++ patternDiscrims
 
-  final lazy val lowPriorityStatements: Seq[DFDLStatement] =
-    setVariableStatements ++ nonPatternAsserts ++ nonPatternDiscrims
+  final lazy val nonPatternStatements: Seq[DFDLStatement] = nonPatternAsserts ++ nonPatternDiscrims
 
   final protected lazy val localStatements = this.annotationObjs.collect {
     case st: DFDLStatement => st

--- a/daffodil-core/src/main/scala/org/apache/daffodil/core/grammar/HasStatementsGrammarMixin.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/core/grammar/HasStatementsGrammarMixin.scala
@@ -23,11 +23,18 @@ trait HasStatementsGrammarMixin extends GrammarMixin { self: Term =>
 
   // Includes setVariable as well as assert/discriminator statements that
   // are not testKind="pattern"
-  private lazy val lowPriorityStatementGrams = lowPriorityStatements.map { _.gram(self) }
+  private lazy val setVariableGrams = setVariableStatements.map { _.gram(self) }
 
-  final lazy val dfdlLowPriorityStatementEvaluations =
-    prod("dfdlStatementEvaluations", lowPriorityStatementGrams.length > 0) {
-      lowPriorityStatementGrams.fold(mt) { _ ~ _ }
+  final lazy val setVariableEvaluations =
+    prod("setVariableEvaluations", setVariableGrams.length > 0) {
+      setVariableGrams.fold(mt) { _ ~ _ }
+    }
+
+  private lazy val nonPatternGrams = nonPatternStatements.map { _.gram(self) }
+
+  final lazy val nonPatternEvaluations =
+    prod("dfdlStatementEvaluations", nonPatternGrams.length > 0) {
+      nonPatternGrams.fold(mt) { _ ~ _ }
     }
 
   // assert/discriminator statements with testKind="pattern"

--- a/daffodil-core/src/main/scala/org/apache/daffodil/core/grammar/ModelGroupGrammarMixin.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/core/grammar/ModelGroupGrammarMixin.scala
@@ -50,8 +50,8 @@ trait ModelGroupGrammarMixin
     // See 9.5 Evaluation Order for Statement Annotations
     dfdlPatternStatementEvaluations ~ // Assert and Discriminator statements with testKind="pattern"
       dfdlScopeBegin ~ // newVariableInstance
-      dfdlLowPriorityStatementEvaluations ~ // setVariable and the rest of the Assert and Discriminator statements
-      groupLeftFraming ~ groupContentWithInitiatorTerminator ~ groupRightFraming ~ dfdlScopeEnd
+      setVariableEvaluations ~
+      groupLeftFraming ~ groupContentWithInitiatorTerminator ~ nonPatternEvaluations ~ groupRightFraming ~ dfdlScopeEnd
   }
 
   private lazy val groupContentWithInitiatorTerminator =

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section07/discriminators/TestDiscriminators.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section07/discriminators/TestDiscriminators.scala
@@ -79,7 +79,7 @@ class TestDiscriminators {
   @Test def test_discrimExpression_03() = { runner.runOneTest("discrimExpression_03") }
 
   // DAFFODIL-1971
-  // @Test def test_discrimExpression_04() = { runner.runOneTest("discrimExpression_04") }
+  @Test def test_discrimExpression_04() = { runner.runOneTest("discrimExpression_04") }
 
   @Test def test_discrimFailStopsFollowingAssert1(): Unit = {
     runner.runOneTest("discrimFailStopsFollowingAssert1")


### PR DESCRIPTION
We had been processing all asserts and discriminators before the group
content, but according to section 9.5.2 of the spec non-pattern asserts
and discriminators should be evaluated after the group content, even if
the group content fails to parse.
    
DFDL-1971