### PR TITLE
Fix non-prefix agnostic test

### DIFF
--- a/daffodil-cli/src/test/scala/org/apache/daffodil/cli/cliTest/Util.scala
+++ b/daffodil-cli/src/test/scala/org/apache/daffodil/cli/cliTest/Util.scala
@@ -57,6 +57,12 @@ object Util {
     Paths.get(s"daffodil-cli/target/universal/stage/bin/daffodil$ext")
   }
 
+  val scalaVersionForTargetPath: String = scala.util.Properties.versionNumberString match {
+    case v if v.startsWith("2.12") => "scala-2.12"
+    case v if v.startsWith("2.13") => "scala-2.13"
+    case _ => throw new IllegalStateException("Unsupported version provided for tests")
+  }
+
   /**
    * Convert the parameter to a java Path. The string
    * parameter should contain unix path separators and it will be interpreted
@@ -68,7 +74,7 @@ object Util {
     Paths.get(string)
   }
 
-  def devNull(): String = if (isWindows) "NUL" else "/dev/null"
+  def devNull: String = if (isWindows) "NUL" else "/dev/null"
 
   def md5sum(path: Path): String = {
     val md = MessageDigest.getInstance("MD5")

--- a/daffodil-tdml-processor/src/test/java/org/apache/daffodil/processor/tdml/TestRunnerFactory.java
+++ b/daffodil-tdml-processor/src/test/java/org/apache/daffodil/processor/tdml/TestRunnerFactory.java
@@ -50,7 +50,7 @@ public class TestRunnerFactory {
       false,
       NoRoundTrip$.MODULE$,
       "off",
-      CollectionConverters.asScala(Arrays.asList("daffodil", "ibm")),
+      CollectionConverters.asScala(Arrays.asList("daffodil", "ibm")).toSeq(),
       false,
       false);
     runner.runOneTest("testPass");

--- a/daffodil-test-integration/src/test/scala/org/apache/daffodil/cliTest/TestCLIPlugins.scala
+++ b/daffodil-test-integration/src/test/scala/org/apache/daffodil/cliTest/TestCLIPlugins.scala
@@ -32,7 +32,7 @@ class TestCLIPlugins {
    * specific test
    */
   private def testClasspath(extra: String*): Seq[Path] = {
-    val classes = path("daffodil-test/target/scala-2.12/test-classes/")
+    val classes = path(s"daffodil-test/target/$scalaVersionForTargetPath/test-classes/")
     val paths = extra.map(path(_))
     classes +: paths
   }
@@ -108,7 +108,7 @@ class TestCLIPlugins {
       "daffodil-udf/src/test/resources/org/apache/daffodil/udf/genericUdfSchema.xsd"
     )
     val classpath = testClasspath(
-      "daffodil-udf/target/scala-2.12/test-classes/"
+      s"daffodil-udf/target/$scalaVersionForTargetPath/test-classes/"
     )
 
     withTempFile { parser =>

--- a/daffodil-test-integration/src/test/scala/org/apache/daffodil/cliTest/TestCLIUdfs.scala
+++ b/daffodil-test-integration/src/test/scala/org/apache/daffodil/cliTest/TestCLIUdfs.scala
@@ -33,7 +33,7 @@ class TestCLIUdfs {
    * the directory containing the META-INF dir needed for the test.
    */
   private def udfClasspath(extra: String*): Seq[Path] = {
-    val classes = path("daffodil-udf/target/scala-2.12/test-classes/")
+    val classes = path(s"daffodil-udf/target/$scalaVersionForTargetPath/test-classes/")
     val paths = extra.map(path(_))
     classes +: paths
   }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/infoset/TestStringAsXml.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/infoset/TestStringAsXml.scala
@@ -33,6 +33,7 @@ import org.apache.daffodil.lib.Implicits.intercept
 import org.apache.daffodil.lib.api.URISchemaSource
 import org.apache.daffodil.lib.api.ValidationMode
 import org.apache.daffodil.lib.util.Misc
+import org.apache.daffodil.lib.xml.XMLUtils
 import org.apache.daffodil.runtime1.api.DFDL.DataProcessor
 
 import org.apache.commons.io.IOUtils
@@ -298,11 +299,12 @@ class TestStringAsXml {
       IOUtils.toString(is, StandardCharsets.UTF_8)
     }
     // diagnostic from full validation
-    assertTrue(parseDiags.exists(_.contains("Element 'xmlStr' is a simple type")))
-    // we still get the expected infoset, replace CRLF with LF because of git windows autocrlf
-    assertEquals(
-      parseInfosetExpected.replace("\r\n", "\n"),
-      parseInfosetActual.replace("\r\n", "\n")
+    assertTrue(parseDiags.exists(_.contains("xmlStr' is a simple type")))
+    // we still get the expected infoset, use compareAndReport so prefix differences
+    // don't matter
+    XMLUtils.compareAndReport(
+      scala.xml.XML.loadString(parseInfosetExpected),
+      scala.xml.XML.loadString(parseInfosetActual)
     )
 
     // validate the infoset using the handwritten WithPayload schema


### PR DESCRIPTION
- fix test that was failing because a scala Buffer doesn't automatically convert to a Seq anymore

Deprecation/Compatibility:
Note that some changes in 2.13 may affect the order of prefixes with the same namespace and may also cause them to appear uniformly but interchangeably. Ex: `xmlns="urn:bin" xmlns:b="urn:bin" <element/>` may become  `xmlns:b="urn:bin" xmlns="urn:bin" <b:element/>` and vice versa.

DAFFODIL-2152