### PR TITLE
Add TDML Exception when there's no Expected Data

### DIFF
--- a/daffodil-tdml-lib/src/main/scala/org/apache/daffodil/tdml/TDMLRunner.scala
+++ b/daffodil-tdml-lib/src/main/scala/org/apache/daffodil/tdml/TDMLRunner.scala
@@ -1597,7 +1597,11 @@ case class UnparserTestCase(ptc: NodeSeq, parentArg: DFDLTestSuite)
           }
         }
       }
-      case _ => Assert.impossibleCase()
+      case _ =>
+        throw TDMLException(
+          "Either tdml:document or tdml:errors must be present in the test.",
+          implString
+        )
     }
 
   }


### PR DESCRIPTION
- note this only gets thrown where there is a warning as well, as UnparserTestCase requires 2 children. So if you just have an infoset and nothing else, you'll get an XSD error.

DAFFODIL-2289