### PR TITLE
Remove Deconstructing XML Literals during Pattern Matching

### DIFF
--- a/daffodil-cli/src/test/scala/org/apache/daffodil/cli/cliTest/schematron/TestSvrlOutput.scala
+++ b/daffodil-cli/src/test/scala/org/apache/daffodil/cli/cliTest/schematron/TestSvrlOutput.scala
@@ -21,6 +21,7 @@ import java.nio.charset.StandardCharsets.UTF_8
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.StandardOpenOption.APPEND
+import scala.xml.Elem
 import scala.xml.XML
 
 import org.apache.daffodil.cli.Main.ExitCode
@@ -62,10 +63,12 @@ class TestSvrlOutput {
           }(ExitCode.Success)
 
           XML.loadFile(svrl.toFile) match {
-            case <svrl:schematron-output>{rules @ _*}</svrl:schematron-output> =>
-              val res = rules.find {
-                case <svrl:failed-assert>{_*}</svrl:failed-assert> => true
-                case _ => false
+            case Elem("svrl", "schematron-output", _, _, rules @ _*) =>
+              val res = rules.find { r =>
+                r match {
+                  case Elem("svrl", "failed-assert", _, _, _*) => true
+                  case _ => false
+                }
               }
               // we should not have found failures
               assertFalse(res.isDefined)
@@ -94,10 +97,12 @@ class TestSvrlOutput {
           }(ExitCode.ParseError)
 
           XML.loadFile(svrl.toFile) match {
-            case <svrl:schematron-output>{rules @ _*}</svrl:schematron-output> =>
-              val res = rules.find {
-                case <svrl:failed-assert>{_*}</svrl:failed-assert> => true
-                case _ => false
+            case Elem("svrl", "schematron-output", _, _, rules @ _*) =>
+              val res = rules.find { r =>
+                r match {
+                  case Elem("svrl", "failed-assert", _, _, _*) => true
+                  case _ => false
+                }
               }
               // we should have found some failures
               assertTrue(res.isDefined)
@@ -170,10 +175,12 @@ class TestSvrlOutput {
           }(ExitCode.Success)
 
           XML.loadFile(svrl.toFile) match {
-            case <svrl:schematron-output>{rules @ _*}</svrl:schematron-output> =>
-              val res = rules.find {
-                case <svrl:failed-assert>{_*}</svrl:failed-assert> => true
-                case _ => false
+            case Elem("svrl", "schematron-output", _, _, rules @ _*) =>
+              val res = rules.find { r =>
+                r match {
+                  case Elem("svrl", "failed-assert", _, _, _*) => true
+                  case _ => false
+                }
               }
               // we should not have found failures
               assertFalse(res.isDefined)

--- a/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/ChoiceGroup.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/ChoiceGroup.scala
@@ -17,6 +17,7 @@
 
 package org.apache.daffodil.core.dsom
 
+import scala.xml.Elem
 import scala.xml.Node
 
 import org.apache.daffodil.core.dsom.walker.ChoiceView
@@ -65,7 +66,8 @@ trait ChoiceDefMixin extends AnnotatedSchemaComponent with GroupDefLike {
 
   protected override def annotationFactory(node: Node): Option[DFDLAnnotation] = {
     node match {
-      case <dfdl:choice>{contents @ _*}</dfdl:choice> => Some(new DFDLChoice(node, this))
+      case Elem("dfdl", "choice", _, _, _*) =>
+        Some(new DFDLChoice(node, this))
       case _ => annotationFactoryForDFDLStatement(node, this)
     }
   }
@@ -74,12 +76,12 @@ trait ChoiceDefMixin extends AnnotatedSchemaComponent with GroupDefLike {
     new DFDLChoice(newDFDLAnnotationXML("choice"), this)
 
   lazy val xmlChildren = xml match {
-    case <choice>{c @ _*}</choice> => c
-    case <group>{_*}</group> => {
+    case Elem(_, "choice", _, _, c @ _*) => c
+    case Elem(_, "group", _, _, _*) => {
       val ch = this match {
         case cgd: GlobalChoiceGroupDef => cgd.xml \ "choice"
       }
-      val <choice>{c @ _*}</choice> = ch(0)
+      val Elem(_, "choice", _, _, c @ _*) = ch(0)
       c
     }
   }

--- a/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/ComplexTypes.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/ComplexTypes.scala
@@ -18,6 +18,7 @@
 package org.apache.daffodil.core.dsom
 
 import scala.xml.Comment
+import scala.xml.Elem
 import scala.xml.Node
 import scala.xml.Text
 
@@ -43,7 +44,7 @@ sealed abstract class ComplexTypeBase(xmlArg: Node, parentArg: SchemaComponent)
   final def sequence = group.asInstanceOf[LocalSequence]
   final def choice = group.asInstanceOf[Choice]
 
-  private lazy val <complexType>{xmlChildren @ _*}</complexType> = xml
+  private lazy val Elem(_, "complexType", _, _, xmlChildren @ _*) = xml
 
   final lazy val Seq(modelGroup) = {
     val s = smg
@@ -73,7 +74,7 @@ sealed abstract class ComplexTypeBase(xmlArg: Node, parentArg: SchemaComponent)
     xmlChildren.flatMap { xmlChild =>
       {
         xmlChild match {
-          case <annotation>{annotationChildren @ _*}</annotation> => {
+          case Elem(_, "annotation", _, _, annotationChildren @ _*) => {
             val dais = annotationChildren.find { ai =>
               ai.attribute("source") match {
                 case Some(n) => n.text.contains("ogf") && n.text.contains("dfdl")

--- a/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/DFDLDefineFormat.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/DFDLDefineFormat.scala
@@ -17,6 +17,7 @@
 
 package org.apache.daffodil.core.dsom
 
+import scala.xml.Elem
 import scala.xml.Node
 import scala.xml.Utility
 
@@ -36,7 +37,7 @@ final class DFDLDefineFormat(node: Node, sd: SchemaDocument)
 
   lazy val formatAnnotation = LV(Symbol("formatAnnotation")) {
     XMLUtils.removeComments(Utility.trim(node)) match {
-      case <defineFormat>{f @ <format>{_*}</format>}</defineFormat> =>
+      case Elem(_, "defineFormat", _, _, Seq(f @ Elem(_, "format", _, _, _*))) =>
         DFDLFormat(f, sd)
       case _ =>
         schemaDefinitionError("dfdl:defineFormat does not contain a dfdl:format element.")

--- a/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/DFDLDefineVariable.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/DFDLDefineVariable.scala
@@ -17,6 +17,7 @@
 
 package org.apache.daffodil.core.dsom
 
+import scala.xml.Elem
 import scala.xml.Node
 import scala.xml.NodeSeq.seqToNodeSeq
 
@@ -136,8 +137,7 @@ final class DFDLNewVariableInstance(node: Node, decl: AnnotatedSchemaComponent)
 
   private lazy val attrValue = getAttributeOption("value")
 
-  private lazy val <dfdl:newVariableInstance>{eltChildren @ _*}</dfdl:newVariableInstance> =
-    node
+  private lazy val Elem("dfdl", "newVariableInstance", _, _, eltChildren @ _*) = node
 
   private lazy val eltValue = eltChildren.text.trim
 
@@ -177,7 +177,7 @@ final class DFDLSetVariable(node: Node, decl: AnnotatedSchemaComponent)
   extends VariableReference(node, decl)
   with DFDLSetVariableRuntime1Mixin {
   private lazy val attrValue = getAttributeOption("value")
-  private lazy val <dfdl:setVariable>{eltChildren @ _*}</dfdl:setVariable> = node
+  private lazy val Elem("dfdl", "setVariable", _, _, eltChildren @ _*) = node
   private lazy val eltValue = eltChildren.text.trim
   final lazy val value = (attrValue, eltValue) match {
     case (None, v) if (v != "") => v

--- a/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/DFDLEscapeScheme.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/DFDLEscapeScheme.scala
@@ -17,6 +17,7 @@
 
 package org.apache.daffodil.core.dsom
 
+import scala.xml.Elem
 import scala.xml.Node
 import scala.xml.Utility
 
@@ -238,9 +239,13 @@ final class DFDLDefineEscapeScheme private (
   lazy val escapeScheme = {
     val des = Utility.trim(node)
     val res = des match {
-      case <dfdl:defineEscapeScheme>{
-            e @ <dfdl:escapeScheme>{contents @ _*}</dfdl:escapeScheme>
-          }</dfdl:defineEscapeScheme> =>
+      case Elem(
+            "dfdl",
+            "defineEscapeScheme",
+            _,
+            _,
+            Seq(e @ Elem("dfdl", "escapeScheme", _, _, _*))
+          ) =>
         new DFDLEscapeScheme(e, decl, this)
       case _ => SDE("The content of %s is not complete.", des.label)
     }

--- a/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/DFDLProperty.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/DFDLProperty.scala
@@ -17,6 +17,7 @@
 
 package org.apache.daffodil.core.dsom
 
+import scala.xml.Elem
 import scala.xml.Node
 import scala.xml.NodeSeq
 
@@ -63,10 +64,10 @@ final class DFDLProperty(xmlArg: Node, formatAnnotation: DFDLFormatAnnotation)
   // have to be resolved by THIS Object
   lazy val value = {
     val values: Option[NodeSeq] = xml match {
-      case <dfdl:property/> => None
-      case <daf:property/> => None
-      case <dfdl:property>{valueNodes @ _*}</dfdl:property> => Some(valueNodes)
-      case <daf:property>{valueNodes @ _*}</daf:property> => Some(valueNodes)
+      case Elem("dfdl", "property", _, _, valueNodes @ _*) if valueNodes.isEmpty => None
+      case Elem("daf", "property", _, _, valueNodes @ _*) if valueNodes.isEmpty => None
+      case Elem("dfdl", "property", _, _, valueNodes @ _*) => Some(valueNodes)
+      case Elem("daf", "property", _, _, valueNodes @ _*) => Some(valueNodes)
     }
 
     values match {

--- a/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/DFDLSchemaFile.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/DFDLSchemaFile.scala
@@ -18,6 +18,7 @@
 package org.apache.daffodil.core.dsom
 
 import java.io.File
+import scala.xml.Elem
 
 import org.apache.daffodil.core.dsom.IIUtils._
 import org.apache.daffodil.lib.api.Diagnostic
@@ -249,7 +250,7 @@ final class DFDLSchemaFile(
     sf: Option[DFDLSchemaFile]
   ): XMLSchemaDocument = {
     val sd = node match {
-      case <schema>{_*}</schema> if (NS(node.namespace) == XMLUtils.xsdURI) => {
+      case Elem(_, "schema", _, _, _*) if (NS(node.namespace) == XMLUtils.xsdURI) => {
         val sd = XMLSchemaDocument(node, sset, Some(iiParent), sf, before, false)
         sd
       }

--- a/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/DFDLStatementMixin.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/DFDLStatementMixin.scala
@@ -17,6 +17,7 @@
 
 package org.apache.daffodil.core.dsom
 
+import scala.xml.Elem
 import scala.xml.Node
 
 import org.apache.daffodil.core.grammar.primitives.AssertBase
@@ -114,18 +115,16 @@ trait ProvidesDFDLStatementMixin extends ThrowsSDE with HasTermCheck {
   ): Option[DFDLAnnotation] = {
     val term = self
     node match {
-      case <dfdl:assert>{content @ _*}</dfdl:assert> => Some(new DFDLAssert(node, term))
-      case <dfdl:discriminator>{content @ _*}</dfdl:discriminator> =>
-        Some(new DFDLDiscriminator(node, term))
-      case <dfdl:setVariable>{content @ _*}</dfdl:setVariable> =>
-        Some(new DFDLSetVariable(node, term))
-      case <dfdl:newVariableInstance>{content @ _*}</dfdl:newVariableInstance> =>
+      case Elem("dfdl", "assert", _, _, _*) => Some(new DFDLAssert(node, term))
+      case Elem("dfdl", "discriminator", _, _, _*) => Some(new DFDLDiscriminator(node, term))
+      case Elem("dfdl", "setVariable", _, _, _*) => Some(new DFDLSetVariable(node, term))
+      case Elem("dfdl", "newVariableInstance", _, _, _*) =>
         Some(new DFDLNewVariableInstance(node, term))
       //
       // property element annotations aren't "statements" so we don't want them back from this
       // and in fact can't construct them here without causing trouble (circular definitions)
       //
-      case <dfdl:property>{_*}</dfdl:property> =>
+      case Elem("dfdl", "property", _, _, _*) =>
         SDE(
           "A dfdl:property annotation element is not allowed without a surrounding dfdl:format, dfdl:element, etc. "
         )

--- a/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/ElementDeclMixin.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/ElementDeclMixin.scala
@@ -17,6 +17,7 @@
 
 package org.apache.daffodil.core.dsom
 
+import scala.xml.Elem
 import scala.xml.Node
 
 import org.apache.daffodil.core.dsom.walker.ElementDeclView
@@ -29,7 +30,8 @@ trait ElementLikeMixin extends AnnotatedSchemaComponent with ProvidesDFDLStateme
 
   protected final def annotationFactory(node: Node): Option[DFDLAnnotation] = {
     node match {
-      case <dfdl:element>{contents @ _*}</dfdl:element> => Some(new DFDLElement(node, this))
+      case Elem("dfdl", "element", _, _, _*) =>
+        Some(new DFDLElement(node, this))
       case _ => annotationFactoryForDFDLStatement(node, this)
     }
   }

--- a/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/GroupDef.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/GroupDef.scala
@@ -18,6 +18,7 @@
 package org.apache.daffodil.core.dsom
 
 import scala.xml.Comment
+import scala.xml.Elem
 import scala.xml.Node
 import scala.xml.Text
 
@@ -29,11 +30,11 @@ object GlobalGroupDef {
   def apply(defXML: Node, schemaDocument: SchemaDocument) = {
     val trimmedXml = scala.xml.Utility.trim(defXML)
     trimmedXml match {
-      case <group>{contents @ _*}</group> => {
+      case Elem(_, "group", _, _, contents @ _*) => {
         val list = contents.collect {
-          case groupXML @ <sequence>{_*}</sequence> =>
+          case groupXML @ Elem(_, "sequence", _, _, _*) =>
             GlobalSequenceGroupDef(defXML, groupXML, schemaDocument)
-          case groupXML @ <choice>{_*}</choice> =>
+          case groupXML @ Elem(_, "choice", _, _, _*) =>
             GlobalChoiceGroupDef(defXML, groupXML, schemaDocument)
         }
         val res = list(0)
@@ -91,7 +92,7 @@ trait GroupDefLike extends AnnotatedSchemaComponent with ProvidesDFDLStatementMi
     val childElem: Option[Node] = child match {
       case _: Text => None
       case _: Comment => None
-      case <annotation>{_*}</annotation> => None
+      case Elem(_, "annotation", _, _, _*) => None
       case _ => Some(child)
     }
     childElem

--- a/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/GroupRef.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/GroupRef.scala
@@ -17,6 +17,7 @@
 
 package org.apache.daffodil.core.dsom
 
+import scala.xml.Elem
 import scala.xml.Node
 
 import org.apache.daffodil.core.dsom.walker.GroupRefView
@@ -44,7 +45,8 @@ trait GroupRef extends GroupRefView { self: ModelGroup =>
 
   override protected def annotationFactory(node: Node): Option[DFDLAnnotation] = {
     node match {
-      case <dfdl:group>{contents @ _*}</dfdl:group> => Some(new DFDLGroup(node, this))
+      case Elem("dfdl", "group", _, _, _*) =>
+        Some(new DFDLGroup(node, this))
       case _ => annotationFactoryForDFDLStatement(node, self)
     }
   }

--- a/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/ModelGroup.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/ModelGroup.scala
@@ -97,8 +97,8 @@ object ModelGroupFactory {
         else
           LocalSequence(xmlNode, lexicalParent, position) // No rewriting the sequence.
       }
-      case <choice>{_*}</choice> => Choice(xmlNode, lexicalParent, position)
-      case <group>{_*}</group> => {
+      case Elem(_, "choice", _, _, _*) => Choice(xmlNode, lexicalParent, position)
+      case Elem(_, "group", _, _, _*) => {
         val pos: Int = lexicalParent match {
           case ct: ComplexTypeBase => 1
           case mg: ModelGroup => position
@@ -142,9 +142,10 @@ object ModelGroupFactory {
       case _: Comment => true
       case _ => false
     }
+
     val newXML = realChildren match {
       // If an annotation is first, that stays on the outer sequence
-      case Seq(annotation @ <annotation>{_*}</annotation>, terms @ _*) =>
+      case Seq(annotation @ Elem(_, "annotation", _, _, _*), terms @ _*) =>
         <sequence dfdlx:layer={seq.xml.attribute("layer")}>
           {annotation}
           <sequence>
@@ -225,7 +226,7 @@ object TermFactory {
     nodesAlreadyTrying: Set[Node] = Set()
   ) = {
     val childTerm: Term = child match {
-      case <element>{_*}</element> => {
+      case Elem(_, "element", _, _, _*) => {
         val refProp = child.attribute("ref").map { _.text }
         // must get an unprefixed attribute name, i.e. ref='foo:bar', and not
         // be tripped up by dfdl:ref="fmt:fooey" which is a format reference.

--- a/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/SchemaDocument.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/SchemaDocument.scala
@@ -17,6 +17,7 @@
 
 package org.apache.daffodil.core.dsom
 
+import scala.xml.Elem
 import scala.xml.Node
 
 import org.apache.daffodil.core.dsom.IIUtils.IIMap
@@ -224,12 +225,11 @@ final class SchemaDocument private (xmlSDoc: XMLSchemaDocument)
 
   protected def annotationFactory(node: Node): Option[DFDLAnnotation] = {
     val res = node match {
-      case <dfdl:format>{content @ _*}</dfdl:format> => DFDLFormat(node, this)
-      case <dfdl:defineFormat>{content @ _*}</dfdl:defineFormat> => DFDLDefineFormat(node, this)
-      case <dfdl:defineEscapeScheme>{content @ _*}</dfdl:defineEscapeScheme> =>
+      case Elem("dfdl", "format", _, _, _*) => DFDLFormat(node, this)
+      case Elem("dfdl", "defineFormat", _, _, _*) => DFDLDefineFormat(node, this)
+      case Elem("dfdl", "defineEscapeScheme", _, _, _*) =>
         DFDLDefineEscapeSchemeFactory(node, this)
-      case <dfdl:defineVariable>{content @ _*}</dfdl:defineVariable> =>
-        DFDLDefineVariable(node, this)
+      case Elem("dfdl", "defineVariable", _, _, _*) => DFDLDefineVariable(node, this)
       case _ => {
         val prefix =
           if (node.prefix == null || node.prefix == "") ""

--- a/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/SequenceGroup.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/SequenceGroup.scala
@@ -271,7 +271,7 @@ trait SequenceDefMixin
 
   protected final def annotationFactory(node: Node): Option[DFDLAnnotation] = {
     node match {
-      case <dfdl:sequence>{contents @ _*}</dfdl:sequence> => Some(new DFDLSequence(node, this))
+      case Elem("dfdl", "sequence", _, _, _*) => Some(new DFDLSequence(node, this))
       case _ => annotationFactoryForDFDLStatement(node, this)
     }
   }

--- a/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/SimpleTypes.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/SimpleTypes.scala
@@ -17,6 +17,7 @@
 
 package org.apache.daffodil.core.dsom
 
+import scala.xml.Elem
 import scala.xml.Node
 
 import org.apache.daffodil.core.dsom.walker.SimpleTypeView
@@ -165,8 +166,7 @@ abstract class SimpleTypeDefBase(xml: Node, lexicalParent: SchemaComponent)
 
   override final def annotationFactory(node: Node): Option[DFDLAnnotation] = {
     node match {
-      case <dfdl:simpleType>{contents @ _*}</dfdl:simpleType> =>
-        Some(new DFDLSimpleType(node, this))
+      case Elem("dfdl", "simpleType", _, _, _*) => Some(new DFDLSimpleType(node, this))
       case _ => annotationFactoryForDFDLStatement(node, this)
     }
   }

--- a/daffodil-lib/src/test/scala/org/apache/daffodil/lib/util/TestXMLCatalogAndValidate.scala
+++ b/daffodil-lib/src/test/scala/org/apache/daffodil/lib/util/TestXMLCatalogAndValidate.scala
@@ -31,8 +31,8 @@ import scala.xml.SAXParseException
 import scala.xml.Text
 import scala.xml.parsing.NoBindingFactoryAdapter
 
+import org.apache.daffodil.lib.Implicits.using
 import org.apache.daffodil.lib.exceptions.Assert
-import org.apache.daffodil.lib.util.Implicits.using
 import org.apache.daffodil.lib.util.collections.Stack
 import org.apache.daffodil.lib.xml.DaffodilSAXParserFactory
 import org.apache.daffodil.lib.xml.NS

--- a/daffodil-schematron/src/main/scala/org/apache/daffodil/validation/schematron/SchematronValidator.scala
+++ b/daffodil-schematron/src/main/scala/org/apache/daffodil/validation/schematron/SchematronValidator.scala
@@ -21,6 +21,7 @@ import java.io.FileOutputStream
 import java.io.InputStream
 import java.nio.file.Path
 import scala.util.Try
+import scala.xml.Elem
 import scala.xml.XML
 
 import org.apache.daffodil.lib.api.ValidationException
@@ -35,7 +36,7 @@ final class SchematronValidator(engine: Schematron, svrlPath: Option[Path]) exte
   def validateXML(document: InputStream): ValidationResult = {
     val svrl = XML.loadString(engine.validate(document))
     val valErr: Seq[ValidationFailure] =
-      for (f @ <svrl:failed-assert>{msg @ _*}</svrl:failed-assert> <- svrl.child) yield {
+      for (f @ Elem("svrl", "failed-assert", _, _, msg @ _*) <- svrl.child) yield {
         SchematronValidationError(msg.text.trim, { f \\ "@location" }.text)
       }
 

--- a/daffodil-tdml-lib/src/main/scala/org/apache/daffodil/tdml/TDMLRunner.scala
+++ b/daffodil-tdml-lib/src/main/scala/org/apache/daffodil/tdml/TDMLRunner.scala
@@ -2266,11 +2266,11 @@ case class Document(d: NodeSeq, parent: TestCase) {
     }
   }
 
-  private lazy val Seq(<document>{children @ _*}</document>) = d
+  private lazy val Seq(Elem(_, "document", _, _, children @ _*)) = d
 
   private val actualDocumentPartElementChildren = children.toList.flatMap { child =>
     child match {
-      case <documentPart>{_*}</documentPart> => {
+      case Elem(_, "documentPart", _, _, _*) => {
         List((child \ "@type").toString match {
           case "text" => new TextDocumentPart(child, this)
           case "byte" => new ByteDocumentPart(child, this)
@@ -2290,7 +2290,7 @@ case class Document(d: NodeSeq, parent: TestCase) {
   if (actualDocumentPartElementChildren.nonEmpty) {
     children.foreach { child =>
       child match {
-        case <documentPart>{_*}</documentPart> => // ok
+        case Elem(_, "documentPart", _, _, _*) => // ok
         case scala.xml.Text(s) if (s.matches("""\s+""")) => // whitespace text nodes ok
         case scala.xml.Comment(_) => // ok
         case scala.xml.PCData(s) => // ok


### PR DESCRIPTION
- XML Literals are soon to be dropped, but they are still supported in the interim. Deconstructing XML Literals using Pattern Matching is no longer supported so we refactor to replace that with equivalent code that is supported in 2.13 and 3.6

DAFFODIL-2975