### PR TITLE
Fix non-exhaustive matches

### DIFF
--- a/daffodil-codegen-c/src/main/scala/org/apache/daffodil/codegen/c/generators/CodeGeneratorState.scala
+++ b/daffodil-codegen-c/src/main/scala/org/apache/daffodil/codegen/c/generators/CodeGeneratorState.scala
@@ -1045,7 +1045,7 @@ class CodeGeneratorState(private val root: ElementBase) {
       // Go up the stack that many times to get that struct's C type
       val C = structs(nUpDirs).C
       // Convert the up dirs to parents
-      val parents = upDirs.replaceAllLiterally("../", "parent->").stripSuffix("->")
+      val parents = upDirs.replace("../", "parent->").stripSuffix("->")
       // Convert exprPath to a parents-> indirection
       s"""(($C *)instance->_base.$parents)->$afterUpDirs"""
     } else {

--- a/daffodil-core/src/main/scala/org/apache/daffodil/core/dpath/DFDLExpressionParser.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/core/dpath/DFDLExpressionParser.scala
@@ -181,23 +181,28 @@ class DFDLPathExpressionParser[T <: AnyRef](
         expressionAST.init()
         expressionAST
       }
-      case NoSuccess(msg, next) => {
-        // blech - no easy way to just grab up to 30 chars from a Reader[Char]
-        var nextRdr = next
-        val nextString = new StringBuilder()
-        var i = 0
-        while (!nextRdr.atEnd && i < 30) {
-          nextString.append(nextRdr.first)
-          nextRdr = nextRdr.rest
-          i += 1
-        }
+      case NoSuccess.I(msg, next) => {
+        val nextString = convertNextToString(next)
         context.SDE(
           "Unable to parse expression. Message: %s\nNext: %s.",
           msg,
-          nextString.toString()
+          nextString
         )
       }
     }
+  }
+
+  // blech - no easy way to just grab up to 30 chars from a Reader[Char]
+  def convertNextToString(next: Input): String = {
+    var nextRdr = next
+    var i = 0
+    val nextString = new StringBuilder()
+    while (!nextRdr.atEnd && i < 30) {
+      nextString.append(nextRdr.first)
+      nextRdr = nextRdr.rest
+      i += 1
+    }
+    nextString.toString()
   }
 
   def wrapAsSuccess[T](p: => Parser[T]): Parser[ParseResult[T]] = Parser { in =>

--- a/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/DFDLDefineVariable.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/DFDLDefineVariable.scala
@@ -158,9 +158,9 @@ final class DFDLNewVariableInstance(node: Node, decl: AnnotatedSchemaComponent)
   final lazy val value = (attrValue, eltValue) match {
     case (None, v) if (v != "") => v
     case (Some(v), "") => v
-    case (Some(v), ev) if (ev != "") =>
+    case (Some(v), _) =>
       decl.SDE("Cannot have both a value attribute and an element value: %s", node)
-    case (None, "") =>
+    case (None, _) =>
       decl.SDE("Must have either a value attribute or an element value: %s", node)
   }
 
@@ -182,9 +182,9 @@ final class DFDLSetVariable(node: Node, decl: AnnotatedSchemaComponent)
   final lazy val value = (attrValue, eltValue) match {
     case (None, v) if (v != "") => v
     case (Some(v), "") => v
-    case (Some(v), ev) if (ev != "") =>
+    case (Some(v), _) =>
       decl.SDE("Cannot have both a value attribute and an element value: %s", node)
-    case (None, "") =>
+    case (None, _) =>
       decl.SDE("Must have either a value attribute or an element value: %s", node)
   }
 

--- a/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/RestrictionUnion.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/RestrictionUnion.scala
@@ -168,7 +168,7 @@ final class Restriction private (xmlArg: Node, val simpleTypeDef: SimpleTypeDefB
     if (hasPattern) {
       val lPattern = localBaseFacets.filter { case (f, v) => f == Facet.pattern }
       val rPattern = remoteBaseFacets.filter { case (f, v) => f == Facet.pattern }
-      val cPattern = lPattern.union(rPattern)
+      val cPattern = lPattern ++: rPattern
       cPattern.foreach(x => combined.enqueue(x))
     }
     if (hasLength) {

--- a/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/SchemaSet.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/SchemaSet.scala
@@ -550,8 +550,7 @@ final class SchemaSet private (
   }
 
   lazy val allDefinedVariables = schemas
-    .flatMap(_.defineVariables)
-    .union(predefinedVars)
+    .flatMap(_.defineVariables) ++: predefinedVars
 
   private lazy val checkUnusedProperties = LV(Symbol("hasUnusedProperties")) {
     root.checkUnusedProperties

--- a/daffodil-core/src/main/scala/org/apache/daffodil/core/grammar/ElementBaseGrammarMixin.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/core/grammar/ElementBaseGrammarMixin.scala
@@ -1269,7 +1269,7 @@ trait ElementBaseGrammarMixin
             )
             LiteralValueNilOfSpecifiedLength(this)
           }
-          case LengthKind.Implicit if isComplexType =>
+          case LengthKind.Implicit =>
             LiteralValueNilOfSpecifiedLength(this)
           case LengthKind.Prefixed => LiteralValueNilOfSpecifiedLength(this)
           case LengthKind.EndOfParent if isComplexType =>
@@ -1286,7 +1286,7 @@ trait ElementBaseGrammarMixin
         lengthKind match {
           case LengthKind.Explicit => LiteralCharacterNilOfSpecifiedLength(this)
           case LengthKind.Implicit if isSimpleType => LiteralCharacterNilOfSpecifiedLength(this)
-          case LengthKind.Implicit if isComplexType =>
+          case LengthKind.Implicit =>
             Assert.invariantFailed("literal nil complex types aren't handled here.")
           case LengthKind.Prefixed =>
             SDE("nilKind='literalCharacter' is not valid for lengthKind='prefixed'")
@@ -1392,6 +1392,10 @@ trait ElementBaseGrammarMixin
           notYetImplemented("lengthKind='endOfParent' for complex type")
         case LengthKind.EndOfParent =>
           notYetImplemented("lengthKind='endOfParent' for simple type")
+        case LengthKind.Delimited | LengthKind.Implicit =>
+          Assert.impossibleCase(
+            "Delimited and ComplexType Implicit cases should not be reached"
+          )
       }
     }
   }

--- a/daffodil-core/src/main/scala/org/apache/daffodil/core/grammar/primitives/Padded.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/core/grammar/primitives/Padded.scala
@@ -49,6 +49,8 @@ trait PaddingInfoMixin {
     eBase.textTrimKind match {
       case TextTrimKind.None => (MaybeChar.Nope, TextJustificationType.None)
       case TextTrimKind.PadChar if eBase.isSimpleType => padCharAndJustificationForType
+      case TextTrimKind.PadChar =>
+        eBase.SDE("padChar textTrimKind not supported for complexType")
     }
 
   lazy val (unparsingPadChar: MaybeChar, justificationPad) = {

--- a/daffodil-core/src/main/scala/org/apache/daffodil/core/grammar/primitives/PrimitivesTextNumber.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/core/grammar/primitives/PrimitivesTextNumber.scala
@@ -454,7 +454,7 @@ case class ConvertTextStandardNumberPrim(e: ElementBase)
           checkPosNegNumPartSyntax(beforeV + "V" + afterV, negNum)
           afterV.length
         }
-        case None =>
+        case Some(_) | None =>
           e.SDE(
             s"""The dfdl:textNumberPattern '%s' contains 'V' (virtual decimal point).
                | Other than the sign indicators, it can contain only

--- a/daffodil-core/src/main/scala/org/apache/daffodil/core/grammar/primitives/SequenceChild.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/core/grammar/primitives/SequenceChild.scala
@@ -392,12 +392,10 @@ class ScalarOrderedSequenceChild(sq: SequenceTermBase, term: Term, groupIndex: I
   import SeparatedSequenceChildBehavior._
 
   lazy val sequenceChildParser: SequenceChildParser = {
-    val HasSep = true
-    val UnSep = false
-    val res = (term, sq.hasSeparator) match {
-      case (_, _) if !term.isRepresented =>
+    val res = term match {
+      case _ if !term.isRepresented =>
         new NonRepresentedSequenceChildParser(childParser, srd, trd)
-      case (_: ElementBase, HasSep) =>
+      case (_: ElementBase) if sq.hasSeparator =>
         new ScalarOrderedElementSeparatedSequenceChildParser(
           childParser,
           srd,
@@ -406,7 +404,7 @@ class ScalarOrderedSequenceChild(sq: SequenceTermBase, term: Term, groupIndex: I
           sq.separatorPosition,
           separatedHelper
         )
-      case (_: ModelGroup, HasSep) => {
+      case (_: ModelGroup) if sq.hasSeparator => {
         Assert.invariant(term.isInstanceOf[ModelGroup])
         new GroupSeparatedSequenceChildParser(
           childParser,
@@ -417,7 +415,7 @@ class ScalarOrderedSequenceChild(sq: SequenceTermBase, term: Term, groupIndex: I
           separatedHelper
         )
       }
-      case (_, UnSep) =>
+      case _ if !sq.hasSeparator =>
         new ScalarOrderedUnseparatedSequenceChildParser(
           childParser,
           srd,

--- a/daffodil-core/src/main/scala/org/apache/daffodil/core/util/FuzzData.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/core/util/FuzzData.scala
@@ -64,7 +64,7 @@ abstract class FuzzData(
    */
   def runLength: Int
 
-  override def hasNext() = true // we can keep fuzzing forever
+  override def hasNext = true // we can keep fuzzing forever
 
   override def next(): Array[Byte] = {
     val data = originalData.clone()

--- a/daffodil-core/src/test/scala/org/apache/daffodil/core/externalvars/TestExternalVariables.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/core/externalvars/TestExternalVariables.scala
@@ -17,14 +17,11 @@
 
 package org.apache.daffodil.core.externalvars
 
-import org.apache.daffodil.lib.Implicits._
-
-import org.junit.Assert._
-import org.junit.Test; object INoWarn2 { ImplicitsSuppressUnusedImportWarning() }
 import scala.util.Success
 
 import org.apache.daffodil.lib.xml._
 
+import org.junit.Assert._
 import org.junit.Test
 
 class TestExternalVariables {

--- a/daffodil-core/src/test/scala/org/apache/daffodil/core/grammar/primitives/TestPrimitives.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/core/grammar/primitives/TestPrimitives.scala
@@ -34,26 +34,28 @@ class TestPrimitives {
 
   @Test def testVRegexPositiveAndNegativeWithPrefixesAndSuffixes(): Unit = {
     val re = TextNumberPatternUtils.vRegexStandard
-    val Some(myMatch) = re.findFirstMatchIn("A###012V34B;C####56V78D")
-    myMatch match {
-      case re("A", "###012", "34", "B", "C", "####56V78", "D") => // ok
+    val optMatch = re.findFirstMatchIn("A###012V34B;C####56V78D")
+    optMatch match {
+      case Some(re("A", "###012", "34", "B", "C", "####56V78", "D")) => // ok
+      case _ => fail()
     }
   }
 
   @Test def testVRegexPositiveAndNegativeWithPrefixesAndSuffixes2(): Unit = {
     val re = TextNumberPatternUtils.vRegexStandard
-    val Some(myMatch) = re.findFirstMatchIn("'P'###012V34B;C####56V78D")
-    myMatch match {
-      case re("'P'", "###012", "34", "B", "C", "####56V78", "D") => // ok
+    val optMatch = re.findFirstMatchIn("'P'###012V34B;C####56V78D")
+    optMatch match {
+      case Some(re("'P'", "###012", "34", "B", "C", "####56V78", "D")) => // ok
+      case _ => fail()
     }
   }
 
   @Test def testVRegexPositiveAndNegativeWithPrefixesAndSuffixes3(): Unit = {
     val re = TextNumberPatternUtils.vRegexStandard
     val optMatch = re.findFirstMatchIn("'P'###012V34'P';N0V0N")
-    println(optMatch)
     optMatch match {
       case Some(re("'P'", "###012", "34", "'P'", "N", "0V0", "N")) => // ok
+      case _ => fail()
     }
   }
 
@@ -63,43 +65,54 @@ class TestPrimitives {
     println(optMatch)
     optMatch match {
       case Some(re("'P'", "###012", "34", "'P'", "N", "#", "N")) => // ok
+      case _ => fail()
     }
   }
 
   @Test def testVRegexOnlyPositivePattern(): Unit = {
     val re = TextNumberPatternUtils.vRegexStandard
-    val Some(myMatch) = re.findFirstMatchIn("A###012V34B")
-    myMatch match {
-      case re("A", "###012", "34", "B", null, null, null) =>
+    val optMatch = re.findFirstMatchIn("A###012V34B")
+    optMatch match {
+      case Some(re("A", "###012", "34", "B", null, null, null)) => // ok
+      case _ => fail()
     }
   }
 
   @Test def testVRegexOnlyPositivePatternNoPrefixNorSuffix(): Unit = {
     val re = TextNumberPatternUtils.vRegexStandard
-    val Some(myMatch) = re.findFirstMatchIn("###012V34")
-    myMatch match {
-      case re("", "###012", "34", "", null, null, null) =>
+    val optMyMatch = re.findFirstMatchIn("###012V34")
+
+    optMyMatch match {
+      case Some(re("", "###012", "34", "", null, null, null)) => // ok
+      case _ => fail()
     }
   }
 
   @Test def testVRegexTrailingSign(): Unit = {
     val re = TextNumberPatternUtils.vRegexStandard
-    val Some(myMatch) = re.findFirstMatchIn("012V34+") // for zoned, overpunched trailing sign.
-    myMatch match {
-      case re("", "012", "34", "+", null, null, null) =>
+    val optMatch = re.findFirstMatchIn("012V34+") // for zoned, overpunched trailing sign.
+    optMatch match {
+      case Some(re("", "012", "34", "+", null, null, null)) => // ok
+      case _ => fail()
     }
   }
 
   @Test def testVRegexZonedLeadingSign(): Unit = {
     val re = TextNumberPatternUtils.vRegexZoned
     val optMyMatch = re.findFirstMatchIn("+012V34") // for zoned, overpunched leading sign.
-    val Some(re("+", "012", "34", "")) = optMyMatch
+    optMyMatch match {
+      case Some(re("+", "012", "34", "")) => // ok
+      case _ => fail()
+    }
   }
 
   @Test def testVRegexZonedTrailingSign(): Unit = {
     val re = TextNumberPatternUtils.vRegexZoned
     val optMyMatch = re.findFirstMatchIn("012V34+") // for zoned, overpunched trailing sign.
-    val Some(re("", "012", "34", "+")) = optMyMatch
+    optMyMatch match {
+      case Some(re("", "012", "34", "+")) => // ok
+      case _ => fail()
+    }
   }
 
   @Test def testVRegexZonedNothingAfterSuffix(): Unit = {
@@ -107,8 +120,9 @@ class TestPrimitives {
     val optMyMatch =
       re.findFirstMatchIn("012V34+garbage") // for zoned, overpunched trailing sign.
     optMyMatch match {
-      case Some(re("", "012", "34", "+")) => fail("accepted trash at end of pattern")
-      case None => // ok
+      case Some(re("", "012", "34", "+")) =>
+        fail("accepted trash at end of pattern")
+      case _ => // ok
     }
   }
 
@@ -116,7 +130,7 @@ class TestPrimitives {
     val re = TextNumberPatternUtils.vRegexZoned
     val optMyMatch = re.findFirstMatchIn("A012V34")
     optMyMatch match {
-      case Some(x @ re(_*)) => fail(s"accepted A as leading sign: $x")
+      case Some(x) => fail(s"accepted A as leading sign: ${x.matched}")
       case None => // ok
     }
   }
@@ -204,76 +218,85 @@ class TestPrimitives {
 
   @Test def testZonedVRegexWithPrefix(): Unit = {
     val re = TextNumberPatternUtils.vRegexZoned
-    val Some(myMatch) = re.findFirstMatchIn("+012V34")
-    myMatch match {
-      case re("+", "012", "34", "") => // ok
+    val optMatch = re.findFirstMatchIn("+012V34")
+    optMatch match {
+      case Some(re("+", "012", "34", "")) => // ok
+      case _ => fail()
     }
   }
 
   @Test def testZonedVRegexWithSuffix(): Unit = {
     val re = TextNumberPatternUtils.vRegexZoned
-    val Some(myMatch) = re.findFirstMatchIn("012V34+")
-    myMatch match {
-      case re("", "012", "34", "+") => // ok
+    val optMatch = re.findFirstMatchIn("012V34+")
+    optMatch match {
+      case Some(re("", "012", "34", "+")) => // ok
+      case _ => fail()
     }
   }
 
   @Test def testStandardPOnLeft(): Unit = {
     val re = TextNumberPatternUtils.pOnLeftRegexStandard
     println(re)
-    val Some(myMatch) = re.findFirstMatchIn("+PPP000")
-    myMatch match {
-      case re("+", "PPP", "000", "", null, null, null) => // ok
+    val optMatch = re.findFirstMatchIn("+PPP000")
+    optMatch match {
+      case Some(re("+", "PPP", "000", "", null, null, null)) => // ok
+      case _ => fail()
     }
   }
 
   @Test def testStandardPOnLeft2(): Unit = {
     val re = TextNumberPatternUtils.pOnLeftRegexStandard
     println(re)
-    val Some(myMatch) = re.findFirstMatchIn("+PPP000;-#")
-    myMatch match {
-      case re("+", "PPP", "000", "", "-", "#", "") => // ok
+    val optMatch = re.findFirstMatchIn("+PPP000;-#")
+    optMatch match {
+      case Some(re("+", "PPP", "000", "", "-", "#", "")) => // ok
+      case _ => fail()
     }
   }
 
   @Test def testStandardPOnLeft3(): Unit = {
     val re = TextNumberPatternUtils.pOnLeftRegexStandard
     println(re)
-    val Some(myMatch) = re.findFirstMatchIn("+PPP000;-P0")
-    myMatch match {
-      case re("+", "PPP", "000", "", "-", "P0", "") => // ok
+    val optMatch = re.findFirstMatchIn("+PPP000;-P0")
+    optMatch match {
+      case Some(re("+", "PPP", "000", "", "-", "P0", "")) => // ok
+      case _ => fail()
     }
   }
 
   @Test def testStandardPOnRight(): Unit = {
     val re = TextNumberPatternUtils.pOnRightRegexStandard
-    val Some(myMatch) = re.findFirstMatchIn("000PPP+")
-    myMatch match {
-      case re("", "000", "PPP", "+", null, null, null) => // ok
+    val optMatch = re.findFirstMatchIn("000PPP+")
+    optMatch match {
+      case Some(re("", "000", "PPP", "+", null, null, null)) => // ok
+      case _ => fail()
     }
   }
 
   @Test def testStandardPOnRight2(): Unit = {
     val re = TextNumberPatternUtils.pOnRightRegexStandard
-    val Some(myMatch) = re.findFirstMatchIn("000PPP+;0P-")
-    myMatch match {
-      case re("", "000", "PPP", "+", "", "0P", "-") => // ok
+    val optMatch = re.findFirstMatchIn("000PPP+;0P-")
+    optMatch match {
+      case Some(re("", "000", "PPP", "+", "", "0P", "-")) => // ok
+      case _ => fail()
     }
   }
 
   @Test def testZonedPOnLeft(): Unit = {
     val re = TextNumberPatternUtils.pOnLeftRegexZoned
-    val Some(myMatch) = re.findFirstMatchIn("+PPP000")
-    myMatch match {
-      case re("+", "PPP", "000", "") => // ok
+    val optMatch = re.findFirstMatchIn("+PPP000")
+    optMatch match {
+      case Some(re("+", "PPP", "000", "")) => // ok
+      case _ => fail()
     }
   }
 
   @Test def testZonedPOnRight(): Unit = {
     val re = TextNumberPatternUtils.pOnRightRegexZoned
-    val Some(myMatch) = re.findFirstMatchIn("000PPP+")
-    myMatch match {
-      case re("", "000", "PPP", "+") => // ok
+    val optMatch = re.findFirstMatchIn("000PPP+")
+    optMatch match {
+      case Some(re("", "000", "PPP", "+")) => // ok
+      case _ => fail()
     }
   }
 

--- a/daffodil-core/src/test/scala/org/apache/daffodil/core/outputValueCalc/TestOutputValueCalcForwardReference.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/core/outputValueCalc/TestOutputValueCalcForwardReference.scala
@@ -21,7 +21,6 @@ import org.apache.daffodil.core.util.TestUtils
 import org.apache.daffodil.lib.Implicits._
 import org.apache.daffodil.lib.util.SchemaUtils
 import org.apache.daffodil.lib.xml.XMLUtils
-import org.apache.daffodil.lib.xml._
 
 import org.junit.Assert._
 import org.junit.Test

--- a/daffodil-lib/src/test/scala/org/apache/daffodil/lib/util/TestListSerialization.scala
+++ b/daffodil-lib/src/test/scala/org/apache/daffodil/lib/util/TestListSerialization.scala
@@ -68,8 +68,8 @@ class TestListSerialization {
         fail("Expected ClassCastException to be thrown")
       } catch {
         case e: ClassCastException => {
-          assertTrue(e.getMessage.contains("List$SerializationProxy"))
-          assertTrue(e.getMessage.contains("scala.collection.Seq"))
+          assertTrue(e.getMessage.contains("SerializationProxy"))
+          assertTrue(e.getMessage.contains("Seq"))
           assertTrue(e.getMessage.contains("Thing"))
         }
         case _: Throwable => fail("Expected ClassCastException to be thrown")

--- a/daffodil-tdml-processor/src/test/scala/org/apache/daffodil/processor/tdml/TestTDMLUnparseCases.scala
+++ b/daffodil-tdml-processor/src/test/scala/org/apache/daffodil/processor/tdml/TestTDMLUnparseCases.scala
@@ -19,7 +19,6 @@ package org.apache.daffodil.processor.tdml
 
 import org.apache.daffodil.lib.xml.XMLUtils
 import org.apache.daffodil.tdml.Runner
-import org.apache.daffodil.tdml._
 
 import org.junit.Assert.assertTrue
 import org.junit.Test


### PR DESCRIPTION
- replaceAllLiterally -> replace
- adding default cases to non-exhaustive matches
- Right(Unit) deprecated in favor of Right(())
- deprecated Seq.union in favor of ++:
- remove unused import

DAFFODIL-2152