### PR TITLE
Fix some more collection errors

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -293,7 +293,11 @@ def buildScalacOptions(scalaVersion: String) = {
       Seq(
         "-Xlint:inaccessible",
         "-Xlint:infer-any",
-        "-Xlint:nullary-unit"
+        "-Xlint:nullary-unit",
+        // TODO: scala 2.12 phase out
+        // the import is needed for Scala 2.12 but issues an unused import warning under 2.13, so we add this to
+        // suppresss the warning
+        "-Wconf:origin=scala.collection.compat.*:s"
       )
     case _ => Seq.empty
   }

--- a/daffodil-codegen-c/src/main/scala/org/apache/daffodil/codegen/c/generators/CodeGeneratorState.scala
+++ b/daffodil-codegen-c/src/main/scala/org/apache/daffodil/codegen/c/generators/CodeGeneratorState.scala
@@ -28,7 +28,7 @@ import org.apache.daffodil.core.dsom.SchemaComponent
 import org.apache.daffodil.lib.api.WarnID
 import org.apache.daffodil.lib.cookers.ChoiceBranchKeyCooker
 import org.apache.daffodil.lib.schema.annotation.props.gen.OccursCountKind
-import org.apache.daffodil.lib.util.Stack
+import org.apache.daffodil.lib.util.collections.Stack
 import org.apache.daffodil.runtime1.dpath.NodeInfo.PrimType
 
 /**

--- a/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/ElementBase.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/ElementBase.scala
@@ -29,6 +29,7 @@ import org.apache.daffodil.lib.schema.annotation.props._
 import org.apache.daffodil.lib.schema.annotation.props.gen._
 import org.apache.daffodil.lib.util.MaybeULong
 import org.apache.daffodil.lib.util.Misc
+import org.apache.daffodil.lib.util.collections.RichMap
 import org.apache.daffodil.lib.xml._
 import org.apache.daffodil.runtime1.dpath.InvalidPrimitiveDataException
 import org.apache.daffodil.runtime1.dpath.NodeInfo
@@ -256,7 +257,9 @@ trait ElementBase
 
       // Creates a Map[prefix, Set[NS]]. Duplicate NS's will be removed from the
       // Set, since it's a Set
-      val bindingsGroupedByPrefix = allBindings.groupBy { _._1 }.mapValues { _.map { _._2 } }
+      val bindingsGroupedByPrefix = new RichMap(allBindings.groupBy { _._1 }).mapValues {
+        _.map { _._2 }
+      }
 
       // Any Set with size > 1 has different namespaces for the same prefix, filter them out
       val bindingsNoConflictsMap = bindingsGroupedByPrefix.filter { case (prefix, bindings) =>
@@ -264,7 +267,7 @@ trait ElementBase
       }
 
       // Create a Map[prefix, NS] now that conflicts are removed
-      val bindingsSingleNSMap = bindingsNoConflictsMap.mapValues { _.head }
+      val bindingsSingleNSMap = new RichMap(bindingsNoConflictsMap).mapValues { _.head }
 
       // Convert back to a set
       val bindings = bindingsSingleNSMap.toSet

--- a/daffodil-core/src/main/scala/org/apache/daffodil/core/grammar/primitives/ChoiceCombinator.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/core/grammar/primitives/ChoiceCombinator.scala
@@ -32,6 +32,7 @@ import org.apache.daffodil.lib.exceptions.Assert
 import org.apache.daffodil.lib.schema.annotation.props.gen.ChoiceLengthKind
 import org.apache.daffodil.lib.util.MaybeInt
 import org.apache.daffodil.lib.util.ProperlySerializableMap._
+import org.apache.daffodil.lib.util.collections.RichMap
 import org.apache.daffodil.runtime1.infoset.ChoiceBranchEvent
 import org.apache.daffodil.runtime1.processors.RangeBound
 import org.apache.daffodil.runtime1.processors.parsers._
@@ -236,17 +237,18 @@ case class ChoiceCombinator(ch: ChoiceTermBase, alternatives: Seq[Gram])
         }
       })
 
-      val dispatchBranchKeyMap = dispatchBranchKeyValueTuples.toMap.mapValues { gram =>
-        val isRepresented =
-          true // choice branches are, currently, always represented (cannot have inputValueCalc).
-        val gramParser = gram.parser
-        val parser =
-          if (gramParser.isEmpty) {
-            new ChoiceBranchEmptyParser(gram.context.runtimeData)
-          } else {
-            gramParser
-          }
-        (parser, isRepresented)
+      val dispatchBranchKeyMap = new RichMap(dispatchBranchKeyValueTuples.toMap).mapValues {
+        gram =>
+          val isRepresented =
+            true // choice branches are, currently, always represented (cannot have inputValueCalc).
+          val gramParser = gram.parser
+          val parser =
+            if (gramParser.isEmpty) {
+              new ChoiceBranchEmptyParser(gram.context.runtimeData)
+            } else {
+              gramParser
+            }
+          (parser, isRepresented)
       }
 
       val serializableMap: ProperlySerializableMap[String, (Parser, Boolean)] =

--- a/daffodil-core/src/main/scala/org/apache/daffodil/core/runtime1/ChoiceTermRuntime1Mixin.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/core/runtime1/ChoiceTermRuntime1Mixin.scala
@@ -26,6 +26,7 @@ import org.apache.daffodil.core.grammar.Gram
 import org.apache.daffodil.lib.api.WarnID
 import org.apache.daffodil.lib.exceptions.Assert
 import org.apache.daffodil.lib.util.Delay
+import org.apache.daffodil.lib.util.collections.RichMap
 import org.apache.daffodil.runtime1.dpath.NodeInfo
 import org.apache.daffodil.runtime1.infoset.ChoiceBranchEndEvent
 import org.apache.daffodil.runtime1.infoset.ChoiceBranchEvent
@@ -121,10 +122,12 @@ trait ChoiceTermRuntime1Mixin { self: ChoiceTermBase =>
     }
 
     // converts a sequence of tuples into a multi-map
-    val eventMap = eventTuples
-      .groupBy {
-        _._1
-      }
+    val eventMap = new RichMap(
+      eventTuples
+        .groupBy {
+          _._1
+        }
+    )
       .mapValues {
         _.map(_._2)
       }

--- a/daffodil-lib/src/main/scala/org/apache/daffodil/lib/util/OnStack.scala
+++ b/daffodil-lib/src/main/scala/org/apache/daffodil/lib/util/OnStack.scala
@@ -19,6 +19,8 @@ package org.apache.daffodil.lib.util
 
 import java.util.regex.Matcher
 
+import org.apache.daffodil.lib.util.collections.Stack
+
 sealed abstract class LocalStackBase[T](constructorFunc: => T, optionalResetFunc: (T => Unit)) {
 
   protected def stack: Stack[T]

--- a/daffodil-lib/src/main/scala/org/apache/daffodil/lib/util/Timer.scala
+++ b/daffodil-lib/src/main/scala/org/apache/daffodil/lib/util/Timer.scala
@@ -19,6 +19,8 @@ package org.apache.daffodil.lib.util
 
 import scala.jdk.CollectionConverters._
 
+import org.apache.daffodil.lib.util.collections.Stack
+
 object Timer {
 
   def printTime(message: String, nanos: Long, units: String): Unit = {
@@ -188,7 +190,7 @@ object TimeTracker {
    *
    * TODO: not covered by tests
    */
-  val childrenTimeStack = new org.apache.daffodil.lib.util.Stack[Long]()
+  val childrenTimeStack = new Stack[Long]()
 
   /**
    * Used to measure a section of code that might get called multiple times.

--- a/daffodil-lib/src/main/scala/org/apache/daffodil/lib/util/collections/ArrayBuffer1.scala
+++ b/daffodil-lib/src/main/scala/org/apache/daffodil/lib/util/collections/ArrayBuffer1.scala
@@ -15,12 +15,13 @@
  * limitations under the License.
  */
 
-package org.apache.daffodil.lib.util
+package org.apache.daffodil.lib.util.collections
 
 import java.util
 import scala.collection.mutable.ArrayBuffer
 
 /**
+ * TODO: scala 2.12 phase out
  * Compatibility ArrayBuffer class for 2.12 and 2.13 since reduceToSize
  * has been removed in 2.13. This allows us to maintain the same
  * functionality as 2.12 while upgraded to 2.13

--- a/daffodil-lib/src/main/scala/org/apache/daffodil/lib/util/collections/MultiMap.scala
+++ b/daffodil-lib/src/main/scala/org/apache/daffodil/lib/util/collections/MultiMap.scala
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.daffodil.lib.util.collections
+
+import scala.collection.mutable
+
+/**
+ * TODO: scala 2.12 phase out
+ * Compatibility class for 2.12 and 2.13 since MultiMap and inheritance
+ * from class mutable.HashMap have been deprecated in 2.13.
+ */
+class MultiMap[K, V] {
+  private val underlying = mutable.Map.empty[K, mutable.Set[V]]
+
+  def addBinding(key: K, value: V): Unit =
+    underlying.getOrElseUpdate(key, mutable.Set.empty) += value
+
+  def addBinding(key: K, values: mutable.Set[V]): Unit = {
+    values.foreach(addBinding(key, _))
+  }
+
+  def removeBinding(key: K, value: V): Unit =
+    underlying.get(key).foreach { values =>
+      values -= value
+      if (values.isEmpty) underlying -= key
+    }
+
+  def get(key: K): Option[mutable.Set[V]] = underlying.get(key)
+
+  def keys: Iterable[K] = underlying.keys
+
+  def iterator: Iterator[(K, mutable.Set[V])] = underlying.iterator
+
+  def filter(func: (K, mutable.Set[V]) => Boolean): MultiMap[K, V] = {
+    val filtered = new MultiMap[K, V]
+    for ((key, values) <- underlying) {
+      if (func(key, values)) {
+        filtered.addBinding(key, values)
+      }
+    }
+    filtered
+  }
+
+  def map[T](func: (K, mutable.Set[V]) => T): collection.Seq[T] = {
+    val ret = mutable.ListBuffer.empty[T]
+    for ((key, values) <- underlying) {
+      ret.append(func(key, values))
+    }
+    ret
+  }
+}

--- a/daffodil-lib/src/main/scala/org/apache/daffodil/lib/util/collections/RichMap.scala
+++ b/daffodil-lib/src/main/scala/org/apache/daffodil/lib/util/collections/RichMap.scala
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.daffodil.lib.util.collections
+
+import scala.language.implicitConversions
+
+// TODO scala 2.12 phase out
+// Define RichMap to add mapValues and filterKeys method
+class RichMap[K, V](val underlying: Map[K, V]) extends AnyVal {
+  implicit def mapValues[V2](f: V => V2): Map[K, V2] = underlying.map { case (k, v) =>
+    k -> f(v)
+  }
+
+  implicit def filterKeys(f: K => Boolean): Map[K, V] = underlying.filter { case (k, _) =>
+    f(k)
+  }
+}

--- a/daffodil-lib/src/main/scala/org/apache/daffodil/lib/util/collections/Stack.scala
+++ b/daffodil-lib/src/main/scala/org/apache/daffodil/lib/util/collections/Stack.scala
@@ -15,11 +15,12 @@
  * limitations under the License.
  */
 
-package org.apache.daffodil.lib.util
+package org.apache.daffodil.lib.util.collections
 
 import scala.collection.mutable.ListBuffer
 
 /**
+ * TODO: scala 2.12 phase out
  * Compatibility class for 2.12 and 2.13 since ArrayStack and Stack
  * have been deprecated in 2.13. This allows us to maintain the same
  * functionality as stack while using ListBuffer instead

--- a/daffodil-lib/src/test/scala/org/apache/daffodil/lib/util/TestXMLCatalogAndValidate.scala
+++ b/daffodil-lib/src/test/scala/org/apache/daffodil/lib/util/TestXMLCatalogAndValidate.scala
@@ -33,6 +33,7 @@ import scala.xml.parsing.NoBindingFactoryAdapter
 
 import org.apache.daffodil.lib.exceptions.Assert
 import org.apache.daffodil.lib.util.Implicits.using
+import org.apache.daffodil.lib.util.collections.Stack
 import org.apache.daffodil.lib.xml.DaffodilSAXParserFactory
 import org.apache.daffodil.lib.xml.NS
 import org.apache.daffodil.lib.xml.NS.implicitNStoString

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/debugger/InteractiveDebugger.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/debugger/InteractiveDebugger.scala
@@ -18,6 +18,7 @@
 package org.apache.daffodil.runtime1.debugger
 
 import java.io.File
+import scala.collection.compat.immutable.ArraySeq
 
 import org.apache.daffodil.lib.api.DaffodilTunables
 import org.apache.daffodil.lib.api.WarnID
@@ -279,7 +280,7 @@ class InteractiveDebugger(
         input
       }
     }
-    cmd.split(" ").filter(_ != "")
+    ArraySeq.unsafeWrapArray(cmd.split(" ").filter(_ != ""))
   }
 
   private val debuggerQName = GlobalQName(Some("daf"), "debugger", XMLUtils.dafintURI)
@@ -1862,7 +1863,7 @@ class InteractiveDebugger(
       }
 
       abstract class InfoProcessorBase extends DebugCommand with DebugCommandValidateZeroArgs {
-        val desc = "display the current Daffodil " + name
+        val desc = "display the current Daffodil " + this.name
         val longDesc = desc
         def act(
           args: Seq[String],
@@ -1871,15 +1872,15 @@ class InteractiveDebugger(
         ): DebugState.Type = {
           state match {
             case pstate: PState => {
-              if (name == "parser") {
-                debugPrintln("%s: %s".format(name, processor.toBriefXML(2)))
+              if (this.name == "parser") {
+                debugPrintln("%s: %s".format(this.name, processor.toBriefXML(2)))
               } else {
                 debugPrintln("unparser: not available")
               }
             }
             case ustate: UState => {
-              if (name == "unparser") {
-                debugPrintln("%s: %s".format(name, processor.toBriefXML(2)))
+              if (this.name == "unparser") {
+                debugPrintln("%s: %s".format(this.name, processor.toBriefXML(2)))
               } else {
                 debugPrintln("parser: not available")
               }

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/dpath/DFDLXFunctions.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/dpath/DFDLXFunctions.scala
@@ -235,7 +235,7 @@ case class DFDLXTrace(recipe: CompiledDPath, msg: String)
 
   // This is toXML for the case class object, not the infoset node it is
   // dealing with.
-  override def toXML = toXML(recipe.toXML)
+  override def toXML = toXMLVarargs(recipe.toXML)
 
 }
 

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/dpath/DPathRuntime.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/dpath/DPathRuntime.scala
@@ -18,6 +18,7 @@
 package org.apache.daffodil.runtime1.dpath
 
 import java.lang.{ Number => JNumber }
+import scala.collection.compat.immutable.ArraySeq
 import scala.xml.NodeSeq.seqToNodeSeq
 
 import org.apache.daffodil.lib.api.DaffodilTunables
@@ -43,7 +44,7 @@ import org.apache.daffodil.runtime1.processors.VariableRuntimeData
 
 class CompiledDPath(val ops: RecipeOp*) extends Serializable {
 
-  def this(ops: List[RecipeOp]) = this(ops.toArray: _*)
+  def this(ops: List[RecipeOp]) = this(ArraySeq.unsafeWrapArray(ops.toArray): _*)
 
   override def toString =
     toXML.toString
@@ -157,9 +158,9 @@ abstract class RecipeOp extends Serializable {
 
   protected def subRecipes: Seq[CompiledDPath] = Nil
 
-  protected def toXML(s: String): scala.xml.Node = toXML(new scala.xml.Text(s))
+  protected def toXML(s: String): scala.xml.Node = toXMLVarargs(new scala.xml.Text(s))
 
-  protected def toXML(children: scala.xml.Node*): scala.xml.Node = toXML(children.toSeq)
+  protected def toXMLVarargs(children: scala.xml.Node*): scala.xml.Node = toXML(children.toSeq)
 
   protected def toXML(children: scala.xml.NodeSeq): scala.xml.Node = {
     val name = Misc.getNameFromClass(this)
@@ -246,7 +247,8 @@ trait BinaryOpMixin { self: RecipeOp =>
   def right: CompiledDPath
   override def subRecipes: Seq[CompiledDPath] = Seq(left, right)
 
-  override def toXML: scala.xml.Node = toXML(new scala.xml.Text(op), left.toXML, right.toXML)
+  override def toXML: scala.xml.Node =
+    toXMLVarargs(new scala.xml.Text(op), left.toXML, right.toXML)
 }
 
 case class CompareOperator(cop: CompareOpBase, left: CompiledDPath, right: CompiledDPath)

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/dpath/FNBases.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/dpath/FNBases.scala
@@ -124,7 +124,7 @@ abstract class FNOneArg(recipe: CompiledDPath, argType: NodeInfo.Kind)
     dstate.setCurrentValue(computeValue(arg, dstate))
   }
 
-  override def toXML = toXML(recipe.toXML)
+  override def toXML = toXMLVarargs(recipe.toXML)
 
   def computeValue(str: DataValuePrimitive, dstate: DState): DataValuePrimitive
 }

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/dpath/FNFunctions.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/dpath/FNFunctions.scala
@@ -714,7 +714,7 @@ case class FNExists(recipe: CompiledDPath, argType: NodeInfo.Kind)
     dstate.setCurrentValue(res)
   }
 
-  override def toXML = toXML(recipe.toXML)
+  override def toXML = toXMLVarargs(recipe.toXML)
 
 }
 
@@ -726,7 +726,7 @@ case class FNEmpty(recipe: CompiledDPath, argType: NodeInfo.Kind)
     dstate.setCurrentValue(!res)
   }
 
-  override def toXML = toXML(recipe.toXML)
+  override def toXML = toXMLVarargs(recipe.toXML)
 
 }
 
@@ -919,13 +919,13 @@ case class FNRound(recipe: CompiledDPath, argType: NodeInfo.Kind)
         val f = asFloat(value.getAnyRef).floatValue()
         if (f.isPosInfinity || f.isNegInfinity) f
         else if (f.isNaN()) throw new NumberFormatException("fn:round received NaN")
-        else f.round: Float
+        else f.round.toFloat
       }
       case NodeInfo.Double => {
         val d = asDouble(value.getAnyRef).doubleValue()
         if (d.isPosInfinity || d.isNegInfinity) d
         else if (d.isNaN()) throw new NumberFormatException("fn:round received NaN")
-        else d.round: Double
+        else d.round.toDouble
       }
       case _: NodeInfo.Numeric.Kind => value
       case _ =>

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/externalvars/ExternalVariablesLoader.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/externalvars/ExternalVariablesLoader.scala
@@ -19,6 +19,7 @@ package org.apache.daffodil.runtime1.externalvars
 
 import java.io.File
 import java.net.URI
+import scala.collection.compat._
 import scala.collection.immutable.Queue
 import scala.io.Codec.string2codec
 import scala.xml.Node
@@ -65,7 +66,7 @@ object ExternalVariablesLoader {
         Binding(name, value)
       }
     }
-    Queue.empty.enqueue(varsKVP)
+    Queue.empty.enqueueAll(varsKVP)
   }
 
   def uriToBindings(uri: URI): Queue[Binding] = {

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/infoset/InfosetImpl.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/infoset/InfosetImpl.scala
@@ -41,7 +41,6 @@ import org.apache.daffodil.lib.equality.TypeEqual
 import org.apache.daffodil.lib.equality.ViewEqual
 import org.apache.daffodil.lib.exceptions.Assert
 import org.apache.daffodil.lib.exceptions.ThinException
-import org.apache.daffodil.lib.util.ArrayBuffer1
 import org.apache.daffodil.lib.util.Logger
 import org.apache.daffodil.lib.util.Maybe
 import org.apache.daffodil.lib.util.Maybe.Nope
@@ -51,6 +50,7 @@ import org.apache.daffodil.lib.util.MaybeInt
 import org.apache.daffodil.lib.util.MaybeULong
 import org.apache.daffodil.lib.util.Misc
 import org.apache.daffodil.lib.util.Numbers
+import org.apache.daffodil.lib.util.collections.ArrayBuffer1
 import org.apache.daffodil.lib.xml.NamedQName
 import org.apache.daffodil.lib.xml.XMLUtils
 import org.apache.daffodil.runtime1.api.ComplexElementMetadata

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/infoset/PartialNextElementResolver.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/infoset/PartialNextElementResolver.scala
@@ -17,12 +17,15 @@
 
 package org.apache.daffodil.runtime1.infoset
 
+import scala.collection.compat.immutable.LazyList
+
 import org.apache.daffodil.lib.exceptions.Assert
 import org.apache.daffodil.lib.util.Logger
 import org.apache.daffodil.lib.util.MStackOf
 import org.apache.daffodil.lib.util.Maybe
 import org.apache.daffodil.lib.util.Maybe._
 import org.apache.daffodil.lib.util.ResettableIterator
+import org.apache.daffodil.lib.util.collections.RichMap
 import org.apache.daffodil.lib.xml.NS
 import org.apache.daffodil.lib.xml.NamedQName
 import org.apache.daffodil.lib.xml.QNameBase
@@ -126,7 +129,7 @@ trait NextElementResolver { self: InfosetInputter =>
   ): Maybe[ElementRuntimeData] = {
     val allTRDs = {
       iter.reset()
-      iter.toStream.takeWhile { stackTRD =>
+      iter.to(LazyList).takeWhile { stackTRD =>
         optTRD.map { _ ne stackTRD }.getOrElse(true)
       }
     }
@@ -334,7 +337,7 @@ class SeveralPossibilitiesForNextElement(
           // with a matching local name, and error if we found more than one.
           // If we only found one we found it. If we didn't find any, there was
           // no match.
-          val localMatches = nextERDMap.filterKeys(_.local == local)
+          val localMatches = new RichMap(nextERDMap).filterKeys(_.local == local)
           if (localMatches.size > 1) {
             val sqn = StepQName(None, local, NS(namespace))
             val keys = localMatches.keys.toSeq

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/EvTextNumber.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/EvTextNumber.scala
@@ -18,7 +18,6 @@
 package org.apache.daffodil.runtime1.processors
 
 import java.math.RoundingMode
-import scala.collection.mutable
 
 import org.apache.daffodil.lib.cookers.TextBooleanFalseRepCooker
 import org.apache.daffodil.lib.cookers.TextBooleanTrueRepCooker
@@ -33,6 +32,7 @@ import org.apache.daffodil.lib.util.Maybe._
 import org.apache.daffodil.lib.util.MaybeChar
 import org.apache.daffodil.lib.util.MaybeDouble
 import org.apache.daffodil.lib.util.MaybeInt
+import org.apache.daffodil.lib.util.collections.MultiMap
 import org.apache.daffodil.runtime1.dpath.NodeInfo.PrimType
 import org.apache.daffodil.runtime1.dsom._
 
@@ -96,8 +96,7 @@ class TextNumberFormatEv(
     exponentRep: Maybe[String]
   ): Unit = {
 
-    val mm = new mutable.HashMap[String, mutable.Set[String]]
-      with mutable.MultiMap[String, String]
+    val mm = new MultiMap[String, String]
     if (decimalSep.isDefined)
       mm.addBinding(decimalSep.get.toString, "textStandardDecimalSeparator")
     if (groupingSep.isDefined)

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/SuspensionTracker.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/SuspensionTracker.scala
@@ -21,6 +21,7 @@ import scala.collection.mutable.Queue
 
 import org.apache.daffodil.lib.exceptions.Assert
 import org.apache.daffodil.lib.util.Logger
+import org.apache.daffodil.lib.util.collections.RichMap
 import org.apache.daffodil.runtime1.dsom.RuntimeSchemaDefinitionError
 
 class SuspensionTracker(suspensionWaitYoung: Int, suspensionWaitOld: Int) {
@@ -121,10 +122,12 @@ class SuspensionDeadlockException(suspExprs: Seq[Suspension])
   extends RuntimeSchemaDefinitionError(
     suspExprs(0).rd.schemaFileLocation,
     "Expressions/Unparsers are circularly deadlocked (mutually defined):\n%s",
-    suspExprs
-      .groupBy {
-        _.rd
-      }
+    new RichMap(
+      suspExprs
+        .groupBy {
+          _.rd
+        }
+    )
       .mapValues {
         _(0)
       }

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/dfa/Parser.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/dfa/Parser.scala
@@ -19,8 +19,8 @@ package org.apache.daffodil.runtime1.processors.dfa
 
 import scala.collection.mutable.ArrayBuffer
 
-import org.apache.daffodil.lib.util.ArrayBuffer1
 import org.apache.daffodil.lib.util.Maybe
+import org.apache.daffodil.lib.util.collections.ArrayBuffer1
 import org.apache.daffodil.runtime1.processors.RuntimeData
 
 /**

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/dfa/TextDelimitedUnparser.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/dfa/TextDelimitedUnparser.scala
@@ -17,6 +17,7 @@
 
 package org.apache.daffodil.runtime1.processors.dfa
 
+import scala.collection.compat.immutable.ArraySeq
 import scala.collection.mutable.ArrayBuffer
 
 import org.apache.daffodil.io.DataInputStream
@@ -97,10 +98,10 @@ class TextDelimitedUnparser(override val context: TermRuntimeData) extends Delim
     val fieldReg: Registers = state.dfaRegistersPool.getFromPool("escapeBlock1")
 
     val fieldEscapesIter = {
-      val ab = ArrayBuffer((blockEnd +: delims): _*)
+      val ab = ArrayBuffer(ArraySeq.unsafeWrapArray(blockEnd +: delims): _*)
       new AllDelimiterIterator(ab)
     }
-    val delimIter = new AllDelimiterIterator(ArrayBuffer(delims: _*))
+    val delimIter = new AllDelimiterIterator(ArrayBuffer(ArraySeq.unsafeWrapArray(delims): _*))
 
     fieldReg.reset(state, input, fieldEscapesIter)
 
@@ -274,7 +275,7 @@ class TextDelimitedUnparser(override val context: TermRuntimeData) extends Delim
     val successes: ArrayBuffer[(DFADelimiter, Registers)] = ArrayBuffer.empty
     val fieldReg: Registers = state.dfaRegistersPool.getFromPool("escapeCharacter1")
 
-    val delimIter = new AllDelimiterIterator(ArrayBuffer(delims: _*))
+    val delimIter = new AllDelimiterIterator(ArrayBuffer(ArraySeq.unsafeWrapArray(delims): _*))
 
     fieldReg.reset(state, input, delimIter)
 

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/PState.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/PState.scala
@@ -30,7 +30,6 @@ import org.apache.daffodil.lib.api.Diagnostic
 import org.apache.daffodil.lib.exceptions.Abort
 import org.apache.daffodil.lib.exceptions.Assert
 import org.apache.daffodil.lib.exceptions.ThrowsSDE
-import org.apache.daffodil.lib.util.ArrayBuffer1
 import org.apache.daffodil.lib.util.MStack
 import org.apache.daffodil.lib.util.MStackOf
 import org.apache.daffodil.lib.util.MStackOfInt
@@ -42,6 +41,7 @@ import org.apache.daffodil.lib.util.Maybe.One
 import org.apache.daffodil.lib.util.MaybeULong
 import org.apache.daffodil.lib.util.Pool
 import org.apache.daffodil.lib.util.Poolable
+import org.apache.daffodil.lib.util.collections.ArrayBuffer1
 import org.apache.daffodil.runtime1.api.DFDL
 import org.apache.daffodil.runtime1.api.InfosetDocument
 import org.apache.daffodil.runtime1.infoset.DIComplex

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/udf/UserDefinedFunctionService.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/udf/UserDefinedFunctionService.scala
@@ -25,6 +25,7 @@ import java.io.Serializable
 import java.lang.reflect.Method
 import java.util.ServiceConfigurationError
 import java.util.ServiceLoader
+import scala.collection.compat.immutable.ArraySeq
 import scala.collection.mutable._
 
 import org.apache.daffodil.lib.util.Logger
@@ -56,7 +57,7 @@ object UserDefinedFunctionService {
     }
 
     def lookupMethod() = {
-      val m = decClass.getMethod(methodName, paramTypes: _*)
+      val m = decClass.getMethod(methodName, ArraySeq.unsafeWrapArray(paramTypes): _*)
       m
     }
 

--- a/daffodil-sapi/src/test/scala/org/apache/daffodil/example/TestScalaAPI.scala
+++ b/daffodil-sapi/src/test/scala/org/apache/daffodil/example/TestScalaAPI.scala
@@ -29,6 +29,7 @@ import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.nio.file.Paths
 import javax.xml.XMLConstants
+import scala.collection.compat.immutable.ArraySeq
 
 import org.apache.daffodil.lib.Implicits.using
 import org.apache.daffodil.lib.exceptions.UsageException
@@ -1213,7 +1214,7 @@ class TestScalaAPI {
 
       val bos = new java.io.ByteArrayOutputStream()
       val wbc = java.nio.channels.Channels.newChannel(bos)
-      val inputter = new TestInfosetInputter(expectedEvents: _*)
+      val inputter = new TestInfosetInputter(ArraySeq.unsafeWrapArray(expectedEvents): _*)
 
       val ur = dp.unparse(inputter, wbc)
       assertFalse(ur.isError())

--- a/daffodil-tdml-lib/src/main/scala/org/apache/daffodil/tdml/RunnerFactory.scala
+++ b/daffodil-tdml-lib/src/main/scala/org/apache/daffodil/tdml/RunnerFactory.scala
@@ -18,6 +18,7 @@
 package org.apache.daffodil.tdml
 
 import java.nio.file.Paths
+import scala.collection.compat.immutable.ArraySeq
 
 import org.apache.daffodil.lib.api.TDMLImplementation
 import org.apache.daffodil.lib.api.URISchemaSource
@@ -49,7 +50,8 @@ object Runner {
     compileAllTopLevel: Boolean = false,
     defaultRoundTripDefault: RoundTrip = defaultRoundTripDefaultDefault,
     defaultValidationDefault: String = defaultValidationDefaultDefault,
-    defaultImplementationsDefault: Seq[String] = defaultImplementationsDefaultDefault
+    defaultImplementationsDefault: Seq[String] =
+      ArraySeq.unsafeWrapArray(defaultImplementationsDefaultDefault)
   ): Runner = {
 
     // Prepend forward slash to turn dir/file into classpath resource
@@ -149,7 +151,8 @@ final class Runner private (
   compileAllTopLevel: Boolean = false,
   defaultRoundTripDefault: RoundTrip = Runner.defaultRoundTripDefaultDefault,
   defaultValidationDefault: String = Runner.defaultValidationDefaultDefault,
-  defaultImplementationsDefault: Seq[String] = Runner.defaultImplementationsDefaultDefault,
+  defaultImplementationsDefault: Seq[String] =
+    ArraySeq.unsafeWrapArray(Runner.defaultImplementationsDefaultDefault),
   defaultIgnoreUnexpectedWarningsDefault: Boolean = true,
   defaultIgnoreUnexpectedValidationErrorsDefault: Boolean = true
 ) {

--- a/project/OsgiCheck.scala
+++ b/project/OsgiCheck.scala
@@ -81,7 +81,7 @@ object OsgiCheckPlugin extends AutoPlugin {
         // create a map, grouping with a key of package name and value of all of the
         // owners that claim to own it. If only one project owns a package, the value
         // should be a list of one.
-        val packageOwnersMap = packageOwnerTuples
+        val packageOwnersMap: Map[String, Seq[String]] = packageOwnerTuples
           .groupBy { case (packageName, _) => packageName }
           .mapValues { list => list.map { case (_, packageOwner) => packageOwner } }
 


### PR DESCRIPTION
- fix implicit Array to Seq error using ArraySeq.unsafeWrapArray
- fix inheritance shadowing error by renaming function and using this._
- fix deprecated Array to Scala varargs
- add MultiMapWrapper class since MultiMaps and extending HashMaps are deprecated
- replace deprecated Map.filterKeys with Map.filter( case(k,v) => k...)
- replace deprecated Map.mapValues with suggested Map.values.map
- remove deprecated Either.right since it's the default view now

DAFFODIL-2152