### PR TITLE
Add GitHub action and reproducibility container for release candidates

### DIFF
--- a/.github/actions/asf-release-candidate/action.yml
+++ b/.github/actions/asf-release-candidate/action.yml
@@ -1,0 +1,99 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: 'ASF Release Candidate'
+description: >
+  Action to setup environment and publish ASF release candidates
+
+  Project source must be checked out prior this action. Following steps should
+  install dependencies, optionally build helper binaries, and optionally
+  publish artifacts to a maven repository. Helper binaries or additional
+  artifacts should be written to the directory specified by the `artifact_dir`
+  output. Maven artifacts should be published with `sbt publishSigned`--this
+  action configures SBT to publish to eitehr a local repository or the ASF
+  staging repo depending on if publishing is enabled.
+
+  Workflows using this action should only be triggered when pushing a release
+  candidate tag of the form 'v*-rcX', or manually dispatched. Manually
+  dispatched triggers disabling publishing.
+
+  When triggered from a tag, the tag name  must match the version found in the
+  build source configuration with the 'v' and -rc suffix removed.
+
+  The 'publish' input parameter must be explicitly set to true to enable
+  publishing. Even if true, the action must be trigger from a tag, the version
+  must not be a SNAPSHOT, and the repository must be an ASF--otherwise
+  publishing is disabled.
+
+  When the workflow is complete, this action automatically performs a post step
+  to to signing, checksum, and commit dist artifacts if publishing is enabled.
+
+inputs:
+  tlp_dir:
+    description: >
+      Directory of the top level project in dist/dev/
+    required: true
+  project_name:
+    description: >
+      Human readable name of the project
+    required: true
+  project_id:
+    description: >
+      ID of the project, used in source artifact file name
+    required: true
+  project_dir:
+    description: >
+      Directory for the project in dev/dist/<tlp_dir>/. Omit if at the root
+    required: false
+    default: ""
+  gpg_signing_key:
+    description: >
+      Key used to sign artifacts
+    required: true
+  svn_username:
+    description: >
+      Username for publishing release artifacts to SVN dev/dist
+    required: true
+  svn_password:
+    description: >
+      Password for publishing release artifacts to SVN dev/dist
+    required: true
+  nexus_username:
+    description: >
+      Username for publishing release artifacts to Nexus
+    required: true
+  nexus_password:
+    description: >
+      Password for publishing release artifacts to Nexus
+    required: true
+  publish:
+    description: >
+      Enable/disabling publish artifacts. Must be explcitly set to true to
+      enable publishing. Maybe ignored depending on other factors.
+    required: false
+    default: false
+
+outputs:
+  artifact_dir:
+    description: >
+      Directory where additional release artifacts can be added by the
+      workflow. They are automatically signed, checksumed, and published at the
+      end of the workflow
+
+runs:
+  using: 'node20'
+  main: 'main.js'
+  post: 'post.js'
+  post-if: success()

--- a/.github/actions/asf-release-candidate/main.js
+++ b/.github/actions/asf-release-candidate/main.js
@@ -1,0 +1,196 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const fs = require("fs");
+const os = require("os");
+const core = require("@actions/core");
+const github = require("@actions/github");
+const { exec } = require('@actions/exec');
+
+async function run() {
+	try {
+		const tlp_dir = core.getInput("tlp_dir", { required: true });
+		const project_id = core.getInput("project_id", { required: true });
+		const project_dir = core.getInput("project_dir");
+		const gpg_signing_key = core.getInput("gpg_signing_key", { required: true });
+		const svn_username = core.getInput("svn_username", { required: true });
+		const svn_password = core.getInput("svn_password", { required: true });
+		const nexus_username = core.getInput("nexus_username", { required: true });
+		const nexus_password = core.getInput("nexus_password", { required: true });
+		let publish = core.getBooleanInput("publish");
+
+		// import signing key into gpg and get it's key id
+		let gpg_import_stdout = ""
+		await exec("gpg", ["--batch", "--import", "--import-options", "import-show"], {
+			input: Buffer.from(gpg_signing_key),
+			listeners: {
+				stdout: (data) => { gpg_import_stdout += data.toString(); }
+			}
+		});
+		const gpg_signing_key_id = gpg_import_stdout.match("[0-9A-Z]{40}")[0];
+		console.info("Using gpgp key id: " + gpg_signing_key_id);
+
+		// tags must be signed with a commiters key, download and import committer
+		// keys for verification later
+		let committer_keys = "";
+		await exec("curl", [`https://downloads.apache.org/${ tlp_dir }/KEYS`], {
+			silent: true,
+			listeners: {
+				stdout: (data) => { committer_keys += data.toString(); }
+			}
+		});
+		await exec("gpg", ["--batch", "--import"], {
+			input: Buffer.from(committer_keys)
+		});
+
+		// get the actual project version from the source build configuration--this
+		// does not have a leading 'v' or -rcX suffix, but might have a -SNAPSHOT
+		// suffix. Note that regex stuff is a bit specific Daffodil projects. We
+		// may want to consider requiring projects using this to have a VERSION
+		// file, and it's up to projects to keep that file in sync with the build
+		// configuration--most configs can probably just read this file. This is
+		// really the only part of this action that is specific to Daffodil.
+		// Everything else would likely work for other ASF projects.
+		let project_version = "";
+		if (fs.existsSync("package.json")) {
+			project_version = fs.readFileSync("package.json").toString().match(/"version": "(.*)"/)[1];
+		} else if (fs.existsSync("build.sbt")) {
+			project_version = fs.readFileSync("build.sbt").toString().match(/version := "(.*)"/)[1];
+		} else {
+			throw new Error("Could not determine project version from package.json or build.sbt");
+		}
+
+		let release_version = "";
+		if (github.context.eventName == "push" && github.context.ref.startsWith("refs/tags/")) {
+			// this was triggered by the push of a tag, the tag name will be the
+			// version used
+			release_version = github.context.ref.slice("refs/tags/".length);
+
+			// make sure the tag name matches the actual project version
+			if (!release_version.startsWith(`v${project_version}-`)) {
+				throw new Error(`Tag ${ release_version } does not match project version: v${ project_version }`);
+			}
+
+			// The github checkout action does not fetch tag information when
+			// triggered from a tag, so we fetch it manually so we can verify its tag
+			await exec("git", ["fetch", "origin", "--deepen=1", `+${ github.context.ref }:${ github.context.ref }`]);
+
+			// make sure the tag is signed by a committer in the KEYS file, this
+			// command fails if the tag does not verify.
+			await exec("git", ["tag", "--verify", release_version]);
+		} else {
+			// this was not triggered by a tag, maybe is was manually triggered via
+			// workflow_dispatch or a normal commit. We should only publish from tags,
+			// so we disable publishing. We also set the release_version so that it has the
+			// same format as a tag (e.g. v1.2.3-rc1)
+			core.warning("Action not triggered from tag, publishing disabled");
+			release_version = `v${ project_version }-rc0`;
+			publish = false;
+		}
+
+		const is_snapshot = project_version.includes("-SNAPSHOT");
+
+		// disable publishing for snapshot builds or non-ASF builds. Note that
+		// publishing could still be disabled if the publish input was explicitly set
+		// to false
+		if (publish && (is_snapshot || process.env.GITHUB_REPOSITORY_OWNER != "apache")) {
+			core.warning("Publishing disabled for snapshot versions and from non-apache repositories");
+			publish = false;
+		}
+
+		const release_dir = `${ os.tmpdir() }/release`;
+		fs.mkdirSync(release_dir);
+
+		// enable and configure SBT for signing and publishing. Note that the
+		// sbt-pgp plugin version should not be updated unless there is a
+		// compelling reason. Release signing has been known to break with newer
+		// versions.
+		const sbt_dir = `${ os.homedir }/.sbt/1.0`
+		fs.mkdirSync(`${ sbt_dir }/plugins`, { recursive: true });
+		fs.appendFileSync(`${ sbt_dir }/plugins/build.sbt`, 'addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.1.2")\n');
+		fs.appendFileSync(`${ sbt_dir }/build.sbt`, `pgpSigningKey := Some("${ gpg_signing_key_id }")\n`);
+
+		if (publish) {
+			// if publishing is enabled, publishing to the apache staging repository
+			// with the provided credentials. We must diable gigahorse since that fails
+			// to publish on some systems
+			fs.appendFileSync(`${ sbt_dir }/build.sbt`, 'ThisBuild / updateOptions := updateOptions.value.withGigahorse(false)\n');
+			fs.appendFileSync(`${ sbt_dir }/build.sbt`, `ThisBuild / credentials += Credentials("Sonatype Nexus Repository Manager", "repository.apache.org", "${ nexus_username }", "${ nexus_password }")\n`);
+			fs.appendFileSync(`${ sbt_dir }/build.sbt`, 'ThisBuild / publishTo := Some("Apache Staging Distribution Repository" at "https://repository.apache.org/service/local/staging/deploy/maven2")\n');
+		} else {
+			// if publishing is not enabled, we still want the ability for workflows to
+			// run 'sbt publishSigned' so they don't have to change logic depending on
+			// if they are publishing or not. To support this, configure sbt to publish
+			// to a local maven repo
+			const maven_local_dir = `${ release_dir }/maven-local`;
+			fs.mkdirSync(maven_local_dir);
+			fs.appendFileSync(`${ sbt_dir }/build.sbt`, `ThisBuild / publishTo := Some(MavenCache("maven-local", file("${ maven_local_dir }")))\n`);
+		}
+
+		// checkout artifact dist directory
+		const project_dist_dir = `${ release_dir }/asf-dist`;
+		await exec("svn", ["checkout", `https://dist.apache.org/repos/dist/dev/${ tlp_dir }/${ project_dir }`, project_dist_dir]);
+
+		// remove previous release candidates of this version (i.e. any directories
+		// that have the same project_version followed by a hyphen)
+		const direntries = fs.readdirSync(project_dist_dir, { withFileTypes: true });
+		for(const dirent of direntries) {
+			if (dirent.isDirectory && dirent.name.startsWith(`${ project_version }-`)) {
+				await exec("svn", ["delete", "--force", `${ dirent.parentPath }/${ dirent.name }`]);
+			}
+		}
+
+		// create the directory for artifacts, this is the version without the leading
+		// 'v', but keeping any -rcX or -SNAPSHOT suffixes
+		const artifact_dir = `${ project_dist_dir }/${ release_version.slice(1) }`;
+		fs.mkdirSync(artifact_dir);
+
+		// create the source artifact
+		const src_artifact_dir = `${ artifact_dir }/src`;
+		const src_artifact_name = `apache-${ project_id }-${ project_version }-src`;
+		fs.mkdirSync(src_artifact_dir);
+		await exec("git", ["archive", "--format=zip", `--prefix=${ src_artifact_name }/`, "--output", `${ src_artifact_dir }/${ src_artifact_name }.zip`, "HEAD"]);
+
+		// get the reproducible build epoch
+		let source_date_epoch = "";
+		await exec("git", ["show", "--no-patch", "--format=%ct", "HEAD"], {
+			listeners: {
+				stdout: (data) => { source_date_epoch += data.toString().trim(); }
+			}
+		});
+
+		// we are done with all the filesystem setup, we now export environment
+		// variables, output variables, and state needed by the post script
+
+		// export environment variables
+		core.exportVariable("SOURCE_DATE_EPOCH", source_date_epoch);
+
+		// export step output variables
+		core.setOutput("artifact_dir", artifact_dir);
+
+		// export state information for the post step
+		core.saveState("artifact_dir", artifact_dir);
+		core.saveState("gpg_signing_key_id", gpg_signing_key_id);
+		core.saveState("publish", publish);
+		core.saveState("release_version", release_version);
+
+	} catch (error) {
+		core.setFailed(error.message);
+	}
+}
+
+run();

--- a/.github/actions/asf-release-candidate/post.js
+++ b/.github/actions/asf-release-candidate/post.js
@@ -1,0 +1,85 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const fs = require("fs");
+const os = require("os");
+const core = require("@actions/core");
+const { DefaultArtifactClient } = require('@actions/artifact')
+const { exec } = require('@actions/exec');
+
+// Sign and publish all release artifacts. If publishing is disabled, we just
+// upload all the release candidate artifacts as GitHub workflow artifacts.
+// The post-if condition in action.yml ensures this is only ever run if a job
+// succeeds.
+async function run() {
+	try {
+		const project_name = core.getInput("project_name", { required: true });
+		const svn_username = core.getInput("svn_username", { required: true });
+		const svn_password = core.getInput("svn_password", { required: true });
+
+		const artifact_dir = core.getState("artifact_dir");
+		const gpg_signing_key_id = core.getState("gpg_signing_key_id");
+		const publish = core.getState("publish") === "true";
+		const release_version = core.getState("release_version");
+
+		// sign/checksum all artifacts
+		const artifacts = fs.readdirSync(artifact_dir, { recursive: true, withFileTypes: true });
+		for(const artifact of artifacts) {
+			if (artifact.isFile()) {
+				// must sign rpms before sha/gpg since rpmsign modifies the RPM
+				if (artifact.name.endsWith(".rpm")) {
+					await exec("rpmsign", ["--define", `_gpg_name ${ gpg_signing_key_id }`, "--define", "_binary_filedigest_algorithm 10", "--addsign", `${ artifact.parentPath }/${ artifact.name }`]);
+				}
+				let checksum = "";
+				await exec("sha512sum", ["--binary", artifact.name], {
+					cwd: artifact.parentPath,
+					listeners: {
+						stdout: (data) => { checksum += data.toString(); }
+					}
+				});
+				fs.appendFileSync(`${ artifact.name }.sha512`, checksum);
+				await exec("gpg", ["--default-key", gpg_signing_key_id, "--batch", "--yes", "--detach-sign", "--armor", "--output", `${ artifact.name }.asc`, artifact.name], {
+					cwd: artifact.parentPath
+				});
+			}
+		}
+
+		if (publish) {
+			await exec("svn", ["add", artifact_dir]);
+			await exec("svn", ["commit", "--username", svn_username, "--password", svn_password, "--message", `Stage ${ project_name } ${ release_version }`, artifact_dir]);
+		} else {
+			// if publishing was disabled then this action was likely just triggered
+			// just for testing, so upload the maven-local and artifact directories so
+			// they can be verified
+			const release_dir = `${ os.tmpdir() }/release`;
+			const upload_artifacts = fs.readdirSync(release_dir, { recursive: true, withFileTypes: true })
+				.filter((dirent) => dirent.isFile())
+				.filter((dirent) => !dirent.parentPath.split("/").includes(".svn"))
+				.map((dirent) => `${ dirent.parentPath }/${ dirent.name }`);
+			const artifact_client = new DefaultArtifactClient();
+			artifact_client.uploadArtifact(`release`, upload_artifacts, os.tmpdir(), {
+				compressionLevel: 0,
+				retentionDays: 1
+			});
+		}
+
+	} catch (error) {
+		core.setFailed(error.message);
+	}
+}
+
+run();

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -1,0 +1,135 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Release Candidate
+
+# We build release candidates using GitHub actions when a rc* tag is pushed.
+# Once the vote passes for a release candidate we promote that candidate to the
+# final release--we do not do a new build for final release tags. When
+# triggered via workflow_dispatch the release candidate action disables
+# publishing regardless of the publish setting--it should be used for testing only
+on:
+  push:
+    tags:
+      - 'v*-rc*'
+  workflow_dispatch:
+
+jobs:
+
+  release-candidate:
+    name: Release Candidate ${{ github.ref_name }}
+    runs-on: ubuntu-22.04
+
+    env:
+      AR: llvm-ar-14
+      CC: clang
+      LANG: en_US.UTF-8
+
+    steps:
+
+      - name: Checkout Repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: ASF Release Candidate
+        id: rc
+        uses: apache/daffodil/.github/actions/asf-release-candidate@main
+        with:
+          tlp_dir: 'daffodil'
+          project_name: 'Apache Daffodil'
+          project_id: 'daffodil'
+          gpg_signing_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          svn_username: ${{ secrets.SVN_USERNAME }}
+          svn_password: ${{ secrets.SVN_PASSWORD }}
+          nexus_username: ${{ secrets.NEXUS_USERNAME }}
+          nexus_password: ${{ secrets.NEXUS_PASSWORD }}
+          publish: false
+
+      - name: Install Dependencies
+        run: |
+          sudo apt-get install -y libmxml-dev rpm
+          sudo locale-gen $LANG
+
+      - name: Setup Java
+        uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9 # v4.2.1
+        with:
+          distribution: temurin
+          java-version: 8
+          cache: sbt
+
+      # WIX is a Microsoft Windows Installer creation tool kit.
+      #
+      # Install wix, including changes to allow WiX to run in wine on Linux.
+      # See src/wix_wine.sh for more details on why we need to do this and how
+      # it works
+      #
+      # Updating WIX should be done only if there is a specific need (for
+      # security, or other compelling reason) because it is likely things will
+      # break and the release scripts/process will have to adapt. The WIX
+      # version 3.11.2 is hard coded into these script lines as tokens
+      # wix3112rtm and wix311.
+      #
+      # In order to ensure we are downloading and using the exact WIX binary we
+      # have tested and trust we verify the sha512 is the same as the one
+      # expected. This protects us from if someone was to get github
+      # credentials allowing them to change the wix binaries on github. If WIX
+      # is updated to a newer version, this sha512 will need to be recomputed.
+      - name: Setup WIX
+        run: |
+          # install wine32 and dotnet to run wine
+          sudo dpkg --add-architecture i386
+          sudo apt-get update
+          sudo apt-get install -y wine32 winetricks
+          winetricks -q dotnet40
+
+          WIXSHA=6fd961c85e1e6adafb99ef50c9659e3eb83c84ecaf49f523e556788845b206e1857aba2c39409405d4cda1df9b30a552ce5aab808be5f8368a37a447d78d1a05
+          curl -sS -L https://github.com/wixtoolset/wix3/releases/download/wix3112rtm/wix311-binaries.zip -o wix311-binaries.zip
+          echo "$WIXSHA wix311-binaries.zip" | sha512sum --quiet -c
+
+          WIX=/opt/wix
+          sudo mkdir $WIX
+          sudo unzip -q wix311-binaries.zip -d $WIX
+          rm wix311-binaries.zip
+          sudo mv $WIX/{candle.exe,real-candle.exe}
+          sudo mv $WIX/{light.exe,real-light.exe}
+          sudo cp containers/build-release/src/wix_wine.sh $WIX/candle.exe
+          sudo cp containers/build-release/src/wix_wine.sh $WIX/light.exe
+          echo "WIX=$WIX" >> $GITHUB_ENV
+
+      # Publish jars to a staging maven repository and write helper binary
+      # artifacts to the artifact directory
+      #
+      # Note that if we are not actually publishing (the publish setting is
+      # false, this is a snapshot, etc.) then the release candidate action will
+      # have configured the system so publishSigned just goes to a local maven
+      # repository so nothing is published externally
+      - name: Create Binary Artifacts
+        run: |
+          sbt \
+            +compile \
+            +publishSigned \
+            daffodil-cli/Rpm/packageBin \
+            daffodil-cli/Universal/packageBin \
+            daffodil-cli/Universal/packageZipTarball \
+            daffodil-cli/Windows/packageBin
+
+          ARTIFACT_BIN_DIR=${{ steps.rc.outputs.artifact_dir }}/bin
+          mkdir -p $ARTIFACT_BIN_DIR
+          cp daffodil-cli/target/universal/apache-daffodil-*.tgz $ARTIFACT_BIN_DIR/
+          cp daffodil-cli/target/universal/apache-daffodil-*.zip $ARTIFACT_BIN_DIR/
+          cp daffodil-cli/target/rpm/RPMS/noarch/apache-daffodil-*.rpm $ARTIFACT_BIN_DIR/
+
+          MSI_NAME=$(basename $ARTIFACT_BIN_DIR/*.zip .zip).msi
+          cp daffodil-cli/target/windows/Daffodil.msi $ARTIFACT_BIN_DIR/$MSI_NAME
+          chmod -x $ARTIFACT_BIN_DIR/$MSI_NAME

--- a/containers/build-release/Dockerfile
+++ b/containers/build-release/Dockerfile
@@ -1,0 +1,93 @@
+#!/bin/bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# To make for reproducibility, this should match the version used by GitHub
+# actions CI release candidate workflow
+FROM docker.io/library/ubuntu:22.04
+WORKDIR /root
+
+# Delete any cruft in the homedir
+RUN rm -rf /root/*
+
+ENV TZ=UTC
+
+# Install/configure dependencies. Note that these are not pinned any any
+# specific version, so depending on when this Docker image is built, it could
+# result in different in changes to the build. Note that the sbt and yarn
+# versions don't really matter all too much since they are just used to
+# bootstrap--the daffodil projects specify the actual versions of yarn/sbt to
+# use/download when building. We also need to install SBT separtely since we
+# need to install dependencies like curl and gpg to verify SBT signature
+RUN \
+  dpkg --add-architecture i386 && \
+  apt-get update && \
+  apt-get install -qy \
+    clang \
+    curl \
+    git \
+    gpg \
+    libmxml-dev \
+    llvm \
+    npm \
+    openjdk-8-jdk-headless \
+    rpm \
+    unzip \
+    wine32 \
+    winetricks && \
+  echo "deb https://repo.scala-sbt.org/scalasbt/debian all main" > /etc/apt/sources.list.d/sbt.list && \
+  curl -sL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x2EE0EA64E40A89B84B2DF73499E82A75642AC823" | \
+    gpg --no-default-keyring --keyring gnupg-ring:/etc/apt/trusted.gpg.d/scalasbt-release.gpg --import && \
+  chmod 644 /etc/apt/trusted.gpg.d/scalasbt-release.gpg && \
+  apt-get update && \
+  apt-get install -y \
+    sbt && \
+  npm --no-update-notifier install --global yarn@1.22.19 node@16 && \
+  winetricks -q dotnet40
+
+# WIX is a Microsoft Windows Installer creation tool kit.
+#
+# Install wix, including changes to allow WiX to run in wine on Linux. See
+# src/wix_wine.sh for more details on why we need to do this and how it works
+#
+# Updating WIX should be done only if there is a specific need (for security, or other compelling reason)
+# because it is likely things will break and the release scripts/process will have to adapt.
+# The WIX version 3.11.2 is hard coded into these script lines as tokens wix3112rtm and wix311.
+#
+# In order to ensure we are downloading and using the exact WIX binary we have tested and trust
+# we verify the sha512 is the same as the one expected. This protects us from if someone
+# was to get github credentials allowing them to change the wix binaries on github.
+# If WIX is updated to a newer version, this sha512 will need to be recomputed.
+RUN \
+  WIXSHA=6fd961c85e1e6adafb99ef50c9659e3eb83c84ecaf49f523e556788845b206e1857aba2c39409405d4cda1df9b30a552ce5aab808be5f8368a37a447d78d1a05 && \
+  curl -sS -L https://github.com/wixtoolset/wix3/releases/download/wix3112rtm/wix311-binaries.zip -o wix311-binaries.zip && \
+  echo "$WIXSHA wix311-binaries.zip" | sha512sum --quiet -c - && \
+  mkdir /opt/wix && \
+  unzip -q wix311-binaries.zip -d /opt/wix/ && \
+  rm wix311-binaries.zip
+RUN mv /opt/wix/candle.exe /opt/wix/real-candle.exe
+RUN mv /opt/wix/light.exe /opt/wix/real-light.exe
+COPY src/wix_wine.sh /opt/wix/candle.exe
+COPY src/wix_wine.sh /opt/wix/light.exe
+
+# We expect users to mount the project repo to /root/project, so we change that
+# to our working directory so the daffodil-build-release command is run from
+# the repo directory
+WORKDIR "/root/project"
+
+# Install and set the entrypoint
+COPY src/daffodil-build-release /usr/bin/
+ENTRYPOINT ["/usr/bin/daffodil-build-release"]

--- a/containers/build-release/README.md
+++ b/containers/build-release/README.md
@@ -1,0 +1,39 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+## Daffodil Build Release Container
+
+Daffodil release artifacts are built using GitHub actions. This container can
+be used to build those same artifacts for testing or verifying reproducibility.
+This can be used for all Daffodil projects, including the Daffodil VS Code
+Extension and the SBT plugin.
+
+To build or update the build release container image:
+
+    podman build -t daffodil-build-release containers/build-release/
+
+To use the container image to build a release, run the following from the root
+of the project git repository:
+
+    podman run -it --privileged --group-add keep-groups --rm \
+      -v $(pwd):/root/project \
+      --hostname daffodil.build \
+      daffodil-build-release
+
+When run, the container will ask for an optional pre-release label (e.g. rc1)
+and the project to build. The resulting artifacts will be placed in the
+target/release-artifacts/ directory.

--- a/containers/build-release/src/daffodil-build-release
+++ b/containers/build-release/src/daffodil-build-release
@@ -1,0 +1,122 @@
+#!/bin/bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+export WIX=/opt/wix/
+export LANG=en_US.UTF-8
+export CC=clang
+export AR=llvm-ar
+export SOURCE_DATE_EPOCH=$(git show --no-patch --format=%ct HEAD)
+
+date
+
+echo "Select a project: "
+select PROJECT in daffodil daffodil-sbt daffodil-vscode; do
+  case $PROJECT in
+    "daffodil" | "daffodil-sbt")
+      PROJECT_VERSION=$(grep 'version :=' build.sbt | cut -d\" -f2)
+      break
+      ;;
+    "daffodil-vscode")
+      PROJECT_VERSION=$(grep '"version"' package.json | cut -d\" -f4)
+      break
+      ;;
+    *)
+      echo "unknown project: $PROJECT" >&2
+      exit 1
+      ;;
+  esac
+done
+echo
+
+read -p "Pre-release label (e.g. rc1 to rc99) or empty for final release: " PRE_RELEASE_LABEL
+echo
+
+# apppend the pre-release label if it is not empty/all whitepsace
+if [[ ! $PRE_RELEASE_LABEL =~ ^[\s]*$ ]]
+then
+  RELEASE_VERSION=$PROJECT_VERSION-$PRE_RELEASE_LABEL
+else
+  RELEASE_VERSION=$PROJECT_VERSION
+fi
+
+echo "==== Building artifacts for $PROJECT $RELEASE_VERSION ===="
+RELEASE_DIR=target/release
+rm -rf $RELEASE_DIR
+
+ARTIFACT_DIR=$RELEASE_DIR/asf-dist/$RELEASE_VERSION
+
+MAVEN_DIR=$RELEASE_DIR/maven-local
+
+mkdir -p ~/.sbt/1.0
+echo "ThisBuild / publishTo := Some(MavenCache(\"maven-local\", file(\"$MAVEN_DIR\")))" >> ~/.sbt/1.0/build.sbt
+
+echo "==== Building source artifact ===="
+mkdir -p $ARTIFACT_DIR/src/
+git archive --format=zip --prefix=apache-$PROJECT-$PROJECT_VERSION-src/ HEAD > $ARTIFACT_DIR/src/apache-$PROJECT-$PROJECT_VERSION-src.zip
+
+echo "==== Building binary artifacts ===="
+
+case $PROJECT in
+  "daffodil")
+    mkdir -p $ARTIFACT_DIR/bin
+    sbt \
+      +compile \
+      +publish \
+      daffodil-cli/Rpm/packageBin \
+      daffodil-cli/Windows/packageBin \
+      daffodil-cli/Universal/packageBin \
+      daffodil-cli/Universal/packageZipTarball
+
+    cp daffodil-cli/target/universal/apache-daffodil-*.tgz $ARTIFACT_DIR/bin/
+    cp daffodil-cli/target/universal/apache-daffodil-*.zip $ARTIFACT_DIR/bin/
+    cp daffodil-cli/target/rpm/RPMS/noarch/apache-daffodil-*.rpm $ARTIFACT_DIR/bin/
+    MSI_NAME=$(basename $ARTIFACT_DIR/bin/*.zip .zip).msi
+    cp daffodil-cli/target/windows/Daffodil.msi $ARTIFACT_DIR/bin/$MSI_NAME
+    chmod -x $ARTIFACT_DIR/bin/$MSI_NAME
+    ;;
+
+  "daffodil-sbt")
+    sbt \
+      "^compile" \
+      "^publish"
+    ;;
+
+  "daffodil-vscode")
+    mkdir -p $ARTIFACT_DIR/bin/
+    yarn package
+    cp *.vsix $ARTIFACT_DIR/bin/
+    ;;
+
+esac
+
+echo "==== Calculating Checksums ===="
+
+for i in $ARTIFACT_DIR/*/
+do
+    pushd $i > /dev/null
+    for file in *
+    do
+       sha512sum --binary $file > $file.sha512
+    done
+    popd &> /dev/null
+done
+
+
+echo
+echo "==== Artifacts created in $RELEASE_DIR ===="

--- a/containers/build-release/src/wix_wine.sh
+++ b/containers/build-release/src/wix_wine.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# We use sbt-native-packager plugin to build a Windows MSI installer.
+# Unfortunately, that uses WiX toolset which requires Windows. It can be run
+# under Wine, but the plugin cannot be easily configured to use Wine. This
+# script is one part of getting that to work and is setup within the container
+# environment as needed.
+
+
+# We run a few wine commands, let's disable all wine debug information since it
+# is interpreted by sbt as errors and makes the output look like something
+# failed.
+export WINEDEBUG=-all
+
+# Create initial wine config, redirecting stderr to stdout. The command outputs
+# debug message to stderr, which SBT makes look like an actual error.
+winecfg 2>&1
+
+# The sbt native-packager plugin executes the $WIX/{candle,light}.exe
+# executables to build the Daffodil MSI. The problem is that those are Windows
+# executables and so can't be directly executed in the Linux container. To get
+# around this, the container Dockerfile copies the $WIX/{candle,light}.exe
+# files to $WIX/real-{candle,light}.exe and installs this script to
+# $WIX/{candle,light}.exe. This way, when the sbt plugin executes
+# $WIX/{candle,light}.exe, it's actually executing this script, which figures
+# out how it was executed (either as candle.exe or light.exe) and redirects the
+# execution to the real-{candle,light}.exe file using wine.
+
+
+# Figure out what was originally executed, and prepend "real-" to it. This is
+# what to execute with wine
+REAL_CMD=real-$(basename "$0")
+
+# The paths passed as arguments to this script by the plugin are all absolute
+# Linux style paths. For arguments that look like a path (i.e. starts with a
+# forward slash), use winepath to convert them to a Windows style path that
+# wine applications can understand. Leave all other arguments unmodified.
+i=0
+NEWARGS=()
+for VAR in "$@"
+do
+	if [[ $VAR == /* ]]
+	then
+		NEWARGS[$i]=$(winepath -w "$VAR")
+	else
+		NEWARGS[$i]=$VAR
+	fi
+	((++i))
+done
+
+# Uncomment to tell bash to output the wine command we are about to execute,
+# helpful for debugging when something goes wrong with wine
+# set -x
+
+# Execute wine with the real WiX command and modified arguments
+wine $WIX/$REAL_CMD "${NEWARGS[@]}"


### PR DESCRIPTION
Although the release candidate container has helped to make builds reproducible and limit the amount of setup needed, it is still difficult to setup in some environments. This adds a custom GitHub action and workflow to build/publish release candidates, and a container to local build the same artifacts for reproducibility verification.

To implement this, the new custom GitHub action is called "asf-release-candidate" and prepares the GitHub CI environment for creating a release candidate for ASF (it's mostly generic and could probably work with many other ASF projects with minor tweaks). This includes things like SBT settings for publishing to ASF maven repositories, creating directories for artifacts on dist.apache.org, importing signing keys, and creating the source artifact. Workflows using this action only need to publish artifacts (e.g. using sbt publishSigned) and write helper binaries to a provided artifacts directory. The post script of the action will then sign, checksum, and commit the artifacts.

This also adds a new "Release Candidate" workflow that uses this custom action and is triggered when a release candidate tag is created, simplifing the release candidate process to just pushing a single signed tag. Workflow dispatch is allowed for testing, but it will not publish anything.

A new container is also created called "build-release", which is essentially a simplified version of the current release candidate container, just without all the complexity related to publishing and closely matching the GitHub CI environment (e.g. switching to ubuntu), now handled by the custom action. When run, it creates all the same artifacts and puts them in a target/release/ directory--this can then be compared against published release artifacts to verify reproducibility.

DAFFODIL-2971