### PR TITLE
Fix all any2StringAdd and Implicit without Return types Errors

### DIFF
--- a/daffodil-core/src/main/scala/org/apache/daffodil/core/grammar/RepTypeMixin.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/core/grammar/RepTypeMixin.scala
@@ -166,9 +166,11 @@ trait RepTypeMixin { self: ElementBase =>
           lt.operate(h1, l2).getBoolean,
           "Overlapping dfdlx:%s (%s) and dfdlx:%s (%s) found",
           if (lt.operate(l1, h1).getBoolean) "repValueRanges" else "repValues",
-          if (lt.operate(l1, h1).getBoolean) l1.value + " " + h1.value else l1.value,
+          if (lt.operate(l1, h1).getBoolean) l1.value.toString + " " + h1.value.toString
+          else l1.value.toString,
           if (lt.operate(l2, h2).getBoolean) "repValueRanges" else "repValues",
-          if (lt.operate(l2, h2).getBoolean) l2.value + " " + h2.value else l2.value
+          if (lt.operate(l2, h2).getBoolean) l2.value.toString + " " + h2.value.toString
+          else l2.value.toString
         )
         (l2, h2)
       }

--- a/daffodil-core/src/test/scala/org/apache/daffodil/core/dsom/walker/TestDSOMWalker.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/core/dsom/walker/TestDSOMWalker.scala
@@ -223,7 +223,8 @@ class TestDSOMWalker {
       )
       val className: String = simpleTypes(index - 1).getSimpleName
       val withoutView: String = className.substring(0, className.length - 4)
-      val fieldName: String = withoutView.charAt(0).toLower + withoutView.substring(1) + "Field"
+      val fieldName: String =
+        withoutView.charAt(0).toLower +: (withoutView.substring(1) + "Field")
       assertEquals(
         s"The $elementIndex${getSuffix(elementIndex)} element in the stack should be named '$fieldName'",
         fieldName,

--- a/daffodil-io/src/test/scala/org/apache/daffodil/io/TestInputSourceDataInputStream.scala
+++ b/daffodil-io/src/test/scala/org/apache/daffodil/io/TestInputSourceDataInputStream.scala
@@ -589,7 +589,6 @@ class TestInputSourceDataInputStream {
     val m = pat.matcher("")
     val cb = CharBuffer.wrap("aaab")
     m.reset(cb)
-    val sb = new StringBuilder
     val isMatch = m.lookingAt()
     assertTrue(isMatch)
     val hitEnd = m.hitEnd
@@ -604,7 +603,6 @@ class TestInputSourceDataInputStream {
     assertEqualsTyped[Long](4, end)
     val group = m.group
     assertEqualsTyped("aaab", group)
-    sb + group
   }
 
   /**

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/dpath/NodeInfo.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/dpath/NodeInfo.scala
@@ -198,7 +198,7 @@ object NodeInfo extends Enum {
       val cname = super.name
       val first = cname(0).toLower
       val rest = cname.substring(1)
-      first + rest
+      first +: rest
     }
 
     def isError: Boolean = false

--- a/daffodil-runtime1/src/test/scala/org/apache/daffodil/runtime1/processors/input/TestICU.scala
+++ b/daffodil-runtime1/src/test/scala/org/apache/daffodil/runtime1/processors/input/TestICU.scala
@@ -263,7 +263,7 @@ class TestICU {
     assertEquals(JDouble.POSITIVE_INFINITY, numInf.doubleValue, 0.0)
 
     val ppNInf = new ParsePosition(0)
-    val numNInf = df.parse(dfs.getMinusSign + dfs.getInfinity, ppNInf)
+    val numNInf = df.parse(dfs.getMinusSign +: dfs.getInfinity, ppNInf)
     assertTrue(numNInf.isInstanceOf[Double])
     assertEquals(JDouble.NEGATIVE_INFINITY, numNInf.doubleValue, 0.0)
   }


### PR DESCRIPTION
- used `scalafixAll dependency:fix.scala213.Any2StringAdd@org.scala-lang:scala-rewrites:0.1.5`
- required fixing some things by hand like `"" + char + string` -> `char +: string` or `String.valueOf(...)` -> `_.toString`
- used `sbt scalafix --rules=ExplicitResultTypes -P:ExplicitResultTypes.onlyImplicits=true

DAFFODIL-2152