### PR TITLE
Enforce HiddenGroupRef not being model group of Complex Type

### DIFF
--- a/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/ComplexTypes.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/ComplexTypes.scala
@@ -51,6 +51,15 @@ sealed abstract class ComplexTypeBase(xmlArg: Node, parentArg: SchemaComponent)
       s.length == 1,
       "A complex type must have exactly one model-group element child which is a sequence, choice, or group reference."
     )
+    s.head match {
+      case sgtb: SequenceGroupTermBase =>
+        sgtb.schemaDefinitionWhen(
+          sgtb.isHidden,
+          "A complex type cannot have a sequence with a hiddenGroupRef as its model group. " +
+            "Wrap the hiddenGroupRef sequence in an empty sequence instead."
+        )
+      case _ => // do nothing
+    }
     s
   }
 

--- a/daffodil-core/src/test/scala/org/apache/daffodil/core/dsom/TestRefMap.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/core/dsom/TestRefMap.scala
@@ -163,7 +163,9 @@ class TestRefMap {
         </xs:group>
           <xs:element name="r1" type="ex:ct1"/>
         <xs:complexType name="ct1">
-          <xs:sequence dfdl:hiddenGroupRef="ex:g1"/>
+          <xs:sequence>
+            <xs:sequence dfdl:hiddenGroupRef="ex:g1"/>
+          </xs:sequence>
         </xs:complexType>
         <xs:group name="g1">
           <xs:choice>
@@ -176,7 +178,7 @@ class TestRefMap {
     val sset = compiler.compileNode(testSchema).sset
     val root = sset.root
     val comps = root.allComponents
-    assertEquals(14, comps.length)
+    assertEquals(15, comps.length)
     val refMap = root.refMap
     val numEntries = refMap.size
     assertEquals(6, numEntries)
@@ -189,8 +191,8 @@ class TestRefMap {
     val gref = rootDecl.complexType.modelGroup.asInstanceOf[ChoiceGroupRef]
     val Seq((grefSSCD, gdRefSpecs)) = refMap.get(gref.groupDef).get
     assertEquals(gref.shortSchemaComponentDesignator, grefSSCD)
-    assertEquals(14, root.numComponents)
-    assertEquals(14, root.numUniqueComponents)
+    assertEquals(15, root.numComponents)
+    assertEquals(15, root.numUniqueComponents)
   }
 
   @Test def testRefMapNonExplosion1(): Unit = {

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section14/sequence_groups/HiddenSequences.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section14/sequence_groups/HiddenSequences.tdml
@@ -282,4 +282,32 @@
     </tdml:errors>
   </tdml:unparserTestCase>
 
+  <tdml:defineSchema name="ComplexTypeWithHiddenGroupRefSequence">
+    <xs:include
+        schemaLocation="/org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd" />
+    <dfdl:format ref="ex:GeneralFormat" lengthKind="delimited" />
+
+    <xs:group name="s4">
+      <xs:sequence>
+        <xs:element name="f" type="xs:int" dfdl:outputValueCalc="{6}"/>
+      </xs:sequence>
+    </xs:group>
+    <xs:element name="e1">
+      <xs:complexType>
+        <xs:sequence dfdl:hiddenGroupRef="ex:s4"/>
+      </xs:complexType>
+    </xs:element>
+  </tdml:defineSchema>
+
+  <tdml:parserTestCase name="ComplexTypeWithHiddenGroupRefSequence1" root="e1"
+      model="ComplexTypeWithHiddenGroupRefSequence">
+    <tdml:document>7</tdml:document>
+    <tdml:errors>
+      <tdml:error>Schema Definition Error</tdml:error>
+      <tdml:error>complex type cannot have</tdml:error>
+      <tdml:error>sequence with a hiddenGroupRef</tdml:error>
+      <tdml:error>model group</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
 </tdml:testSuite>
+

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section14/sequence_groups/SequencesWithHiddenRefs.dfdl.xsd
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section14/sequence_groups/SequencesWithHiddenRefs.dfdl.xsd
@@ -82,7 +82,9 @@
           <xs:sequence>
             <xs:element name="h">
               <xs:complexType>
-                <xs:sequence dfdl:hiddenGroupRef="ex:s1" />
+                <xs:sequence>
+                  <xs:sequence dfdl:hiddenGroupRef="ex:s1" />
+                </xs:sequence>
               </xs:complexType>
             </xs:element>
           </xs:sequence>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section15/choice_groups/ChoicesInHiddenContexts.dfdl.xsd
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section15/choice_groups/ChoicesInHiddenContexts.dfdl.xsd
@@ -106,7 +106,9 @@
               dfdl:outputValueCalc="{ 1 }" />
             <xs:element name="h">
               <xs:complexType>
-                <xs:sequence dfdl:hiddenGroupRef="ex:c1" />
+                <xs:sequence>
+                  <xs:sequence dfdl:hiddenGroupRef="ex:c1" />
+                </xs:sequence>
               </xs:complexType>
             </xs:element>
           </xs:choice>
@@ -119,7 +121,9 @@
               dfdl:outputValueCalc="{ 'hello' }" />
             <xs:element name="h">
               <xs:complexType>
-                <xs:sequence dfdl:hiddenGroupRef="ex:c1" />
+                <xs:sequence>
+                  <xs:sequence dfdl:hiddenGroupRef="ex:c1" />
+                </xs:sequence>
               </xs:complexType>
             </xs:element>
           </xs:choice>
@@ -160,7 +164,9 @@
             <xs:sequence>
               <xs:element name="g">
                 <xs:complexType>
-                  <xs:sequence dfdl:hiddenGroupRef="ex:c3" />
+                  <xs:sequence>
+                    <xs:sequence dfdl:hiddenGroupRef="ex:c3" />
+                  </xs:sequence>
                 </xs:complexType>
               </xs:element>
             </xs:sequence>
@@ -178,7 +184,9 @@
             <xs:sequence>
               <xs:element name="g">
                 <xs:complexType>
-                  <xs:sequence dfdl:hiddenGroupRef="ex:c1" />
+                  <xs:sequence>
+                    <xs:sequence dfdl:hiddenGroupRef="ex:c1" />
+                  </xs:sequence>
                 </xs:complexType>
               </xs:element>
             </xs:sequence>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section23/dfdl_functions/Functions.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section23/dfdl_functions/Functions.tdml
@@ -4919,7 +4919,9 @@
                   <xs:element name="name" type="xs:string" dfdl:lengthKind="delimited"/>
                   <xs:element name="data">
                     <xs:complexType>
-                      <xs:sequence dfdl:hiddenGroupRef="ex:hiddenData"/>
+                      <xs:sequence>
+                        <xs:sequence dfdl:hiddenGroupRef="ex:hiddenData"/>
+                      </xs:sequence>
                     </xs:complexType>
                   </xs:element>
                 </xs:sequence>

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section14/sequence_groups/TestHiddenSequences.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section14/sequence_groups/TestHiddenSequences.scala
@@ -78,4 +78,8 @@ class TestHiddenSequences {
   @Test def test_invalidGroupDefWithHiddenSequenceModelGroup(): Unit = {
     runnerNoValidate.runOneTest("invalidGroupDefWithHiddenSequenceModelGroup")
   }
+
+  @Test def test_ComplexTypeWithHiddenGroupRefSequence1(): Unit = {
+    runnerNoValidate.runOneTest("ComplexTypeWithHiddenGroupRefSequence1")
+  }
 }


### PR DESCRIPTION
- currently we don't check if a hiddenGroupRef is the model group of a complexType, which allows schemas to have them. This check will ensure schemas can't have hiddenGroupRefs as their model group, and instead suggest wrapping the HGR in an empty sequence
- add test to show SDE
- update tests with HiddenGroupRef as model group of ComplexType

DAFFODIL-2419