### PR TITLE
Add convenience feature to TDML Runner

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -154,8 +154,14 @@ lazy val sapi = Project("daffodil-sapi", file("daffodil-sapi"))
   .settings(commonSettings)
 
 lazy val tdmlLib = Project("daffodil-tdml-lib", file("daffodil-tdml-lib"))
-  .dependsOn(macroLib % "compile-internal", lib, io, io % "test->test", slf4jLogger % "test")
-  .settings(commonSettings)
+  .dependsOn(
+    macroLib % "compile-internal",
+    lib,
+    io,
+    io % "test->test",
+    slf4jLogger % "test"
+  )
+  .settings(commonSettings, libraryDependencies ++= Dependencies.tdmlTest)
 
 lazy val tdmlProc = Project("daffodil-tdml-processor", file("daffodil-tdml-processor"))
   .dependsOn(tdmlLib, codeGenC, core, slf4jLogger)

--- a/build.sbt
+++ b/build.sbt
@@ -161,7 +161,7 @@ lazy val tdmlLib = Project("daffodil-tdml-lib", file("daffodil-tdml-lib"))
     io % "test->test",
     slf4jLogger % "test"
   )
-  .settings(commonSettings, libraryDependencies ++= Dependencies.tdmlTest)
+  .settings(commonSettings, libraryDependencies ++= Dependencies.tdml)
 
 lazy val tdmlProc = Project("daffodil-tdml-processor", file("daffodil-tdml-processor"))
   .dependsOn(tdmlLib, codeGenC, core, slf4jLogger)

--- a/daffodil-cli/bin.LICENSE
+++ b/daffodil-cli/bin.LICENSE
@@ -672,7 +672,8 @@ is subject to the terms and conditions of the following licenses.
 
 - com.lihaoyi.geny_<VERSION>.jar
 - com.lihaoyi.os-lib_<VERSION>.jar
-  This product bundles 'os-lib' from the above files.
+- com.lihaoyi.sourcecode_<VERSION>.jar
+  This product bundles 'os-lib' and 'sourcecode' by Li Haoyi from the above files.
   These files are available under the MIT license:
 
     License

--- a/daffodil-tdml-lib/src/main/scala/org/apache/daffodil/tdml/RunnerFactory.scala
+++ b/daffodil-tdml-lib/src/main/scala/org/apache/daffodil/tdml/RunnerFactory.scala
@@ -196,6 +196,15 @@ class Runner private (
   def this(elem: scala.xml.Elem) =
     this(Left(elem))
 
+  /**
+   * Uses sourcecode library to capture method name
+   * and use it as the test name.
+   *
+   * @param methodName implicitly computed name of method calling this method.
+   */
+  def doTest(implicit methodName: sourcecode.Enclosing): Unit =
+    runOneTest(methodName.value.split("#").last)
+
   private var ts: DFDLTestSuite = null
 
   // This Runner should only ever have a single DFDLTestSuite associated with

--- a/daffodil-tdml-processor/src/test/scala/org/apache/daffodil/processor/tdml/TestTDMLRunner.scala
+++ b/daffodil-tdml-processor/src/test/scala/org/apache/daffodil/processor/tdml/TestTDMLRunner.scala
@@ -42,6 +42,39 @@ class TestTDMLRunner {
   val tns = example
   // val sub = XMLUtils.DFDL_XMLSCHEMASUBSET_NAMESPACE
 
+  private lazy val verySimpleTestSuite =
+    <testSuite xmlns={tdml}
+               xmlns:tdml={tdml}
+               xmlns:xs={xsd}
+               xmlns:ex="http://example.com"
+               xmlns:dfdl={dfdl}>
+      <defineSchema name="mySchema" useDefaultNamespace="false">
+        <xs:include schemaLocation="/org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+        <dfdl:format ref="ex:GeneralFormat"/>
+        <xs:element name="data" type="xs:int" dfdl:lengthKind="delimited"/>
+      </defineSchema>
+      <parserTestCase name="testImplicitTestName" root="data" model="mySchema" validation="off">
+        <document>37</document>
+        <infoset>
+          <dfdlInfoset>
+            <ex:data>37</ex:data>
+          </dfdlInfoset>
+        </infoset>
+      </parserTestCase>
+    </testSuite>
+
+  /**
+   * Test that we can use the method name as the test name
+   * when invoking the test.
+   *
+   * This is just convenient as it makes for less redundant typing.
+   */
+  @Test def testImplicitTestName(): Unit = {
+    val runner = new Runner(verySimpleTestSuite)
+    runner.doTest // Run the test. This method name is used as the test name.
+    runner.reset
+  }
+
   @Test def test3(): Unit = {
     // This tests when there are parseTestCases in the same suite that use the
     // same DFDL schema but have different validation modes. The non-validation

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -53,8 +53,8 @@ object Dependencies {
   lazy val test = Seq(
     "junit" % "junit" % "4.13.2" % "test",
     "com.github.sbt" % "junit-interface" % "0.13.3" % "test",
-    "org.scalacheck" %% "scalacheck" % "1.18.1" % "test",
-    "com.lihaoyi" %% "sourcecode" % "0.4.2"
+    "com.lihaoyi" %% "sourcecode" % "0.4.2", // NOT a "test" dependency
+    "org.scalacheck" %% "scalacheck" % "1.18.1" % "test"
   )
 
   lazy val schematron = Seq(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -53,7 +53,8 @@ object Dependencies {
   lazy val test = Seq(
     "junit" % "junit" % "4.13.2" % "test",
     "com.github.sbt" % "junit-interface" % "0.13.3" % "test",
-    "org.scalacheck" %% "scalacheck" % "1.18.1" % "test"
+    "org.scalacheck" %% "scalacheck" % "1.18.1" % "test",
+    "com.lihaoyi" %% "sourcecode" % "0.4.2"
   )
 
   lazy val schematron = Seq(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -50,10 +50,13 @@ object Dependencies {
     "net.sf.expectit" % "expectit-core" % "0.9.0" % "test"
   )
 
+  lazy val tdmlTest = Seq(
+    "com.lihaoyi" %% "sourcecode" % "0.4.2" // NOT a "test" dependency
+  )
+
   lazy val test = Seq(
     "junit" % "junit" % "4.13.2" % "test",
     "com.github.sbt" % "junit-interface" % "0.13.3" % "test",
-    "com.lihaoyi" %% "sourcecode" % "0.4.2", // NOT a "test" dependency
     "org.scalacheck" %% "scalacheck" % "1.18.1" % "test"
   )
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -50,7 +50,7 @@ object Dependencies {
     "net.sf.expectit" % "expectit-core" % "0.9.0" % "test"
   )
 
-  lazy val tdmlTest = Seq(
+  lazy val tdml = Seq(
     "com.lihaoyi" %% "sourcecode" % "0.4.2" // NOT a "test" dependency
   )
 


### PR DESCRIPTION
This lets you use the name of the test method implicitly as the name of the TDML test it will run.

For example

    @Test def testCaseName(): Unit = runner.doTest

That's all you need to run a parser or unparser test case named "testCaseName".

DAFFODIL-2958