### PR TITLE
Replace ArrayBuffer[State] with Array[State]

### DIFF
--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/dfa/CreateDelimiterDFA.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/dfa/CreateDelimiterDFA.scala
@@ -17,7 +17,7 @@
 
 package org.apache.daffodil.runtime1.processors.dfa
 
-import scala.collection.mutable.ArrayBuffer
+import scala.collection.compat.immutable.ArraySeq
 
 import org.apache.daffodil.runtime1.dsom.DPathCompileInfo
 import org.apache.daffodil.runtime1.processors.CharDelim
@@ -44,14 +44,14 @@ object CreateDelimiterDFA {
     outputNewLine: String
   ): DFADelimiter = {
 
-    val allStates: ArrayBuffer[State] = ArrayBuffer.empty
+    val allStates: Array[State] = new Array[State](delimiter.length)
 
     buildTransitions(delimiter, allStates, false)
 
     val unparseValue = delimiter.map { _.unparseValue(outputNewLine) }.mkString
     new DFADelimiterImplUnparse(
       delimType,
-      allStates.reverse.toArray,
+      allStates.reverse,
       delimiterStr,
       unparseValue,
       ci.schemaFileLocation
@@ -70,13 +70,13 @@ object CreateDelimiterDFA {
     ignoreCase: Boolean
   ): DFADelimiter = {
 
-    val allStates: ArrayBuffer[State] = ArrayBuffer.empty
+    val allStates: Array[State] = new Array[State](delimiter.length)
 
     buildTransitions(delimiter, allStates, ignoreCase)
 
     new DFADelimiterImpl(
       delimType,
-      allStates.reverse.toArray,
+      allStates.reverse,
       delimiterStr,
       ci.schemaFileLocation
     )
@@ -95,7 +95,7 @@ object CreateDelimiterDFA {
     val d = new Delimiter()
     d.compileDelimiter(delimiterStr, ignoreCase)
     val db = d.delimBuf
-    apply(delimType, ci, db, delimiterStr, ignoreCase)
+    apply(delimType, ci, ArraySeq.unsafeWrapArray(db), delimiterStr, ignoreCase)
   }
 
   /**
@@ -111,7 +111,7 @@ object CreateDelimiterDFA {
     val d = new Delimiter()
     d.compileDelimiter(delimiterStr, false)
     val db = d.delimBuf
-    apply(delimType, ci, db, delimiterStr, outputNewLine)
+    apply(delimType, ci, ArraySeq.unsafeWrapArray(db), delimiterStr, outputNewLine)
   }
 
   /**
@@ -147,7 +147,7 @@ object CreateDelimiterDFA {
     d: DelimBase,
     nextState: Int,
     stateNum: Int,
-    allStates: ArrayBuffer[State],
+    allStates: Array[State],
     ignoreCase: Boolean
   ): DelimStateBase = {
 
@@ -176,7 +176,7 @@ object CreateDelimiterDFA {
 
   private def buildTransitions(
     delim: Seq[DelimBase],
-    allStates: ArrayBuffer[State],
+    allStates: Array[State],
     ignoreCase: Boolean
   ): State = {
     assert(!delim.isEmpty)
@@ -186,26 +186,33 @@ object CreateDelimiterDFA {
   private def buildTransitions(
     nextState: DelimStateBase,
     delim: Seq[DelimBase],
-    allStates: ArrayBuffer[State],
+    allStates: Array[State],
     ignoreCase: Boolean
   ): State = {
 
-    if (delim.isEmpty && nextState != null) {
-      // We are initial state
-      nextState.stateName = "StartState" // "PTERM0"
-      return nextState
+    var i = 0
+    var remainingDelim = delim
+    var currentNextState = nextState
+
+    while (remainingDelim.nonEmpty) {
+      val currentState = getState(
+        remainingDelim.head,
+        if (currentNextState == null) DFA.FinalState else currentNextState.stateNum,
+        remainingDelim.length - 1,
+        allStates,
+        ignoreCase
+      )
+      remainingDelim = remainingDelim.tail
+      allStates(i) = currentState
+      currentNextState = currentState
+      i += 1
     }
 
-    val currentState = getState(
-      delim(0),
-      if (nextState == null) DFA.FinalState else nextState.stateNum,
-      delim.length - 1,
-      allStates,
-      ignoreCase
-    )
-    val rest = delim.tail
+    if (currentNextState != null) {
+      // We are initial state
+      currentNextState.stateName = "StartState" // "PTERM0"
+    }
 
-    allStates += currentState
-    return buildTransitions(currentState, rest, allStates, ignoreCase)
+    currentNextState
   }
 }

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/dfa/CreateFieldDFA.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/dfa/CreateFieldDFA.scala
@@ -17,8 +17,6 @@
 
 package org.apache.daffodil.runtime1.processors.dfa
 
-import scala.collection.mutable.ArrayBuffer
-
 import org.apache.daffodil.lib.util.MaybeChar
 
 /**
@@ -43,13 +41,13 @@ object CreateFieldDFA {
    */
   def apply(): DFAField = {
 
-    val allStates: ArrayBuffer[State] = ArrayBuffer.empty
+    val allStates: Array[State] = new Array[State](1)
 
     val startState = new StartState(allStates, 0)
 
-    allStates.insert(0, startState)
+    allStates(0) = startState
 
-    new DFAFieldImpl(allStates.toArray)
+    new DFAFieldImpl(allStates)
   }
 
   /**
@@ -57,17 +55,17 @@ object CreateFieldDFA {
    */
   def apply(EC: Char, EEC: MaybeChar): DFAField = {
 
-    val allStates: ArrayBuffer[State] = ArrayBuffer.empty
+    val allStates: Array[State] = new Array(3)
 
     val ecState = new ECState(allStates, EC, 1)
     val eecState = new EECState(allStates, EEC, EC, 2)
     val startState = new StartStateEscapeChar(allStates, EEC, EC, 0)
 
-    allStates.insert(0, eecState)
-    allStates.insert(0, ecState)
-    allStates.insert(0, startState)
+    allStates(2) = eecState
+    allStates(1) = ecState
+    allStates(0) = startState
 
-    new DFAFieldImpl(allStates.toArray)
+    new DFAFieldImpl(allStates)
   }
 
   /**
@@ -75,15 +73,15 @@ object CreateFieldDFA {
    */
   def apply(blockEnd: DFADelimiter, EEC: MaybeChar): DFAField = {
 
-    val allStates: ArrayBuffer[State] = ArrayBuffer.empty
+    val allStates: Array[State] = new Array[State](2)
 
     val eecState = new EECStateBlock(allStates, blockEnd, EEC, 1)
     val startState = new StartStateEscapeBlock(allStates, blockEnd, EEC, 0)
 
-    allStates.insert(0, eecState)
-    allStates.insert(0, startState)
+    allStates(1) = eecState
+    allStates(0) = startState
 
-    new DFAFieldImpl(allStates.toArray)
+    new DFAFieldImpl(allStates)
   }
 
 }

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/dfa/CreatePaddingDFA.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/dfa/CreatePaddingDFA.scala
@@ -17,8 +17,6 @@
 
 package org.apache.daffodil.runtime1.processors.dfa
 
-import scala.collection.mutable.ArrayBuffer
-
 import org.apache.daffodil.runtime1.processors.Delimiter
 import org.apache.daffodil.runtime1.processors.TermRuntimeData
 import org.apache.daffodil.runtime1.processors.parsers.DelimiterTextType
@@ -33,15 +31,15 @@ object CreatePaddingDFA {
     // TODO: In the future we will need to change this because the padChar isn't necessarily a char.
     // One can use it to specify a numeric byte to be used to pad as well.
 
-    val allStates: ArrayBuffer[State] = ArrayBuffer.empty
+    val allStates: Array[State] = new Array[State](1)
 
     val startState = new StartStatePadding(allStates, padChar)
 
-    allStates.insert(0, startState)
+    allStates(0) = startState
 
     new DFADelimiterImpl(
       DelimiterTextType.Other,
-      allStates.toArray,
+      allStates,
       padChar.toString(),
       rd.schemaFileLocation
     )
@@ -55,11 +53,11 @@ object CreatePaddingDFA {
     // TODO: In the future we will need to change this because the padChar isn't necessarily a char.
     // One can use it to specify a numeric byte to be used to pad as well.
 
-    val allStates: ArrayBuffer[State] = ArrayBuffer.empty
+    val allStates: Array[State] = new Array[State](1)
 
     val startState = new StartStatePadding(allStates, padChar)
 
-    allStates.insert(0, startState)
+    allStates(0) = startState
 
     val d = new Delimiter()
     d.compileDelimiter(padChar.toString, false)
@@ -68,7 +66,7 @@ object CreatePaddingDFA {
 
     new DFADelimiterImplUnparse(
       DelimiterTextType.Other,
-      allStates.toArray,
+      allStates,
       padChar.toString(),
       unparseValue,
       rd.schemaFileLocation


### PR DESCRIPTION
- currently in 2.13 we are getting a "ReflectiveOperationException durins deserialzation" error on account of states being a pass by name parameter leading to lambda serialization, removing that resulted in a ClassCastException where it was complaining about not being able to cast DefaultSerializationProxy to ArrayBuffer, which was weird because in a separate example class we were able to deserialize ArrayBuffer[SomeSerializableClass] just fine. So we set about converting ArrayBuffer to Array to see if it fixed the error, which it did...we also changed recursive buildTransitions function to an iterative function to support using an Array for allstates instead of an ArrayBuffer

DAFFODIL-2152