### PR TITLE
Fix some deprecated collections

### DIFF
--- a/daffodil-core/src/main/scala/org/apache/daffodil/core/grammar/SequenceGrammarMixin.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/core/grammar/SequenceGrammarMixin.scala
@@ -16,6 +16,8 @@
  */
 
 package org.apache.daffodil.core.grammar
+import scala.collection.compat.immutable.LazyList
+
 import org.apache.daffodil.core.dsom._
 import org.apache.daffodil.core.grammar.primitives.OrderedSequence
 import org.apache.daffodil.core.grammar.primitives.UnorderedSequence
@@ -60,7 +62,7 @@ trait SequenceGrammarMixin extends GrammarMixin with SequenceTermRuntime1Mixin {
   }
 
   private lazy val seqChildren = LV(Symbol("seqChildren")) {
-    (groupMembers.zip(Stream.from(1))).map { case (gm, i) =>
+    (groupMembers.zip(LazyList.from(1))).map { case (gm, i) =>
       sequenceChild(gm, i)
     }
   }.value

--- a/daffodil-core/src/main/scala/org/apache/daffodil/core/util/TestUtils.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/core/util/TestUtils.scala
@@ -22,6 +22,7 @@ import java.io.InputStream
 import java.nio.channels.Channels
 import java.nio.channels.ReadableByteChannel
 import java.nio.channels.WritableByteChannel
+import scala.collection.compat.immutable.LazyList
 import scala.collection.mutable.ArrayBuffer
 import scala.util.Try
 import scala.xml._
@@ -376,13 +377,13 @@ object StreamParser {
     }
   }
 
-  def doStreamTest(schema: Node, data: String): Stream[Result] = {
+  def doStreamTest(schema: Node, data: String): LazyList[Result] = {
     val mp = new StreamParser(schema)
     val is: InputStream = new ByteArrayInputStream(data.getBytes("ascii"))
     mp.setInputStream(is)
     var r: StreamParser.Result = null
     val results = new ArrayBuffer[Result]
-    val resStream = Stream.continually(mp.parse).takeWhile(r => !r.isProcessingError)
+    val resStream = LazyList.continually(mp.parse).takeWhile(r => !r.isProcessingError)
     resStream
   }
 }

--- a/daffodil-core/src/test/scala/org/apache/daffodil/core/dsom/TestSimpleTypeUnions.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/core/dsom/TestSimpleTypeUnions.scala
@@ -103,7 +103,7 @@ class TestSimpleTypeUnions {
       .asInstanceOf[PState]
       .infoset
       .asInstanceOf[DIDocument]
-      .contents(0)
+      .child(0)
       .asInstanceOf[DISimple]
     val umstrd = i.unionMemberRuntimeData.get
     assertEquals("int1Type", umstrd.diagnosticDebugName)
@@ -118,7 +118,7 @@ class TestSimpleTypeUnions {
       .asInstanceOf[PState]
       .infoset
       .asInstanceOf[DIDocument]
-      .contents(0)
+      .child(0)
       .asInstanceOf[DISimple]
     val umstrd = i.unionMemberRuntimeData.get
     assertEquals("int2Type", umstrd.diagnosticDebugName)
@@ -133,7 +133,7 @@ class TestSimpleTypeUnions {
       .asInstanceOf[PState]
       .infoset
       .asInstanceOf[DIDocument]
-      .contents(0)
+      .child(0)
       .asInstanceOf[DISimple]
     val Some(dv: java.lang.Integer) = Some(i.dataValue.getInt)
     assertEquals(3, dv.intValue())
@@ -226,7 +226,7 @@ class TestSimpleTypeUnions {
       .asInstanceOf[PState]
       .infoset
       .asInstanceOf[DIDocument]
-      .contents(0)
+      .child(0)
       .asInstanceOf[DISimple]
     val Some(dv: java.lang.Integer) = Some(i.dataValue.getInt)
     assertEquals(3, dv.intValue())
@@ -256,7 +256,7 @@ class TestSimpleTypeUnions {
       .asInstanceOf[PState]
       .infoset
       .asInstanceOf[DIDocument]
-      .contents(0)
+      .child(0)
       .asInstanceOf[DISimple]
     val umstrd = i.unionMemberRuntimeData.get
     assertEquals("int12Type", umstrd.diagnosticDebugName)
@@ -271,7 +271,7 @@ class TestSimpleTypeUnions {
       .asInstanceOf[PState]
       .infoset
       .asInstanceOf[DIDocument]
-      .contents(0)
+      .child(0)
       .asInstanceOf[DISimple]
     val umstrd = i.unionMemberRuntimeData.get
     assertEquals("int12Type", umstrd.diagnosticDebugName)
@@ -286,7 +286,7 @@ class TestSimpleTypeUnions {
       .asInstanceOf[PState]
       .infoset
       .asInstanceOf[DIDocument]
-      .contents(0)
+      .child(0)
       .asInstanceOf[DISimple]
     val umstrd = i.unionMemberRuntimeData.get
     assertEquals(
@@ -351,7 +351,7 @@ class TestSimpleTypeUnions {
       .asInstanceOf[PState]
       .infoset
       .asInstanceOf[DIDocument]
-      .contents(0)
+      .child(0)
       .asInstanceOf[DISimple]
     val umstrd = i.unionMemberRuntimeData.get
     assertEquals("ex:foo3or4bar", umstrd.diagnosticDebugName)
@@ -366,7 +366,7 @@ class TestSimpleTypeUnions {
       .asInstanceOf[PState]
       .infoset
       .asInstanceOf[DIDocument]
-      .contents(0)
+      .child(0)
       .asInstanceOf[DISimple]
     val umstrd = i.unionMemberRuntimeData.get
     assertEquals("foo1or2bar", umstrd.diagnosticDebugName)
@@ -381,7 +381,7 @@ class TestSimpleTypeUnions {
       .asInstanceOf[PState]
       .infoset
       .asInstanceOf[DIDocument]
-      .contents(0)
+      .child(0)
       .asInstanceOf[DISimple]
     val umstrd = i.unionMemberRuntimeData.get
     assertEquals("foo1or2bar", umstrd.diagnosticDebugName)
@@ -396,7 +396,7 @@ class TestSimpleTypeUnions {
       .asInstanceOf[PState]
       .infoset
       .asInstanceOf[DIDocument]
-      .contents(0)
+      .child(0)
       .asInstanceOf[DISimple]
     val Some(dv: String) = Some(i.dataValue.getString)
     assertEquals("foo4bar", dv)
@@ -430,7 +430,7 @@ class TestSimpleTypeUnions {
       .asInstanceOf[PState]
       .infoset
       .asInstanceOf[DIDocument]
-      .contents(0)
+      .child(0)
       .asInstanceOf[DISimple]
     val Some(dv: String) = Some(i.dataValue.getString)
     assertEquals("notfoo1bar", dv)

--- a/daffodil-core/src/test/scala/org/apache/daffodil/core/infoset/TestInfoset.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/core/infoset/TestInfoset.scala
@@ -70,7 +70,7 @@ object TestInfoset {
     val infosetRootNode = {
       val ustate = unparseResult.resultState.asInstanceOf[UStateMain]
       val diDocument: DIDocument = ustate.documentElement
-      val rootElement = diDocument.contents(0).asInstanceOf[DIElement]
+      val rootElement = diDocument.child(0).asInstanceOf[DIElement]
       Assert.invariant(rootElement ne null)
       rootElement
     }
@@ -440,7 +440,7 @@ class TestInfoset1 {
     }><enum>EQUAL_TO_OR_&lt;_0.0001_SQUARE_DATA_MILES</enum></root>
 
     val (infoset: DIComplex, _, tunable) = testInfoset(testSchema, xmlInfoset)
-    val enumElt: DISimple = infoset.children.head.asInstanceOf[DISimple]
+    val enumElt: DISimple = infoset.child(0).asInstanceOf[DISimple]
     val value = enumElt.dataValueAsString
     assertEquals("EQUAL_TO_OR_<_0.0001_SQUARE_DATA_MILES", value)
 

--- a/daffodil-core/src/test/scala/org/apache/daffodil/core/infoset/TestInfosetCursorFromReader2.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/core/infoset/TestInfosetCursorFromReader2.scala
@@ -17,7 +17,7 @@
 
 package org.apache.daffodil.core.infoset
 
-import scala.collection.immutable.Stream.consWrapper
+import scala.collection.compat.immutable.LazyList
 
 import org.apache.daffodil.core.compiler.Compiler
 import org.apache.daffodil.lib.Implicits._
@@ -60,7 +60,7 @@ class TestInfosetInputterFromReader2 {
     }
     val rootERD = u.ssrd.elementRuntimeData
 
-    def foos: Stream[String] = "<foo>Hello</foo>" #:: foos
+    def foos: LazyList[String] = "<foo>Hello</foo>" #:: foos
     val ex = XMLUtils.EXAMPLE_NAMESPACE.toString
     def strings =
       (("<bar xmlns='" + ex + "' >") #:: foos.take(size))
@@ -72,11 +72,11 @@ class TestInfosetInputterFromReader2 {
     (ic, rootERD, inputter)
   }
 
-  class StreamInputStream(private var strings: Stream[String]) extends java.io.InputStream {
+  class StreamInputStream(private var strings: LazyList[String]) extends java.io.InputStream {
 
     private var bytes = {
       val ss = strings.flatMap { _.getBytes() } ++ "</bar>".getBytes().toStream
-      strings = Nil.toStream
+      strings = Nil.to(LazyList)
       ss
     }
 
@@ -89,7 +89,7 @@ class TestInfosetInputterFromReader2 {
       }
     }
 
-    override def close(): Unit = { bytes = Nil.toStream }
+    override def close(): Unit = { bytes = Nil.to(LazyList) }
   }
 
   @Test def testStreamingBehavior1(): Unit = {

--- a/daffodil-io/src/main/scala/org/apache/daffodil/io/RegexLimitingInputStream.scala
+++ b/daffodil-io/src/main/scala/org/apache/daffodil/io/RegexLimitingInputStream.scala
@@ -23,6 +23,7 @@ import java.nio.charset.Charset
 import java.nio.charset.StandardCharsets
 import java.util.Scanner
 import java.util.regex.Pattern
+import scala.collection.compat.immutable.LazyList
 
 import org.apache.daffodil.lib.exceptions.Assert
 
@@ -134,8 +135,8 @@ class RegexLimitingInputStream(
    * consider that the overhead is once per chunk, so honestly the
    * regex match is of more concern.
    */
-  private def chunks: Stream[String] = {
-    if (noMoreChunks) Stream()
+  private def chunks: LazyList[String] = {
+    if (noMoreChunks) LazyList()
     else {
       in.mark(lookAheadMax)
       //
@@ -168,7 +169,7 @@ class RegexLimitingInputStream(
       if (delimMatchLength > 0)
         noMoreChunks = true
       if (beforeMatchString.isEmpty)
-        Stream()
+        LazyList()
       else
         // lazy list construction. chunks will not be recursively evaluated unless demanded
         beforeMatchString #:: chunks

--- a/daffodil-io/src/main/scala/org/apache/daffodil/io/StringDataInputStreamForUnparse.scala
+++ b/daffodil-io/src/main/scala/org/apache/daffodil/io/StringDataInputStreamForUnparse.scala
@@ -88,7 +88,7 @@ final class StringDataInputStreamForUnparse extends DataInputStreamImplMixin {
   override def setBitLimit0b(bitLimit0b: MaybeULong): Boolean = doNotUse
   override def setDebugging(setting: Boolean): Unit = doNotUse
   override def isDefinedForLength(length: Long): Boolean = doNotUse
-  override def hasData: Boolean = doNotUse
+  override def hasData(): Boolean = doNotUse
   override def skip(nBits: Long, finfo: FormatInfo): Boolean = doNotUse
   override def resetBitLimit0b(savedBitLimit0b: MaybeULong): Unit = doNotUse
   // $COVERAGE-ON$

--- a/daffodil-io/src/main/scala/org/apache/daffodil/io/processors/charset/BitsCharset.scala
+++ b/daffodil-io/src/main/scala/org/apache/daffodil/io/processors/charset/BitsCharset.scala
@@ -24,7 +24,7 @@ import java.nio.charset.CoderResult
 import java.nio.charset.CodingErrorAction
 import java.nio.charset.{ Charset => JavaCharset }
 import java.nio.charset.{ CharsetEncoder => JavaCharsetEncoder }
-import scala.collection.convert.ImplicitConversions.`collection AsScalaIterable`
+import scala.jdk.CollectionConverters._
 
 import org.apache.daffodil.lib.exceptions.Assert
 import org.apache.daffodil.lib.schema.annotation.props.gen.BitOrder
@@ -153,9 +153,10 @@ trait BitsCharsetJava extends BitsCharset {
   }
 
   private lazy val hasNameOrAliasContainingEBCDIC = {
-    val allCharsetNames = (javaCharset.aliases().toSeq :+ name :+ javaCharset.name()).map {
-      _.toUpperCase
-    }
+    val allCharsetNames =
+      (javaCharset.aliases().asScala.toSeq :+ name :+ javaCharset.name()).map {
+        _.toUpperCase
+      }
     val res = allCharsetNames.exists(_.contains("EBCDIC"))
     res
   }
@@ -227,7 +228,7 @@ final class BitsCharsetWrappingJavaCharsetEncoder(
     isReset = true
     this
   }
-  def isMandatoryAlignmentNeeded = isReset
+  def isMandatoryAlignmentNeeded() = isReset
   def malformedInputAction() = enc.malformedInputAction()
   def onMalformedInput(action: CodingErrorAction) = {
     Assert.usage(isReset)

--- a/daffodil-io/src/main/scala/org/apache/daffodil/io/processors/charset/X_DFDL_MIL_STD.scala
+++ b/daffodil-io/src/main/scala/org/apache/daffodil/io/processors/charset/X_DFDL_MIL_STD.scala
@@ -36,7 +36,7 @@ object BitsCharset6BitDFI264DUI001 extends BitsCharsetNonByteSize {
   override lazy val name = "X-DFDL-6-BIT-DFI-264-DUI-001"
   override lazy val bitWidthOfACodeUnit = 6
   override lazy val decodeString =
-    """ 123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ\uFFFD\uFFFD\uFFFD\uFFFD\uFFFD\uFFFD\uFFFD\uFFFD\uFFFD\uFFFD\uFFFD\uFFFD\uFFFD\uFFFD\uFFFD\uFFFD\uFFFD\uFFFD\uFFFD\uFFFD\uFFFD\uFFFD\uFFFD\uFFFD\uFFFD\uFFFD\uFFFD0"""
+    " 123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ\uFFFD\uFFFD\uFFFD\uFFFD\uFFFD\uFFFD\uFFFD\uFFFD\uFFFD\uFFFD\uFFFD\uFFFD\uFFFD\uFFFD\uFFFD\uFFFD\uFFFD\uFFFD\uFFFD\uFFFD\uFFFD\uFFFD\uFFFD\uFFFD\uFFFD\uFFFD\uFFFD0"
   override lazy val replacementCharCode = 0x0
   override lazy val requiredBitOrder = BitOrder.LeastSignificantBitFirst
 }
@@ -47,7 +47,7 @@ final class BitsCharset6BitDFI264DUI001Definition
 sealed abstract class BitsCharset6BitDFI311DUI002Base extends BitsCharsetNonByteSize {
   override lazy val bitWidthOfACodeUnit = 6
   override lazy val decodeString =
-    """\u00A0ABCDEFGHIJKLMNOPQRSTUVWXYZ\uFFFD\uFFFD\uFFFD\uFFFD\uFFFD \uFFFD\uFFFD\uFFFD\uFFFD\uFFFD\uFFFD\uFFFD\uFFFD\uFFFD\uFFFD\uFFFD\uFFFD\uFFFD\uFFFD\uFFFD0123456789\uFFFD\uFFFD\uFFFD\uFFFD\uFFFD\uFFFD"""
+    "\u00A0ABCDEFGHIJKLMNOPQRSTUVWXYZ\uFFFD\uFFFD\uFFFD\uFFFD\uFFFD \uFFFD\uFFFD\uFFFD\uFFFD\uFFFD\uFFFD\uFFFD\uFFFD\uFFFD\uFFFD\uFFFD\uFFFD\uFFFD\uFFFD\uFFFD0123456789\uFFFD\uFFFD\uFFFD\uFFFD\uFFFD\uFFFD"
   override lazy val replacementCharCode = 0x0
 }
 
@@ -126,7 +126,7 @@ object BitsCharset5BitDFI1661DUI001 extends BitsCharsetNonByteSize {
   override lazy val name = "X-DFDL-5-BIT-DFI-1661-DUI-001"
   override lazy val bitWidthOfACodeUnit = 5
   override lazy val decodeString =
-    """\u00A0ABCDEFGHIJKLMNOPQRSTUVWXYZ\uFFFD\uFFFD\uFFFD\uFFFD\uFFFD"""
+    "\u00A0ABCDEFGHIJKLMNOPQRSTUVWXYZ\uFFFD\uFFFD\uFFFD\uFFFD\uFFFD"
   override lazy val replacementCharCode = 0x0
   override lazy val requiredBitOrder = BitOrder.LeastSignificantBitFirst
 }

--- a/daffodil-io/src/test/scala/org/apache/daffodil/io/TestDirectOrBufferedDataOutputStream.scala
+++ b/daffodil-io/src/test/scala/org/apache/daffodil/io/TestDirectOrBufferedDataOutputStream.scala
@@ -34,7 +34,7 @@ class TestDirectOrBufferedDataOutputStream {
     val is = new ByteArrayInputStream(baos.getBuf)
     val ir = new InputStreamReader(is, "ascii")
     val line = IOUtils.toString(ir)
-    val res = line.replace("""\u0000""", "")
+    val res = line.replace("\u0000", "")
     res
   }
 

--- a/daffodil-lib/src/main/scala/org/apache/daffodil/lib/util/ArrayBuffer1.scala
+++ b/daffodil-lib/src/main/scala/org/apache/daffodil/lib/util/ArrayBuffer1.scala
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.daffodil.lib.util
+
+import java.util
+import scala.collection.mutable.ArrayBuffer
+
+/**
+ * Compatibility ArrayBuffer class for 2.12 and 2.13 since reduceToSize
+ * has been removed in 2.13. This allows us to maintain the same
+ * functionality as 2.12 while upgraded to 2.13
+ */
+class ArrayBuffer1[T](initialSize: Int = 16) extends ArrayBuffer[T] {
+  // Preallocate space to avoid frequent resizing
+  this.sizeHint(initialSize)
+
+  def reduceToSize1(sz: Int): Unit = {
+    if (sz >= 0 && sz <= size0) {
+      // to ensure things are not left un-garbage collected
+      util.Arrays.fill(array, sz, size0, null)
+      size0 = sz
+    } else
+      throw new IndexOutOfBoundsException(
+        "Invalid size: Must be between 0 and the current size of the buffer."
+      )
+  }
+}
+
+object ArrayBuffer1 extends ArrayBuffer {
+  def apply[T](ab: ArrayBuffer[T]): ArrayBuffer1[T] = {
+    val s = ab.length
+    val arr = new ArrayBuffer1[T](s)
+    arr ++= ab
+    arr
+  }
+}

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/debugger/InteractiveDebugger.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/debugger/InteractiveDebugger.scala
@@ -1807,7 +1807,7 @@ class InteractiveDebugger(
             }
 
             node match {
-              case d: DIDocument if d.contents.size == 0 => {
+              case d: DIDocument if d.numChildren == 0 => {
                 debugPrintln("No Infoset", "  ")
               }
               case _ => {

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/dpath/DState.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/dpath/DState.scala
@@ -25,7 +25,6 @@ import org.apache.daffodil.lib.util.Maybe
 import org.apache.daffodil.lib.util.Maybe.Nope
 import org.apache.daffodil.lib.util.Maybe.One
 import org.apache.daffodil.runtime1.infoset.DIArray
-import org.apache.daffodil.runtime1.infoset.DIComplex
 import org.apache.daffodil.runtime1.infoset.DIElement
 import org.apache.daffodil.runtime1.infoset.DINode
 import org.apache.daffodil.runtime1.infoset.DISimple
@@ -282,17 +281,15 @@ case class DState(
   def currentComplex = currentNode.asComplex
 
   def nextSibling = {
-    val contents = currentElement.parent.asInstanceOf[DIComplex].contents
-
     // TOOD, currentNode should really know this
-    val i = contents.indexOf(currentNode)
-    if (i == contents.length - 1) {
+    val i = currentElement.parent.indexOf(currentNode)
+    if (i == currentElement.parent.numChildren - 1) {
       throw new InfosetNoNextSiblingException(
         currentNode.asSimple,
         currentNode.erd.dpathElementCompileInfo
       )
     } else {
-      contents(i + 1)
+      currentElement.parent.child(i + 1)
     }
   }
 

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/infoset/InfosetWalker.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/infoset/InfosetWalker.scala
@@ -95,7 +95,7 @@ object InfosetWalker {
         val container: DINode =
           if (root.maybeArray.isDefined) root.maybeArray.get.asInstanceOf[DINode]
           else root.parent.asInstanceOf[DINode]
-        (container, container.contents.indexOf(root))
+        (container, container.indexOf(root))
       }
     }
     new InfosetWalker(
@@ -386,12 +386,10 @@ class InfosetWalker private (
       // no blocks on the container, figure out if we can take a step for the
       // element at the child index of this container
 
-      val children = containerNode.contents
-
-      if (containerIndex < children.length) {
+      if (containerIndex < containerNode.numChildren) {
         // There is a child element at this index. Taking a step would create
         // the events for, and moved passed, this element.
-        val elem = children(containerIndex)
+        val elem = containerNode.child(containerIndex)
         if (elem.infosetWalkerBlockCount > 0) {
           // This element has a block associated with it, likely meaning we are
           // speculatively parsing this element and so it may or may not exist.
@@ -492,18 +490,16 @@ class InfosetWalker private (
    * so we are looking at the next node in the infoset.
    */
   private def infosetWalkerStepMove(containerNode: DINode, containerIndex: Int): Unit = {
-    val children = containerNode.contents
-
-    if (containerIndex < children.size) {
-      // This block means we need to create a start event for the element in
-      // the children array at containerIndex. Once we create that event we
+    if (containerIndex < containerNode.numChildren) {
+      // This block means we need to create a start event for the element
+      // at containerIndex. Once we create that event we
       // need to mutate the state of the InfosetWalker so that the next time we
       // take a step we are looking at the next element. If this is a complex
       // type, that next element is the first child. If this is a simple type,
       // that next element is the next sibling of this element. We will mutate
       // the state accordingly.
 
-      val child = children(containerIndex)
+      val child = containerNode.child(containerIndex)
 
       if (child.isSimple) {
         if (!child.isHidden || walkHidden) {

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/infoset/JDOMInfosetInputter.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/infoset/JDOMInfosetInputter.scala
@@ -136,7 +136,7 @@ class JDOMInfosetInputter(doc: Document) extends InfosetInputter {
   }
 
   override def fini = {
-    stack.clear
+    stack.clear()
   }
 
   /**

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/infoset/JDOMInfosetOutputter.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/infoset/JDOMInfosetOutputter.scala
@@ -36,7 +36,7 @@ class JDOMInfosetOutputter extends InfosetOutputter {
   def reset()
     : Unit = { // call to reuse these. When first constructed no reset call is necessary.
     result = Maybe.Nope
-    stack.clear
+    stack.clear()
   }
 
   def startDocument(): Unit = {

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/infoset/ScalaXMLInfosetInputter.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/infoset/ScalaXMLInfosetInputter.scala
@@ -152,7 +152,7 @@ class ScalaXMLInfosetInputter(rootNode: Node) extends InfosetInputter {
   }
 
   override def fini = {
-    stack.clear
+    stack.clear()
   }
 
   /**

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/infoset/ScalaXMLInfosetOutputter.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/infoset/ScalaXMLInfosetOutputter.scala
@@ -39,7 +39,7 @@ class ScalaXMLInfosetOutputter(showFreedInfo: Boolean = false) extends InfosetOu
   def reset()
     : Unit = { // call to reuse these. When first constructed no reset call is necessary.
     resultNode = Maybe.Nope
-    stack.clear
+    stack.clear()
   }
 
   def startDocument(): Unit = {
@@ -59,7 +59,7 @@ class ScalaXMLInfosetOutputter(showFreedInfo: Boolean = false) extends InfosetOu
         val selfFreed = diElem.wouldHaveBeenFreed
         val arrayFreed =
           if (diElem.erd.isArray)
-            diElem.diParent.children
+            diElem.diParent
               .find {
                 _.erd eq diElem.erd
               }

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/infoset/W3CDOMInfosetInputter.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/infoset/W3CDOMInfosetInputter.scala
@@ -138,7 +138,7 @@ class W3CDOMInfosetInputter(doc: Document) extends InfosetInputter {
   }
 
   override def fini = {
-    stack.clear
+    stack.clear()
   }
 
   /**

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/infoset/W3CDOMInfosetOutputter.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/infoset/W3CDOMInfosetOutputter.scala
@@ -43,7 +43,7 @@ class W3CDOMInfosetOutputter extends InfosetOutputter {
     : Unit = { // call to reuse these. When first constructed no reset call is necessary.
     result = Maybe.Nope
     document = null
-    stack.clear
+    stack.clear()
   }
 
   def startDocument(): Unit = {

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/layers/LayerDriver.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/layers/LayerDriver.scala
@@ -20,7 +20,7 @@ package org.apache.daffodil.runtime1.layers
 import java.io.FilterInputStream
 import java.io.InputStream
 import java.io.OutputStream
-import scala.collection.convert.ImplicitConversions.`collection AsScalaIterable`
+import scala.jdk.CollectionConverters._
 
 import org.apache.daffodil.io.DataInputStream.Mark
 import org.apache.daffodil.io.DataOutputStream
@@ -92,7 +92,7 @@ class LayerDriver private (val layer: Layer) {
       // because we want to deal with RuntimeException as if it was NOT a subclass of
       // Exception, we first divide up the classes as to whether they are RuntimeExceptions or not.
       val (runtimeExceptionSubClasses, regularExceptionSubclasses) =
-        layer.getProcessingErrorExceptions.partition { c =>
+        layer.getProcessingErrorExceptions.asScala.partition { c =>
           classOf[RuntimeException].isAssignableFrom(c)
         }
 

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/DataProcessor.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/DataProcessor.scala
@@ -475,7 +475,7 @@ class DataProcessor(
           // is the root node has not been set final because isFinal is handled
           // by the sequence parser and there is no sequence around the root
           // node. So mark it final and do one last walk to end the document.
-          state.infoset.contents(0).isFinal = true
+          state.infoset.child(0).isFinal = true
           state.walker.walk(lastWalk = true)
           Assert.invariant(state.walker.isFinished)
         }

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/SuspensionTracker.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/SuspensionTracker.scala
@@ -85,7 +85,7 @@ class SuspensionTracker(suspensionWaitYoung: Int, suspensionWaitOld: Int) {
     )
 
     if (suspensionsOld.nonEmpty) {
-      throw new SuspensionDeadlockException(suspensionsOld.seq)
+      throw new SuspensionDeadlockException(suspensionsOld.toSeq)
     }
 
     Logger.log.debug(

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/dfa/Parser.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/dfa/Parser.scala
@@ -19,6 +19,7 @@ package org.apache.daffodil.runtime1.processors.dfa
 
 import scala.collection.mutable.ArrayBuffer
 
+import org.apache.daffodil.lib.util.ArrayBuffer1
 import org.apache.daffodil.lib.util.Maybe
 import org.apache.daffodil.runtime1.processors.RuntimeData
 
@@ -35,7 +36,7 @@ abstract class DFAParser extends Serializable {
 }
 
 class LongestMatchTracker {
-  val longestMatches: ArrayBuffer[DFADelimiter] = ArrayBuffer.empty
+  val longestMatches: ArrayBuffer1[DFADelimiter] = new ArrayBuffer1[DFADelimiter]
   var longestMatchedStartPos: Int = Int.MaxValue
   var longestMatchedString: String = null
 
@@ -54,14 +55,14 @@ class LongestMatchTracker {
       // match starts earlier than previous matches, make it the longest
       longestMatchedStartPos = matchedStartPos
       longestMatchedString = matchedString.toString
-      longestMatches.reduceToSize(0)
+      longestMatches.reduceToSize1(0)
       longestMatches.append(dfa)
     } else if (matchedStartPos == longestMatchedStartPos) {
       if (matchedString.length > longestMatchedString.length) {
         // match starts at the same point as previous matches, but
         // is longer. make it the only match
         longestMatchedString = matchedString.toString
-        longestMatches.reduceToSize(0)
+        longestMatches.reduceToSize1(0)
         longestMatches.append(dfa)
       } else if (matchedString.length == longestMatchedString.length) {
         // match starts at the same point as previous matches,

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/DelimiterParsers.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/DelimiterParsers.scala
@@ -81,7 +81,7 @@ class DelimiterTextParser(
     val localIndexStart = state.mpstate.delimitersLocalIndexStack.top
     val inScopeDelimiters = state.mpstate.delimiters
     val res = inScopeDelimiters.slice(localIndexStart, inScopeDelimiters.length)
-    res
+    res.toSeq
   }
 
   private def didNotFindExpectedDelimiter(foundDelimiter: ParseResult, start: PState): Unit = {

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/ElementKindParsers.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/ElementKindParsers.scala
@@ -80,7 +80,7 @@ class DelimiterStackParser(
       bodyParser.parse1(start)
     } finally {
       // pop delimiters
-      start.mpstate.delimiters.reduceToSize(start.mpstate.delimitersLocalIndexStack.pop)
+      start.mpstate.delimiters.reduceToSize1(start.mpstate.delimitersLocalIndexStack.pop())
     }
   }
 }

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/HiddenGroupCombinatorParser.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/HiddenGroupCombinatorParser.scala
@@ -34,11 +34,11 @@ class HiddenGroupCombinatorParser(ctxt: ModelGroupRuntimeData, bodyParser: Parse
 
   def parse(start: PState): Unit = {
     try {
-      start.incrementHiddenDef
+      start.incrementHiddenDef()
       // parse
       bodyParser.parse1(start)
     } finally {
-      start.decrementHiddenDef
+      start.decrementHiddenDef()
     }
   }
 }

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/PState.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/PState.scala
@@ -21,7 +21,6 @@ import java.nio.channels.Channels
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.nio.file.Path
-import scala.collection.mutable
 
 import org.apache.daffodil.io.DataInputStream
 import org.apache.daffodil.io.InputSourceDataInputStream
@@ -31,6 +30,7 @@ import org.apache.daffodil.lib.api.Diagnostic
 import org.apache.daffodil.lib.exceptions.Abort
 import org.apache.daffodil.lib.exceptions.Assert
 import org.apache.daffodil.lib.exceptions.ThrowsSDE
+import org.apache.daffodil.lib.util.ArrayBuffer1
 import org.apache.daffodil.lib.util.MStack
 import org.apache.daffodil.lib.util.MStackOf
 import org.apache.daffodil.lib.util.MStackOfInt
@@ -130,14 +130,13 @@ class MPState private () {
   // TODO: it doesn't look anything is actually reading the value of childindex
   // stack. Can we get rid of it?
   val childIndexStack = MStackOfLong()
-  def moveOverOneElementChildOnly() = childIndexStack.push(childIndexStack.pop + 1)
+  def moveOverOneElementChildOnly() = childIndexStack.push(childIndexStack.pop() + 1)
   def childPos = {
     val res = childIndexStack.top
     Assert.invariant(res >= 1)
     res
   }
-
-  val delimiters = new mutable.ArrayBuffer[DFADelimiter]
+  val delimiters = new ArrayBuffer1[DFADelimiter]
   val delimitersLocalIndexStack = MStackOfInt()
 
   val escapeSchemeEVCache = new MStackOfMaybe[EscapeSchemeParserHelper]

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/RepTypeParsers.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/RepTypeParsers.scala
@@ -71,7 +71,7 @@ trait WithDetachedParser {
       detachedParser.parse1(pstate)
 
       val res: DataValuePrimitiveNullable = pstate.processorStatus match {
-        case Success => pstate.infoset.children.last.asSimple.dataValue
+        case Success => pstate.infoset.child(pstate.infoset.numChildren - 1).asSimple.dataValue
         case _ => DataValue.NoValue
       }
 

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/SequenceParserBases.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/SequenceParserBases.scala
@@ -87,7 +87,7 @@ abstract class SequenceParserBase(
 
       var resultOfTry: ParseAttemptStatus = ParseAttemptStatus.Uninitialized
 
-      val infosetIndexStart = pstate.infoset.asInstanceOf[DIComplex].childNodes.size
+      val infosetIndexStart = pstate.infoset.asInstanceOf[DIComplex].numChildren
 
       if (!isOrdered) {
         // If this is an unordered sequence, upon completion of parsing all the

--- a/daffodil-tdml-lib/src/main/scala/org/apache/daffodil/tdml/TDMLRunner.scala
+++ b/daffodil-tdml-lib/src/main/scala/org/apache/daffodil/tdml/TDMLRunner.scala
@@ -28,6 +28,7 @@ import java.nio.CharBuffer
 import java.nio.LongBuffer
 import java.nio.charset.CoderResult
 import java.nio.charset.StandardCharsets
+import scala.collection.compat.immutable.LazyList
 import scala.collection.mutable
 import scala.language.postfixOps
 import scala.util.Try
@@ -1835,7 +1836,7 @@ object VerifyTestCase {
       )
     }
 
-    val pairs = expectedBytes.zip(actualBytes).zip(Stream.from(1))
+    val pairs = expectedBytes.zip(actualBytes).zip(LazyList.from(1))
     pairs.foreach { case ((expected, actual), index) =>
       if (expected != actual) {
         val msg = ("Unparsed data differs at byte %d. Expected 0x%02x. Actual was 0x%02x.\n" +
@@ -2051,7 +2052,7 @@ object VerifyTestCase {
       )
     }
 
-    val pairs = expectedText.toSeq.zip(actualText.toSeq).zip(Stream.from(1))
+    val pairs = expectedText.toSeq.zip(actualText.toSeq).zip(LazyList.from(1))
     pairs.foreach { case ((expected, actual), index) =>
       if (expected != actual) {
         val msg =
@@ -2111,7 +2112,7 @@ object VerifyTestCase {
       )
     }
 
-    val pairs = expectedBytes.zip(actualBytes).zip(Stream.from(1))
+    val pairs = expectedBytes.zip(actualBytes).zip(LazyList.from(1))
     pairs.foreach { case ((expected, actual), index) =>
       if (expected != actual) {
         val msg = "Unparsed data differs at byte %d. Expected 0x%02x. Actual was 0x%02x."

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section23/dfdl_functions/Functions.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section23/dfdl_functions/Functions.tdml
@@ -11323,7 +11323,7 @@
     model="XPathFunctions" description="Section 23 - Functions - fn:count - DFDL-23-124R">
 
     <tdml:document>
-      <tdml:documentPart type="text">B:6,B:1,P:3,B:6,B:2,P:3,P:3</tdml:documentPart>
+      <tdml:documentPart type="text">B:6,B:1,P:3,B:5,B:4,P:8,P:9</tdml:documentPart>
     </tdml:document>
     <tdml:infoset>
       <tdml:dfdlInfoset>
@@ -11331,11 +11331,11 @@
           <scores>
             <bobcats>6</bobcats>
             <bobcats>1</bobcats>
-            <bobcats>6</bobcats>
-            <bobcats>2</bobcats>
+            <bobcats>5</bobcats>
+            <bobcats>4</bobcats>
             <pirates>3</pirates>
-            <pirates>3</pirates>
-            <pirates>3</pirates>
+            <pirates>8</pirates>
+            <pirates>9</pirates>
           </scores>
           <bobcatScoreCount>4</bobcatScoreCount>
           <pirateScoreCount>3</pirateScoreCount>


### PR DESCRIPTION
- like Stream -> LazyList
- JavaConverters -> CollectionConverters
- some () added to method invocations
- replace triple quoted unicode characters with regular doublequote
- make some vals that use reduceToSize (removed in 2.13) to vars so we can use slice instead

DAFFODIL-2152