### PR TITLE
Fix Overriding Immutable Variables

### DIFF
--- a/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/unparsers/runtime1/BinaryBooleanUnparsers.scala
+++ b/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/unparsers/runtime1/BinaryBooleanUnparsers.scala
@@ -54,7 +54,7 @@ abstract class BinaryBooleanUnparserBase(
     val nBits = getBitLength(state)
     val node = state.currentInfosetNode.asSimple
     val value = node.dataValue.getBoolean
-    val dos = state.dataOutputStream
+    val dos = state.getDataOutputStream
 
     if (nBits < 1 || nBits > 32) {
       UnparseError(

--- a/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/unparsers/runtime1/BinaryNumberUnparsers.scala
+++ b/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/unparsers/runtime1/BinaryNumberUnparsers.scala
@@ -57,7 +57,7 @@ abstract class BinaryNumberBaseUnparser(override val context: ElementRuntimeData
   def unparse(state: UState): Unit = {
     val nBits = getBitLength(state)
     val value = getNumberToPut(state)
-    val dos = state.dataOutputStream
+    val dos = state.getDataOutputStream
     val res = putNumber(dos, value, nBits, state)
 
     if (!res) {

--- a/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/unparsers/runtime1/BlobLengthUnparser.scala
+++ b/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/unparsers/runtime1/BlobLengthUnparser.scala
@@ -88,10 +88,10 @@ abstract class BlobUnparserBase(override val context: ElementRuntimeData) extend
     // blob data output stream is marked as finished in addBufferedBlob, the
     // second data output stream will then be delivered, finally making it the
     // direct stream.
-    val dos = state.dataOutputStream
+    val dos = state.getDataOutputStream
     val newStream =
       dos.addBufferedBlob(path, lengthInBits, state.tunable.blobChunkSizeInBytes, state)
-    state.dataOutputStream = newStream
+    state.setDataOutputStream(newStream)
     dos.setFinished(state)
   }
 }

--- a/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/unparsers/runtime1/ConvertBinaryCalendarUnparser.scala
+++ b/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/unparsers/runtime1/ConvertBinaryCalendarUnparser.scala
@@ -84,7 +84,7 @@ case class ConvertBinaryCalendarSecMilliUnparser(
       case _ => Assert.impossibleCase
     }
 
-    val dos = state.dataOutputStream
+    val dos = state.getDataOutputStream
     val res = putNumber(dos, diff, lengthInBits, state)
 
     if (!res) {

--- a/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/unparsers/runtime1/DelimitedUnparsers.scala
+++ b/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/unparsers/runtime1/DelimitedUnparsers.scala
@@ -118,7 +118,7 @@ sealed class StringDelimitedUnparser(
           }
         } else valueString // No EscapeScheme
 
-      val outStream = state.dataOutputStream
+      val outStream = state.getDataOutputStream
       val nCharsWritten = outStream.putString(escapedValue, state)
       if (nCharsWritten != escapedValue.length)
         UE(

--- a/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/unparsers/runtime1/DelimiterUnparsers.scala
+++ b/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/unparsers/runtime1/DelimiterUnparsers.scala
@@ -51,7 +51,7 @@ class DelimiterTextUnparser(
   def unparse(state: UState): Unit = {
 
     Logger.log.debug(
-      s"Unparsing starting at bit position: ${state.dataOutputStream.maybeAbsBitPos0b}"
+      s"Unparsing starting at bit position: ${state.getDataOutputStream.maybeAbsBitPos0b}"
     )
 
     val localDelimNode = state.localDelimiters
@@ -72,7 +72,7 @@ class DelimiterTextUnparser(
     try {
       val valueString = delimDFA.unparseValue
 
-      val outStream = state.dataOutputStream
+      val outStream = state.getDataOutputStream
       val nCharsWritten = outStream.putString(valueString, state)
       if (nCharsWritten != valueString.length)
         UE(

--- a/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/unparsers/runtime1/FramingUnparsers.scala
+++ b/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/unparsers/runtime1/FramingUnparsers.scala
@@ -29,7 +29,7 @@ class SkipRegionUnparser(skipInBits: Int, override val context: TermRuntimeData)
   override def runtimeDependencies = Vector()
 
   override def unparse(state: UState) = {
-    val dos = state.dataOutputStream
+    val dos = state.getDataOutputStream
     if (!dos.skip(skipInBits, state)) UE(state, "Unable to skip %s(bits).", skipInBits)
   }
 }
@@ -40,7 +40,7 @@ trait AlignmentFillUnparserSuspendableMixin { this: SuspendableOperation =>
   def rd: TermRuntimeData
 
   def test(ustate: UState) = {
-    val dos = ustate.dataOutputStream
+    val dos = ustate.getDataOutputStream
     if (dos.maybeAbsBitPos0b.isEmpty) {
       Logger.log.debug(
         s"${this} ${ustate} Unable to align to ${alignmentInBits} bits because there is no absolute bit position."
@@ -50,7 +50,7 @@ trait AlignmentFillUnparserSuspendableMixin { this: SuspendableOperation =>
   }
 
   def continuation(state: UState): Unit = {
-    val dos = state.dataOutputStream
+    val dos = state.getDataOutputStream
     val b4 = dos.relBitPos0b
     if (!dos.align(alignmentInBits, state))
       UE(state, "Unable to align to %s(bits).", alignmentInBits)

--- a/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/unparsers/runtime1/HexBinaryLengthUnparser.scala
+++ b/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/unparsers/runtime1/HexBinaryLengthUnparser.scala
@@ -72,7 +72,7 @@ abstract class HexBinaryUnparserBase(override val context: ElementRuntimeData)
         lengthInBits
       }
 
-    val dos = state.dataOutputStream
+    val dos = state.getDataOutputStream
 
     if (bitsFromValueToPut > 0) {
       val ret = dos.putByteArray(value, bitsFromValueToPut, state)

--- a/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/unparsers/runtime1/LayeredSequenceUnparser.scala
+++ b/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/unparsers/runtime1/LayeredSequenceUnparser.scala
@@ -30,7 +30,7 @@ class LayeredSequenceUnparser(
 
   override def unparse(state: UState): Unit = {
 
-    val originalDOS = state.dataOutputStream
+    val originalDOS = state.getDataOutputStream
 
     // create a new buffered DOS that this layer will flush to when the layer
     // completes unparsing. This ensures that any fragment bits or bitOrder
@@ -73,7 +73,7 @@ class LayeredSequenceUnparser(
       val layerDOS = layerDriver.addOutputLayer(layerUnderlyingDOS)
 
       // unparse the layer body into layerDOS
-      state.dataOutputStream = layerDOS
+      state.setDataOutputStream(layerDOS)
       super.unparse(state)
       // now we're done unparsing the layer recursively.
       // While doing that unparsing, the data output stream may have been split, so the
@@ -83,7 +83,7 @@ class LayeredSequenceUnparser(
       // DOS is consolidated and written out, that is when the layer is finished
       // and the wrap-up of the layer (such as writing output variables) can occur.
       //
-      val endOfLayerUnparseDOS = state.dataOutputStream
+      val endOfLayerUnparseDOS = state.getDataOutputStream
       val formatInfoPost =
         state.asInstanceOf[UStateMain].cloneForSuspension(endOfLayerUnparseDOS)
 
@@ -101,7 +101,7 @@ class LayeredSequenceUnparser(
       // just let that propagate.
     } finally {
       // reset the state so subsequent unparsers write to the following DOS
-      state.dataOutputStream = layerFollowingDOS
+      state.setDataOutputStream(layerFollowingDOS)
     }
   }
 

--- a/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/unparsers/runtime1/PackedBinaryUnparserTraits.scala
+++ b/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/unparsers/runtime1/PackedBinaryUnparserTraits.scala
@@ -66,7 +66,7 @@ abstract class PackedBinaryBaseUnparser(override val context: ElementRuntimeData
   override def unparse(state: UState): Unit = {
     val nBits = getBitLength(state)
     val value = getNumberToPut(state)
-    val dos = state.dataOutputStream
+    val dos = state.getDataOutputStream
     val res = putNumber(dos, value, nBits, state)
 
     if (!res) {

--- a/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/unparsers/runtime1/SpecifiedLength2.scala
+++ b/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/unparsers/runtime1/SpecifiedLength2.scala
@@ -21,7 +21,6 @@ import java.nio.charset.MalformedInputException
 import java.nio.charset.UnmappableCharacterException
 
 import org.apache.daffodil.io.DataOutputStream
-import org.apache.daffodil.io.DirectOrBufferedDataOutputStream
 import org.apache.daffodil.io.ZeroLengthStatus
 import org.apache.daffodil.io.processors.charset.BitsCharset
 import org.apache.daffodil.lib.exceptions.Assert
@@ -229,7 +228,7 @@ class CaptureStartOfContentLengthUnparser(override val context: ElementRuntimeDa
   override def runtimeDependencies = Vector()
 
   override def unparse(state: UState): Unit = {
-    val dos = state.dataOutputStream
+    val dos = state.getDataOutputStream
     val elem = state.currentInfosetNode.asInstanceOf[DIElement]
     if (dos.maybeAbsBitPos0b.isDefined) {
       elem.contentLength.setAbsStartPos0bInBits(dos.maybeAbsBitPos0b.getULong)
@@ -247,7 +246,7 @@ class CaptureEndOfContentLengthUnparser(
   override def runtimeDependencies = Vector()
 
   override def unparse(state: UState): Unit = {
-    val dos = state.dataOutputStream.asInstanceOf[DirectOrBufferedDataOutputStream]
+    val dos = state.getDataOutputStream
     val elem = state.currentInfosetNode.asInstanceOf[DIElement]
 
     if (
@@ -278,7 +277,7 @@ class CaptureStartOfValueLengthUnparser(override val context: ElementRuntimeData
   override def runtimeDependencies = Vector()
 
   override def unparse(state: UState): Unit = {
-    val dos = state.dataOutputStream
+    val dos = state.getDataOutputStream
     val elem = state.currentInfosetNode.asInstanceOf[DIElement]
     if (dos.maybeAbsBitPos0b.isDefined) {
       elem.valueLength.setAbsStartPos0bInBits(dos.maybeAbsBitPos0b.getULong)
@@ -294,7 +293,7 @@ class CaptureEndOfValueLengthUnparser(override val context: ElementRuntimeData)
   override def runtimeDependencies = Vector()
 
   override def unparse(state: UState): Unit = {
-    val dos = state.dataOutputStream
+    val dos = state.getDataOutputStream
     val elem = state.currentInfosetNode.asInstanceOf[DIElement]
     if (dos.maybeAbsBitPos0b.isDefined) {
       elem.valueLength.setAbsEndPos0bInBits(dos.maybeAbsBitPos0b.getULong)
@@ -431,17 +430,17 @@ trait SkipTheBits { self: SuspendableOperation =>
 
   protected final def skipTheBits(ustate: UState, skipInBits: Long): Unit = {
     if (skipInBits > 0) {
-      val dos = ustate.dataOutputStream
+      val dos = ustate.getDataOutputStream
       if (!dos.skip(skipInBits, ustate))
         UE(ustate, "Unable to skip %s(bits).", skipInBits)
     }
     if (skipInBits == 0) {
       Logger.log.debug(
-        s"${Misc.getNameFromClass(this)} no fill for ${rd.diagnosticDebugName} DOS ${ustate.dataOutputStream}."
+        s"${Misc.getNameFromClass(this)} no fill for ${rd.diagnosticDebugName} DOS ${ustate.getDataOutputStream}."
       )
     } else {
       Logger.log.debug(
-        s"${Misc.getNameFromClass(this)} filled ${skipInBits} bits for ${rd.diagnosticDebugName} DOS ${ustate.dataOutputStream}."
+        s"${Misc.getNameFromClass(this)} filled ${skipInBits} bits for ${rd.diagnosticDebugName} DOS ${ustate.getDataOutputStream}."
       )
     }
   }
@@ -623,7 +622,7 @@ trait PaddingUnparserMixin extends NeedValueAndTargetLengthMixin { self: Suspend
 
     val nChars = numPadChars(skipInBits, cs.padCharWidthInBits)
     if (nChars > 0) {
-      val dos = state.dataOutputStream
+      val dos = state.getDataOutputStream
       var i = 0
       val padChar = maybePadChar.get
       val padString = padChar.toString

--- a/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/unparsers/runtime1/StreamSplitterMixin.scala
+++ b/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/unparsers/runtime1/StreamSplitterMixin.scala
@@ -92,7 +92,7 @@ class RegionSplitUnparser(override val context: TermRuntimeData)
 
   override lazy val suspendableOperation = new RegionSplitSuspendableOperation(context)
 
-  lazy val dataOutputStream = suspendableOperation.savedUstate.dataOutputStream
+  lazy val dataOutputStream = suspendableOperation.savedUstate.getDataOutputStream
 }
 
 final class RegionSplitSuspendableOperation(override val rd: TermRuntimeData)

--- a/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/unparsers/runtime1/StringLengthUnparsers.scala
+++ b/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/unparsers/runtime1/StringLengthUnparsers.scala
@@ -49,7 +49,7 @@ class StringNoTruncateUnparser(erd: ElementRuntimeData)
   override def runtimeDependencies: Vector[Evaluatable[AnyRef]] = Vector()
 
   override def unparse(state: UState): Unit = {
-    val dos = state.dataOutputStream
+    val dos = state.getDataOutputStream
     val valueToWrite = contentString(state)
     val nCharsWritten =
       try {
@@ -178,7 +178,7 @@ class StringMaybeTruncateBitsUnparser(
     // Then we can figure out the number of padChars to add because a padChar must
     // be a minimum-width character.
     //
-    val dos = state.dataOutputStream
+    val dos = state.getDataOutputStream
     val valueString = contentString(state)
     val valueToWrite = {
       //
@@ -260,7 +260,7 @@ class StringMaybeTruncateCharactersUnparser(
   override def runtimeDependencies = Vector(lengthInCharactersEv)
 
   override def unparse(state: UState): Unit = {
-    val dos = state.dataOutputStream
+    val dos = state.getDataOutputStream
     val valueString = contentString(state)
     val targetLengthInCharacters =
       lengthInCharactersEv.evaluate(state)

--- a/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/unparsers/runtime1/SuppressableSeparatorUnparser.scala
+++ b/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/unparsers/runtime1/SuppressableSeparatorUnparser.scala
@@ -88,7 +88,7 @@ final class SuppressableSeparatorUnparserSuspendableOperation(
    */
   private lazy val dosToCheck_ = {
     Assert.usage(maybeDOSAfterSeparatorRegion.isDefined)
-    val dosForStartOfSeparatedRegion = savedUstate.dataOutputStream.maybeNextInChain.get
+    val dosForStartOfSeparatedRegion = savedUstate.getDataOutputStream.maybeNextInChain.get
     val dosForEndOfSeparatedRegion = maybeDOSAfterSeparatorRegion.get
     val primaryDOSList =
       getDOSFromAtoB(dosForStartOfSeparatedRegion, dosForEndOfSeparatedRegion)

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/DataProcessor.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/DataProcessor.scala
@@ -553,7 +553,9 @@ class DataProcessor(
           unparserState.notifyDebugging(true)
         }
         unparserState.dataProc.get.init(unparserState, ssrd.unparser)
-        unparserState.dataOutputStream.setPriorBitOrder(ssrd.elementRuntimeData.defaultBitOrder)
+        unparserState.getDataOutputStream.setPriorBitOrder(
+          ssrd.elementRuntimeData.defaultBitOrder
+        )
         doUnparse(unparserState)
         unparserState.evalSuspensions(isFinal = true)
         unparserState.unparseResult
@@ -600,7 +602,7 @@ class DataProcessor(
         }
         case th: Throwable => throw th
       } finally {
-        unparserState.dataOutputStream.cleanUp()
+        unparserState.getDataOutputStream.cleanUp()
       }
     res
   }
@@ -656,9 +658,9 @@ class DataProcessor(
     // An application could do this in a loop calling unparse repeatedly
     // without having to create a new infoset event stream or outputstream.
     //
-    Assert.invariant(!state.dataOutputStream.isFinished)
+    Assert.invariant(!state.getDataOutputStream.isFinished)
     try {
-      state.dataOutputStream.setFinished(state)
+      state.getDataOutputStream.setFinished(state)
     } catch {
       case boc: BitOrderChangeException =>
         state.SDE(boc)

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/SuspendableOperation.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/SuspendableOperation.scala
@@ -70,7 +70,7 @@ trait SuspendableOperation extends Suspension {
           val nodeOpt =
             if (ustate.currentInfosetNodeMaybe.isDefined) ustate.currentInfosetNodeMaybe.get
             else "No Node"
-          block(nodeOpt, ustate.dataOutputStream, 0, this)
+          block(nodeOpt, ustate.getDataOutputStream, 0, this)
         }
       } catch {
         case e: RetryableException => {
@@ -78,7 +78,7 @@ trait SuspendableOperation extends Suspension {
           val nodeOpt =
             if (ustate.currentInfosetNodeMaybe.isDefined) ustate.currentInfosetNodeMaybe.get
             else "No Node"
-          block(nodeOpt, ustate.dataOutputStream, 0, e)
+          block(nodeOpt, ustate.getDataOutputStream, 0, e)
         }
       }
       if (!isDone) {

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/Suspension.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/Suspension.scala
@@ -84,7 +84,7 @@ trait Suspension extends Serializable {
         // We are done, and we're not readOnly, so the
         // DOS needs to be set finished now.
         //
-        savedUstate.dataOutputStream.setFinished(savedUstate)
+        savedUstate.getDataOutputStream.setFinished(savedUstate)
       } catch {
         case boc: BitOrderChangeException =>
           savedUstate.SDE(boc)
@@ -113,7 +113,7 @@ trait Suspension extends Serializable {
     // specifically known length of zero bits. So nothing being written out.
     // In that case, why do we need to split at all?
     //
-    val original = ustate.dataOutputStream.asInstanceOf[DirectOrBufferedDataOutputStream]
+    val original = ustate.getDataOutputStream
     if (mkl.isEmpty || (mkl.isDefined && mkl.get > 0)) {
       //
       // only split if the length is either unknown
@@ -168,7 +168,7 @@ trait Suspension extends Serializable {
 
     // the main-thread will carry on using the original ustate but unparsing
     // into this buffered stream.
-    ustate.dataOutputStream = buffered
+    ustate.setDataOutputStream(buffered)
   }
 
   private def suspend(ustate: UState, original: DirectOrBufferedDataOutputStream): Unit = {
@@ -178,7 +178,7 @@ trait Suspension extends Serializable {
     // TODO: Performance - copying this whole state, just for OVC is painful.
     // Some sort of copy-on-write scheme would be better.
     //
-    val didSplit = (ustate.dataOutputStream ne original)
+    val didSplit = (ustate.getDataOutputStream ne original)
     val cloneUState = ustate.asInstanceOf[UStateMain].cloneForSuspension(original)
     if (isReadOnly && didSplit) {
       Assert.invariantFailed("Shouldn't have split. read-only case")

--- a/daffodil-tdml-processor/src/main/scala/org/apache/daffodil/processor/tdml/DaffodilTDMLDFDLProcessor.scala
+++ b/daffodil-tdml-processor/src/main/scala/org/apache/daffodil/processor/tdml/DaffodilTDMLDFDLProcessor.scala
@@ -452,7 +452,7 @@ final class DaffodilTDMLUnparseResult(
 
   private val ustate = actual.resultState.asInstanceOf[UState]
 
-  override def finalBitPos0b = ustate.dataOutputStream.maybeAbsBitPos0b.get
+  override def finalBitPos0b = ustate.getDataOutputStream.maybeAbsBitPos0b.get
 
   override def isScannable: Boolean = actual.isScannable
 


### PR DESCRIPTION
- since we can no longer override immutable variables in Scala 3, we change Ustate's dataOutputStream field to be a private mutable variable with a setter and getter method

DAFFODIL-2975