### PR TITLE
Daf 2959 cleanup

### DIFF
--- a/daffodil-core/src/main/scala/org/apache/daffodil/core/dpath/Conversions.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/core/dpath/Conversions.scala
@@ -280,12 +280,11 @@ object Conversion {
       //      case (AnyAtomic, Date) => AnyAtomicToString +: conversionOps(String, tt, context)
       //      case (AnyAtomic, DateTime) => AnyAtomicToString +: conversionOps(String, tt, context)
 
-      // TODO: Is this a valid solution for DFDL-1074 and the like?
-      // Essentially, all of the 'types' should fall under AnyAtomic and there
-      // is no need to conver to an AnyAtomic.  So anything converted to AnyAtomic
+      // All of the 'types' should fall under AnyAtomic and there
+      // is no need to convert to an AnyAtomic.  So anything converted to AnyAtomic
       // should be itself.
       //
-      case (_, AnyAtomic) => Nil // is this correct?
+      case (_, AnyAtomic) => Nil
 
       case (_, Exists) => Nil
       case (_, other) => {

--- a/daffodil-core/src/main/scala/org/apache/daffodil/core/dpath/Expression.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/core/dpath/Expression.scala
@@ -2836,14 +2836,10 @@ case class XSConverterExpr(
   override def targetTypeForSubexpression(childExpr: Expression): NodeInfo.Kind =
     resultType // NodeInfo.AnyType
 
-  // TODO: this should work... why do we need to call an additional converter. The
-  // args(0).compiledDPath should already have taken into account converting into
-  // their target types which are the same as this conversion's output result type.
-
   override lazy val compiledDPath = {
     checkArgCount(1)
     val arg0Recipe = args(0).compiledDPath
-    val c = conversions
+    val c = conversions // additional final conversions are added
     val res = new CompiledDPath(arg0Recipe.ops.toList ++ c)
     res
   }

--- a/daffodil-core/src/main/scala/org/apache/daffodil/core/util/FuzzData.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/core/util/FuzzData.scala
@@ -22,12 +22,11 @@ import scala.util.Random
 import scala.xml.Elem
 import scala.xml.Node
 
-import org.apache.daffodil.core.util.TestUtils.getAMessage
 import org.apache.daffodil.lib.exceptions.Assert
+import org.apache.daffodil.lib.util.Misc.getAMessage
+import org.apache.daffodil.lib.xml.XMLUtils
 import org.apache.daffodil.lib.xml.XMLUtils.XMLDifferenceException
 import org.apache.daffodil.runtime1.processors.parsers.ParseError
-
-import org.junit.Assert.fail
 
 /**
  * Utility base class to support fuzz testing. Given a piece of data,
@@ -187,7 +186,7 @@ class FuzzParseTester(
         }
       if (pr ne null) {
         try {
-          TestUtils.assertEqualsXMLElements(expected, node)
+          XMLUtils.compareAndReport(expected, node)
         } catch {
           case e: XMLDifferenceException =>
             handleUnexpectedSuccess(node, testData, e)
@@ -230,6 +229,6 @@ class LayerParseTester(
     if (okParses.size > 0)
       println(s"Parse succeeded on fuzzed data ${okParses.size} times.")
     if (shouldFail)
-      fail("errors were found")
+      throw new AssertionError("errors were found")
   }
 }

--- a/daffodil-core/src/test/scala/org/apache/daffodil/core/api/TestAPI.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/core/api/TestAPI.scala
@@ -19,6 +19,7 @@ package org.apache.daffodil.core.api
 
 import org.apache.daffodil.lib.Implicits._
 import org.apache.daffodil.lib.util._
+import org.apache.daffodil.lib.xml.XMLUtils
 
 import org.junit.Test; object INoWarn7 { ImplicitsSuppressUnusedImportWarning() }
 import org.apache.daffodil.core.util.TestUtils
@@ -40,7 +41,7 @@ class TestDFDLParser_New {
     )
     val (_, actual) = TestUtils.testString(sch, "5;6;7;8;.")
     val expected = <e1><s1>5</s1><s1>6</s1><s1>7</s1><s1>8</s1></e1>
-    TestUtils.assertEqualsXMLElements(expected, actual)
+    XMLUtils.compareAndReport(expected, actual)
   }
 
   @Test def testParseOccursCountKindOfParsedDelimitedBySeparatorImplicitWithMaxOccurs2()
@@ -58,6 +59,6 @@ class TestDFDLParser_New {
     )
     val (_, actual) = TestUtils.testString(sch, "5;6;7;8!.")
     val expected = <e1><s1>5</s1><s1>6</s1><s1>7</s1><s1>8</s1></e1>
-    TestUtils.assertEqualsXMLElements(expected, actual)
+    XMLUtils.compareAndReport(expected, actual)
   }
 }

--- a/daffodil-core/src/test/scala/org/apache/daffodil/core/api/TestAPI1.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/core/api/TestAPI1.scala
@@ -19,9 +19,10 @@ package org.apache.daffodil.core.api
 
 import scala.xml._
 
-import org.apache.daffodil.core.util._
+import org.apache.daffodil.core.util.TestUtils
 import org.apache.daffodil.lib.Implicits._
 import org.apache.daffodil.lib.util._
+import org.apache.daffodil.lib.xml.XMLUtils
 
 import org.junit.Assert._
 import org.junit.Test
@@ -36,7 +37,7 @@ class TestDFDLParser {
     )
     val (_, actual) = TestUtils.testString(sch, "5678")
     val expected: Node = <e1>5678</e1>
-    TestUtils.assertEqualsXMLElements(expected, actual)
+    XMLUtils.compareAndReport(expected, actual)
   }
 
   @Test def testParseSequenceOfJustOneScalar(): Unit = {
@@ -53,7 +54,7 @@ class TestDFDLParser {
     )
     val (_, actual) = TestUtils.testString(sch, "5")
     val expected = <e1><s1>5</s1></e1>
-    TestUtils.assertEqualsXMLElements(expected, actual)
+    XMLUtils.compareAndReport(expected, actual)
   }
 
   @Test def testParseSequence1(): Unit = {
@@ -71,7 +72,7 @@ class TestDFDLParser {
     )
     val (_, actual) = TestUtils.testString(sch, "56")
     val expected = <e1><s1>5</s1><s2>6</s2></e1>
-    TestUtils.assertEqualsXMLElements(expected, actual)
+    XMLUtils.compareAndReport(expected, actual)
   }
 
   @Test def testParseSequence2(): Unit = {
@@ -88,7 +89,7 @@ class TestDFDLParser {
     )
     val (_, actual) = TestUtils.testString(sch, "567")
     val expected = <e1><s1>5</s1><s1>6</s1><s1>7</s1></e1>
-    TestUtils.assertEqualsXMLElements(expected, actual)
+    XMLUtils.compareAndReport(expected, actual)
   }
 
   @Test def testParseSequence3(): Unit = {
@@ -105,7 +106,7 @@ class TestDFDLParser {
     )
     val (_, actual) = TestUtils.testString(sch, "5,6,7")
     val expected = <e1><s1>5</s1><s1>6</s1><s1>7</s1></e1>
-    TestUtils.assertEqualsXMLElements(expected, actual)
+    XMLUtils.compareAndReport(expected, actual)
   }
 
   @Test def testInt1(): Unit = {
@@ -122,7 +123,7 @@ class TestDFDLParser {
       </xs:element>
     )
     val (_, actual) = TestUtils.testString(sch, "55,000")
-    TestUtils.assertEqualsXMLElements(<e1><s1>5</s1><s2>5000</s2></e1>, actual)
+    XMLUtils.compareAndReport(<e1><s1>5</s1><s2>5000</s2></e1>, actual)
   }
 
   @Test def testInt2(): Unit = {
@@ -158,7 +159,7 @@ class TestDFDLParser {
       </xs:element>
     )
     val (_, actual) = TestUtils.testString(sch, "55,000")
-    TestUtils.assertEqualsXMLElements(<e1><s1>5</s1><s2>5000</s2></e1>, actual)
+    XMLUtils.compareAndReport(<e1><s1>5</s1><s2>5000</s2></e1>, actual)
   }
 
   @Test def testShort2(): Unit = {
@@ -193,7 +194,7 @@ class TestDFDLParser {
       </xs:element>
     )
     val (_, actual) = TestUtils.testString(sch, "55123")
-    TestUtils.assertEqualsXMLElements(<e1><s1>55</s1><s2>123</s2></e1>, actual)
+    XMLUtils.compareAndReport(<e1><s1>55</s1><s2>123</s2></e1>, actual)
   }
 
   @Test def testNumber1(): Unit = {
@@ -212,7 +213,7 @@ class TestDFDLParser {
       </xs:element>
     )
     val (_, actual) = TestUtils.testString(sch, "1-800-555-1212")
-    TestUtils.assertEqualsXMLElements(
+    XMLUtils.compareAndReport(
       <e1><country>1</country><area>-800</area><region>-555</region><number>-1212</number></e1>,
       actual
     )
@@ -225,7 +226,7 @@ class TestDFDLParser {
       <xs:element name="mersenne" type="xs:byte" dfdl:lengthKind="explicit" dfdl:length="{ 4 }"/>
     )
     val (_, actual) = TestUtils.testString(sch, "-127")
-    TestUtils.assertEqualsXMLElements(<mersenne>-127</mersenne>, actual)
+    XMLUtils.compareAndReport(<mersenne>-127</mersenne>, actual)
   }
 
   @Test def testNumber3(): Unit = {
@@ -235,7 +236,7 @@ class TestDFDLParser {
       <xs:element name="perfect" type="xs:byte" dfdl:textNumberPattern="+0" dfdl:lengthKind="explicit" dfdl:length="{ 2 }"/>
     )
     val (_, actual) = TestUtils.testString(sch, "+3")
-    TestUtils.assertEqualsXMLElements(<perfect>3</perfect>, actual)
+    XMLUtils.compareAndReport(<perfect>3</perfect>, actual)
   }
 
   @Test def testUnsignedLong1(): Unit = {
@@ -319,7 +320,7 @@ class TestDFDLParser {
     )
     val (_, actual) = TestUtils.testString(sch, "[[{{((55)),,((66)),,((77))}}]]")
     val expected = <e1><s1>55</s1><s1>66</s1><s1>77</s1></e1>
-    TestUtils.assertEqualsXMLElements(expected, actual)
+    XMLUtils.compareAndReport(expected, actual)
   }
 
   @Test def testParseSequenceInt3Operands(): Unit = {
@@ -336,7 +337,7 @@ class TestDFDLParser {
     )
     val (_, actual) = TestUtils.testString(sch, "[[{{((55)),,((66)),,((77))}}]]")
     val expected = <e1><s1>55</s1><s1>66</s1><s1>77</s1></e1>
-    TestUtils.assertEqualsXMLElements(expected, actual)
+    XMLUtils.compareAndReport(expected, actual)
   }
 
   @Test def testBadInt(): Unit = {
@@ -366,7 +367,7 @@ class TestDFDLParser {
     )
     val (_, actual) = TestUtils.testString(sch, "5678A")
     val expected = <e1><s1>5</s1><s1>6</s1><s1>7</s1><s1>8</s1><s2>A</s2></e1>
-    TestUtils.assertEqualsXMLElements(expected, actual)
+    XMLUtils.compareAndReport(expected, actual)
   }
 
   @Test def testParseOccursCountKindOfParsedWithTerminator(): Unit = {
@@ -384,7 +385,7 @@ class TestDFDLParser {
     )
     val (_, actual) = TestUtils.testString(sch, "5;6;7;8;A")
     val expected = <e1><s1>5</s1><s1>6</s1><s1>7</s1><s1>8</s1><s2>A</s2></e1>
-    TestUtils.assertEqualsXMLElements(expected, actual)
+    XMLUtils.compareAndReport(expected, actual)
   }
 
   @Test def testParseOccursCountKindOfParsedDelimitedByTerminator(): Unit = {
@@ -403,7 +404,7 @@ class TestDFDLParser {
     val areTracing = false
     val (_, actual) = TestUtils.testString(sch, "5;6;7;8;A.", areTracing)
     val expected = <e1><s1>5</s1><s1>6</s1><s1>7</s1><s1>8</s1><s2>A</s2></e1>
-    TestUtils.assertEqualsXMLElements(expected, actual)
+    XMLUtils.compareAndReport(expected, actual)
   }
 
   @Test def testParseOccursCountKindOfParsedDelimitedByTerminator2(): Unit = {
@@ -421,7 +422,7 @@ class TestDFDLParser {
     val areTracing = false
     val (_, actual) = TestUtils.testString(sch, "5;6;7;8;.", areTracing)
     val expected = <e1><s1>5</s1><s1>6</s1><s1>7</s1><s1>8</s1></e1>
-    TestUtils.assertEqualsXMLElements(expected, actual)
+    XMLUtils.compareAndReport(expected, actual)
   }
 
   @Test def testParseOccursCountKindOfParsedDelimitedBySeparator(): Unit = {
@@ -440,7 +441,7 @@ class TestDFDLParser {
     val (_, actual) = TestUtils.testString(sch, "5;6;7;8;.", areTracing)
     val expected = <e1><s1>5</s1><s1>6</s1><s1>7</s1><s1>8</s1></e1>
 
-    TestUtils.assertEqualsXMLElements(expected, actual)
+    XMLUtils.compareAndReport(expected, actual)
   }
 
   @Test def testParseOccursCountKindOfParsedDelimitedBySeparator3(): Unit = {
@@ -459,7 +460,7 @@ class TestDFDLParser {
     val (_, actual) = TestUtils.testString(sch, "5;6;7;8!.", areTracing)
     val expected = <e1><s1>5</s1><s1>6</s1><s1>7</s1><s1>8</s1></e1>
 
-    TestUtils.assertEqualsXMLElements(expected, actual)
+    XMLUtils.compareAndReport(expected, actual)
   }
 
   @Test def testBinaryIntMinusOne(): Unit = {
@@ -476,7 +477,7 @@ class TestDFDLParser {
     )
     val (_, actual) = TestUtils.testBinary(sch, "FFFFFFFF")
     val expected = <e1><s1>-1</s1></e1>
-    TestUtils.assertEqualsXMLElements(expected, actual)
+    XMLUtils.compareAndReport(expected, actual)
   }
 
   @Test def testBinaryInts(): Unit = {
@@ -496,7 +497,7 @@ class TestDFDLParser {
     val (_, actual) =
       TestUtils.testBinary(sch, "000000013bFFFFFFFF3b080402013b000000003bFFFFFF7F", areTracing)
     val expected = <e1><s1>1</s1><s1>-1</s1><s1>134480385</s1><s1>0</s1><s2>2147483647</s2></e1>
-    TestUtils.assertEqualsXMLElements(expected, actual)
+    XMLUtils.compareAndReport(expected, actual)
   }
 
   @Test def testBinaryDoubleOne(): Unit = {
@@ -507,7 +508,7 @@ class TestDFDLParser {
     )
     val (_, actual) = TestUtils.testBinary(sch, "3FF0000000000000")
     val expected = <e1>1.0</e1>
-    TestUtils.assertEqualsXMLElements(expected, actual)
+    XMLUtils.compareAndReport(expected, actual)
   }
 
   @Test def testBinaryDoubleMinusOne(): Unit = {
@@ -518,7 +519,7 @@ class TestDFDLParser {
     )
     val (_, actual) = TestUtils.testBinary(sch, "BFF0000000000000")
     val expected = <e1>-1.0</e1>
-    TestUtils.assertEqualsXMLElements(expected, actual)
+    XMLUtils.compareAndReport(expected, actual)
   }
 
   @Test def testBinaryDoubleLSB(): Unit = {
@@ -529,7 +530,7 @@ class TestDFDLParser {
     )
     val (_, actual) = TestUtils.testBinary(sch, "0000000000000001")
     val expected = <e1>4.9E-324</e1>
-    TestUtils.assertEqualsXMLElements(expected, actual)
+    XMLUtils.compareAndReport(expected, actual)
   }
 
   @Test def testBinaryDoubles(): Unit = {
@@ -551,7 +552,7 @@ class TestDFDLParser {
     )
     val expected =
       <e1><s1>1.0</s1><s1>-1.0</s1><s1>4.7340609871421765E-270</s1><s1>0.0</s1><s2>NaN</s2></e1>
-    TestUtils.assertEqualsXMLElements(expected, actual)
+    XMLUtils.compareAndReport(expected, actual)
   }
 
   @Test def testTextDoubles(): Unit = {
@@ -571,7 +572,7 @@ class TestDFDLParser {
     val (_, actual) = TestUtils.testString(sch, "01.0;-1.0;4.15;0.31;8.6E-2001,234.9")
     val expected =
       <e1><s1>1.0</s1><s1>-1.0</s1><s1>4.15</s1><s1>0.31</s1><s2>8.6E-200</s2><s3>1234.9</s3></e1>
-    TestUtils.assertEqualsXMLElements(expected, actual)
+    XMLUtils.compareAndReport(expected, actual)
   }
 
   @Test def testBinaryFloats(): Unit = {
@@ -591,7 +592,7 @@ class TestDFDLParser {
       TestUtils.testBinary(sch, "3F8000003bBF8000003b080402013b000000003b0000C07F")
     val expected =
       <e1><s1>1.0</s1><s1>-1.0</s1><s1>3.972466E-34</s1><s1>0.0</s1><s2>NaN</s2></e1>
-    TestUtils.assertEqualsXMLElements(expected, actual)
+    XMLUtils.compareAndReport(expected, actual)
   }
 
   @Test def testTextFloats(): Unit = {
@@ -612,7 +613,7 @@ class TestDFDLParser {
     val (_, actual) = TestUtils.testString(sch, "01.0;-1.0;4.15;0.31;-7.1E81,234.9", areTracing)
     val expected =
       <e1><s1>1.0</s1><s1>-1.0</s1><s1>4.15</s1><s1>0.31</s1><s2>-7.1E8</s2><s3>1234.9</s3></e1>
-    TestUtils.assertEqualsXMLElements(expected, actual)
+    XMLUtils.compareAndReport(expected, actual)
   }
 
 }

--- a/daffodil-core/src/test/scala/org/apache/daffodil/core/dsom/TestAppinfoSyntax.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/core/dsom/TestAppinfoSyntax.scala
@@ -68,7 +68,7 @@ class TestAppinfoSyntax {
     assertEquals(expected, ns.toString())
     val (_, actual) = TestUtils.testString(sc, "5")
     val expectedParseInfoset = <root>5</root>
-    TestUtils.assertEqualsXMLElements(expectedParseInfoset, actual)
+    XMLUtils.compareAndReport(expectedParseInfoset, actual)
   }
 
   /**
@@ -198,7 +198,7 @@ class TestAppinfoSyntax {
     assertEquals(expected, anna.toString())
     val (_, actual) = TestUtils.testString(sc, "5")
     val expectedParseInfoset = <root>5</root>
-    TestUtils.assertEqualsXMLElements(expectedParseInfoset, actual)
+    XMLUtils.compareAndReport(expectedParseInfoset, actual)
   }
 
   /**
@@ -248,7 +248,7 @@ class TestAppinfoSyntax {
     assertEquals(expected, anna.toString())
     val (_, actual) = TestUtils.testString(sc, "5")
     val expectedParseInfoset = <root>5</root>
-    TestUtils.assertEqualsXMLElements(expectedParseInfoset, actual)
+    XMLUtils.compareAndReport(expectedParseInfoset, actual)
   }
 
 }

--- a/daffodil-core/src/test/scala/org/apache/daffodil/core/dsom/TestDsomCompiler.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/core/dsom/TestDsomCompiler.scala
@@ -22,7 +22,7 @@ import scala.xml.Node
 import scala.xml.Utility
 import scala.xml.XML
 
-import org.apache.daffodil.core.util._
+import org.apache.daffodil.core.util.TestUtils
 import org.apache.daffodil.lib.Implicits._
 
 import org.junit.Assert._

--- a/daffodil-core/src/test/scala/org/apache/daffodil/core/dsom/TestDsomCompilerUnparse1.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/core/dsom/TestDsomCompilerUnparse1.scala
@@ -16,8 +16,7 @@
  */
 
 package org.apache.daffodil.core.dsom
-
-import org.apache.daffodil.core.util._
+import org.apache.daffodil.core.util.TestUtils
 import org.apache.daffodil.lib.Implicits._
 import org.apache.daffodil.lib.util._
 import org.apache.daffodil.lib.xml.XMLUtils

--- a/daffodil-core/src/test/scala/org/apache/daffodil/core/dsom/TestInputValueCalc.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/core/dsom/TestInputValueCalc.scala
@@ -19,8 +19,9 @@ package org.apache.daffodil.core.dsom
 
 import scala.xml.Node
 
-import org.apache.daffodil.core.util._
+import org.apache.daffodil.core.util.TestUtils
 import org.apache.daffodil.lib.util._
+import org.apache.daffodil.lib.xml.XMLUtils
 
 import org.junit.Test
 
@@ -35,7 +36,7 @@ class TestInputValueCalc {
     )
     val (_, actual) = TestUtils.testString(testSchema, "")
     val expected: Node = <data>42</data>
-    TestUtils.assertEqualsXMLElements(expected, actual)
+    XMLUtils.compareAndReport(expected, actual)
   }
 
   // @Test
@@ -55,7 +56,7 @@ class TestInputValueCalc {
 
     val (_, actual) = TestUtils.testString(testSchema, "A")
     val expected: Node = <data><e1>A</e1><e2>A</e2></data>
-    TestUtils.assertEqualsXMLElements(expected, actual)
+    XMLUtils.compareAndReport(expected, actual)
   }
 
   // @Test
@@ -75,6 +76,6 @@ class TestInputValueCalc {
 
     val (_, actual) = TestUtils.testString(testSchema, "8")
     val expected: Node = <data><e1>8</e1><e2>8</e2></data>
-    TestUtils.assertEqualsXMLElements(expected, actual)
+    XMLUtils.compareAndReport(expected, actual)
   }
 }

--- a/daffodil-core/src/test/scala/org/apache/daffodil/core/dsom/TestInteriorAlignmentElimination.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/core/dsom/TestInteriorAlignmentElimination.scala
@@ -16,8 +16,7 @@
  */
 
 package org.apache.daffodil.core.dsom
-
-import org.apache.daffodil.core.util._
+import org.apache.daffodil.core.util.TestUtils
 import org.apache.daffodil.lib.util._
 import org.apache.daffodil.lib.xml.XMLUtils
 
@@ -106,7 +105,7 @@ class TestInteriorAlignmentElimination {
         <int1>4</int1>
         <ex:e2><ex:eShared><int1>5</int1><aligned>7</aligned></ex:eShared></ex:e2>
       </ex:r>
-    TestUtils.assertEqualsXMLElements(expected, actual)
+    XMLUtils.compareAndReport(expected, actual)
   }
 
 }

--- a/daffodil-core/src/test/scala/org/apache/daffodil/core/dsom/TestMiddleEndAttributes2.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/core/dsom/TestMiddleEndAttributes2.scala
@@ -19,6 +19,7 @@ package org.apache.daffodil.core.dsom
 
 import org.apache.daffodil.core.util.TestUtils
 import org.apache.daffodil.lib.util.SchemaUtils
+import org.apache.daffodil.lib.xml.XMLUtils
 
 import org.junit.Test
 
@@ -52,7 +53,7 @@ class TestMiddleEndAttributes2 {
     t1.asInstanceOf[LocalSequence]
     val (_, actual) = TestUtils.testString(testSchema, "/5")
     val expected = <e1><x>5</x></e1>
-    TestUtils.assertEqualsXMLElements(expected, actual)
+    XMLUtils.compareAndReport(expected, actual)
   }
 
 }

--- a/daffodil-core/src/test/scala/org/apache/daffodil/core/dsom/TestPolymorphicUpwardRelativeExpressions.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/core/dsom/TestPolymorphicUpwardRelativeExpressions.scala
@@ -16,8 +16,7 @@
  */
 
 package org.apache.daffodil.core.dsom
-
-import org.apache.daffodil.core.util._
+import org.apache.daffodil.core.util.TestUtils
 import org.apache.daffodil.lib.Implicits._
 import org.apache.daffodil.lib.util._
 import org.apache.daffodil.lib.xml.XMLUtils
@@ -264,6 +263,6 @@ class TestPolymorphicUpwardRelativeExpressions {
           </ex:eShared>
         </ex:e2>
       </ex:r>
-    TestUtils.assertEqualsXMLElements(expected, actual)
+    XMLUtils.compareAndReport(expected, actual)
   }
 }

--- a/daffodil-core/src/test/scala/org/apache/daffodil/core/dsom/TestPropertyScoping.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/core/dsom/TestPropertyScoping.scala
@@ -20,7 +20,6 @@ package org.apache.daffodil.core.dsom
 import scala.xml.Node
 
 import org.apache.daffodil.core.util.Fakes
-import org.apache.daffodil.core.util._
 
 import org.junit.Assert._
 import org.junit.Test

--- a/daffodil-core/src/test/scala/org/apache/daffodil/core/dsom/TestSimpleTypeUnions.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/core/dsom/TestSimpleTypeUnions.scala
@@ -16,8 +16,7 @@
  */
 
 package org.apache.daffodil.core.dsom
-
-import org.apache.daffodil.core.util._
+import org.apache.daffodil.core.util.TestUtils
 import org.apache.daffodil.lib.util._
 import org.apache.daffodil.lib.xml.XMLUtils
 import org.apache.daffodil.runtime1.dpath.NodeInfo._
@@ -110,7 +109,7 @@ class TestSimpleTypeUnions {
     assertEquals("int1Type", umstrd.diagnosticDebugName)
     assertTrue(i.valid.get)
     val expected = <e1>1</e1>
-    TestUtils.assertEqualsXMLElements(expected, actual)
+    XMLUtils.compareAndReport(expected, actual)
   }
 
   @Test def testUnionSecondUnionMemberOk(): Unit = {
@@ -125,7 +124,7 @@ class TestSimpleTypeUnions {
     assertEquals("int2Type", umstrd.diagnosticDebugName)
     assertTrue(i.valid.get)
     val expected = <e1>2</e1>
-    TestUtils.assertEqualsXMLElements(expected, actual)
+    XMLUtils.compareAndReport(expected, actual)
   }
 
   @Test def testUnionNoUnionMemberOK(): Unit = {
@@ -263,7 +262,7 @@ class TestSimpleTypeUnions {
     assertEquals("int12Type", umstrd.diagnosticDebugName)
     assertTrue(i.valid.get)
     val expected = <e1>1</e1>
-    TestUtils.assertEqualsXMLElements(expected, actual)
+    XMLUtils.compareAndReport(expected, actual)
   }
 
   @Test def testUnionNot3_02(): Unit = {
@@ -278,7 +277,7 @@ class TestSimpleTypeUnions {
     assertEquals("int12Type", umstrd.diagnosticDebugName)
     assertTrue(i.valid.get)
     val expected = <e1>2</e1>
-    TestUtils.assertEqualsXMLElements(expected, actual)
+    XMLUtils.compareAndReport(expected, actual)
   }
 
   @Test def testUnionNot3_03(): Unit = {
@@ -296,7 +295,7 @@ class TestSimpleTypeUnions {
     ) // anonymous simple type gets this name from base.
     assertTrue(i.valid.get)
     val expected = <e1>-1</e1>
-    TestUtils.assertEqualsXMLElements(expected, actual)
+    XMLUtils.compareAndReport(expected, actual)
   }
 
   val testSchema3 = SchemaUtils.dfdlTestSchema(
@@ -358,7 +357,7 @@ class TestSimpleTypeUnions {
     assertEquals("ex:foo3or4bar", umstrd.diagnosticDebugName)
     assertTrue(i.valid.get)
     val expected = <e1>foo3bar</e1>
-    TestUtils.assertEqualsXMLElements(expected, actual)
+    XMLUtils.compareAndReport(expected, actual)
   }
 
   @Test def testRestrictionOnUnion_02(): Unit = {
@@ -373,7 +372,7 @@ class TestSimpleTypeUnions {
     assertEquals("foo1or2bar", umstrd.diagnosticDebugName)
     assertTrue(i.valid.get)
     val expected = <e1>foo1bar</e1>
-    TestUtils.assertEqualsXMLElements(expected, actual)
+    XMLUtils.compareAndReport(expected, actual)
   }
 
   @Test def testRestrictionOnUnion_03(): Unit = {
@@ -388,7 +387,7 @@ class TestSimpleTypeUnions {
     assertEquals("foo1or2bar", umstrd.diagnosticDebugName)
     assertTrue(i.valid.get)
     val expected = <e1>foo2bar</e1>
-    TestUtils.assertEqualsXMLElements(expected, actual)
+    XMLUtils.compareAndReport(expected, actual)
   }
 
   @Test def testRestrictionOnUnionFail_01(): Unit = {

--- a/daffodil-core/src/test/scala/org/apache/daffodil/core/general/TestPrimitives.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/core/general/TestPrimitives.scala
@@ -21,6 +21,7 @@ import scala.xml._
 
 import org.apache.daffodil.core.util.TestUtils
 import org.apache.daffodil.lib.Implicits._
+import org.apache.daffodil.lib.xml.XMLUtils
 
 import org.junit.Test; object INoWarn9 { ImplicitsSuppressUnusedImportWarning() }
 import org.apache.daffodil.lib.util.SchemaUtils
@@ -37,7 +38,7 @@ class TestPrimitives {
     val areTracing = false
     val (_, actual) = TestUtils.testString(sch, "abcdefgh", areTracing)
     val expected: Node = <e1>efgh</e1>
-    TestUtils.assertEqualsXMLElements(expected, actual)
+    XMLUtils.compareAndReport(expected, actual)
   }
 
   @Test def testTerminator(): Unit = {
@@ -50,7 +51,7 @@ class TestPrimitives {
     val areTracing = false
     val (_, actual) = TestUtils.testString(sch, "abcdefgh", areTracing)
     val expected: Node = <e1>abcd</e1>
-    TestUtils.assertEqualsXMLElements(expected, actual)
+    XMLUtils.compareAndReport(expected, actual)
   }
 
   @Test def testSeparator(): Unit = {
@@ -69,7 +70,7 @@ class TestPrimitives {
     val areTracing = false
     val (_, actual) = TestUtils.testString(sch, "abcd,efgh", areTracing)
     val expected: Node = <e1><s1>abcd</s1><s2>efgh</s2></e1>
-    TestUtils.assertEqualsXMLElements(expected, actual)
+    XMLUtils.compareAndReport(expected, actual)
   }
 
   @Test def testLengthKindDelimited(): Unit = {
@@ -88,7 +89,7 @@ class TestPrimitives {
     val areTracing = false
     val (_, actual) = TestUtils.testString(sch, "abcd,efgh", areTracing)
     val expected: Node = <e1><s1>abcd</s1><s2>efgh</s2></e1>
-    TestUtils.assertEqualsXMLElements(expected, actual)
+    XMLUtils.compareAndReport(expected, actual)
   }
 
   @Test def testLengthKindDelimited2(): Unit = {
@@ -106,7 +107,7 @@ class TestPrimitives {
     )
     val (_, actual) = TestUtils.testString(sch, "abcd  \\\n  efgh")
     val expected: Node = <e1><s1>abcd</s1><s2>efgh</s2></e1>
-    TestUtils.assertEqualsXMLElements(expected, actual)
+    XMLUtils.compareAndReport(expected, actual)
   }
 
   @Test def testLengthKindDelimited3(): Unit = {
@@ -132,7 +133,7 @@ class TestPrimitives {
     val areTracing = false
     val (_, actual) = TestUtils.testString(sch, "abcd}efgh}}}ijkl", areTracing)
     val expected: Node = <e1><s1><ss1>abcd</ss1><ss2>efgh</ss2></s1><s2>ijkl</s2></e1>
-    TestUtils.assertEqualsXMLElements(expected, actual)
+    XMLUtils.compareAndReport(expected, actual)
   }
 
   @Test def testDelimiterInheritance(): Unit = {
@@ -172,7 +173,7 @@ class TestPrimitives {
     // a,b,c./d//::
 
     val expected: Node = <root><e1>a</e1><e2>b</e2><e3><e3_1>c</e3_1><e3_2>d</e3_2></e3></root>
-    TestUtils.assertEqualsXMLElements(expected, actual)
+    XMLUtils.compareAndReport(expected, actual)
   }
 
   @Test def testEntityReplacementSeparator(): Unit = {
@@ -191,7 +192,7 @@ class TestPrimitives {
     val (_, actual) = TestUtils.testString(sch, "abcd\u0000efgh")
 
     val expected: Node = <e1><s1>abcd</s1><s2>efgh</s2></e1>
-    TestUtils.assertEqualsXMLElements(expected, actual)
+    XMLUtils.compareAndReport(expected, actual)
   }
 
   @Test def testEntityReplacementInitiator(): Unit = {
@@ -203,7 +204,7 @@ class TestPrimitives {
     )
     val (_, actual) = TestUtils.testString(sch, "\u0000efgh")
     val expected: Node = <e1>efgh</e1>
-    TestUtils.assertEqualsXMLElements(expected, actual)
+    XMLUtils.compareAndReport(expected, actual)
   }
 
   @Test def testEntityReplacementTerminator(): Unit = {
@@ -216,7 +217,7 @@ class TestPrimitives {
     val (_, actual) = TestUtils.testString(sch, "abcd\u0000")
 
     val expected: Node = <e1>abcd</e1>
-    TestUtils.assertEqualsXMLElements(expected, actual)
+    XMLUtils.compareAndReport(expected, actual)
   }
 
 }

--- a/daffodil-core/src/test/scala/org/apache/daffodil/core/general/TestRuntimeProperties.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/core/general/TestRuntimeProperties.scala
@@ -21,6 +21,7 @@ import org.apache.daffodil.core.util.TestUtils
 import org.apache.daffodil.io.InputSourceDataInputStream
 import org.apache.daffodil.lib.Implicits.intercept
 import org.apache.daffodil.lib.util.SchemaUtils
+import org.apache.daffodil.lib.xml.XMLUtils
 import org.apache.daffodil.runtime1.api.InfosetSimpleElement
 import org.apache.daffodil.runtime1.dpath.NodeInfo
 import org.apache.daffodil.runtime1.infoset.ScalaXMLInfosetInputter
@@ -113,7 +114,7 @@ class TestRuntimeProperties {
 
     assertFalse(pr.isError)
     val actual = outputter.getResult()
-    TestUtils.assertEqualsXMLElements(expected, actual)
+    XMLUtils.compareAndReport(expected, actual)
   }
 
   @Test def testRuntimeProperties_02(): Unit = {
@@ -226,7 +227,7 @@ class TestRuntimeProperties {
 
     assertFalse(pr.isError)
     val actual = outputter.getResult()
-    TestUtils.assertEqualsXMLElements(expected, actual)
+    XMLUtils.compareAndReport(expected, actual)
   }
 
 }

--- a/daffodil-core/src/test/scala/org/apache/daffodil/core/infoset/TestInfoset2.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/core/infoset/TestInfoset2.scala
@@ -16,8 +16,7 @@
  */
 
 package org.apache.daffodil.core.infoset
-
-import org.apache.daffodil.core.util._
+import org.apache.daffodil.core.util.TestUtils
 import org.apache.daffodil.lib.Implicits._
 import org.apache.daffodil.lib.util._
 import org.apache.daffodil.lib.xml.XMLUtils
@@ -59,7 +58,7 @@ class TestInfoset2 {
       // make sure that is resolved.
       assertFalse(xmlStr.contains("No_Namespace"))
       assertTrue(xmlStr.contains("xmlns=\"\""))
-      TestUtils.assertEqualsXMLElements(<b><c>2</c><a>A</a><a>B</a></b>, xml)
+      XMLUtils.compareAndReport(<b><c>2</c><a>A</a><a>B</a></b>, xml)
     } finally {
       // Debugger.setDebugging(false)
     }

--- a/daffodil-core/src/test/scala/org/apache/daffodil/core/layers/TestBoundaryMarkLayer.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/core/layers/TestBoundaryMarkLayer.scala
@@ -73,7 +73,7 @@ class TestBoundaryMarkLayer {
     val infoset = abcInfoset
 
     val (_, actual) = TestUtils.testString(sch, data, areTracing = false)
-    TestUtils.assertEqualsXMLElements(infoset, actual)
+    XMLUtils.compareAndReport(infoset, actual)
 
     TestUtils.testUnparsing(sch, infoset, data, areTracing = false)
   }

--- a/daffodil-core/src/test/scala/org/apache/daffodil/core/layers/TestFixedLengthLayer.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/core/layers/TestFixedLengthLayer.scala
@@ -70,7 +70,7 @@ class TestFixedLengthLayer {
     val infoset = abcInfoset
 
     val (_, actual) = TestUtils.testString(sch, data, areTracing = false)
-    TestUtils.assertEqualsXMLElements(infoset, actual)
+    XMLUtils.compareAndReport(infoset, actual)
 
     TestUtils.testUnparsing(sch, infoset, data, areTracing = false)
   }

--- a/daffodil-core/src/test/scala/org/apache/daffodil/core/layers/TestGzipErrors.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/core/layers/TestGzipErrors.scala
@@ -125,7 +125,7 @@ a few lines of pointless text like this.""".replace("\r\n", "\n").replace("\n", 
       </e1>
     </ex:root>
     val (_, actual) = TestUtils.testBinary(sch, data, areTracing = false)
-    TestUtils.assertEqualsXMLElements(infoset, actual)
+    XMLUtils.compareAndReport(infoset, actual)
   }
 
   @Test def testGZIPLayerErr1(): Unit = {
@@ -139,7 +139,7 @@ a few lines of pointless text like this.""".replace("\r\n", "\n").replace("\n", 
         <hex xmlns=""><![CDATA[000000D41F8B08000000000000FF4D904176C3200C44AF3207C8F33DBA6F0F40CCD85683918B44D3DC3EC2C9A2EFB1013EF3357C6E6288F5DDCD61BA137BCA443FE0FC73F8967C5C4B75D6CC0C575C8984857714A93414ADEB848F25D800B794036045632A67C605E2B86B2F19553D800000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000]]></hex>
       </ex:root>
     val (_, actual) = TestUtils.testBinary(sch, data, areTracing = false)
-    TestUtils.assertEqualsXMLElements(infoset, actual)
+    XMLUtils.compareAndReport(infoset, actual)
   }
 
   @Test def testGZIPLayerErr2(): Unit = {
@@ -153,7 +153,7 @@ a few lines of pointless text like this.""".replace("\r\n", "\n").replace("\n", 
         <hex xmlns=""><![CDATA[000000D41F8B08000000000000FF4D904176C3200C44AF3207C8F33DBA6F0F40CCD85683918B44D3DC3EC2C9A2EFB1013EF3357C6E6288F5DDCD61BA137BCA443FE0FC73F8967C5C4B75D6CC0C575C8984857714A93414ADEB848F25D800B794036045632A67C605E2B86B2F19553D805FBE889F2ECE70E2AA4DEA3AA2E3519EF065842E58D2AEDD02530F8DB640832A8F26F3B94DF511CA712437BE27ADDE34F739F8598F20D7CD875566460BEBB4CB10CAD989C9846D684DF6A33CA2F9ED6CFEBF5DCC7168C4169ABDBEFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF]]></hex>
       </ex:root>
     val (_, actual) = TestUtils.testBinary(sch, data, areTracing = false)
-    TestUtils.assertEqualsXMLElements(infoset, actual)
+    XMLUtils.compareAndReport(infoset, actual)
   }
 
   val GZIPLayerErrSchema =
@@ -279,7 +279,9 @@ a few lines of pointless text like this.""".replace("\r\n", "\n").replace("\n", 
   // which only takes a few seconds, and
   // all errors thrown were converted to parse errors
   // so that means they were all IOExceptions from the gzip layer.
-  @Test def testGZIPLayerFuzz3(): Unit =
-    fuzz3(10, sch = GZIPLayerErrSchema, data = makeGZIPLayer1Data()._1, expected)
+  @Test def testGZIPLayerFuzz3(): Unit = {
+    // 2000 trials gives us good test coverage of the fuzz testing framework.
+    fuzz3(2000, sch = GZIPLayerErrSchema, data = makeGZIPLayer1Data()._1, expected)
+  }
 
 }

--- a/daffodil-core/src/test/scala/org/apache/daffodil/core/layers/TestLayers.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/core/layers/TestLayers.scala
@@ -89,7 +89,7 @@ class TestLayers {
     val data = "cGxl!" // encoding of "ple" + "!"
     val infoset = <ex:e1 xmlns:ex={example}><s1>ple</s1></ex:e1>
     val (_, actual) = TestUtils.testString(sch, data)
-    TestUtils.assertEqualsXMLElements(infoset, actual)
+    XMLUtils.compareAndReport(infoset, actual)
 
     val areTracing = false
     TestUtils.testUnparsing(sch, infoset, data, areTracing)
@@ -126,7 +126,7 @@ class TestLayers {
     val data = "cGxl!" // encoding of "ple" + "!"
     val infoset = <ex:e1 xmlns:ex={example}><s1>ple</s1></ex:e1>
     val (_, actual) = TestUtils.testString(sch, data)
-    TestUtils.assertEqualsXMLElements(infoset, actual)
+    XMLUtils.compareAndReport(infoset, actual)
 
     val areTracing = false
     TestUtils.testUnparsing(sch, infoset, data, areTracing)
@@ -166,7 +166,7 @@ class TestLayers {
     val data = "cGxl" + "!" + "moreDataAfter"
     val infoset = <ex:e1 xmlns:ex={example}><s1>ple</s1><s2>moreDataAfter</s2></ex:e1>
     val (_, actual) = TestUtils.testString(sch, data)
-    TestUtils.assertEqualsXMLElements(infoset, actual)
+    XMLUtils.compareAndReport(infoset, actual)
 
     val areTracing = false
     TestUtils.testUnparsing(sch, infoset, data, areTracing)
@@ -230,7 +230,7 @@ a few lines of pointless text like this.""".replace("\r\n", "\n").replace("\n", 
       text
     }</s1></ex:e1>
     val (_, actual) = TestUtils.testBinary(sch, data, areTracing = false)
-    TestUtils.assertEqualsXMLElements(infoset, actual)
+    XMLUtils.compareAndReport(infoset, actual)
 
     TestUtils.testUnparsingBinary(sch, infoset, data)
   }
@@ -288,7 +288,7 @@ a few lines of pointless text like this.""".replace("\r\n", "\n").replace("\n", 
       text
     }</s1></data></x1><s2>afterGzip</s2></ex:e1>
     val (_, actual) = TestUtils.testBinary(sch, data, areTracing = false)
-    TestUtils.assertEqualsXMLElements(infoset, actual)
+    XMLUtils.compareAndReport(infoset, actual)
 
     TestUtils.testUnparsingBinary(sch, infoset, data)
   }
@@ -385,7 +385,7 @@ a few lines of pointless text like this.""".replace("\r\n", "\n").replace("\n", 
     }</len><x1><data><s2>{
       text
     }</s2></data></x1><s3>{after}</s3></ex:e1>
-    TestUtils.assertEqualsXMLElements(infoset, actual)
+    XMLUtils.compareAndReport(infoset, actual)
 
     TestUtils.testUnparsingBinary(sch, infoset, data)
   }
@@ -422,7 +422,7 @@ a few lines of pointless text like this.""".replace("\r\n", "\n").replace("\n", 
     val data = ipsumLorem1
     val infoset = <e1 xmlns={example}><s1>{ipsumLorem1Unfolded}</s1></e1>
     val (_, actual) = TestUtils.testString(sch, data)
-    TestUtils.assertEqualsXMLElements(infoset, actual)
+    XMLUtils.compareAndReport(infoset, actual)
   }
 
   val ipsumLorem2 =
@@ -472,7 +472,7 @@ a few lines of pointless text like this.""".replace("\r\n", "\n").replace("\n", 
     val data = ipsumLorem3
     val infoset = <e1 xmlns={example}><s1>{ipsumLorem3Unfolded}</s1></e1>
     val (_, actual) = TestUtils.testString(sch, data)
-    TestUtils.assertEqualsXMLElements(infoset, actual)
+    XMLUtils.compareAndReport(infoset, actual)
   }
 
   val ipsumLorem4 =
@@ -524,7 +524,7 @@ a few lines of pointless text like this.""".replace("\r\n", "\n").replace("\n", 
     val data = ipsumLorem5
     val infoset = <e1 xmlns={example}><s1>{ipsumLorem5Unfolded}</s1></e1>
     val (_, actual) = TestUtils.testString(sch, data)
-    TestUtils.assertEqualsXMLElements(infoset, actual)
+    XMLUtils.compareAndReport(infoset, actual)
   }
 
   val ipsumLorem6 =
@@ -603,7 +603,7 @@ a few lines of pointless text like this.""".replace("\r\n", "\n").replace("\n", 
       </e1>
 
     val (_, actual) = TestUtils.testBinary(sch, data, areTracing = false)
-    TestUtils.assertEqualsXMLElements(infoset, actual)
+    XMLUtils.compareAndReport(infoset, actual)
 
     TestUtils.testUnparsingBinary(sch, infoset, data)
   }

--- a/daffodil-core/src/test/scala/org/apache/daffodil/core/runtime1/TestStreamingUnparserCompilerAttributes.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/core/runtime1/TestStreamingUnparserCompilerAttributes.scala
@@ -24,12 +24,11 @@ import org.apache.daffodil.core.dsom.LocalElementDecl
 import org.apache.daffodil.core.dsom.LocalSequence
 import org.apache.daffodil.core.dsom.SequenceGroupRef
 import org.apache.daffodil.core.dsom.Term
+import org.apache.daffodil.core.util.TestUtils.getRoot
 
 import org.junit.Test
 
 class TestStreamingUnparserCompilerAttributes {
-
-  import org.apache.daffodil.core.util.TestUtils._
 
   import PossibleNextElements._
 

--- a/daffodil-lib/src/main/scala/org/apache/daffodil/lib/util/Misc.scala
+++ b/daffodil-lib/src/main/scala/org/apache/daffodil/lib/util/Misc.scala
@@ -696,31 +696,35 @@ object Misc {
    * gets the message from that, if that has no message, it chases further.
    * Ultimately, if there's no message, it just uses the innermost cause object's class name.
    */
-
-  def getSomeMessage(th: Throwable): Some[String] = {
+  def getAMessage(th: Throwable): String = {
     val m = th.getMessage()
     val c = th.getCause()
     val res = (m, c) match {
       case (null, null) => Misc.getNameFromClass(th)
       case ("", null) => Misc.getNameFromClass(th)
       case (m, null) => m
-      case (null, c) => getSomeMessage(c).get
+      case (null, c) => getAMessage(c)
       case (m, c) => {
-        val Some(cmsg) = getSomeMessage(c)
+        val cmsg = getAMessage(c)
         cmsg + " (within " + th.getClass.getSimpleName + " " + m + ")"
       }
     }
-    Some(res)
+    Assert.invariant(res != null)
+    res
   }
 
-  def getSomeCause(th: Throwable): Some[Throwable] = {
+  def getSomeMessage(th: Throwable): Some[String] = Some(getAMessage(th))
+
+  def getACause(th: Throwable): Throwable = {
     val c = th.getCause()
     val res = c match {
       case null => th
-      case _ => getSomeCause(c).get
+      case _ => getACause(c)
     }
-    Some(res)
+    res
   }
+
+  def getSomeCause(th: Throwable): Some[Throwable] = Some(getACause(th))
 
   /**
    * Get the diagnosticFilepath from a uri

--- a/daffodil-lib/src/main/scala/org/apache/daffodil/lib/xml/XMLUtils.scala
+++ b/daffodil-lib/src/main/scala/org/apache/daffodil/lib/xml/XMLUtils.scala
@@ -814,6 +814,11 @@ object XMLUtils {
 
   class XMLDifferenceException(message: String) extends Exception(message)
 
+  /**
+   * Compares two XML Elements, after having (optionally) stripped off all attributes.
+   *
+   * Throws XMLDifferenceException if not the same.
+   */
   def compareAndReport(
     expected: Node,
     actual: Node,

--- a/daffodil-tdml-lib/src/main/scala/org/apache/daffodil/tdml/RunnerFactory.scala
+++ b/daffodil-tdml-lib/src/main/scala/org/apache/daffodil/tdml/RunnerFactory.scala
@@ -141,7 +141,7 @@ object Runner {
  * were a resource on the classpath. Otherwise it is treated as if it were a
  * URI.
  */
-class Runner private (
+final class Runner private (
   source: Either[scala.xml.Elem, String],
   optTDMLImplementation: Option[TDMLImplementation] = None,
   validateTDMLFile: Boolean = true,

--- a/daffodil-test/src/test/scala/org/apache/daffodil/runtime1/layers/TestCheckDigit.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/runtime1/layers/TestCheckDigit.scala
@@ -20,6 +20,7 @@ import scala.xml.Elem
 
 import org.apache.daffodil.core.util.TestUtils
 import org.apache.daffodil.lib.Implicits.intercept
+import org.apache.daffodil.lib.util.Misc.getAMessage
 import org.apache.daffodil.lib.util.SchemaUtils
 import org.apache.daffodil.lib.xml.XMLUtils
 import org.apache.daffodil.runtime1.processors.parsers.ParseError
@@ -137,7 +138,7 @@ class TestCheckDigit {
     val infoset = okInfoset
 
     val (_, actual) = TestUtils.testString(sch, data, areTracing = false)
-    TestUtils.assertEqualsXMLElements(infoset, actual)
+    XMLUtils.compareAndReport(infoset, actual)
 
     TestUtils.testUnparsing(sch, infoset, data, areTracing = false)
   }
@@ -151,7 +152,7 @@ class TestCheckDigit {
       val e = intercept[ParseError] {
         TestUtils.testString(sch, data, areTracing = false)
       }
-      val msg = TestUtils.getAMessage(e)
+      val msg = getAMessage(e)
       assertTrue(msg.contains("length is negative"))
     }
     // unparse
@@ -159,7 +160,7 @@ class TestCheckDigit {
       val e = intercept[UnparseError] {
         TestUtils.testUnparsing(sch, infoset, data, areTracing = false)
       }
-      val msg = TestUtils.getAMessage(e)
+      val msg = getAMessage(e)
       assertTrue(msg.contains("length is negative"))
     }
   }
@@ -173,7 +174,7 @@ class TestCheckDigit {
       val e = intercept[ParseError] {
         TestUtils.testString(sch, data, areTracing = false)
       }
-      val msg = TestUtils.getAMessage(e)
+      val msg = getAMessage(e)
       assertTrue(msg.contains("out of range for type"))
     }
     // unparse
@@ -181,7 +182,7 @@ class TestCheckDigit {
       val e = intercept[UnparseError] {
         TestUtils.testUnparsing(sch, infoset, data, areTracing = false)
       }
-      val msg = TestUtils.getAMessage(e)
+      val msg = getAMessage(e)
       assertTrue(msg.contains("out of range for type"))
     }
   }
@@ -193,7 +194,7 @@ class TestCheckDigit {
     val e = intercept[ParseError] {
       TestUtils.testString(sch, data, areTracing = false)
     }
-    val msg = TestUtils.getAMessage(e)
+    val msg = getAMessage(e)
     assertTrue(msg.toLowerCase.contains("insufficient data"))
   }
 
@@ -231,7 +232,7 @@ class TestCheckDigit {
     val e = intercept[UnparseError] {
       TestUtils.testUnparsing(sch, infoset, data, areTracing = false)
     }
-    val msg = TestUtils.getAMessage(e)
+    val msg = getAMessage(e)
     assertTrue(msg.toLowerCase.contains("exceeded fixed layer length"))
   }
 
@@ -248,13 +249,13 @@ class TestCheckDigit {
     val e = intercept[Throwable] {
       TestUtils.testString(sch, data, areTracing = false)
     }
-    val msg = TestUtils.getAMessage(e)
+    val msg = getAMessage(e)
     assertTrue(msg.contains("notACharsetName"))
 
     val f = intercept[UnparseError] {
       TestUtils.testUnparsing(sch, infoset, data, areTracing = false)
     }
-    val m = TestUtils.getAMessage(f)
+    val m = getAMessage(f)
     assertTrue(m.contains("notACharsetName"))
   }
 

--- a/daffodil-test/src/test/scala/org/apache/daffodil/runtime1/layers/TestLayers2.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/runtime1/layers/TestLayers2.scala
@@ -17,9 +17,9 @@
 
 package org.apache.daffodil.runtime1.layers
 
-import org.apache.daffodil.core.util.TestUtils
 import org.apache.daffodil.lib.Implicits.intercept
 import org.apache.daffodil.lib.exceptions.Abort
+import org.apache.daffodil.lib.util.Misc
 import org.apache.daffodil.tdml.Runner
 import org.apache.daffodil.tdml.TDMLException
 
@@ -152,7 +152,7 @@ class TestLayers2 {
         .replace("WithSuspension", "")
         .toLowerCase
       val e = f(testName)
-      val cMsg = TestUtils.getAMessage(e)
+      val cMsg = Misc.getAMessage(e)
       // println(s">>>>\n     $cMsg\n<<<<<") // keep this.
       if (cMsg == null)
         fail("no cause message")


### PR DESCRIPTION
Moved TestUtils and FuzzData in core to src/main 

so FuzzData can be used outside of daffodil proper.  

Removed unused and trivial methods from TestUtils. 

Made private all methods possible. 
We're left with minimum footprint of public methods.  

Removed dependency on JUnit from TestUtils and FuzzData so they don't have to be in src/test. 

Tested for and removed a couple of TODOs that are no longer needed. 
Reducing the number of TODOs and FIXMEs is DAFFODIL-1569.  

DAFFODIL-2959, DAFFODIL-1569

Add final  

DAFFODIL-2797