### PR TITLE
Fix More Deprecated Auto Application of ()

### DIFF
--- a/daffodil-io/src/main/scala/org/apache/daffodil/io/InputSourceDataInputStream.scala
+++ b/daffodil-io/src/main/scala/org/apache/daffodil/io/InputSourceDataInputStream.scala
@@ -141,7 +141,7 @@ final class InputSourceDataInputStream private (val inputSource: InputSource)
    * may become available in the future. This should really only be used for
    * debug or diagnostic purposes.
    */
-  def knownBytesAvailable: Long = inputSource.knownBytesAvailable
+  def knownBytesAvailable: Long = inputSource.knownBytesAvailable()
 
   def setBitPos0b(newBitPos0b: Long): Unit = {
     // threadCheck()
@@ -612,7 +612,7 @@ final class InputSourceDataInputStream private (val inputSource: InputSource)
 
   def validateFinalStreamState(): Unit = {
     // threadCheck()
-    markPool.finalCheck
+    markPool.finalCheck()
   }
 
   /**
@@ -804,7 +804,8 @@ final class InputSourceDataInputStream private (val inputSource: InputSource)
     // need to call areBytesAvailable first to ensure at least length bytes are
     // buffered if they exist
     val available = inputSource.areBytesAvailable(nBytesRequested)
-    val bytesToRead = if (available) nBytesRequested else inputSource.knownBytesAvailable.toInt
+    val bytesToRead =
+      if (available) nBytesRequested else inputSource.knownBytesAvailable().toInt
     val array = new Array[Byte](bytesToRead)
     inputSource.get(array, 0, bytesToRead)
 

--- a/daffodil-io/src/main/scala/org/apache/daffodil/io/processors/charset/BitsCharsetNonByteSize.scala
+++ b/daffodil-io/src/main/scala/org/apache/daffodil/io/processors/charset/BitsCharsetNonByteSize.scala
@@ -247,7 +247,7 @@ final class BitsCharsetNonByteSizeEncoder(
             charCode.get
           } else {
             // character must fit in the bit width of a code unit, unmappable error
-            val unmappableAction = unmappableCharacterAction
+            val unmappableAction = unmappableCharacterAction()
             if (unmappableAction == CodingErrorAction.REPLACE) {
               // CharsetEncoder, which handles character replacement, assumes
               // that the replacement character is made up of full bytes. That

--- a/daffodil-io/src/main/scala/org/apache/daffodil/io/processors/charset/CharsetUtils.scala
+++ b/daffodil-io/src/main/scala/org/apache/daffodil/io/processors/charset/CharsetUtils.scala
@@ -38,7 +38,7 @@ object CharsetUtils {
     if (cs == null)
       null
     else
-      cs.charset
+      cs.charset()
   }
 
   def supportedEncodingsString = BitsCharsetDefinitionRegistry.supportedEncodingsString

--- a/daffodil-lib/src/test/scala/org/apache/daffodil/lib/testEquality/TestEqualityOperators.scala
+++ b/daffodil-lib/src/test/scala/org/apache/daffodil/lib/testEquality/TestEqualityOperators.scala
@@ -43,8 +43,8 @@ class TestEqualityOperators {
   }
 
   // prevent optimizations from using constant objects
-  val xObj = if (scala.math.random == -0.0) "foo" else "bar"
-  val yObj = if (scala.math.random == -0.0) "bar" else "foo"
+  val xObj = if (scala.math.random() == -0.0) "foo" else "bar"
+  val yObj = if (scala.math.random() == -0.0) "bar" else "foo"
 
   @Test
   def testStronglyTypedEqualityInlineAnyRef(): Unit = {

--- a/daffodil-lib/src/test/scala/org/apache/daffodil/lib/util/TestMaybeInlineForeach.scala
+++ b/daffodil-lib/src/test/scala/org/apache/daffodil/lib/util/TestMaybeInlineForeach.scala
@@ -99,9 +99,9 @@ final class TestMaybeInlineForeach {
    */
   // @Test
   def testForeachVersusIfDefined(): Unit = {
-    val foreachNanos: Double = time(testForeach)
-    val ifDefinedNanos: Double = time(testIfDefined)
-    val ifNullNanos: Double = time(testIfNull)
+    val foreachNanos: Double = time(testForeach()).toDouble
+    val ifDefinedNanos: Double = time(testIfDefined()).toDouble
+    val ifNullNanos: Double = time(testIfNull()).toDouble
     //
     // if foreach is taking more than 4x the time of ifDefined, that's
     // what we expect if scala can't inline-away the function object allocation

--- a/daffodil-lib/src/test/scala/org/apache/daffodil/lib/util/TestXMLCatalogAndValidate.scala
+++ b/daffodil-lib/src/test/scala/org/apache/daffodil/lib/util/TestXMLCatalogAndValidate.scala
@@ -35,6 +35,7 @@ import scala.xml.parsing.NoBindingFactoryAdapter
 import org.apache.daffodil.lib.exceptions.Assert
 import org.apache.daffodil.lib.util.Implicits.using
 import org.apache.daffodil.lib.xml.DaffodilSAXParserFactory
+import org.apache.daffodil.lib.xml.NS
 import org.apache.daffodil.lib.xml.NS.implicitNStoString
 import org.apache.daffodil.lib.xml.XMLUtils
 
@@ -350,9 +351,9 @@ class SchemaAwareFactoryAdapter() extends NoBindingFactoryAdapter {
     // If we're the xs:schema node, then append attribute for _file_ as well.
     val nsURI = scope.getURI(pre)
     val isXSSchemaNode = (label == "schema" && nsURI != null &&
-      (nsURI == XMLUtils.XSD_NAMESPACE))
+      (NS(nsURI) == XMLUtils.XSD_NAMESPACE))
     val isTDMLTestSuiteNode = (label == "testSuite" && nsURI != null &&
-      nsURI == XMLUtils.TDML_NAMESPACE)
+      NS(nsURI) == XMLUtils.TDML_NAMESPACE)
     val isFileRootNode = isXSSchemaNode || isTDMLTestSuiteNode
 
     // augment the scope with the dafint namespace binding but only

--- a/daffodil-lib/src/test/scala/org/apache/daffodil/lib/validation/TestValidatorsSPI.scala
+++ b/daffodil-lib/src/test/scala/org/apache/daffodil/lib/validation/TestValidatorsSPI.scala
@@ -53,8 +53,8 @@ class TestValidatorsSPI {
     val v = f.make(XercesValidatorFactory.makeConfig(Seq(schema)))
     val r = v.validateXML(infoset)
 
-    assertTrue(r.warnings.isEmpty)
-    assertTrue(r.errors.isEmpty)
+    assertTrue(r.warnings().isEmpty)
+    assertTrue(r.errors().isEmpty)
   }
 
   @Test def testFailingValidator(): Unit = {
@@ -62,9 +62,9 @@ class TestValidatorsSPI {
     val v = f.make(XercesValidatorFactory.makeConfig(Seq(schema)))
     val r = v.validateXML(infoset)
 
-    assertTrue(r.warnings.isEmpty)
-    assertFalse(r.errors.isEmpty)
+    assertTrue(r.warnings().isEmpty)
+    assertFalse(r.errors().isEmpty)
 
-    assertEquals(r.errors.iterator().next().getMessage, "boom")
+    assertEquals(r.errors().iterator().next().getMessage, "boom")
   }
 }

--- a/daffodil-lib/src/test/scala/org/apache/daffodil/lib/validation/TestXercesValidator.scala
+++ b/daffodil-lib/src/test/scala/org/apache/daffodil/lib/validation/TestXercesValidator.scala
@@ -29,7 +29,7 @@ class TestXercesValidator {
     val v = f.make(XercesValidatorFactory.makeConfig(Seq(schema)))
     val r = v.validateXML(infoset)
 
-    assertTrue(r.warnings.isEmpty)
-    assertTrue(r.errors.isEmpty)
+    assertTrue(r.warnings().isEmpty)
+    assertTrue(r.errors().isEmpty)
   }
 }

--- a/daffodil-lib/src/test/scala/org/apache/daffodil/lib/xml/test/unit/TestXMLUtils.scala
+++ b/daffodil-lib/src/test/scala/org/apache/daffodil/lib/xml/test/unit/TestXMLUtils.scala
@@ -254,7 +254,7 @@ class TestXMLUtils {
     // somewhat fungible.
     //
     val parser = ConstructingParser.fromSource(scala.io.Source.fromString(xmlRaw), true)
-    val xml = parser.document.docElem
+    val xml = parser.document().docElem
     assertEquals(5, xml.child.length)
     assertFalse(xml.child.forall { _.isInstanceOf[Text] })
     assertTrue(xml.child(1).isInstanceOf[PCData])
@@ -290,7 +290,7 @@ class TestXMLUtils {
     // Constructing parser.
     //
     val parser = ConstructingParser.fromSource(scala.io.Source.fromString(xmlRaw), true)
-    val xml = parser.document.docElem
+    val xml = parser.document().docElem
     assertEquals(1, xml.child.length)
     assertTrue(xml.child(0).isInstanceOf[PCData])
     val res = XMLUtils.coalesceAdjacentTextNodes(xml.child)

--- a/daffodil-lib/src/test/scala/passera/test/UnsignedPerf.scala
+++ b/daffodil-lib/src/test/scala/passera/test/UnsignedPerf.scala
@@ -35,7 +35,7 @@ object UnsignedPerf {
       val t0 = System.nanoTime
       val r = body
       val t1 = System.nanoTime
-      println((t1 - t0) / 1e3 + " us")
+      println(((t1 - t0) / 1e3).toString + " us")
       r
     }
 


### PR DESCRIPTION
- add () to some method invocations
- fix comparison of String to NS
- use immutable.Seq instead of collection.Seq for arguments
- explicitly convert long to double using .toDouble
- convert number to string before concatenating

DAFFODIL-2152