### PR TITLE
Replace Deprecated classes like Stack/Stream

### DIFF
--- a/daffodil-cli/bin.NOTICE
+++ b/daffodil-cli/bin.NOTICE
@@ -167,3 +167,19 @@ The following NOTICE information applies to binary components distributed with t
   Portions of this code are derived from classes placed in the
   public domain by Arbortext on 10 Apr 2000. See:
   http://www.arbortext.com/customer_support/updates_and_technical_notes/catalogs/docs/README.htm
+
+- org.scala-lang.scala-collection-compat_2.13-<VERSION>.jar
+  scala-collection-compat
+  Copyright (c) 2002-2025 EPFL
+  Copyright (c) 2011-2025 Lightbend, Inc. dba Akka
+
+  Scala includes software developed at
+  LAMP/EPFL (https://lamp.epfl.ch/) and
+  Akka (https://akka.io/).
+
+  Licensed under the Apache License, Version 2.0 (the "License").
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.

--- a/daffodil-cli/src/main/scala/org/apache/daffodil/cli/debugger/CLIDebuggerRunner.scala
+++ b/daffodil-cli/src/main/scala/org/apache/daffodil/cli/debugger/CLIDebuggerRunner.scala
@@ -20,8 +20,8 @@ package org.apache.daffodil.cli.debugger
 import java.io.File
 import java.io.InputStream
 import java.io.PrintStream
-import scala.collection.JavaConverters._
 import scala.io.Source
+import scala.jdk.CollectionConverters._
 
 import org.apache.daffodil.runtime1.debugger._
 

--- a/daffodil-cli/src/test/scala/org/apache/daffodil/cli/cliTest/Util.scala
+++ b/daffodil-cli/src/test/scala/org/apache/daffodil/cli/cliTest/Util.scala
@@ -31,8 +31,8 @@ import java.nio.file.Path
 import java.nio.file.Paths
 import java.security.MessageDigest
 import java.util.concurrent.TimeUnit
-import scala.collection.JavaConverters._
 import scala.collection.mutable
+import scala.jdk.CollectionConverters._
 
 import org.apache.daffodil.cli.Main
 import org.apache.daffodil.cli.Main.ExitCode

--- a/daffodil-codegen-c/src/main/scala/org/apache/daffodil/codegen/c/DaffodilCCodeGenerator.scala
+++ b/daffodil-codegen-c/src/main/scala/org/apache/daffodil/codegen/c/DaffodilCCodeGenerator.scala
@@ -21,7 +21,7 @@ import java.io.File
 import java.net.JarURLConnection
 import java.nio.file.Files
 import java.nio.file.Paths
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.util.Properties.isWin
 
 import org.apache.daffodil.codegen.c.generators.AlignmentFillCodeGenerator

--- a/daffodil-core/src/test/scala/org/apache/daffodil/core/layers/TestLayers.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/core/layers/TestLayers.scala
@@ -21,7 +21,7 @@ import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
 import java.io.InputStreamReader
 import java.nio.charset.StandardCharsets
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 import org.apache.daffodil.core.util.TestUtils
 import org.apache.daffodil.lib.util._

--- a/daffodil-io/src/test/scala/org/apache/daffodil/layers/TestJavaIOStreams.scala
+++ b/daffodil-io/src/test/scala/org/apache/daffodil/layers/TestJavaIOStreams.scala
@@ -22,10 +22,10 @@ import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
 import java.nio.charset.StandardCharsets
 import java.util.Scanner
+import scala.jdk.CollectionConverters._
 
 import org.apache.daffodil.lib.exceptions.Assert
 
-import collection.JavaConverters._
 import org.apache.commons.io.IOUtils
 import org.junit.Assert._
 import org.junit.Test

--- a/daffodil-japi/src/main/scala/org/apache/daffodil/japi/Daffodil.scala
+++ b/daffodil-japi/src/main/scala/org/apache/daffodil/japi/Daffodil.scala
@@ -21,7 +21,7 @@ import java.io.File
 import java.net.URI
 import java.nio.channels.ReadableByteChannel
 import java.nio.channels.WritableByteChannel
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 import org.apache.daffodil.core.compiler.{ Compiler => SCompiler }
 import org.apache.daffodil.core.compiler.{ InvalidParserException => SInvalidParserException }

--- a/daffodil-japi/src/test/java/org/apache/daffodil/example/TestJavaAPI.java
+++ b/daffodil-japi/src/test/java/org/apache/daffodil/example/TestJavaAPI.java
@@ -39,7 +39,7 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
-import scala.collection.JavaConverters;
+import scala.jdk.javaapi.CollectionConverters;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
@@ -1357,7 +1357,7 @@ public class TestJavaAPI {
             output.setBlobAttributes(blobDir, "pre-", ".suf");
 
             ParseResult res = dp.parse(input, output);
-            List<Path> blobPaths = JavaConverters.seqAsJavaList(output.getBlobPaths());
+            List<Path> blobPaths = CollectionConverters.asJava(output.getBlobPaths());
 
             try {
                 assertFalse(res.isError());

--- a/daffodil-lib/src/main/scala/org/apache/daffodil/lib/Implicits.scala
+++ b/daffodil-lib/src/main/scala/org/apache/daffodil/lib/Implicits.scala
@@ -20,7 +20,6 @@ package org.apache.daffodil.lib
 import java.io.{ BufferedInputStream, ByteArrayInputStream }
 import scala.language.implicitConversions
 import scala.language.reflectiveCalls
-import scala.language.{ implicitConversions, reflectiveCalls } // silences scala 2.10 warnings
 
 import org.apache.daffodil.lib.exceptions.Assert
 import org.apache.daffodil.lib.xml.NS

--- a/daffodil-lib/src/main/scala/org/apache/daffodil/lib/api/Validator.scala
+++ b/daffodil-lib/src/main/scala/org/apache/daffodil/lib/api/Validator.scala
@@ -69,7 +69,7 @@ object ValidationResult {
   val empty: ValidationResult = ValidationResult(Seq.empty, Seq.empty)
 
   def apply(w: Seq[ValidationWarning], e: Seq[ValidationFailure]): ValidationResult = {
-    import scala.collection.JavaConverters.asJavaCollectionConverter
+    import scala.jdk.CollectionConverters._
     new ValidationResult {
       val warnings: java.util.Collection[ValidationWarning] = w.asJavaCollection
       val errors: java.util.Collection[ValidationFailure] = e.asJavaCollection

--- a/daffodil-lib/src/main/scala/org/apache/daffodil/lib/util/DecimalUtils.scala
+++ b/daffodil-lib/src/main/scala/org/apache/daffodil/lib/util/DecimalUtils.scala
@@ -553,7 +553,7 @@ object DecimalUtils {
         }
 
         val allDigits = opl match {
-          case OverpunchLocation.Start => digit + num.substring(1)
+          case OverpunchLocation.Start => digit.toString + num.substring(1)
           case OverpunchLocation.End => num.substring(0, opindex) + digit
           case _ => Assert.impossible()
         }
@@ -603,7 +603,7 @@ object DecimalUtils {
         }
 
         val convertedNum = opl match {
-          case OverpunchLocation.Start => digit + inStr.substring(1)
+          case OverpunchLocation.Start => digit +: inStr.substring(1)
           case OverpunchLocation.End => inStr.substring(0, opindex) + digit
           case _ => Assert.impossible()
         }

--- a/daffodil-lib/src/main/scala/org/apache/daffodil/lib/util/Misc.scala
+++ b/daffodil-lib/src/main/scala/org/apache/daffodil/lib/util/Misc.scala
@@ -32,8 +32,8 @@ import java.nio.charset.StandardCharsets
 import java.nio.charset.{ Charset => JavaCharset }
 import java.nio.file.Files
 import java.nio.file.Paths
-import scala.collection.JavaConverters._
 import scala.io.Source
+import scala.jdk.CollectionConverters._
 
 import org.apache.daffodil.lib.equality._
 import org.apache.daffodil.lib.exceptions.Assert
@@ -272,8 +272,9 @@ object Misc {
     }
   }
 
-  def initialUpperCase(s: String): String = s.head.toUpper + s.substring(1)
-  def initialLowerCase(s: String): String = s.head.toLower + s.substring(1)
+  // TODO: no test coverage
+  def initialUpperCase(s: String): String = s.head.toUpper +: s.substring(1)
+  def initialLowerCase(s: String): String = s.head.toLower +: s.substring(1)
 
   /**
    * Convert FooBar to fooBar, but leave FOOBAR as FOOBAR.
@@ -284,7 +285,7 @@ object Misc {
     // At this point we know the first letter is uppercase
     //
     if (isAllUpper(s, 1)) s
-    else s(0).toLower + s.substring(1)
+    else s(0).toLower +: s.substring(1)
   }
 
   def isAllUpper(s: String, start: Int): Boolean = {

--- a/daffodil-lib/src/main/scala/org/apache/daffodil/lib/util/NonAllocatingMap.scala
+++ b/daffodil-lib/src/main/scala/org/apache/daffodil/lib/util/NonAllocatingMap.scala
@@ -17,8 +17,8 @@
 
 package org.apache.daffodil.lib.util
 
-import scala.collection.JavaConverters._
 import scala.collection.mutable
+import scala.jdk.CollectionConverters._
 
 import org.apache.daffodil.lib.exceptions.Assert
 

--- a/daffodil-lib/src/main/scala/org/apache/daffodil/lib/util/OnStack.scala
+++ b/daffodil-lib/src/main/scala/org/apache/daffodil/lib/util/OnStack.scala
@@ -18,11 +18,10 @@
 package org.apache.daffodil.lib.util
 
 import java.util.regex.Matcher
-import scala.collection.mutable
 
 sealed abstract class LocalStackBase[T](constructorFunc: => T, optionalResetFunc: (T => Unit)) {
 
-  protected def stack: mutable.ArrayStack[T]
+  protected def stack: Stack[T]
 
   /**
    * This must be inlined to achieve what we're trying to achieve with OnStack/LocalStack.
@@ -61,9 +60,9 @@ class OnStack[T](constructorFunc: => T, optionalResetFunc: (T => Unit))
    */
   def this(constructorFunc: => T) = this(constructorFunc, x => {})
 
-  private val tl = new ThreadLocal[mutable.ArrayStack[T]] {
-    protected final override def initialValue(): mutable.ArrayStack[T] = {
-      val stack = new mutable.ArrayStack[T]
+  private val tl = new ThreadLocal[Stack[T]] {
+    protected final override def initialValue(): Stack[T] = {
+      val stack = new Stack[T]
       stack
     }
   }
@@ -94,7 +93,7 @@ class LocalStack[T](constructorFunc: => T, optionalResetFunc: (T => Unit))
    */
   def this(constructorFunc: => T) = this(constructorFunc, x => {})
 
-  final protected val stack = new mutable.ArrayStack[T]
+  final protected val stack = new Stack[T]
 
 }
 

--- a/daffodil-lib/src/main/scala/org/apache/daffodil/lib/util/Serialize.scala
+++ b/daffodil-lib/src/main/scala/org/apache/daffodil/lib/util/Serialize.scala
@@ -17,8 +17,8 @@
 
 package org.apache.daffodil.lib.util
 
-import scala.collection.JavaConverters._
 import scala.collection.mutable.HashMap
+import scala.jdk.CollectionConverters._
 
 import org.apache.daffodil.lib.exceptions.Assert
 

--- a/daffodil-lib/src/main/scala/org/apache/daffodil/lib/util/Stack.scala
+++ b/daffodil-lib/src/main/scala/org/apache/daffodil/lib/util/Stack.scala
@@ -17,11 +17,42 @@
 
 package org.apache.daffodil.lib.util
 
-import scala.annotation.meta._
+import scala.collection.mutable.ListBuffer
 
-// The @transient annotation on a constructor parameter doesn't work properly
-// in scala >= 2.11, this is because it does not include the @param annotation.
-// This custom annotation extends transient, but adds the @param annotation so
-// construcutor parameters are properly made transient
-@param
-class TransientParam extends scala.transient
+/**
+ * Compatibility class for 2.12 and 2.13 since ArrayStack and Stack
+ * have been deprecated in 2.13. This allows us to maintain the same
+ * functionality as stack while using ListBuffer instead
+ */
+class Stack[T] {
+  def apply(index: Int): T = {
+    _stackLike(index)
+  }
+
+  private val _stackLike: ListBuffer[T] = new ListBuffer[T]
+
+  def pop(): T = {
+    _stackLike.remove(_stackLike.length - 1)
+  }
+
+  def push(item: T): Unit = {
+    _stackLike += item
+  }
+
+  def isEmpty: Boolean = {
+    _stackLike.isEmpty
+  }
+
+  def clear(): Unit = {
+    // TODO: not covered by tests
+    _stackLike.clear()
+  }
+
+  def top(): T = {
+    _stackLike.last
+  }
+
+  def nonEmpty: Boolean = {
+    _stackLike.nonEmpty
+  }
+}

--- a/daffodil-lib/src/main/scala/org/apache/daffodil/lib/util/Timer.scala
+++ b/daffodil-lib/src/main/scala/org/apache/daffodil/lib/util/Timer.scala
@@ -17,7 +17,7 @@
 
 package org.apache.daffodil.lib.util
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 object Timer {
 
@@ -185,8 +185,10 @@ object TimeTracker {
    * necessary since we often want to track the time each parser takes to
    * complete, but our parsers are nested making that difficult with standard
    * profilers. This makes that much easier.
+   *
+   * TODO: not covered by tests
    */
-  val childrenTimeStack = scala.collection.mutable.Stack[Long]()
+  val childrenTimeStack = new org.apache.daffodil.lib.util.Stack[Long]()
 
   /**
    * Used to measure a section of code that might get called multiple times.

--- a/daffodil-lib/src/main/scala/org/apache/daffodil/lib/validation/XercesValidator.scala
+++ b/daffodil-lib/src/main/scala/org/apache/daffodil/lib/validation/XercesValidator.scala
@@ -20,7 +20,7 @@ package org.apache.daffodil.lib.validation
 import java.net.URI
 import javax.xml.XMLConstants
 import javax.xml.transform.stream.StreamSource
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.xml.SAXException
 
 import org.apache.daffodil.lib.api.ValidationException

--- a/daffodil-lib/src/main/scala/org/apache/daffodil/lib/xml/DaffodilXMLLoader.scala
+++ b/daffodil-lib/src/main/scala/org/apache/daffodil/lib/xml/DaffodilXMLLoader.scala
@@ -35,7 +35,7 @@ import javax.xml.transform.sax.SAXSource
 import javax.xml.transform.stream.StreamSource
 import javax.xml.validation.Schema
 import javax.xml.validation.SchemaFactory
-import scala.collection.JavaConverters.asScalaBufferConverter
+import scala.jdk.CollectionConverters._
 import scala.xml.SAXParseException
 import scala.xml.SAXParser
 import scala.xml.parsing.NoBindingFactoryAdapter

--- a/daffodil-lib/src/main/scala/org/apache/daffodil/lib/xml/XMLUtils.scala
+++ b/daffodil-lib/src/main/scala/org/apache/daffodil/lib/xml/XMLUtils.scala
@@ -282,7 +282,7 @@ object XMLUtils {
     }
     // we fell out of the loop. So
     processText() // in case there is text left pending when we hit the end
-    ab.result()
+    ab.result().toSeq
   }
 
   val XSD_NAMESPACE = NS(

--- a/daffodil-lib/src/main/scala/passera/numerics/package.scala
+++ b/daffodil-lib/src/main/scala/passera/numerics/package.scala
@@ -30,16 +30,16 @@ import scala.language.implicitConversions
 
 package object numerics {
   implicit def toRicherInt(x: Int): RicherInt = new RicherInt(x)
-  implicit def toRicherInt(x: scala.runtime.RichInt) = new YetRicherInt(
+  implicit def toRicherInt(x: scala.runtime.RichInt): YetRicherInt = new YetRicherInt(
     x.self.asInstanceOf[Int]
   )
 
   implicit def toRicherLong(x: Long): RicherLong = new RicherLong(x)
-  implicit def toRicherLong(x: scala.runtime.RichLong) = new YetRicherLong(
+  implicit def toRicherLong(x: scala.runtime.RichLong): YetRicherLong = new YetRicherLong(
     x.self.asInstanceOf[Long]
   )
 
-  class RicherInt(x: Int) extends Proxy {
+  class RicherInt(x: Int) {
     def self: Any = x
 
     import java.lang.Integer
@@ -58,17 +58,24 @@ package object numerics {
 
     def <<@(dist: Int) = rotateLeft(dist)
     def >>@(dist: Int) = rotateRight(dist)
+
+    override def equals(obj: Any): Boolean = super.equals(obj)
+    override def toString: String = super.toString
+    override def hashCode(): Int = super.hashCode()
   }
 
-  class YetRicherInt(x: Int) extends Proxy {
+  class YetRicherInt(x: Int) {
     def self: Any = x
     def to(y: Long, step: Long = 1L) = x.toLong to y by step
     def until(y: Long, step: Long = 1L) = x.toLong until y by step
     def max(y: Long) = x.toLong.max(y)
     def min(y: Long) = x.toLong.min(y)
+    override def equals(obj: Any): Boolean = super.equals(obj)
+    override def toString: String = super.toString
+    override def hashCode(): Int = super.hashCode()
   }
 
-  class RicherLong(x: Long) extends Proxy {
+  class RicherLong(x: Long) {
     def self: Any = x
 
     import java.lang.Long
@@ -87,9 +94,16 @@ package object numerics {
 
     def <<@(dist: Int) = rotateLeft(dist)
     def >>@(dist: Int) = rotateRight(dist)
+
+    override def equals(obj: Any): Boolean = super.equals(obj)
+    override def toString: String = super.toString
+    override def hashCode(): Int = super.hashCode()
   }
 
-  class YetRicherLong(x: Long) extends Proxy {
+  class YetRicherLong(x: Long) {
     def self: Any = x
+    override def equals(obj: Any): Boolean = super.equals(obj)
+    override def toString: String = super.toString
+    override def hashCode(): Int = super.hashCode()
   }
 }

--- a/daffodil-lib/src/main/scala/passera/unsigned/package.scala
+++ b/daffodil-lib/src/main/scala/passera/unsigned/package.scala
@@ -29,21 +29,22 @@ package passera
 import scala.language.implicitConversions
 
 package object unsigned {
-  implicit def ubyte2uint(x: UByte) = UInt(x.toInt)
-  implicit def ushort2uint(x: UShort) = UInt(x.toInt)
-  implicit def ubyte2ulong(x: UByte) = ULong(x.toLong)
-  implicit def ushort2ulong(x: UShort) = ULong(x.toLong)
-  implicit def uint2ulong(x: UInt) = ULong(x.toLong)
+  implicit def ubyte2uint(x: UByte): UInt = UInt(x.toInt)
+  implicit def ushort2uint(x: UShort): UInt = UInt(x.toInt)
+  implicit def ubyte2ulong(x: UByte): ULong = ULong(x.toLong)
+  implicit def ushort2ulong(x: UShort): ULong = ULong(x.toLong)
+  implicit def uint2ulong(x: UInt): ULong = ULong(x.toLong)
 
-  implicit def signedIntOps(x: Int) = new SignedIntOps(x)
-  implicit def signedLongOps(x: Long) = new SignedLongOps(x)
-  implicit def floatOps(x: Float) = new FloatOps(x)
-  implicit def doubleOps(x: Double) = new DoubleOps(x)
-  implicit def signedRichIntOps(x: scala.runtime.RichInt) = new SignedRichIntOps(
-    x.self.asInstanceOf[Int]
-  )
-  implicit def richUInt(x: UInt) = new RichUInt(x)
-  implicit def richerUInt(x: UInt) = new RicherUInt(x.toInt)
+  implicit def signedIntOps(x: Int): SignedIntOps = new SignedIntOps(x)
+  implicit def signedLongOps(x: Long): SignedLongOps = new SignedLongOps(x)
+  implicit def floatOps(x: Float): FloatOps = new FloatOps(x)
+  implicit def doubleOps(x: Double): DoubleOps = new DoubleOps(x)
+  implicit def signedRichIntOps(x: scala.runtime.RichInt): SignedRichIntOps =
+    new SignedRichIntOps(
+      x.self.asInstanceOf[Int]
+    )
+  implicit def richUInt(x: UInt): RichUInt = new RichUInt(x)
+  implicit def richerUInt(x: UInt): RicherUInt = new RicherUInt(x.toInt)
 
   class FloatOps(x: Float) {
     def toUByte = UByte(x.toByte)
@@ -169,7 +170,9 @@ package object unsigned {
     def toFloat(x: UByte): Float = x.toFloat
     def toDouble(x: UByte): Double = x.toDouble
   }
-  implicit object UByteIsIntegral extends UByteIsIntegral with UByteOrdering
+  implicit object UByteIsIntegral extends UByteIsIntegral with UByteOrdering {
+    def parseString(str: String): Option[UByte] = None
+  }
 
   trait UShortIsIntegral extends Integral[UShort] {
     def plus(x: UShort, y: UShort): UShort = (x + y).toUShort
@@ -184,7 +187,9 @@ package object unsigned {
     def toFloat(x: UShort): Float = x.toFloat
     def toDouble(x: UShort): Double = x.toDouble
   }
-  implicit object UShortIsIntegral extends UShortIsIntegral with UShortOrdering
+  implicit object UShortIsIntegral extends UShortIsIntegral with UShortOrdering {
+    def parseString(str: String): Option[UShort] = None
+  }
 
   trait UIntIsIntegral extends Integral[UInt] {
     def plus(x: UInt, y: UInt): UInt = x + y
@@ -199,7 +204,9 @@ package object unsigned {
     def toFloat(x: UInt): Float = x.toFloat
     def toDouble(x: UInt): Double = x.toDouble
   }
-  implicit object UIntIsIntegral extends UIntIsIntegral with UIntOrdering
+  implicit object UIntIsIntegral extends UIntIsIntegral with UIntOrdering {
+    def parseString(str: String): Option[UInt] = None
+  }
 
   trait ULongIsIntegral extends Integral[ULong] {
     def plus(x: ULong, y: ULong): ULong = x + y
@@ -214,7 +221,9 @@ package object unsigned {
     def toFloat(x: ULong): Float = x.toFloat
     def toDouble(x: ULong): Double = x.toDouble
   }
-  implicit object ULongIsIntegral extends ULongIsIntegral with ULongOrdering
+  implicit object ULongIsIntegral extends ULongIsIntegral with ULongOrdering {
+    def parseString(str: String): Option[ULong] = None
+  }
 
   class RicherUInt(rep: Int) {
     def bitCount = Integer.bitCount(rep)

--- a/daffodil-lib/src/test/scala/org/apache/daffodil/lib/util/TestXMLCatalogAndValidate.scala
+++ b/daffodil-lib/src/test/scala/org/apache/daffodil/lib/util/TestXMLCatalogAndValidate.scala
@@ -20,7 +20,6 @@ package org.apache.daffodil.lib.util
 import java.io.File
 import javax.xml.XMLConstants
 import javax.xml.parsers.SAXParser
-import scala.collection.mutable
 import scala.language.reflectiveCalls
 import scala.xml.Attribute
 import scala.xml.Elem
@@ -335,7 +334,7 @@ class SchemaAwareFactoryAdapter() extends NoBindingFactoryAdapter {
   // starting element tag.
 
   // startElement saves locator information on stack
-  val locatorStack = new mutable.ArrayStack[Locator]
+  val locatorStack = new Stack[Locator]
   // endElement pops it off into here
   var elementStartLocator: Locator = _
 
@@ -436,7 +435,7 @@ class SchemaAwareFactoryAdapter() extends NoBindingFactoryAdapter {
 
   override def endElement(uri: String, _localName: String, qname: String): Unit = {
     // println("endElement")
-    elementStartLocator = locatorStack.pop
+    elementStartLocator = locatorStack.pop()
     super.endElement(uri, _localName, qname)
   }
 

--- a/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/unparsers/runtime1/ChoiceAndOtherVariousUnparsers.scala
+++ b/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/unparsers/runtime1/ChoiceAndOtherVariousUnparsers.scala
@@ -17,7 +17,7 @@
 
 package org.apache.daffodil.unparsers.runtime1
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 import org.apache.daffodil.lib.util.Maybe
 import org.apache.daffodil.lib.util.Maybe._

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/dsom/CompiledExpression1.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/dsom/CompiledExpression1.scala
@@ -27,7 +27,6 @@ import org.apache.daffodil.lib.util.Delay
 import org.apache.daffodil.lib.util.Maybe
 import org.apache.daffodil.lib.util.MaybeULong
 import org.apache.daffodil.lib.util.PreSerialization
-import org.apache.daffodil.lib.util.TransientParam
 import org.apache.daffodil.lib.xml.NS
 import org.apache.daffodil.lib.xml.NamedQName
 import org.apache.daffodil.lib.xml.NoNamespace
@@ -204,7 +203,7 @@ class DPathCompileInfo(
   // parentsDelay is a transient due to serialization order issues causing
   // stack overflows. There is no delay/lazy/by-name involvement here. See the
   // lazy val parents scaladoc for a detailed explanation.
-  @TransientParam parentsDelay: Delay[Seq[DPathCompileInfo]],
+  @transient parentsDelay: Delay[Seq[DPathCompileInfo]],
   val variableMap: VariableMap,
   val namespaces: scala.xml.NamespaceBinding,
   val noPrefixNamespace: NS,
@@ -331,7 +330,7 @@ class DPathElementCompileInfo(
   // parentsDelay is a transient due to serialization order issues causing
   // stack overflows. There is no delay/lazy/by-name involvement here. See the
   // lazy val parents scaladoc for a detailed explanation.
-  @TransientParam parentsDelay: Delay[Seq[DPathElementCompileInfo]],
+  @transient parentsDelay: Delay[Seq[DPathElementCompileInfo]],
   variableMap: VariableMap,
   // This next arg must be a Delay as we're creating a circular
   // structure here. Element's compile info points down to their children. Children

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/Evaluatable.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/Evaluatable.scala
@@ -17,7 +17,7 @@
 
 package org.apache.daffodil.runtime1.processors
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 import org.apache.daffodil.lib.api.DaffodilTunables
 import org.apache.daffodil.lib.api.Diagnostic

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/ElementKindParsers.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/ElementKindParsers.scala
@@ -18,7 +18,7 @@
 package org.apache.daffodil.runtime1.processors.parsers
 
 import java.math.{ BigInteger => JBigInt }
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 import org.apache.daffodil.lib.util.Logger
 import org.apache.daffodil.lib.util.Maybe

--- a/daffodil-schematron/src/main/scala/org/apache/daffodil/validation/schematron/SchematronResult.scala
+++ b/daffodil-schematron/src/main/scala/org/apache/daffodil/validation/schematron/SchematronResult.scala
@@ -18,7 +18,7 @@
 package org.apache.daffodil.validation.schematron
 
 import java.util
-import scala.collection.JavaConverters.asJavaCollectionConverter
+import scala.jdk.CollectionConverters._
 
 import org.apache.daffodil.lib.api.ValidationFailure
 import org.apache.daffodil.lib.api.ValidationResult

--- a/daffodil-tdml-processor/src/test/java/org/apache/daffodil/processor/tdml/TestRunnerFactory.java
+++ b/daffodil-tdml-processor/src/test/java/org/apache/daffodil/processor/tdml/TestRunnerFactory.java
@@ -29,7 +29,7 @@ import org.junit.Test;
 import org.xml.sax.InputSource;
 
 import scala.Option;
-import scala.collection.JavaConverters;
+import scala.jdk.javaapi.CollectionConverters;
 import scala.xml.Elem;
 import scala.xml.XML;
 import scala.util.Right;
@@ -50,7 +50,7 @@ public class TestRunnerFactory {
       false,
       NoRoundTrip$.MODULE$,
       "off",
-      JavaConverters.asScalaBufferConverter(Arrays.asList("daffodil", "ibm")).asScala(),
+      CollectionConverters.asScala(Arrays.asList("daffodil", "ibm")),
       false,
       false);
     runner.runOneTest("testPass");

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -20,7 +20,7 @@ import sbtunidoc.GenJavadocPlugin.autoImport.unidocGenjavadocVersion
 
 object Dependencies {
 
-  lazy val common = core ++ infoset ++ test
+  lazy val common = core ++ infoset ++ test ++ compat
 
   lazy val core = Seq(
     "com.lihaoyi" %% "os-lib" % "0.11.3", // for writing/compiling C source files
@@ -66,6 +66,10 @@ object Dependencies {
 
   lazy val exi = Seq(
     "com.siemens.ct.exi" % "exificient" % "1.0.7"
+  )
+
+  lazy val compat = Seq(
+    "org.scala-lang.modules" %% "scala-collection-compat" % "2.13.0"
   )
 
   lazy val genjavadocVersion = {


### PR DESCRIPTION
- remove TransientParam class, replace with just @transient
- replace deprecated Stream with LazyList
- rename iterator to eventIterator since Iterator trait now defines iterator field
- .toIterator -> .iterator
- update collection converters for 2.13, add compat class to enable for 2.12
- remove additional implicitCoversions/reflectiveCalls imports since it causes an unused import error in 2.13
- replace mutable.ArrayStack/Stack with custom StackLike that is backed by ListBuffer
- replace deprecated Proxy class with overrides to toString, hashCode and equals
- non-explicit implicit return types are deprecated in 2.13
- parseString is required for 2.13 extenders of Numeric, set to None

DAFFODIL-2152