### PR TITLE
Improve reproduciblity for release candidate artifacts

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -184,12 +184,12 @@ jobs:
       - name: Build Documentation
         run: $SBT unidoc genTunablesDoc
 
-      - name: Package Zip & Tar
-        run: $SBT daffodil-cli/Universal/packageBin daffodil-cli/Universal/packageZipTarball
+      - name: Package Zip
+        run: $SBT daffodil-cli/Universal/packageBin
 
-      - name: Package RPM (Linux)
+      - name: Package RPM & Tar (Linux)
         if: runner.os == 'Linux'
-        run: $SBT daffodil-cli/Rpm/packageBin
+        run: $SBT daffodil-cli/Rpm/packageBin daffodil-cli/Universal/packageZipTarball
 
       ############################################################
       # Check

--- a/daffodil-cli/src/templates/bash-template
+++ b/daffodil-cli/src/templates/bash-template
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with


### PR DESCRIPTION
The SBT native packager plugin is used to build helper binaries for release candidate. In some cases these binaries are difficult to check for reproducibility due to metadata that is embedded in the files. This modifies our SBT configurations where possible to remove as much variance as possible.

For tar, this adds options (based on tar reproducibility documentation) that sets things like userid's and modification times to consistent values. Note that the --sort=name option does not work on the version of tar available on GitHub Windows and MacOS systems, so we now only generate the tar on Linux CI.

For rpm, this sets a number of macros (e.g buildhost) so that the embedded values in the RPM are always the same regardless of the actual environment properties, which can differ between systems. We also change the shebang in the bash script from /bin/bash to /usr/bin/bash since Fedora changes bash shebangs to /usr/bin/bash while other systems keep the original shebang. By changing to /usr/bin/bash it ensures the RPM is the same regardless of the system where it is built. Note that are still some macros in RPM that cannot be controlled my %defines, so in general a same or similar environment is needed for reproducible RPMs.

For msi, there is nothing more we can do. There are only a couple of timestamps and UUID's that cannot be changed. msidiff is a useful tool that shows these are the only differences.

Zip artifacts are already reproducible and do not need changes.

DAFFODIL-2971