### PR TITLE
Fix Deserialization Errors with ChildProcessors

### DIFF
--- a/daffodil-core/src/main/scala/org/apache/daffodil/core/grammar/Grammar.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/core/grammar/Grammar.scala
@@ -92,7 +92,7 @@ class SeqComp private (context: SchemaComponent, children: Seq[Gram])
   final override lazy val parser = {
     if (parserChildren.isEmpty) new NadaParser(context.runtimeData)
     else if (parserChildren.length == 1) parserChildren.head
-    else new SeqCompParser(context.runtimeData, parserChildren.toVector)
+    else new SeqCompParser(context.runtimeData, parserChildren.toArray)
   }
 
   lazy val unparserChildren = {
@@ -110,7 +110,7 @@ class SeqComp private (context: SchemaComponent, children: Seq[Gram])
   final override lazy val unparser = {
     if (unparserChildren.isEmpty) new NadaUnparser(context.runtimeData)
     else if (unparserChildren.length == 1) unparserChildren.head
-    else new SeqCompUnparser(context.runtimeData, unparserChildren.toVector)
+    else new SeqCompUnparser(context.runtimeData, unparserChildren.toArray)
   }
 }
 

--- a/daffodil-core/src/main/scala/org/apache/daffodil/core/grammar/primitives/ChoiceCombinator.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/core/grammar/primitives/ChoiceCombinator.scala
@@ -79,7 +79,7 @@ case class ChoiceCombinator(ch: ChoiceTermBase, alternatives: Seq[Gram])
 
   lazy val parser: Parser = {
     if (!ch.isDirectDispatch) {
-      val cp = new ChoiceParser(ch.termRuntimeData, parsers.toVector)
+      val cp = new ChoiceParser(ch.termRuntimeData, parsers.toArray)
       ch.choiceLengthKind match {
         case ChoiceLengthKind.Implicit => cp
         case ChoiceLengthKind.Explicit =>

--- a/daffodil-core/src/main/scala/org/apache/daffodil/core/grammar/primitives/SequenceCombinator.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/core/grammar/primitives/SequenceCombinator.scala
@@ -27,6 +27,7 @@ import org.apache.daffodil.lib.util.Misc
 import org.apache.daffodil.runtime1.processors.parsers._
 import org.apache.daffodil.runtime1.processors.unparsers._
 import org.apache.daffodil.unparsers.runtime1._
+import org.apache.daffodil.unparsers.runtime1.{ Separated => SeparatedUnparser }
 
 /**
  * Base class for all kinds of sequences.
@@ -71,7 +72,7 @@ class OrderedSequence(sq: SequenceTermBase, sequenceChildrenArg: Seq[SequenceChi
   // the mta parser differently to avoid this
   private lazy val sepUnparser = sepGram.unparser
 
-  lazy val sequenceChildren = sequenceChildrenArg.toVector
+  lazy val sequenceChildren = sequenceChildrenArg.toArray
 
   override lazy val parser: Parser = sq.hasSeparator match {
     case true =>
@@ -117,7 +118,7 @@ class OrderedSequence(sq: SequenceTermBase, sequenceChildrenArg: Seq[SequenceChi
             sepMtaAlignmentMaybe,
             sepMtaUnparserMaybe,
             sepUnparser,
-            childUnparsers
+            childUnparsers.map(_.asInstanceOf[SequenceChildUnparser with SeparatedUnparser])
           )
         case false =>
           new OrderedUnseparatedSequenceUnparser(srd, childUnparsers)
@@ -155,7 +156,7 @@ class UnorderedSequence(
   // the mta parser differently to avoid this
   private lazy val sepUnparser = sepGram.unparser
 
-  private lazy val sequenceChildren = sequenceChildrenArg.toVector
+  private lazy val sequenceChildren = sequenceChildrenArg.toArray
 
   private lazy val parsers = alternatives.map(_.parser)
 
@@ -209,7 +210,11 @@ class UnorderedSequence(
             sepMtaAlignmentMaybe,
             sepMtaUnparserMaybe,
             sepUnparser,
-            childUnparsers
+            childUnparsers.map(
+              _.asInstanceOf[
+                SequenceChildUnparser with SeparatedUnparser
+              ]
+            )
           )
         case false =>
           new OrderedUnseparatedSequenceUnparser(srd, childUnparsers)

--- a/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/unparsers/runtime1/BCDUnparsers.scala
+++ b/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/unparsers/runtime1/BCDUnparsers.scala
@@ -47,7 +47,7 @@ class BCDIntegerRuntimeLengthUnparser(
 ) extends BCDIntegerBaseUnparser(e)
   with HasRuntimeExplicitLength {
 
-  override lazy val runtimeDependencies = Vector(lengthEv)
+  override def runtimeDependencies = Vector(lengthEv)
 }
 
 final class BCDIntegerDelimitedUnparser(e: ElementRuntimeData)
@@ -59,7 +59,7 @@ final class BCDIntegerDelimitedUnparser(e: ElementRuntimeData)
 final class BCDIntegerMinimumLengthUnparser(e: ElementRuntimeData)
   extends BCDIntegerBaseUnparser(e) {
 
-  override lazy val runtimeDependencies = Vector()
+  override def runtimeDependencies = Vector()
 
   override def getBitLength(s: ParseOrUnparseState): Int = {
     val number = getNumberToPut(s.asInstanceOf[UState])
@@ -91,7 +91,7 @@ class BCDDecimalRuntimeLengthUnparser(
 ) extends BCDDecimalBaseUnparser(e, binaryDecimalVirtualPoint)
   with HasRuntimeExplicitLength {
 
-  override lazy val runtimeDependencies = Vector(lengthEv)
+  override def runtimeDependencies = Vector(lengthEv)
 }
 
 final class BCDDecimalDelimitedUnparser(e: ElementRuntimeData, binaryDecimalVirtualPoint: Int)
@@ -105,7 +105,7 @@ final class BCDDecimalMinimumLengthUnparser(
   binaryDecimalVirtualPoint: Int
 ) extends BCDDecimalBaseUnparser(e, binaryDecimalVirtualPoint) {
 
-  override lazy val runtimeDependencies = Vector()
+  override def runtimeDependencies = Vector()
 
   override def getBitLength(s: ParseOrUnparseState): Int = {
     val number = getNumberToPut(s.asInstanceOf[UState])

--- a/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/unparsers/runtime1/BinaryBooleanUnparsers.scala
+++ b/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/unparsers/runtime1/BinaryBooleanUnparsers.scala
@@ -116,7 +116,7 @@ class BinaryBooleanUnparser(
     lengthUnits
   ) {
 
-  override lazy val runtimeDependencies = Vector(lengthEv)
+  override def runtimeDependencies = Vector(lengthEv)
 
   override def getBitLength(s: ParseOrUnparseState): Int = {
     val nBytesAsJLong = lengthEv.evaluate(s)
@@ -140,7 +140,7 @@ class BinaryBooleanMinimumLengthUnparser(
     lengthUnits
   ) {
 
-  override lazy val runtimeDependencies = Vector()
+  override def runtimeDependencies = Vector()
 
   override def getBitLength(s: ParseOrUnparseState): Int = 32
 

--- a/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/unparsers/runtime1/BinaryNumberUnparsers.scala
+++ b/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/unparsers/runtime1/BinaryNumberUnparsers.scala
@@ -111,7 +111,7 @@ class BinaryIntegerKnownLengthUnparser(
 ) extends BinaryIntegerBaseUnparser(e)
   with HasKnownLengthInBits {
 
-  override lazy val runtimeDependencies = Vector()
+  override def runtimeDependencies = Vector()
 
 }
 
@@ -122,7 +122,7 @@ class BinaryIntegerRuntimeLengthUnparser(
 ) extends BinaryIntegerBaseUnparser(e)
   with HasRuntimeExplicitLength {
 
-  override val runtimeDependencies = Vector(lengthEv)
+  override def runtimeDependencies = Vector(lengthEv)
 }
 
 class BinaryIntegerMinimumLengthUnparser(
@@ -132,7 +132,7 @@ class BinaryIntegerMinimumLengthUnparser(
 
   private val primNumeric = e.optPrimType.get.asInstanceOf[NodeInfo.PrimType.PrimNumeric]
 
-  override lazy val runtimeDependencies = Vector()
+  override def runtimeDependencies = Vector()
 
   override def getBitLength(s: ParseOrUnparseState): Int = {
     if (maybeNBits.isDefined) {
@@ -151,7 +151,7 @@ class BinaryIntegerMinimumLengthUnparser(
 
 class BinaryFloatUnparser(e: ElementRuntimeData) extends BinaryNumberBaseUnparser(e) {
 
-  override lazy val runtimeDependencies = Vector()
+  override def runtimeDependencies = Vector()
 
   override def getBitLength(s: ParseOrUnparseState) = 32
 
@@ -168,7 +168,7 @@ class BinaryFloatUnparser(e: ElementRuntimeData) extends BinaryNumberBaseUnparse
 
 class BinaryDoubleUnparser(e: ElementRuntimeData) extends BinaryNumberBaseUnparser(e) {
 
-  override lazy val runtimeDependencies = Vector()
+  override def runtimeDependencies = Vector()
 
   override def getBitLength(s: ParseOrUnparseState) = 64
 
@@ -190,7 +190,7 @@ class BinaryDecimalKnownLengthUnparser(
 ) extends BinaryDecimalUnparserBase(e, signed, binaryDecimalVirtualPoint)
   with HasKnownLengthInBits {
 
-  override lazy val runtimeDependencies = Vector()
+  override def runtimeDependencies = Vector()
 
 }
 
@@ -203,7 +203,7 @@ class BinaryDecimalRuntimeLengthUnparser(
 ) extends BinaryDecimalUnparserBase(e, signed, binaryDecimalVirtualPoint)
   with HasRuntimeExplicitLength {
 
-  override val runtimeDependencies = Vector(lengthEv)
+  override def runtimeDependencies = Vector(lengthEv)
 }
 
 class BinaryDecimalMinimumLengthUnparser(
@@ -212,7 +212,7 @@ class BinaryDecimalMinimumLengthUnparser(
   binaryDecimalVirtualPoint: Int
 ) extends BinaryDecimalUnparserBase(e, signed, binaryDecimalVirtualPoint) {
 
-  override lazy val runtimeDependencies = Vector()
+  override def runtimeDependencies = Vector()
 
   override def getBitLength(s: ParseOrUnparseState): Int = {
     // type is xs:decimal, the length is determined by the minimum number of

--- a/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/unparsers/runtime1/BlobLengthUnparser.scala
+++ b/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/unparsers/runtime1/BlobLengthUnparser.scala
@@ -28,7 +28,7 @@ import org.apache.daffodil.runtime1.processors.unparsers._
 
 abstract class BlobUnparserBase(override val context: ElementRuntimeData) extends PrimUnparser {
 
-  override lazy val runtimeDependencies = Vector()
+  override def runtimeDependencies = Vector()
 
   protected def getLengthInBits(state: UState): Long
 

--- a/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/unparsers/runtime1/ChoiceAndOtherVariousUnparsers.scala
+++ b/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/unparsers/runtime1/ChoiceAndOtherVariousUnparsers.scala
@@ -67,7 +67,7 @@ case class ChoiceBranchMap(
  */
 class ChoiceBranchEmptyUnparser(val context: RuntimeData) extends PrimUnparserNoData {
 
-  override lazy val runtimeDependencies = Vector()
+  override def runtimeDependencies = Vector()
 
   def unparse(state: UState): Unit = {
     // do nothing
@@ -82,9 +82,9 @@ class ChoiceCombinatorUnparser(
   with ToBriefXMLImpl {
   override def nom = "Choice"
 
-  override val runtimeDependencies = Vector()
+  override def runtimeDependencies = Vector()
 
-  override val childProcessors = choiceBranchMap.childProcessors.toVector
+  override def childProcessors = choiceBranchMap.childProcessors
 
   def unparse(state: UState): Unit = {
     if (state.withinHiddenNest) {
@@ -159,9 +159,9 @@ class DelimiterStackUnparser(
         "</DelimiterStack>"
   }
 
-  override lazy val childProcessors = Vector(bodyUnparser)
+  override def childProcessors = Vector(bodyUnparser)
 
-  override lazy val runtimeDependencies =
+  override def runtimeDependencies =
     (initiatorOpt.toList ++ separatorOpt.toList ++ terminatorOpt.toList).toVector
 
   def unparse(state: UState): Unit = {
@@ -193,9 +193,9 @@ class DynamicEscapeSchemeUnparser(
 ) extends CombinatorUnparser(ctxt) {
   override def nom = "EscapeSchemeStack"
 
-  override lazy val childProcessors = Vector(bodyUnparser)
+  override def childProcessors = Vector(bodyUnparser)
 
-  override lazy val runtimeDependencies = Vector(escapeScheme)
+  override def runtimeDependencies = Vector(escapeScheme)
 
   def unparse(state: UState): Unit = {
     // evaluate the dynamic escape scheme in the correct scope. the resulting

--- a/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/unparsers/runtime1/ConvertBinaryCalendarUnparser.scala
+++ b/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/unparsers/runtime1/ConvertBinaryCalendarUnparser.scala
@@ -40,7 +40,7 @@ case class ConvertBinaryCalendarSecMilliUnparser(
   /**
    * Primitive unparsers must override runtimeDependencies
    */
-  override lazy val runtimeDependencies = Vector()
+  override def runtimeDependencies = Vector()
 
   protected def putNumber(
     dos: DataOutputStream,

--- a/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/unparsers/runtime1/ConvertNonBaseTenTextNumberUnparser.scala
+++ b/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/unparsers/runtime1/ConvertNonBaseTenTextNumberUnparser.scala
@@ -29,7 +29,7 @@ case class ConvertNonBaseTenTextNumberUnparser(
   base: Int
 ) extends TextPrimUnparser {
 
-  override lazy val runtimeDependencies = Vector()
+  override def runtimeDependencies = Vector()
 
   override def unparse(state: UState): Unit = {
 

--- a/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/unparsers/runtime1/ConvertTextBooleanUnparser.scala
+++ b/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/unparsers/runtime1/ConvertTextBooleanUnparser.scala
@@ -34,7 +34,7 @@ case class ConvertTextBooleanUnparser(
   /**
    * Primitive unparsers must override runtimeDependencies
    */
-  override lazy val runtimeDependencies = Vector(textBooleanTrueRepEv, textBooleanFalseRepEv)
+  override def runtimeDependencies = Vector(textBooleanTrueRepEv, textBooleanFalseRepEv)
 
   def unparse(state: UState): Unit = {
 

--- a/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/unparsers/runtime1/ConvertTextCalendarUnparser.scala
+++ b/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/unparsers/runtime1/ConvertTextCalendarUnparser.scala
@@ -37,7 +37,7 @@ case class ConvertTextCalendarUnparser(
   /**
    * Primitive unparsers must override runtimeDependencies
    */
-  override lazy val runtimeDependencies = Vector(calendarEv, dateTimeFormatterEv)
+  override def runtimeDependencies = Vector(calendarEv, dateTimeFormatterEv)
 
   def unparse(state: UState): Unit = {
 

--- a/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/unparsers/runtime1/ConvertTextStandardNumberUnparser.scala
+++ b/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/unparsers/runtime1/ConvertTextStandardNumberUnparser.scala
@@ -35,9 +35,9 @@ case class ConvertTextCombinatorUnparser(
   converterUnparser: Unparser
 ) extends CombinatorUnparser(rd) {
 
-  override lazy val runtimeDependencies = Vector()
+  override def runtimeDependencies = Vector()
 
-  override lazy val childProcessors = Vector(converterUnparser, valueUnparser)
+  override def childProcessors = Vector(converterUnparser, valueUnparser)
 
   override def unparse(state: UState): Unit = {
     converterUnparser.unparse1(state)
@@ -57,7 +57,7 @@ case class ConvertTextNumberUnparser(
   with TextDecimalVirtualPointMixin
   with ToBriefXMLImpl {
 
-  override lazy val runtimeDependencies = Vector(textNumberFormatEv)
+  override def runtimeDependencies = Vector(textNumberFormatEv)
 
   override def unparse(state: UState): Unit = {
 

--- a/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/unparsers/runtime1/ConvertZonedNumberUnparser.scala
+++ b/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/unparsers/runtime1/ConvertZonedNumberUnparser.scala
@@ -30,9 +30,9 @@ case class ConvertZonedCombinatorUnparser(
   converterUnparser: Unparser
 ) extends CombinatorUnparser(rd) {
 
-  override lazy val runtimeDependencies = Vector()
+  override def runtimeDependencies = Vector()
 
-  override lazy val childProcessors = Vector(converterUnparser, valueUnparser)
+  override def childProcessors = Vector(converterUnparser, valueUnparser)
 
   override def unparse(state: UState): Unit = {
     converterUnparser.unparse1(state)
@@ -52,7 +52,7 @@ case class ConvertZonedNumberUnparser(
   with TextDecimalVirtualPointMixin
   with ToBriefXMLImpl {
 
-  override lazy val runtimeDependencies = Vector()
+  override def runtimeDependencies = Vector()
 
   override def unparse(state: UState): Unit = {
 

--- a/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/unparsers/runtime1/DelimitedUnparsers.scala
+++ b/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/unparsers/runtime1/DelimitedUnparsers.scala
@@ -40,7 +40,7 @@ sealed class StringDelimitedUnparser(
   isDelimRequired: Boolean
 ) extends TextPrimUnparser {
 
-  override lazy val runtimeDependencies = Vector()
+  override def runtimeDependencies = Vector()
 
   val fieldDFA = CreateFieldDFA()
   val textUnparser = new TextDelimitedUnparser(context)

--- a/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/unparsers/runtime1/DelimiterUnparsers.scala
+++ b/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/unparsers/runtime1/DelimiterUnparsers.scala
@@ -35,7 +35,7 @@ class DelimiterTextUnparser(
 
   private def erd = context
 
-  override lazy val runtimeDependencies = Vector()
+  override def runtimeDependencies = Vector()
 
   override lazy val nom = {
     if (delimiterType == DelimiterTextType.Initiator) "InitiatorUnparser"

--- a/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/unparsers/runtime1/ElementUnparser.scala
+++ b/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/unparsers/runtime1/ElementUnparser.scala
@@ -55,7 +55,7 @@ class ElementUnspecifiedLengthUnparser(
   with RegularElementUnparserStartEndStrategy
   with RepMoveMixin {
 
-  override lazy val runtimeDependencies = Vector()
+  override def runtimeDependencies = Vector()
 
 }
 
@@ -79,7 +79,7 @@ class ElementUnparserInputValueCalc(erd: ElementRuntimeData, setVarUnparsers: Ar
   extends ElementUnparserBase(erd, setVarUnparsers, Nope, Nope, Nope, Nope)
   with RegularElementUnparserStartEndStrategy {
 
-  override lazy val runtimeDependencies = Vector()
+  override def runtimeDependencies = Vector()
 
   /**
    * Move over in the element children, but not in the group.
@@ -108,7 +108,7 @@ class ElementOVCUnspecifiedLengthUnparser(
   with OVCStartEndStrategy
   with RepMoveMixin {
 
-  override lazy val runtimeDependencies = Vector()
+  override def runtimeDependencies = Vector()
 
 }
 
@@ -130,7 +130,7 @@ sealed abstract class ElementUnparserBase(
   with RepMoveMixin
   with ElementUnparserStartEndStrategy {
 
-  final override lazy val childProcessors =
+  final override def childProcessors =
     (eBeforeUnparser.toList ++ eUnparser.toList ++ eAfterUnparser.toList ++ eReptypeUnparser.toList ++ setVarUnparsers.toList).toVector
 
   private val name = erd.name
@@ -298,7 +298,7 @@ class ElementSpecifiedLengthUnparser(
   with RegularElementUnparserStartEndStrategy
   with ElementSpecifiedLengthMixin {
 
-  override lazy val runtimeDependencies = maybeTargetLengthEv.toList.toVector
+  override def runtimeDependencies = maybeTargetLengthEv.toList.toVector
 
   override def runContentUnparser(state: UState): Unit = {
     computeTargetLength(
@@ -357,7 +357,7 @@ class ElementOVCSpecifiedLengthUnparser(
   with OVCStartEndStrategy
   with ElementSpecifiedLengthMixin {
 
-  override lazy val runtimeDependencies = maybeTargetLengthEv.toList.toVector
+  override def runtimeDependencies = maybeTargetLengthEv.toList.toVector
 
   private def suspendableExpression =
     new ElementOVCSpecifiedLengthUnparserSuspendableExpression(this, expr)

--- a/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/unparsers/runtime1/ExpressionEvaluatingUnparsers.scala
+++ b/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/unparsers/runtime1/ExpressionEvaluatingUnparsers.scala
@@ -60,9 +60,9 @@ final class SetVariableUnparser(
   referencingContext: NonTermRuntimeData
 ) extends PrimUnparserNoData {
 
-  override lazy val runtimeDependencies = Vector()
+  override def runtimeDependencies = Vector()
 
-  override lazy val childProcessors = Vector()
+  override def childProcessors = Vector()
 
   def suspendableExpression =
     new SetVariableSuspendableExpression(expr, context, referencingContext)
@@ -95,9 +95,9 @@ class NewVariableInstanceStartUnparser(vrd: VariableRuntimeData, trd: TermRuntim
   extends PrimUnparserNoData {
 
   override def context = trd
-  override lazy val runtimeDependencies = Vector()
+  override def runtimeDependencies = Vector()
 
-  override lazy val childProcessors = Vector()
+  override def childProcessors = Vector()
 
   override def unparse(state: UState) = {
     val nvi = state.newVariableInstance(vrd)
@@ -120,9 +120,9 @@ class NewVariableInstanceEndUnparser(vrd: VariableRuntimeData, trd: TermRuntimeD
   extends PrimUnparserNoData {
 
   override def context = trd
-  override lazy val runtimeDependencies = Vector()
+  override def runtimeDependencies = Vector()
 
-  override lazy val childProcessors = Vector()
+  override def childProcessors = Vector()
 
   override def unparse(state: UState) = state.removeVariableInstance(vrd)
 }

--- a/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/unparsers/runtime1/HexBinaryLengthUnparser.scala
+++ b/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/unparsers/runtime1/HexBinaryLengthUnparser.scala
@@ -27,7 +27,7 @@ import org.apache.daffodil.runtime1.processors.unparsers._
 abstract class HexBinaryUnparserBase(override val context: ElementRuntimeData)
   extends PrimUnparser {
 
-  override lazy val runtimeDependencies = Vector()
+  override def runtimeDependencies = Vector()
 
   protected def getLengthInBits(state: UState): Long
 

--- a/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/unparsers/runtime1/HiddenGroupCombinatorUnparser.scala
+++ b/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/unparsers/runtime1/HiddenGroupCombinatorUnparser.scala
@@ -29,9 +29,9 @@ import org.apache.daffodil.runtime1.processors.unparsers._
 class HiddenGroupCombinatorUnparser(ctxt: ModelGroupRuntimeData, bodyUnparser: Unparser)
   extends CombinatorUnparser(ctxt) {
 
-  override lazy val childProcessors = Vector(bodyUnparser)
+  override def childProcessors = Vector(bodyUnparser)
 
-  override lazy val runtimeDependencies = Vector()
+  override def runtimeDependencies = Vector()
 
   def unparse(start: UState): Unit = {
     try {

--- a/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/unparsers/runtime1/IBM4690PackedDecimalUnparsers.scala
+++ b/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/unparsers/runtime1/IBM4690PackedDecimalUnparsers.scala
@@ -49,7 +49,7 @@ class IBM4690PackedIntegerRuntimeLengthUnparser(
 ) extends IBM4690PackedIntegerBaseUnparser(e)
   with HasRuntimeExplicitLength {
 
-  override lazy val runtimeDependencies = Vector(lengthEv)
+  override def runtimeDependencies = Vector(lengthEv)
 }
 
 final class IBM4690PackedIntegerDelimitedUnparser(e: ElementRuntimeData)
@@ -61,7 +61,7 @@ final class IBM4690PackedIntegerDelimitedUnparser(e: ElementRuntimeData)
 final class IBM4690PackedIntegerMinimumLengthUnparser(e: ElementRuntimeData)
   extends IBM4690PackedIntegerBaseUnparser(e) {
 
-  override lazy val runtimeDependencies = Vector()
+  override def runtimeDependencies = Vector()
 
   override def getBitLength(s: ParseOrUnparseState): Int = {
     val number = getNumberToPut(s.asInstanceOf[UState])
@@ -97,7 +97,7 @@ class IBM4690PackedDecimalRuntimeLengthUnparser(
 ) extends IBM4690PackedDecimalBaseUnparser(e, binaryDecimalVirtualPoint)
   with HasRuntimeExplicitLength {
 
-  override lazy val runtimeDependencies = Vector(lengthEv)
+  override def runtimeDependencies = Vector(lengthEv)
 }
 
 final class IBM4690PackedDecimalDelimitedUnparser(
@@ -113,7 +113,7 @@ final class IBM4690PackedDecimalMinimumLengthUnparser(
   binaryDecimalVirtualPoint: Int
 ) extends IBM4690PackedDecimalBaseUnparser(e, binaryDecimalVirtualPoint) {
 
-  override lazy val runtimeDependencies = Vector()
+  override def runtimeDependencies = Vector()
 
   override def getBitLength(s: ParseOrUnparseState): Int = {
     val number = getNumberToPut(s.asInstanceOf[UState])

--- a/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/unparsers/runtime1/LayeredSequenceUnparser.scala
+++ b/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/unparsers/runtime1/LayeredSequenceUnparser.scala
@@ -24,7 +24,7 @@ import org.apache.daffodil.runtime1.processors.unparsers._
 class LayeredSequenceUnparser(
   ctxt: SequenceRuntimeData,
   childUnparser: SequenceChildUnparser
-) extends OrderedUnseparatedSequenceUnparser(ctxt, Seq(childUnparser)) {
+) extends OrderedUnseparatedSequenceUnparser(ctxt, Array(childUnparser)) {
 
   override def nom = "LayeredSequence"
 

--- a/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/unparsers/runtime1/NadaUnparser.scala
+++ b/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/unparsers/runtime1/NadaUnparser.scala
@@ -27,7 +27,7 @@ class NadaUnparser(override val context: RuntimeData) extends PrimUnparser {
 
   override def toString = "Nada"
 
-  override lazy val runtimeDependencies = Vector()
+  override def runtimeDependencies = Vector()
 
   override def unparse(start: UState) = {
     Assert.abort("NadaUnparsers are all supposed to optimize out!")

--- a/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/unparsers/runtime1/NilEmptyCombinatorUnparsers.scala
+++ b/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/unparsers/runtime1/NilEmptyCombinatorUnparsers.scala
@@ -28,9 +28,9 @@ case class SimpleNilOrValueUnparser(
   valueUnparser: Unparser
 ) extends CombinatorUnparser(ctxt) {
 
-  override lazy val runtimeDependencies = Vector()
+  override def runtimeDependencies = Vector()
 
-  override lazy val childProcessors = Vector(nilUnparser, valueUnparser)
+  override def childProcessors = Vector(nilUnparser, valueUnparser)
 
   def unparse(state: UState): Unit = {
     Assert.invariant(Maybe.WithNulls.isDefined(state.currentInfosetNode))
@@ -54,9 +54,9 @@ case class ComplexNilOrContentUnparser(
   contentUnparser: Unparser
 ) extends CombinatorUnparser(ctxt) {
 
-  override lazy val runtimeDependencies = Vector()
+  override def runtimeDependencies = Vector()
 
-  override lazy val childProcessors = Vector(nilUnparser, contentUnparser)
+  override def childProcessors = Vector(nilUnparser, contentUnparser)
 
   def unparse(state: UState): Unit = {
     Assert.invariant(Maybe.WithNulls.isDefined(state.currentInfosetNode))

--- a/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/unparsers/runtime1/NilUnparsers.scala
+++ b/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/unparsers/runtime1/NilUnparsers.scala
@@ -26,7 +26,7 @@ class LiteralValueNilOfSpecifiedLengthUnparser(
   isForPattern: Boolean
 ) extends StringNoTruncateUnparser(erd) {
 
-  override lazy val runtimeDependencies = Vector(slEv)
+  override def runtimeDependencies = Vector(slEv)
 
   override protected def contentString(state: UState) = {
     slEv.evaluate(state)

--- a/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/unparsers/runtime1/PackedBinaryUnparserTraits.scala
+++ b/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/unparsers/runtime1/PackedBinaryUnparserTraits.scala
@@ -39,7 +39,7 @@ abstract class PackedBinaryBaseUnparser(override val context: ElementRuntimeData
   extends PrimUnparser
   with PackedBinaryConversion {
 
-  override lazy val runtimeDependencies: Vector[Evaluatable[AnyRef]] = Vector()
+  override def runtimeDependencies: Vector[Evaluatable[AnyRef]] = Vector()
 
   protected def getBitLength(s: ParseOrUnparseState): Int
 

--- a/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/unparsers/runtime1/PackedDecimalUnparsers.scala
+++ b/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/unparsers/runtime1/PackedDecimalUnparsers.scala
@@ -53,7 +53,7 @@ class PackedIntegerRuntimeLengthUnparser(
 ) extends PackedIntegerBaseUnparser(e, packedSignCodes)
   with HasRuntimeExplicitLength {
 
-  override lazy val runtimeDependencies = Vector(lengthEv)
+  override def runtimeDependencies = Vector(lengthEv)
 }
 
 final class PackedIntegerDelimitedUnparser(
@@ -69,7 +69,7 @@ final class PackedIntegerMinimumLengthUnparser(
   packedSignCodes: PackedSignCodes
 ) extends PackedIntegerBaseUnparser(e, packedSignCodes) {
 
-  override lazy val runtimeDependencies = Vector()
+  override def runtimeDependencies = Vector()
 
   override def getBitLength(s: ParseOrUnparseState): Int = {
     val number = getNumberToPut(s.asInstanceOf[UState])
@@ -106,7 +106,7 @@ class PackedDecimalRuntimeLengthUnparser(
 ) extends PackedDecimalBaseUnparser(e, binaryDecimalVirtualPoint, packedSignCodes)
   with HasRuntimeExplicitLength {
 
-  override lazy val runtimeDependencies = Vector(lengthEv)
+  override def runtimeDependencies = Vector(lengthEv)
 }
 
 final class PackedDecimalDelimitedUnparser(
@@ -124,7 +124,7 @@ final class PackedDecimalMinimumLengthUnparser(
   packedSignCodes: PackedSignCodes
 ) extends PackedDecimalBaseUnparser(e, binaryDecimalVirtualPoint, packedSignCodes) {
 
-  override lazy val runtimeDependencies = Vector()
+  override def runtimeDependencies = Vector()
 
   override def getBitLength(s: ParseOrUnparseState): Int = {
     val number = getNumberToPut(s.asInstanceOf[UState])

--- a/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/unparsers/runtime1/SeparatedSequenceUnparsers.scala
+++ b/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/unparsers/runtime1/SeparatedSequenceUnparsers.scala
@@ -48,7 +48,7 @@ trait Separated { self: SequenceChildUnparser =>
 
   def isPositional: Boolean
 
-  val childProcessors = Vector(childUnparser, sep)
+  def childProcessors = Vector(childUnparser, sep)
 }
 
 sealed abstract class ScalarOrderedSeparatedSequenceChildUnparserBase(
@@ -121,14 +121,15 @@ class OrderedSeparatedSequenceUnparser(
   sepMtaAlignmentMaybe: MaybeInt,
   sepMtaUnparserMaybe: Maybe[Unparser],
   sep: Unparser,
-  childUnparsersArg: Vector[SequenceChildUnparser]
-) extends OrderedSequenceUnparserBase(
-    rd,
-    (childUnparsersArg :+ sep) ++ sepMtaUnparserMaybe.toSeq
-  ) {
+  childUnparsers: Array[SequenceChildUnparser with Separated]
+) extends OrderedSequenceUnparserBase(rd) {
+  // Sequences of nothing (no initiator, no terminator, nothing at all) should
+  // have been optimized away
+  Assert.invariant(childUnparsers.length > 0)
 
-  private val childUnparsers =
-    childUnparsersArg.asInstanceOf[Seq[SequenceChildUnparser with Separated]]
+  override def runtimeDependencies = Vector()
+
+  override def childProcessors = childUnparsers.toVector
 
   /**
    * Unparses one occurrence with associated separator (non-suppressable).

--- a/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/unparsers/runtime1/SequenceChildUnparsers.scala
+++ b/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/unparsers/runtime1/SequenceChildUnparsers.scala
@@ -67,7 +67,7 @@ abstract class RepeatingChildUnparser(
     childUnparser.unparse1(state)
   }
 
-  override lazy val runtimeDependencies = Vector()
+  override def runtimeDependencies = Vector()
 
   override def toString = "RepUnparser(" + childUnparser.toString + ")"
 

--- a/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/unparsers/runtime1/SequenceUnparserBases.scala
+++ b/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/unparsers/runtime1/SequenceUnparserBases.scala
@@ -16,23 +16,11 @@
  */
 package org.apache.daffodil.unparsers.runtime1
 
-import org.apache.daffodil.lib.exceptions.Assert
-import org.apache.daffodil.runtime1.processors.Evaluatable
 import org.apache.daffodil.runtime1.processors.SequenceRuntimeData
 import org.apache.daffodil.runtime1.processors.unparsers._
 
 abstract class OrderedSequenceUnparserBase(
-  srd: SequenceRuntimeData,
-  childUnparsers: Vector[Unparser]
+  srd: SequenceRuntimeData
 ) extends CombinatorUnparser(srd) {
-
   override def nom = "Sequence"
-
-  override lazy val runtimeDependencies: Vector[Evaluatable[AnyRef]] = Vector()
-
-  override lazy val childProcessors = childUnparsers
-
-  // Sequences of nothing (no initiator, no terminator, nothing at all) should
-  // have been optimized away
-  Assert.invariant(childUnparsers.length > 0)
 }

--- a/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/unparsers/runtime1/SpecifiedLength2.scala
+++ b/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/unparsers/runtime1/SpecifiedLength2.scala
@@ -213,7 +213,7 @@ class SimpleTypeRetryUnparser(
 
   override final def runtimeDependencies = maybeUnparserTargetLengthInBitsEv.toSeq.toVector
 
-  final override lazy val childProcessors = Vector(vUnparser)
+  final override def childProcessors = Vector(vUnparser)
 
   def suspendableOperation = new SimpleTypeRetryUnparserSuspendableOperation(
     context,
@@ -226,7 +226,7 @@ class SimpleTypeRetryUnparser(
 class CaptureStartOfContentLengthUnparser(override val context: ElementRuntimeData)
   extends PrimUnparser {
 
-  override lazy val runtimeDependencies = Vector()
+  override def runtimeDependencies = Vector()
 
   override def unparse(state: UState): Unit = {
     val dos = state.dataOutputStream
@@ -244,7 +244,7 @@ class CaptureEndOfContentLengthUnparser(
   maybeFixedLengthInBits: MaybeULong
 ) extends PrimUnparser {
 
-  override lazy val runtimeDependencies = Vector()
+  override def runtimeDependencies = Vector()
 
   override def unparse(state: UState): Unit = {
     val dos = state.dataOutputStream.asInstanceOf[DirectOrBufferedDataOutputStream]
@@ -275,7 +275,7 @@ class CaptureEndOfContentLengthUnparser(
 class CaptureStartOfValueLengthUnparser(override val context: ElementRuntimeData)
   extends PrimUnparser {
 
-  override lazy val runtimeDependencies = Vector()
+  override def runtimeDependencies = Vector()
 
   override def unparse(state: UState): Unit = {
     val dos = state.dataOutputStream
@@ -291,7 +291,7 @@ class CaptureStartOfValueLengthUnparser(override val context: ElementRuntimeData
 class CaptureEndOfValueLengthUnparser(override val context: ElementRuntimeData)
   extends PrimUnparser {
 
-  override lazy val runtimeDependencies = Vector()
+  override def runtimeDependencies = Vector()
 
   override def unparse(state: UState): Unit = {
     val dos = state.dataOutputStream
@@ -480,7 +480,7 @@ class ElementUnusedUnparser(
 ) extends PrimUnparser
   with SuspendableUnparser {
 
-  override lazy val runtimeDependencies = Vector(targetLengthEv)
+  override def runtimeDependencies = Vector(targetLengthEv)
 
   override def suspendableOperation =
     new ElementUnusedUnparserSuspendableOperation(
@@ -584,7 +584,7 @@ class ChoiceUnusedUnparser(
 ) extends PrimUnparser
   with SuspendableUnparser {
 
-  override lazy val runtimeDependencies = Vector()
+  override def runtimeDependencies = Vector()
 
   override def suspendableOperation = suspendableOp
 }
@@ -678,7 +678,7 @@ class OnlyPaddingUnparser(
 ) extends TextPrimUnparser
   with SuspendableUnparser {
 
-  override lazy val runtimeDependencies = Vector(targetLengthEv)
+  override def runtimeDependencies = Vector(targetLengthEv)
 
   override def suspendableOperation =
     new OnlyPaddingUnparserSuspendableOperation(
@@ -735,7 +735,7 @@ class NilLiteralCharacterUnparser(
 ) extends TextPrimUnparser
   with SuspendableUnparser {
 
-  override lazy val runtimeDependencies = Vector(targetLengthEv)
+  override def runtimeDependencies = Vector(targetLengthEv)
 
   override def suspendableOperation = new NilLiteralCharacterUnparserSuspendableOperation(
     context,

--- a/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/unparsers/runtime1/SpecifiedLengthUnparsers.scala
+++ b/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/unparsers/runtime1/SpecifiedLengthUnparsers.scala
@@ -37,9 +37,9 @@ final class SpecifiedLengthExplicitImplicitUnparser(
   targetLengthInBitsEv: UnparseTargetLengthInBitsEv
 ) extends CombinatorUnparser(erd) {
 
-  override lazy val runtimeDependencies = Vector()
+  override def runtimeDependencies = Vector()
 
-  override lazy val childProcessors = Vector(eUnparser)
+  override def childProcessors = Vector(eUnparser)
 
   private val libEv = targetLengthInBitsEv.lengthInBitsEv
   private val mcsEv = libEv.maybeCharsetEv
@@ -141,9 +141,9 @@ class SpecifiedLengthPrefixedUnparser(
 ) extends CombinatorUnparser(erd)
   with CalculatedPrefixedLengthUnparserMixin {
 
-  override lazy val runtimeDependencies = Vector()
+  override def runtimeDependencies = Vector()
 
-  override lazy val childProcessors = Vector(prefixedLengthUnparser, eUnparser)
+  override def childProcessors = Vector(prefixedLengthUnparser, eUnparser)
 
   override def unparse(state: UState): Unit = {
     // Create a "detached" DIDocument with a single child element that the

--- a/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/unparsers/runtime1/StreamSplitterMixin.scala
+++ b/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/unparsers/runtime1/StreamSplitterMixin.scala
@@ -86,7 +86,7 @@ class RegionSplitUnparser(override val context: TermRuntimeData)
   extends PrimUnparser
   with SuspendableUnparser {
 
-  override val childProcessors: Vector[Processor] = Vector()
+  override def childProcessors: Vector[Processor] = Vector()
 
   override def runtimeDependencies = Vector()
 

--- a/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/unparsers/runtime1/StringLengthUnparsers.scala
+++ b/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/unparsers/runtime1/StringLengthUnparsers.scala
@@ -120,7 +120,7 @@ class StringMaybeTruncateBitsUnparser(
   charsetEv: CharsetEv
 ) extends StringSpecifiedLengthUnparserTruncateBase(stringTruncationType, erd) {
 
-  override lazy val runtimeDependencies = Vector(targetLengthInBitsEv, charsetEv)
+  override def runtimeDependencies = Vector(targetLengthInBitsEv, charsetEv)
 
   private def getLengthInBits(str: String, state: UState): (Long, Long) = {
     val cs = charsetEv.evaluate(state)
@@ -257,7 +257,7 @@ class StringMaybeTruncateCharactersUnparser(
   erd: ElementRuntimeData
 ) extends StringSpecifiedLengthUnparserTruncateBase(stringTruncationType, erd) {
 
-  override lazy val runtimeDependencies = Vector(lengthInCharactersEv)
+  override def runtimeDependencies = Vector(lengthInCharactersEv)
 
   override def unparse(state: UState): Unit = {
     val dos = state.dataOutputStream

--- a/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/unparsers/runtime1/StringLiteralForUnparser.scala
+++ b/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/unparsers/runtime1/StringLiteralForUnparser.scala
@@ -33,7 +33,7 @@ class NilStringLiteralForUnparserEv(
 ) extends Evaluatable[String](tci)
   with InfosetCachedEvaluatable[String] {
 
-  override lazy val runtimeDependencies = maybeOutputNewLineEv.toList
+  override def runtimeDependencies = maybeOutputNewLineEv.toList
 
   override protected def compute(state: ParseOrUnparseState): String = {
     val endMarker = "__daffodil_stringLiteralForUnparser_endMarker__"

--- a/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/unparsers/runtime1/SuppressableSeparatorUnparser.scala
+++ b/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/unparsers/runtime1/SuppressableSeparatorUnparser.scala
@@ -203,7 +203,7 @@ final class SuppressableSeparatorUnparser private (
 ) extends PrimUnparser
   with SuspendableUnparser {
 
-  override val childProcessors: Vector[Processor] = Vector(sepUnparser)
+  override def childProcessors: Vector[Processor] = Vector(sepUnparser)
 
   override def runtimeDependencies = Vector()
 }

--- a/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/unparsers/runtime1/UnseparatedSequenceUnparsers.scala
+++ b/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/unparsers/runtime1/UnseparatedSequenceUnparsers.scala
@@ -24,7 +24,7 @@ import org.apache.daffodil.runtime1.processors.{ SequenceRuntimeData, TermRuntim
 
 trait Unseparated { self: SequenceChildUnparser =>
 
-  val childProcessors = Vector(childUnparser)
+  def childProcessors = Vector(childUnparser)
 }
 
 class ScalarOrderedUnseparatedSequenceChildUnparser(
@@ -54,8 +54,16 @@ class RepOrderedUnseparatedSequenceChildUnparser(
 
 class OrderedUnseparatedSequenceUnparser(
   rd: SequenceRuntimeData,
-  childUnparsers: Seq[SequenceChildUnparser]
-) extends OrderedSequenceUnparserBase(rd, childUnparsers.toVector) {
+  childUnparsers: Array[SequenceChildUnparser]
+) extends OrderedSequenceUnparserBase(rd) {
+
+  // Sequences of nothing (no initiator, no terminator, nothing at all) should
+  // have been optimized away
+  Assert.invariant(childUnparsers.length > 0)
+
+  override def runtimeDependencies = Vector()
+
+  override def childProcessors = childUnparsers.toVector
 
   /**
    * Unparses one iteration of an array/optional element

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/EncodingRuntimeData.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/EncodingRuntimeData.scala
@@ -122,7 +122,7 @@ final class EncodingRuntimeData(
   with ImplementsThrowsSDE
   with Serializable {
 
-  lazy val runtimeDependencies = Vector(charsetEv)
+  def runtimeDependencies = Vector(charsetEv)
 
   def getDecoderInfo(state: ParseOrUnparseState) = {
     val cs = charsetEv.evaluate(state)

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/EvBinaryFloat.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/EvBinaryFloat.scala
@@ -24,6 +24,6 @@ class BinaryFloatRepEv(expr: CompiledExpression[String], eci: DPathElementCompil
   extends EvaluatableConvertedExpression[String, BinaryFloatRep](expr, BinaryFloatRep, eci)
   with InfosetCachedEvaluatable[BinaryFloatRep] {
 
-  override lazy val runtimeDependencies = Vector()
+  override def runtimeDependencies = Vector()
 
 }

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/EvByteOrder.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/EvByteOrder.scala
@@ -28,7 +28,7 @@ import org.apache.daffodil.runtime1.dsom._
 class ByteOrderEv(override val expr: CompiledExpression[String], eci: DPathElementCompileInfo)
   extends EvaluatableConvertedExpression[String, ByteOrder](expr, ByteOrder, eci)
   with InfosetCachedEvaluatable[ByteOrder] {
-  override lazy val runtimeDependencies = Vector()
+  override def runtimeDependencies = Vector()
 
 }
 
@@ -48,7 +48,7 @@ class CheckByteAndBitOrderEv(
 ) extends Evaluatable[Ok](t)
   with InfosetCachedEvaluatable[Ok] { // can't use unit here, not <: AnyRef
 
-  override lazy val runtimeDependencies = Vector()
+  override def runtimeDependencies = Vector()
 
   override final protected def compute(state: ParseOrUnparseState): Ok = {
     t match {
@@ -78,7 +78,7 @@ class CheckBitOrderAndCharsetEv(t: DPathCompileInfo, bitOrder: BitOrder, charset
   extends Evaluatable[Ok](t)
   with InfosetCachedEvaluatable[Ok] { // can't use unit here, not <: AnyRef
 
-  override lazy val runtimeDependencies = Vector(charsetEv)
+  override def runtimeDependencies = Vector(charsetEv)
 
   override final protected def compute(state: ParseOrUnparseState): Ok = {
     val bitsCharset = charsetEv.evaluate(state)

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/EvCalendarLanguage.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/EvCalendarLanguage.scala
@@ -57,7 +57,7 @@ class CalendarLanguageEv(
     eci
   )
   with InfosetCachedEvaluatable[ULocale] {
-  override lazy val runtimeDependencies = Vector()
+  override def runtimeDependencies = Vector()
 }
 
 class CalendarEv(
@@ -70,7 +70,7 @@ class CalendarEv(
 ) extends Evaluatable[Calendar](eci)
   with InfosetCachedEvaluatable[Calendar] {
 
-  override lazy val runtimeDependencies = Seq(localeEv)
+  override def runtimeDependencies = Seq(localeEv)
 
   override def compute(state: ParseOrUnparseState) = {
     // Used to configure the dataFormatter
@@ -106,7 +106,7 @@ class DateTimeFormatterEv(
 ) extends Evaluatable[ThreadLocal[SimpleDateFormat]](eci)
   with InfosetCachedEvaluatable[ThreadLocal[SimpleDateFormat]] {
 
-  override lazy val runtimeDependencies = Seq(localeEv)
+  override def runtimeDependencies = Seq(localeEv)
 
   override def compute(state: ParseOrUnparseState) = {
     val calendar = calendarEv.evaluate(state)

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/EvDelimiters.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/EvDelimiters.scala
@@ -60,7 +60,7 @@ abstract class DelimiterParseEv(
   with InfosetCachedEvaluatable[Array[DFADelimiter]]
   with DelimiterEvMixin[Array[DFADelimiter]] {
 
-  override lazy val runtimeDependencies = Vector()
+  override def runtimeDependencies = Vector()
 
   override protected def compute(state: ParseOrUnparseState): Array[DFADelimiter] = {
     if (state.isInstanceOf[UState]) {
@@ -85,7 +85,7 @@ abstract class DelimiterUnparseEv(
   with InfosetCachedEvaluatable[Array[DFADelimiter]]
   with DelimiterEvMixin[Array[DFADelimiter]] {
 
-  override lazy val runtimeDependencies = Seq(outputNewLine)
+  override def runtimeDependencies = Seq(outputNewLine)
 
   override protected def compute(state: ParseOrUnparseState): Array[DFADelimiter] = {
     if (state.isInstanceOf[PState]) {

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/EvElement.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/EvElement.scala
@@ -36,7 +36,7 @@ class ExplicitLengthEv(expr: CompiledExpression[JLong], ci: DPathCompileInfo)
   extends EvaluatableExpression[JLong](expr, ci)
   with LengthEv
   with InfosetCachedEvaluatable[JLong] {
-  override lazy val runtimeDependencies = Vector()
+  override def runtimeDependencies = Vector()
 
   /**
    * Length is special. For the dfdl:length property, when it's an expression
@@ -61,7 +61,7 @@ class ImplicitLengthEv(lengthValue: Long, ci: DPathElementCompileInfo)
   with LengthEv
   with NoCacheEvaluatable[JLong] {
 
-  override val runtimeDependencies = Vector()
+  override def runtimeDependencies = Vector()
 
   private val jLength = JLong.valueOf(lengthValue)
 
@@ -161,7 +161,7 @@ class LengthInBitsEv(
   ci: DPathCompileInfo
 ) extends LengthInBitsEvBase(ci, lengthUnits, lengthKind) {
 
-  override lazy val runtimeDependencies = maybeCharsetEv.toList :+ lengthEv
+  override def runtimeDependencies = maybeCharsetEv.toList :+ lengthEv
 
   override protected def lengthInLengthUnits(state: ParseOrUnparseState) =
     lengthEv.evaluate(state).longValue()
@@ -183,7 +183,7 @@ class MinLengthInBitsEv(
   ci: DPathCompileInfo
 ) extends LengthInBitsEvBase(ci, lengthUnits, lengthKind) {
 
-  override lazy val runtimeDependencies = maybeCharsetEv.toList
+  override def runtimeDependencies = maybeCharsetEv.toList
 
   override protected def lengthInLengthUnits(state: ParseOrUnparseState) = minLen
 }
@@ -206,7 +206,7 @@ class UnparseTargetLengthInBitsEv(
 ) extends Evaluatable[MaybeJULong](ci)
   with InfosetCachedEvaluatable[MaybeJULong] {
 
-  override lazy val runtimeDependencies = Vector(this.lengthInBitsEv, this.minLengthInBitsEv)
+  override def runtimeDependencies = Vector(this.lengthInBitsEv, this.minLengthInBitsEv)
 
   /**
    * Note: use of MaybeJULong type. New Maybe type added which can be stored in
@@ -242,7 +242,7 @@ class UnparseTargetLengthInCharactersEv(
 ) extends Evaluatable[MaybeJULong](ci)
   with InfosetCachedEvaluatable[MaybeJULong] {
 
-  override lazy val runtimeDependencies = Vector(this.lengthEv, charsetEv)
+  override def runtimeDependencies = Vector(this.lengthEv, charsetEv)
 
   /**
    * Note: use of MaybeJULong type. New Maybe type added which can be stored in
@@ -268,17 +268,17 @@ class UnparseTargetLengthInCharactersEv(
 class OccursCountEv(expr: CompiledExpression[JLong], ci: DPathElementCompileInfo)
   extends EvaluatableExpression[JLong](expr, ci)
   with InfosetCachedEvaluatable[JLong] {
-  override lazy val runtimeDependencies = Vector()
+  override def runtimeDependencies = Vector()
 }
 
 class OutputNewLineEv(expr: CompiledExpression[String], ci: DPathCompileInfo)
   extends EvaluatableConvertedExpression[String, String](expr, OutputNewLineCooker, ci)
   with InfosetCachedEvaluatable[String] {
-  override lazy val runtimeDependencies = Vector()
+  override def runtimeDependencies = Vector()
 }
 
 class ChoiceDispatchKeyEv(expr: CompiledExpression[String], ci: DPathCompileInfo)
   extends EvaluatableConvertedExpression[String, String](expr, ChoiceDispatchKeyCooker, ci)
   with InfosetCachedEvaluatable[String] {
-  override lazy val runtimeDependencies = Vector()
+  override def runtimeDependencies = Vector()
 }

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/EvEncoding.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/EvEncoding.scala
@@ -58,7 +58,7 @@ abstract class EncodingEvBase(
     tci
   )
   with InfosetCachedEvaluatable[String] {
-  override lazy val runtimeDependencies = Vector()
+  override def runtimeDependencies = Vector()
 
   override protected def compute(state: ParseOrUnparseState): String = {
     // compute via the cooker first
@@ -85,7 +85,7 @@ abstract class CharsetEvBase(encodingEv: EncodingEvBase, tci: DPathCompileInfo)
   extends Evaluatable[BitsCharset](tci)
   with InfosetCachedEvaluatable[BitsCharset] {
 
-  override lazy val runtimeDependencies = Seq(encodingEv)
+  override def runtimeDependencies = Seq(encodingEv)
 
   private def checkCharset(state: ParseOrUnparseState, bitsCharset: BitsCharset): Unit = {
     if (bitsCharset.bitWidthOfACodeUnit != 8) {
@@ -120,7 +120,7 @@ class FillByteEv(fillByteRaw: String, charsetEv: CharsetEv, tci: DPathCompileInf
   extends Evaluatable[Integer](tci)
   with InfosetCachedEvaluatable[Integer] {
 
-  override lazy val runtimeDependencies = Seq(charsetEv)
+  override def runtimeDependencies = Seq(charsetEv)
 
   private val maybeSingleRawByteValue: MaybeInt = {
     val RawByte = """\%\#r([0-9a-fA-F]{2})\;""".r

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/EvEscapeSchemes.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/EvEscapeSchemes.scala
@@ -33,13 +33,13 @@ import org.apache.daffodil.runtime1.processors.unparsers.UState
 class EscapeCharEv(expr: CompiledExpression[String], ci: DPathCompileInfo)
   extends EvaluatableConvertedExpression[String, String](expr, EscapeCharacterCooker, ci)
   with InfosetCachedEvaluatable[String] {
-  override lazy val runtimeDependencies = Vector()
+  override def runtimeDependencies = Vector()
 }
 
 class EscapeEscapeCharEv(expr: CompiledExpression[String], ci: DPathCompileInfo)
   extends EvaluatableConvertedExpression[String, String](expr, EscapeEscapeCharacterCooker, ci)
   with InfosetCachedEvaluatable[String] {
-  override lazy val runtimeDependencies = Vector()
+  override def runtimeDependencies = Vector()
 }
 class ExtraEscapedCharsEv(expr: CompiledExpression[String], ci: DPathCompileInfo)
   extends EvaluatableConvertedExpression[String, Seq[String]](
@@ -48,7 +48,7 @@ class ExtraEscapedCharsEv(expr: CompiledExpression[String], ci: DPathCompileInfo
     ci
   )
   with InfosetCachedEvaluatable[Seq[String]] {
-  override lazy val runtimeDependencies = Vector()
+  override def runtimeDependencies = Vector()
 }
 
 trait EscapeSchemeCommonEv {
@@ -103,7 +103,7 @@ class EscapeSchemeCharParseEv(
   ci: DPathCompileInfo
 ) extends EscapeSchemeParseEv(ci) {
 
-  override val runtimeDependencies = Vector(escapeChar) ++ optEscapeEscapeChar.toList
+  override def runtimeDependencies = Vector(escapeChar) ++ optEscapeEscapeChar.toList
 
   def compute(state: ParseOrUnparseState) = {
     val escChar = escapeChar.evaluate(state).charAt(0)
@@ -119,7 +119,7 @@ class EscapeSchemeCharUnparseEv(
   ci: DPathCompileInfo
 ) extends EscapeSchemeUnparseEv(ci) {
 
-  override val runtimeDependencies =
+  override def runtimeDependencies =
     Vector(escapeChar) ++ optEscapeEscapeChar.toList ++ extraEscapedChars.toList
 
   def compute(state: ParseOrUnparseState) = {
@@ -142,7 +142,7 @@ class EscapeSchemeBlockParseEv(
   ci: DPathCompileInfo
 ) extends EscapeSchemeParseEv(ci) {
 
-  override val runtimeDependencies = optEscapeEscapeChar.toList
+  override def runtimeDependencies = optEscapeEscapeChar.toList
 
   val bs = EscapeBlockStartCooker.convertConstant(blockStart, ci, forUnparse = false)
   val be = EscapeBlockEndCooker.convertConstant(blockEnd, ci, forUnparse = false)
@@ -162,7 +162,7 @@ class EscapeSchemeBlockUnparseEv(
   ci: DPathCompileInfo
 ) extends EscapeSchemeUnparseEv(ci) {
 
-  override val runtimeDependencies = optEscapeEscapeChar.toList ++ extraEscapedChars.toList
+  override def runtimeDependencies = optEscapeEscapeChar.toList ++ extraEscapedChars.toList
 
   val bs = EscapeBlockStartCooker.convertConstant(blockStart, ci, forUnparse = true)
   val be = EscapeBlockEndCooker.convertConstant(blockEnd, ci, forUnparse = true)

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/EvFieldDFA.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/EvFieldDFA.scala
@@ -26,7 +26,7 @@ class FieldDFAParseEv(val escapeSchemeEv: Maybe[EscapeSchemeParseEv], ci: DPathC
   extends Evaluatable[DFAField](ci)
   with InfosetCachedEvaluatable[DFAField] {
 
-  override lazy val runtimeDependencies = escapeSchemeEv.toList
+  override def runtimeDependencies = escapeSchemeEv.toList
 
   def compute(state: ParseOrUnparseState) = {
 

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/EvTextNumber.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/EvTextNumber.scala
@@ -46,7 +46,7 @@ class TextStandardDecimalSeparatorEv(expr: CompiledExpression[String], tci: DPat
     tci
   )
   with InfosetCachedEvaluatable[List[String]] {
-  override lazy val runtimeDependencies = Vector()
+  override def runtimeDependencies = Vector()
 }
 
 class TextStandardGroupingSeparatorEv(expr: CompiledExpression[String], tci: DPathCompileInfo)
@@ -56,7 +56,7 @@ class TextStandardGroupingSeparatorEv(expr: CompiledExpression[String], tci: DPa
     tci
   )
   with InfosetCachedEvaluatable[String] {
-  override lazy val runtimeDependencies = Vector()
+  override def runtimeDependencies = Vector()
 }
 
 class TextStandardExponentRepEv(expr: CompiledExpression[String], tci: DPathCompileInfo)
@@ -66,7 +66,7 @@ class TextStandardExponentRepEv(expr: CompiledExpression[String], tci: DPathComp
     tci
   )
   with InfosetCachedEvaluatable[String] {
-  override lazy val runtimeDependencies = Vector()
+  override def runtimeDependencies = Vector()
 }
 
 class TextNumberFormatEv(
@@ -87,7 +87,7 @@ class TextNumberFormatEv(
 ) extends Evaluatable[DecimalFormat](tci)
   with InfosetCachedEvaluatable[DecimalFormat] {
 
-  override lazy val runtimeDependencies =
+  override def runtimeDependencies =
     (decimalSepEv.toList ++ groupingSepEv.toList ++ exponentRepEv.toList).toVector
 
   private def checkUnique(
@@ -242,7 +242,7 @@ class TextBooleanTrueRepEv(
     tci
   )
   with InfosetCachedEvaluatable[List[String]] {
-  override lazy val runtimeDependencies = Vector()
+  override def runtimeDependencies = Vector()
 
   override final protected def compute(state: ParseOrUnparseState): List[String] = {
     if (mustBeSameLength) {
@@ -276,5 +276,5 @@ class TextBooleanFalseRepEv(expr: CompiledExpression[String], tci: DPathCompileI
     tci
   )
   with InfosetCachedEvaluatable[List[String]] {
-  override lazy val runtimeDependencies = Vector()
+  override def runtimeDependencies = Vector()
 }

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/Evaluatable.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/Evaluatable.scala
@@ -456,7 +456,7 @@ abstract class EvaluatableExpression[ExprType <: AnyRef](
 ) extends Evaluatable[ExprType](ci)
   with ExprEvalMixin[ExprType] {
 
-  override lazy val runtimeDependencies = Vector()
+  override def runtimeDependencies = Vector()
 
   override final def toBriefXML(depth: Int = -1) =
     "<EvaluatableExpression eName='" + ci.diagnosticDebugName + "' expr=" + expr
@@ -478,7 +478,7 @@ trait EvaluatableConvertedExpressionMixin[ExprType <: AnyRef, +ConvertedType <: 
 
   protected def converter: Converter[ExprType, ConvertedType]
 
-  override lazy val runtimeDependencies = Vector()
+  override def runtimeDependencies = Vector()
 
   override final def toBriefXML(depth: Int = -1) =
     if (this.isConstant) this.constValue.toString else expr.toBriefXML(depth)

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/PackedBinaryTraits.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/PackedBinaryTraits.scala
@@ -91,7 +91,7 @@ abstract class PackedBinaryDecimalBaseParser(
 ) extends PrimParser
   with PackedBinaryConversion[JBigDecimal]
   with PackedBinaryLengthCheck {
-  override lazy val runtimeDependencies = Vector()
+  override def runtimeDependencies = Vector()
 
   protected def getBitLength(s: ParseOrUnparseState): Int
 
@@ -125,7 +125,7 @@ abstract class PackedBinaryIntegerBaseParser(
 ) extends PrimParser
   with PackedBinaryConversion[JBigInteger]
   with PackedBinaryLengthCheck {
-  override lazy val runtimeDependencies = Vector()
+  override def runtimeDependencies = Vector()
 
   protected def getBitLength(s: ParseOrUnparseState): Int
 

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/AssertPatternParsers.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/AssertPatternParsers.scala
@@ -73,7 +73,7 @@ class AssertPatternParser(
   override val failureType: FailureType
 ) extends PrimParser
   with AssertParserMixin {
-  override lazy val runtimeDependencies = Vector()
+  override def runtimeDependencies = Vector()
 
   override def toBriefXML(depthLimit: Int = -1) = {
     val kindString = if (discrim) "Discriminator" else "Assertion"

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/BinaryBooleanParsers.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/BinaryBooleanParsers.scala
@@ -93,7 +93,7 @@ class BinaryBooleanParser(
   lengthKind: LengthKind
 ) extends BinaryBooleanParserBase(binaryBooleanTrueRep, binaryBooleanFalseRep, lengthUnits) {
 
-  override lazy val runtimeDependencies = Vector(lengthEv)
+  override def runtimeDependencies = Vector(lengthEv)
 
   override def getBitLength(state: PState): Int = {
     val nBytesAsJLong = lengthEv.evaluate(state)
@@ -113,7 +113,7 @@ class BinaryBooleanBitLimitLengthParser(
 ) extends BinaryBooleanParserBase(binaryBooleanTrueRep, binaryBooleanFalseRep, lengthUnits)
   with BitLengthFromBitLimitMixin {
 
-  override val runtimeDependencies = Vector()
+  override def runtimeDependencies = Vector()
 
   override def getBitLength(state: PState): Int = {
     getLengthInBits(state).toInt

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/BinaryNumberParsers.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/BinaryNumberParsers.scala
@@ -31,7 +31,7 @@ import org.apache.daffodil.runtime1.processors.ParseOrUnparseState
 import org.apache.daffodil.runtime1.processors.unparsers.UState
 
 class BinaryFloatParser(override val context: ElementRuntimeData) extends PrimParser {
-  override lazy val runtimeDependencies = Vector()
+  override def runtimeDependencies = Vector()
 
   def parse(start: PState): Unit = {
     val dis = start.dataInputStream
@@ -47,7 +47,7 @@ class BinaryFloatParser(override val context: ElementRuntimeData) extends PrimPa
 }
 
 class BinaryDoubleParser(override val context: ElementRuntimeData) extends PrimParser {
-  override lazy val runtimeDependencies = Vector()
+  override def runtimeDependencies = Vector()
 
   def parse(start: PState): Unit = {
     val dis = start.dataInputStream
@@ -92,7 +92,7 @@ abstract class BinaryDecimalParserBase(
   binaryDecimalVirtualPoint: Int
 ) extends PrimParser
   with BinaryNumberCheckWidth {
-  override lazy val runtimeDependencies = Vector()
+  override def runtimeDependencies = Vector()
 
   protected def getBitLength(s: ParseOrUnparseState): Int
 
@@ -138,7 +138,7 @@ abstract class BinaryIntegerBaseParser(
   override val context: ElementRuntimeData
 ) extends PrimParser
   with BinaryNumberCheckWidth {
-  override lazy val runtimeDependencies = Vector()
+  override def runtimeDependencies = Vector()
 
   protected def getBitLength(s: ParseOrUnparseState): Int
 

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/BlobLengthParsers.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/BlobLengthParsers.scala
@@ -105,7 +105,7 @@ sealed abstract class BlobLengthParser(override val context: ElementRuntimeData)
 final class BlobSpecifiedLengthParser(erd: ElementRuntimeData, lengthEv: LengthInBitsEv)
   extends BlobLengthParser(erd) {
 
-  override val runtimeDependencies = Vector(lengthEv)
+  override def runtimeDependencies = Vector(lengthEv)
 
   override def getLengthInBits(pstate: PState): Long = {
     lengthEv.evaluate(pstate).get

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/ConvertTextStandardNumberParser.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/ConvertTextStandardNumberParser.scala
@@ -43,9 +43,9 @@ case class ConvertTextCombinatorParser(
   converterParser: Parser
 ) extends CombinatorParser(rd) {
 
-  override lazy val runtimeDependencies = Vector()
+  override def runtimeDependencies = Vector()
 
-  override lazy val childProcessors = Vector(valueParser, converterParser)
+  override def childProcessors = Vector(valueParser, converterParser)
 
   def parse(start: PState): Unit = {
     valueParser.parse1(start)
@@ -166,7 +166,7 @@ case class ConvertTextStandardNumberParser(
 ) extends TextPrimParser
   with TextDecimalVirtualPointMixin {
 
-  override lazy val runtimeDependencies = Vector(textNumberFormatEv)
+  override def runtimeDependencies = Vector(textNumberFormatEv)
 
   private val primNumeric = context.optPrimType.get.asInstanceOf[NodeInfo.PrimType.PrimNumeric]
 

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/DelimitedParsers.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/DelimitedParsers.scala
@@ -49,7 +49,7 @@ class StringDelimitedParser(
 ) extends TextPrimParser
   with CaptureParsingValueLength {
 
-  override val runtimeDependencies = Vector(fieldDFAEv, context.encInfo.charsetEv)
+  override def runtimeDependencies = Vector(fieldDFAEv, context.encInfo.charsetEv)
 
   override val charsetEv = context.encInfo.charsetEv
 

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/DelimiterParsers.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/DelimiterParsers.scala
@@ -51,7 +51,7 @@ class DelimiterTextParser(
   mustMatchNonZeroData: Boolean
 ) extends TextPrimParser {
 
-  override lazy val runtimeDependencies = rd.encodingInfo.runtimeDependencies
+  override def runtimeDependencies = rd.encodingInfo.runtimeDependencies
   override def context = rd
 
   override val nom = delimiterType.toString

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/ElementCombinator1.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/ElementCombinator1.scala
@@ -44,13 +44,13 @@ abstract class ElementParserBase(
   eRepTypeParser: Maybe[Parser]
 ) extends CombinatorParser(erd) {
 
-  override lazy val runtimeDependencies = Vector()
+  override def runtimeDependencies = Vector()
 
   def move(pstate: PState): Unit // implement for different kinds of "moving over to next thing"
   def parseBegin(pstate: PState): Unit
   def parseEnd(pstate: PState): Unit
 
-  override lazy val childProcessors: Vector[Processor] = (patDiscrimParser.toSeq ++
+  override def childProcessors: Vector[Processor] = (patDiscrimParser.toSeq ++
     patAssertParser ++
     eBeforeParser.toSeq ++
     eParser.toSeq ++

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/ElementKindParsers.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/ElementKindParsers.scala
@@ -34,9 +34,9 @@ import org.apache.daffodil.runtime1.processors.TermRuntimeData
 class ComplexTypeParser(rd: RuntimeData, bodyParser: Parser) extends CombinatorParser(rd) {
   override def nom = "ComplexType"
 
-  override lazy val runtimeDependencies = Vector()
+  override def runtimeDependencies = Vector()
 
-  override lazy val childProcessors = Vector(bodyParser)
+  override def childProcessors = Vector(bodyParser)
 
   def parse(start: PState): Unit = {
     start.mpstate.childIndexStack.push(1L) // one-based indexing
@@ -59,9 +59,9 @@ class DelimiterStackParser(
   bodyParser: Parser
 ) extends CombinatorParser(ctxt) {
 
-  override lazy val childProcessors = Vector(bodyParser)
+  override def childProcessors = Vector(bodyParser)
 
-  override lazy val runtimeDependencies = delimiters.toVector
+  override def runtimeDependencies = delimiters.toVector
 
   def parse(start: PState): Unit = {
 
@@ -101,9 +101,9 @@ class DynamicEscapeSchemeParser(
   bodyParser: Parser
 ) extends CombinatorParser(ctxt) {
 
-  override lazy val childProcessors = Vector(bodyParser)
+  override def childProcessors = Vector(bodyParser)
 
-  override lazy val runtimeDependencies = Vector(escapeScheme)
+  override def runtimeDependencies = Vector(escapeScheme)
 
   def parse(start: PState): Unit = {
     // evaluate the dynamic escape scheme in the correct scope. the resulting
@@ -129,7 +129,7 @@ class DynamicEscapeSchemeParser(
  */
 class ChoiceBranchEmptyParser(val context: RuntimeData) extends PrimParserNoData {
 
-  override lazy val runtimeDependencies = Vector()
+  override def runtimeDependencies = Vector()
 
   def parse(state: PState): Unit = {
     // do nothing
@@ -148,7 +148,7 @@ abstract class ChoiceDispatchCombinatorParserBase(
 
   override def nom = "ChoiceDispatch"
 
-  override lazy val runtimeDependencies = Vector()
+  override def runtimeDependencies = Vector()
 
   override def childProcessors =
     dispatchBranchKeyMap.values.iterator.asScala.map(_._1).toVector ++

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/ExpressionEvaluatingParsers.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/ExpressionEvaluatingParsers.scala
@@ -40,9 +40,9 @@ abstract class ExpressionEvaluationParser(
   override val context: RuntimeData
 ) extends PrimParserNoData {
 
-  override lazy val runtimeDependencies = Vector()
+  override def runtimeDependencies = Vector()
 
-  override lazy val childProcessors = Vector()
+  override def childProcessors = Vector()
 
   /**
    * Modifies the PState
@@ -88,7 +88,7 @@ final class NewVariableInstanceStartParser(vrd: VariableRuntimeData, trd: TermRu
 
   override def context = trd
 
-  override lazy val runtimeDependencies = Vector()
+  override def runtimeDependencies = Vector()
 
   def parse(start: PState): Unit = {
     val nvi = start.newVariableInstance(vrd)
@@ -109,7 +109,7 @@ final class NewVariableInstanceEndParser(vrd: VariableRuntimeData, trd: TermRunt
   extends PrimParser {
 
   override def context = trd
-  override lazy val runtimeDependencies = Vector()
+  override def runtimeDependencies = Vector()
 
   def parse(start: PState) = {
     start.removeVariableInstance(vrd)

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/FramingParsers.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/FramingParsers.scala
@@ -23,7 +23,7 @@ import org.apache.daffodil.runtime1.processors.TextProcessor
 class SkipRegionParser(skipInBits: Int, override val context: TermRuntimeData)
   extends PrimParser {
 
-  override lazy val runtimeDependencies = Vector()
+  override def runtimeDependencies = Vector()
 
   override def parse(pstate: PState) = {
     val dis = pstate.dataInputStream
@@ -34,7 +34,7 @@ class SkipRegionParser(skipInBits: Int, override val context: TermRuntimeData)
 class AlignmentFillParser(alignmentInBits: Int, override val context: TermRuntimeData)
   extends PrimParser {
 
-  override lazy val runtimeDependencies = Vector()
+  override def runtimeDependencies = Vector()
 
   override def parse(pstate: PState): Unit = {
     val dis = pstate.dataInputStream

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/HexBinaryLengthParsers.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/HexBinaryLengthParsers.scala
@@ -75,7 +75,7 @@ sealed abstract class HexBinaryLengthParser(override val context: ElementRuntime
 final class HexBinarySpecifiedLengthParser(erd: ElementRuntimeData, lengthEv: LengthInBitsEv)
   extends HexBinaryLengthParser(erd) {
 
-  override val runtimeDependencies = Vector(lengthEv)
+  override def runtimeDependencies = Vector(lengthEv)
 
   override def getLengthInBits(pstate: PState): Long = {
     lengthEv.evaluate(pstate).get
@@ -86,7 +86,7 @@ final class HexBinarySpecifiedLengthParser(erd: ElementRuntimeData, lengthEv: Le
 final class HexBinaryEndOfBitLimitParser(erd: ElementRuntimeData)
   extends HexBinaryLengthParser(erd) {
 
-  override val runtimeDependencies = Vector()
+  override def runtimeDependencies = Vector()
 
   override def getLengthInBits(pstate: PState): Long = {
     pstate.bitLimit0b.get - pstate.bitPos0b

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/HiddenGroupCombinatorParser.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/HiddenGroupCombinatorParser.scala
@@ -28,9 +28,9 @@ import org.apache.daffodil.runtime1.processors.ModelGroupRuntimeData
 class HiddenGroupCombinatorParser(ctxt: ModelGroupRuntimeData, bodyParser: Parser)
   extends CombinatorParser(ctxt) {
 
-  override lazy val childProcessors = Vector(bodyParser)
+  override def childProcessors = Vector(bodyParser)
 
-  override lazy val runtimeDependencies = Vector()
+  override def runtimeDependencies = Vector()
 
   def parse(start: PState): Unit = {
     try {

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/InitiatedContentParsers.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/InitiatedContentParsers.scala
@@ -24,7 +24,7 @@ final class InitiatedContentDiscrimOnIndexGreaterThanMinParser(
   min: Int,
   override val context: ElementRuntimeData
 ) extends PrimParser {
-  override lazy val runtimeDependencies = Vector()
+  override def runtimeDependencies = Vector()
 
   final def parse(start: PState): Unit = {
     if (start.arrayIterationPos > min)
@@ -34,7 +34,7 @@ final class InitiatedContentDiscrimOnIndexGreaterThanMinParser(
 
 final class InitiatedContentDiscrimChoiceParser(override val context: TermRuntimeData)
   extends PrimParser {
-  override lazy val runtimeDependencies = Vector()
+  override def runtimeDependencies = Vector()
 
   final def parse(start: PState): Unit = {
     start.resolvePointOfUncertainty()
@@ -44,7 +44,7 @@ final class InitiatedContentDiscrimChoiceParser(override val context: TermRuntim
 final class InitiatedContentDiscrimChoiceOnlyOnFirstIndexParser(
   override val context: TermRuntimeData
 ) extends PrimParser {
-  override lazy val runtimeDependencies = Vector()
+  override def runtimeDependencies = Vector()
 
   final def parse(start: PState): Unit = {
     if (start.arrayIterationPos == 1)
@@ -56,7 +56,7 @@ final class InitiatedContentDiscrimChoiceAndIndexGreaterThanMinParser(
   min: Int,
   override val context: ElementRuntimeData
 ) extends PrimParser {
-  override lazy val runtimeDependencies = Vector()
+  override def runtimeDependencies = Vector()
 
   final def parse(start: PState): Unit = {
     // Resolves PoUs associated with arrays with some minimum number of

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/LayeredSequenceParser.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/LayeredSequenceParser.scala
@@ -23,7 +23,7 @@ import org.apache.daffodil.runtime1.processors.SequenceRuntimeData
 class LayeredSequenceParser(
   rd: SequenceRuntimeData,
   bodyParser: SequenceChildParser
-) extends OrderedUnseparatedSequenceParser(rd, Vector(bodyParser)) {
+) extends OrderedUnseparatedSequenceParser(rd, Array(bodyParser)) {
   override def nom = "LayeredSequence"
 
   override def parse(state: PState): Unit = {

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/NilEmptyCombinatorParsers.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/NilEmptyCombinatorParsers.scala
@@ -23,8 +23,8 @@ import org.apache.daffodil.runtime1.processors.TermRuntimeData
 abstract class NilOrValueParser(ctxt: TermRuntimeData, nilParser: Parser, valueParser: Parser)
   extends CombinatorParser(ctxt) {
 
-  override lazy val childProcessors = Vector(nilParser, valueParser)
-  override lazy val runtimeDependencies = Vector()
+  override def childProcessors = Vector(nilParser, valueParser)
+  override def runtimeDependencies = Vector()
 
   def parse(pstate: PState): Unit = {
 

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/NilParsers.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/NilParsers.scala
@@ -28,7 +28,7 @@ abstract class LiteralNilOfSpecifiedLengthParserBase(erd: ElementRuntimeData)
 
   private val eName = erd.name
 
-  override val runtimeDependencies = Vector(erd.encInfo.charsetEv)
+  override def runtimeDependencies = Vector(erd.encInfo.charsetEv)
   override val context = erd
 
   override val charsetEv = erd.encInfo.charsetEv

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/NonBaseTenTextNumberParser.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/NonBaseTenTextNumberParser.scala
@@ -26,7 +26,7 @@ import org.apache.daffodil.runtime1.processors.ElementRuntimeData
 class ConvertNonBaseTenTextNumberParser(override val context: ElementRuntimeData, base: Int)
   extends TextPrimParser {
 
-  override lazy val runtimeDependencies = Vector()
+  override def runtimeDependencies = Vector()
 
   private val primNumeric = context.optPrimType.get.asInstanceOf[NodeInfo.PrimType.PrimNumeric]
 

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/Parser.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/Parser.scala
@@ -227,10 +227,10 @@ abstract class CombinatorParser(override val context: RuntimeData)
   extends Parser
   with CombinatorProcessor
 
-final class SeqCompParser(context: RuntimeData, val childParsers: Vector[Parser])
+final class SeqCompParser(context: RuntimeData, val childParsers: Array[Parser])
   extends CombinatorParser(context) {
-  override lazy val runtimeDependencies = Vector()
-  override def childProcessors = childParsers
+  override def runtimeDependencies = Vector()
+  override def childProcessors = childParsers.toVector
 
   override def nom = "seq"
 
@@ -249,10 +249,10 @@ final class SeqCompParser(context: RuntimeData, val childParsers: Vector[Parser]
 
 }
 
-class ChoiceParser(ctxt: RuntimeData, val childParsers: Vector[Parser])
+class ChoiceParser(ctxt: RuntimeData, val childParsers: Array[Parser])
   extends CombinatorParser(ctxt) {
-  override lazy val runtimeDependencies = Vector()
-  override lazy val childProcessors = childParsers
+  override def runtimeDependencies = Vector()
+  override def childProcessors = childParsers.toVector
 
   override def nom = "choice"
 
@@ -347,6 +347,6 @@ case class NotParsableParser(context: ElementRuntimeData) extends PrimParserNoDa
     context.toss(rsde)
   }
 
-  override lazy val childProcessors = Vector()
-  override lazy val runtimeDependencies = Vector()
+  override def childProcessors = Vector()
+  override def runtimeDependencies = Vector()
 }

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/PrimitivesDateTime1.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/PrimitivesDateTime1.scala
@@ -41,7 +41,7 @@ case class ConvertTextCalendarParser(
   dateTimeFormatterEv: DateTimeFormatterEv
 ) extends TextPrimParser {
 
-  override lazy val runtimeDependencies = Vector(calendarEv, dateTimeFormatterEv)
+  override def runtimeDependencies = Vector(calendarEv, dateTimeFormatterEv)
 
   def parse(start: PState): Unit = {
     val node = start.simpleElement
@@ -134,7 +134,7 @@ case class ConvertBinaryCalendarSecMilliParser(
   lengthInBits: Int
 ) extends PrimParser {
 
-  override lazy val runtimeDependencies = Vector()
+  override def runtimeDependencies = Vector()
 
   def parse(start: PState): Unit = {
 

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/RepTypeParsers.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/RepTypeParsers.scala
@@ -99,8 +99,8 @@ class RepTypeParser(
 ) extends CombinatorParser(e)
   with WithDetachedParser {
 
-  override lazy val childProcessors = Vector(repTypeParser)
-  override lazy val runtimeDependencies = Vector()
+  override def childProcessors = Vector(repTypeParser)
+  override def runtimeDependencies = Vector()
 
   override def parse(pstate: PState): Unit = {
     val repValue =

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/SeparatedSequenceParsers.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/SeparatedSequenceParsers.scala
@@ -128,18 +128,20 @@ final class OrderedSeparatedSequenceParser(
   rd: SequenceRuntimeData,
   spos: SeparatorPosition,
   sep: Parser,
-  childrenArg: Vector[SequenceChildParser]
-) extends SequenceParserBase(rd, childrenArg, isOrdered = true) {
+  override val childParsers: Array[SequenceChildParser]
+) extends SequenceParserBase(rd, isOrdered = true) {
 
-  override lazy val childProcessors = (sep +: childrenArg.asInstanceOf[Seq[Parser]]).toVector
+  override def runtimeDependencies = Vector()
+  override def childProcessors = (sep +: childParsers).toVector
 }
 
 final class UnorderedSeparatedSequenceParser(
   rd: SequenceRuntimeData,
   spos: SeparatorPosition,
   sep: Parser,
-  childrenArg: Vector[SequenceChildParser]
-) extends SequenceParserBase(rd, childrenArg, isOrdered = false) {
+  override val childParsers: Array[SequenceChildParser]
+) extends SequenceParserBase(rd, isOrdered = false) {
 
-  override lazy val childProcessors = (sep +: childrenArg.asInstanceOf[Seq[Parser]]).toVector
+  override def runtimeDependencies = Vector()
+  override def childProcessors = (sep +: childParsers).toVector
 }

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/SequenceChildBases.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/SequenceChildBases.scala
@@ -458,7 +458,7 @@ abstract class OccursCountExpressionParser(
 
   final override def pouStatus = PoUStatus.NoPoU
 
-  final override lazy val runtimeDependencies = Vector(occursCountEv)
+  final override def runtimeDependencies = Vector(occursCountEv)
 
   final override def isBoundedMax = true
 

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/SequenceParserBases.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/SequenceParserBases.scala
@@ -23,7 +23,6 @@ import org.apache.daffodil.lib.util.Maybe.One
 import org.apache.daffodil.runtime1.dsom.TunableLimitExceededError
 import org.apache.daffodil.runtime1.infoset.DIComplex
 import org.apache.daffodil.runtime1.processors.ElementRuntimeData
-import org.apache.daffodil.runtime1.processors.Evaluatable
 import org.apache.daffodil.runtime1.processors.Failure
 import org.apache.daffodil.runtime1.processors.SequenceRuntimeData
 import org.apache.daffodil.runtime1.processors.Success
@@ -34,13 +33,11 @@ import org.apache.daffodil.runtime1.processors.Success
  */
 abstract class SequenceParserBase(
   srd: SequenceRuntimeData,
-  childParsers: Vector[Parser],
   isOrdered: Boolean
 ) extends CombinatorParser(srd) {
   override def nom = "Sequence"
 
-  override lazy val runtimeDependencies: Vector[Evaluatable[AnyRef]] = Vector()
-  override lazy val childProcessors = childParsers
+  val childParsers: Array[SequenceChildParser]
 
   import ArrayIndexStatus._
   import ParseAttemptStatus._

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/SpecifiedLengthParsers.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/SpecifiedLengthParsers.scala
@@ -38,9 +38,9 @@ sealed abstract class SpecifiedLengthParserBase(eParser: Parser, erd: RuntimeDat
   extends CombinatorParser(erd)
   with CaptureParsingValueLength {
 
-  override lazy val runtimeDependencies = Vector()
+  override def runtimeDependencies = Vector()
 
-  override lazy val childProcessors = Vector(eParser)
+  override def childProcessors = Vector(eParser)
 
   override def charsetEv = Assert.invariantFailed(
     "Specified Length parsers should not capture value length using the charset"
@@ -170,7 +170,7 @@ class SpecifiedLengthPrefixedParser(
 ) extends SpecifiedLengthParserBase(eParser, erd)
   with PrefixedLengthParserMixin {
 
-  override lazy val childProcessors = Vector(eParser, prefixedLengthParser)
+  override def childProcessors = Vector(eParser, prefixedLengthParser)
 
   final override def getBitLength(s: PState): MaybeULong = {
     MaybeULong(getPrefixedLengthInBits(s))
@@ -270,7 +270,7 @@ final class SpecifiedLengthPrefixedCharactersParser(
 ) extends SpecifiedLengthCharactersParserBase(eParser, erd)
   with PrefixedLengthParserMixin {
 
-  override lazy val childProcessors = Vector(eParser, prefixedLengthParser)
+  override def childProcessors = Vector(eParser, prefixedLengthParser)
 
   override lazy val lengthUnits = LengthUnits.Characters
 
@@ -283,7 +283,7 @@ final class SpecifiedLengthPrefixedCharactersParser(
 class CaptureStartOfContentLengthParser(override val context: ElementRuntimeData)
   extends PrimParser {
 
-  override val runtimeDependencies = Vector()
+  override def runtimeDependencies = Vector()
 
   override def parse(state: PState): Unit = {
     val dis = state.dataInputStream
@@ -295,7 +295,7 @@ class CaptureStartOfContentLengthParser(override val context: ElementRuntimeData
 class CaptureEndOfContentLengthParser(override val context: ElementRuntimeData)
   extends PrimParser {
 
-  override val runtimeDependencies = Vector()
+  override def runtimeDependencies = Vector()
 
   override def parse(state: PState): Unit = {
     val dis = state.dataInputStream
@@ -307,7 +307,7 @@ class CaptureEndOfContentLengthParser(override val context: ElementRuntimeData)
 class CaptureStartOfValueLengthParser(override val context: ElementRuntimeData)
   extends PrimParser {
 
-  override val runtimeDependencies = Vector()
+  override def runtimeDependencies = Vector()
 
   override def parse(state: PState): Unit = {
     val dis = state.dataInputStream
@@ -319,7 +319,7 @@ class CaptureStartOfValueLengthParser(override val context: ElementRuntimeData)
 class CaptureEndOfValueLengthParser(override val context: ElementRuntimeData)
   extends PrimParser {
 
-  override val runtimeDependencies = Vector()
+  override def runtimeDependencies = Vector()
 
   override def parse(state: PState): Unit = {
     val dis = state.dataInputStream

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/StringLengthParsers.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/StringLengthParsers.scala
@@ -39,7 +39,7 @@ final class StringOfSpecifiedLengthParser(
 ) extends TextPrimParser
   with StringOfSpecifiedLengthMixin {
 
-  override lazy val runtimeDependencies = Vector(erd.encInfo.charsetEv)
+  override def runtimeDependencies = Vector(erd.encInfo.charsetEv)
 
   override lazy val charsetEv = erd.encInfo.charsetEv
 

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/TextBooleanParser.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/TextBooleanParser.scala
@@ -31,7 +31,7 @@ case class ConvertTextBooleanParser(
   ignoreCase: Boolean
 ) extends TextPrimParser {
 
-  override lazy val runtimeDependencies = Vector(textBooleanTrueRepEv, textBooleanFalseRepEv)
+  override def runtimeDependencies = Vector(textBooleanTrueRepEv, textBooleanFalseRepEv)
 
   private def matches(str1: String, str2: String): Boolean = {
     if (ignoreCase) str1.equalsIgnoreCase(str2) else str1 == str2

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/UnseparatedSequenceParsers.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/UnseparatedSequenceParsers.scala
@@ -18,6 +18,7 @@ package org.apache.daffodil.runtime1.processors.parsers
 
 import org.apache.daffodil.runtime1.processors.ElementRuntimeData
 import org.apache.daffodil.runtime1.processors.OccursCountEv
+import org.apache.daffodil.runtime1.processors.Processor
 import org.apache.daffodil.runtime1.processors.{ SequenceRuntimeData, TermRuntimeData }
 
 trait Unseparated { self: SequenceChildParser =>
@@ -79,10 +80,19 @@ class RepOrderedWithMinMaxUnseparatedSequenceChildParser(
 
 class OrderedUnseparatedSequenceParser(
   rd: SequenceRuntimeData,
-  childParsersArg: Vector[SequenceChildParser]
-) extends SequenceParserBase(rd, childParsersArg, isOrdered = true)
+  override val childParsers: Array[SequenceChildParser]
+) extends SequenceParserBase(rd, isOrdered = true) {
+
+  override def runtimeDependencies = Vector()
+
+  override def childProcessors: Vector[Processor] = childParsers.toVector
+}
 
 class UnorderedUnseparatedSequenceParser(
   rd: SequenceRuntimeData,
-  choiceParser: Vector[SequenceChildParser]
-) extends SequenceParserBase(rd, choiceParser, isOrdered = false)
+  override val childParsers: Array[SequenceChildParser]
+) extends SequenceParserBase(rd, isOrdered = false) {
+  override def runtimeDependencies = Vector()
+
+  override def childProcessors: Vector[Processor] = childParsers.toVector
+}

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/ZonedTextParsers.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/ZonedTextParsers.scala
@@ -37,9 +37,9 @@ case class ConvertZonedCombinatorParser(
   converterParser: Parser
 ) extends CombinatorParser(rd) {
 
-  override lazy val runtimeDependencies = Vector()
+  override def runtimeDependencies = Vector()
 
-  override lazy val childProcessors = Vector(valueParser, converterParser)
+  override def childProcessors = Vector(valueParser, converterParser)
 
   def parse(start: PState): Unit = {
     valueParser.parse1(start)
@@ -58,7 +58,7 @@ case class ConvertZonedNumberParser(
 ) extends TextPrimParser
   with TextDecimalVirtualPointMixin {
 
-  override lazy val runtimeDependencies = Vector(textNumberFormatEv)
+  override def runtimeDependencies = Vector(textNumberFormatEv)
 
   private val primNumeric = context.optPrimType.get.asInstanceOf[NodeInfo.PrimType.PrimNumeric]
 

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/unparsers/Unparser.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/unparsers/Unparser.scala
@@ -139,24 +139,24 @@ trait SuspendableUnparser extends PrimUnparser {
 final class ErrorUnparser(override val context: TermRuntimeData = null)
   extends PrimUnparserNoData {
 
-  override lazy val runtimeDependencies = Vector()
+  override def runtimeDependencies = Vector()
 
   def unparse(ustate: UState): Unit = {
     Assert.abort("Error Unparser")
   }
-  override lazy val childProcessors = Vector()
+  override def childProcessors = Vector()
 
   override def toBriefXML(depthLimit: Int = -1) = "<error/>"
   override def toString = "Error Unparser"
 }
 
-final class SeqCompUnparser(context: RuntimeData, val childUnparsers: Vector[Unparser])
+final class SeqCompUnparser(context: RuntimeData, val childUnparsers: Array[Unparser])
   extends CombinatorUnparser(context)
   with ToBriefXMLImpl {
 
-  override lazy val runtimeDependencies = Vector()
+  override def runtimeDependencies = Vector()
 
-  override val childProcessors = childUnparsers
+  override def childProcessors = childUnparsers.toVector
 
   override def nom = "seq"
 
@@ -179,14 +179,14 @@ case class DummyUnparser(primitiveName: String) extends PrimUnparserNoData {
 
   override def context = null
 
-  override lazy val runtimeDependencies = Vector()
+  override def runtimeDependencies = Vector()
 
   override def isEmpty = true
 
   def unparse(state: UState): Unit =
     state.SDE("Unparser (%s) is not yet implemented.", primitiveName)
 
-  override lazy val childProcessors = Vector()
+  override def childProcessors = Vector()
   override def toBriefXML(depthLimit: Int = -1) =
     "<dummy primitive=\"%s\"/>".format(primitiveName)
   override def toString = "DummyUnparser (%s)".format(primitiveName)
@@ -206,6 +206,6 @@ case class NotUnparsableUnparser(override val context: ElementRuntimeData)
     context.toss(rsde)
   }
 
-  override lazy val childProcessors = Vector()
-  override lazy val runtimeDependencies = Vector()
+  override def childProcessors = Vector()
+  override def runtimeDependencies = Vector()
 }


### PR DESCRIPTION
- Make childProcessors a def instead of a lazy val
- Make childParsers an array instead of a vector

Making the childProcessors a def and childParsers an array is necessary to avoid deserialization error with DefaultSerializationProxy and Vector
