### PR TITLE
Fix unseen Inner Class of Abstract Class

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -88,7 +88,7 @@ lazy val runtime1 = Project("daffodil-runtime1", file("daffodil-runtime1"))
   .settings(Dependencies.genjavadocVersion) // converts scaladoc to javadoc
   .dependsOn(
     io,
-    lib % "test->test",
+    lib % "compile-internal, test->test",
     udf,
     macroLib % "compile-internal, test-internal",
     slf4jLogger % "test"

--- a/daffodil-core/src/test/scala/org/apache/daffodil/core/schema/annotation/props/TestPropertyRuntime.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/core/schema/annotation/props/TestPropertyRuntime.scala
@@ -26,7 +26,7 @@ import org.apache.daffodil.lib.schema.annotation.props._
 import org.junit.Assert._
 import org.junit.Test
 
-sealed trait MyPropType extends MyProp.Value
+sealed trait MyPropType extends EnumValue
 object MyProp
   extends Enum[MyPropType] // with ThrowsSDE
   {
@@ -87,7 +87,7 @@ class HasMixin
   lazy val properties: PropMap = Map.empty
 }
 
-sealed trait TheExampleProp extends TheExampleProp.Value
+sealed trait TheExampleProp extends EnumValue
 object TheExampleProp extends Enum[TheExampleProp] {
   case object Left extends TheExampleProp
   case object Right extends TheExampleProp

--- a/daffodil-lib/src/main/scala/org/apache/daffodil/lib/schema/annotation/props/ByHandMixins.scala
+++ b/daffodil-lib/src/main/scala/org/apache/daffodil/lib/schema/annotation/props/ByHandMixins.scala
@@ -55,7 +55,7 @@ import passera.unsigned.ULong
  * So the code generator has exclusions for these.
  */
 
-sealed trait AlignmentType extends AlignmentType.Value
+sealed trait AlignmentType extends EnumValue
 object AlignmentType extends Enum[AnyRef] { // Note: Was using AlignmentUnits mixin here!
   case object Implicit extends AlignmentType
   override lazy val values = Array(Implicit)
@@ -140,7 +140,7 @@ trait TextStandardBaseMixin extends PropertyMixin {
   }
 }
 
-sealed trait SeparatorSuppressionPolicy extends SeparatorSuppressionPolicy.Value
+sealed trait SeparatorSuppressionPolicy extends EnumValue
 object SeparatorSuppressionPolicy extends Enum[SeparatorSuppressionPolicy] {
   case object Never extends SeparatorSuppressionPolicy
   case object TrailingEmpty extends SeparatorSuppressionPolicy
@@ -484,7 +484,7 @@ trait TextStandardExponentRepMixin extends PropertyMixin {
  * By hand because we can set our preference for it via a tunable.
  * And also can require it to be present or not via a tunable.
  */
-sealed trait EmptyElementParsePolicy extends EmptyElementParsePolicy.Value
+sealed trait EmptyElementParsePolicy extends EnumValue
 object EmptyElementParsePolicy extends Enum[EmptyElementParsePolicy] {
   case object TreatAsMissing extends EmptyElementParsePolicy // deprecated
   case object TreatAsEmpty extends EmptyElementParsePolicy

--- a/daffodil-lib/src/main/scala/org/apache/daffodil/lib/schema/annotation/props/Properties.scala
+++ b/daffodil-lib/src/main/scala/org/apache/daffodil/lib/schema/annotation/props/Properties.scala
@@ -84,23 +84,6 @@ import org.apache.daffodil.lib.util._
 abstract class EnumBase
 abstract class EnumValueBase extends Serializable
 abstract class Enum[A] extends EnumBase with Converter[String, A] {
-  class Value extends EnumValueBase { self: A =>
-    override lazy val toString = {
-      val theVal = this
-      val cn = getNameFromClass(this)
-      val en = cn match {
-        //
-        // Special case for CalendarFirstDayOfWeek
-        //
-        case "Sunday" | "Monday" | "Tuesday" | "Wednesday" | "Thursday" | "Friday" |
-            "Saturday" =>
-          cn
-        case _ => Misc.toInitialLowerCaseUnlessAllUpperCase(cn)
-      }
-      en
-    }
-  }
-
   def toPropName(prop: A) = prop.toString
 
   val values: Array[A]
@@ -133,6 +116,21 @@ abstract class Enum[A] extends EnumBase with Converter[String, A] {
 
   def apply(name: String, context: ThrowsSDE): A
 } // end class
+trait EnumValue extends EnumValueBase {
+  override lazy val toString = {
+    val theVal = this
+    val cn = getNameFromClass(this)
+    val en = cn match {
+      //
+      // Special case for CalendarFirstDayOfWeek
+      //
+      case "Sunday" | "Monday" | "Tuesday" | "Wednesday" | "Thursday" | "Friday" | "Saturday" =>
+        cn
+      case _ => Misc.toInitialLowerCaseUnlessAllUpperCase(cn)
+    }
+    en
+  }
+}
 
 /**
  * base mixin for traits representing collections of DFDL properties

--- a/daffodil-propgen/src/main/scala/org/apache/daffodil/propGen/PropertyGenerator.scala
+++ b/daffodil-propgen/src/main/scala/org/apache/daffodil/propGen/PropertyGenerator.scala
@@ -379,7 +379,7 @@ class PropertyGenerator(arg: Node) {
    */
 
   val templateStart =
-    """sealed trait Currency extends Currency.Value
+    """sealed trait Currency extends EnumValue
 object Currency extends Enum[Currency] {
 """
   val templateMiddle =

--- a/daffodil-propgen/src/main/scala/org/apache/daffodil/propGen/TunableGenerator.scala
+++ b/daffodil-propgen/src/main/scala/org/apache/daffodil/propGen/TunableGenerator.scala
@@ -56,6 +56,7 @@ class TunableGenerator(schemaRootConfig: scala.xml.Node, schemaRootExt: scala.xm
     |import org.apache.daffodil.lib.exceptions.ThrowsSDE
     |import org.apache.daffodil.lib.schema.annotation.props.EmptyElementParsePolicy
     |import org.apache.daffodil.lib.schema.annotation.props.Enum
+    |import org.apache.daffodil.lib.schema.annotation.props.EnumValue
     |import org.apache.daffodil.lib.util.Misc
     |import org.apache.daffodil.lib.xml.DaffodilXMLLoader
     |import org.apache.daffodil.lib.xml.XMLUtils
@@ -347,7 +348,7 @@ class TunableEnumDefinition(
   private val allEnumerationValues = getAllEnumerationValues(simpleTypeNode)
 
   private val top = s"""
-    |sealed trait ${scalaType} extends ${scalaType}.Value
+    |sealed trait ${scalaType} extends EnumValue
     |object ${scalaType} extends Enum[${scalaType}] {
 """.trim.stripMargin
 

--- a/daffodil-propgen/src/main/scala/org/apache/daffodil/propGen/WarnIDGenerator.scala
+++ b/daffodil-propgen/src/main/scala/org/apache/daffodil/propGen/WarnIDGenerator.scala
@@ -53,8 +53,9 @@ class WarnIDGenerator(schema: scala.xml.Node) {
     |import org.apache.daffodil.lib.exceptions.Assert
     |import org.apache.daffodil.lib.exceptions.ThrowsSDE
     |import org.apache.daffodil.lib.schema.annotation.props.Enum
+    |import org.apache.daffodil.lib.schema.annotation.props.EnumValue
     |
-    |sealed trait WarnID extends WarnID.Value
+    |sealed trait WarnID extends EnumValue
     |object WarnID extends Enum[WarnID] {
     """.trim.stripMargin
 

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/debugger/InteractiveDebugger.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/debugger/InteractiveDebugger.scala
@@ -139,7 +139,7 @@ class InteractiveDebugger(
     var parseStep = 0
 
     /* how to display data */
-    var representation: Representation.Value = Representation.Text
+    var representation: Representation = Representation.Text
   }
 
   var debugState: DebugState.Type = DebugState.Pause

--- a/daffodil-test/src/test/scala/org/apache/daffodil/runtime1/layers/SimpleBombOutLayer.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/runtime1/layers/SimpleBombOutLayer.scala
@@ -24,6 +24,7 @@ import java.io.OutputStream
 import org.apache.daffodil.lib.exceptions.Assert
 import org.apache.daffodil.lib.exceptions.ThrowsSDE
 import org.apache.daffodil.lib.schema.annotation.props.Enum
+import org.apache.daffodil.lib.schema.annotation.props.EnumValue
 import org.apache.daffodil.runtime1.layers.api.Layer
 
 /**
@@ -34,7 +35,7 @@ final class STL_BombOutLayer() extends Layer("stlBombOutLayer", "urn:STL") {
 
   private lazy val context: ThrowsSDE = this.getLayerRuntime.layerRuntimeData.context
 
-  sealed trait Loc extends Loc.Value
+  sealed trait Loc extends EnumValue
   object Loc
     extends Enum[Loc] // with ThrowsSDE
     {
@@ -66,7 +67,7 @@ final class STL_BombOutLayer() extends Layer("stlBombOutLayer", "urn:STL") {
   }
   import Loc._
 
-  sealed trait Kind extends Kind.Value
+  sealed trait Kind extends EnumValue
   object Kind extends Enum[Kind] {
     final case object ThrowRE extends Kind
     final case object ThrowEX extends Kind


### PR DESCRIPTION
- Scala 3.3.5 complains about not seeing the inner class Value of Enum, so we refactor to make Value a trait of an Enum companion object

DAFFODIL-2975