### PR TITLE
Assign Type to Overridden UDF Function

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -20,6 +20,7 @@ docstrings.style = keep
 indent.defnSite = 2
 indent.extendSite = 2
 maxColumn = 96
+importSelectors = noBinPack
 rewrite.imports.groups = [
     ["scala\\..*", "java\\..*", "javax\\..*"],
     ["org\\.apache\\.daffodil\\..*"],

--- a/daffodil-io/src/test/scala/org/apache/daffodil/io/TestInputSourceDataInputStream.scala
+++ b/daffodil-io/src/test/scala/org/apache/daffodil/io/TestInputSourceDataInputStream.scala
@@ -332,7 +332,7 @@ class TestInputSourceDataInputStream {
   @Test def testUnsignedBigInt1(): Unit = {
     val dis = InputSourceDataInputStream(List(0xff).map { _.toByte }.toArray)
     val ml = dis.getUnsignedBigInt(2, finfo)
-    assertEqualsTyped(2, dis.bitPos0b)
+    assertEqualsTyped(2L, dis.bitPos0b)
     val expected = JBigInt.valueOf(3)
     assertEqualsTyped[JBigInt](expected, ml)
   }
@@ -342,7 +342,7 @@ class TestInputSourceDataInputStream {
       _.toByte
     }.toArray)
     val ml = dis.getUnsignedBigInt(40, finfo)
-    assertEqualsTyped(40, dis.bitPos0b)
+    assertEqualsTyped(40L, dis.bitPos0b)
     val expected = JBigInt.valueOf(0xc1c2c3c4c5L)
     assertEqualsTyped[JBigInt](expected, ml)
   }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/runtime1/layers/TestCheckDigit.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/runtime1/layers/TestCheckDigit.scala
@@ -114,7 +114,7 @@ class TestCheckDigit extends TdmlTests {
   }
 
   val okInfoset: Elem =
-    <ex:e1 xmlns="" xmlns:ex={example}>
+    <ex:e1 xmlns:ex={example}>
       <value>2021-09-25</value>
       <checkDigit>1</checkDigit>
       <computedCheckDigit>1</computedCheckDigit>
@@ -200,7 +200,7 @@ class TestCheckDigit extends TdmlTests {
     val sch = cdSchema(10, "ascii")
     val data = "123:6"
     val infoset =
-      <ex:e1 xmlns="" xmlns:ex={example}>
+      <ex:e1 xmlns:ex={example}>
         <value>123</value>
         <checkDigit>0</checkDigit>
         <computedCheckDigit>0</computedCheckDigit>
@@ -212,7 +212,7 @@ class TestCheckDigit extends TdmlTests {
     val sch = cdSchema(5, "ascii")
     val data = "1234567890:1"
     val infoset =
-      <ex:e1 xmlns="" xmlns:ex={example}>
+      <ex:e1 xmlns:ex={example}>
         <value>1234567890</value>
         <checkDigit>0</checkDigit>
         <computedCheckDigit>0</computedCheckDigit>
@@ -228,7 +228,7 @@ class TestCheckDigit extends TdmlTests {
     val sch = cdSchema(10, "notACharsetName")
     val data = "1234567890:1"
     val infoset =
-      <ex:e1 xmlns="" xmlns:ex={example}>
+      <ex:e1 xmlns:ex={example}>
         <value>1234567890</value>
         <checkDigit>0</checkDigit>
         <computedCheckDigit>0</computedCheckDigit>

--- a/daffodil-udf/src/test/scala/org/sbadudfs/functionclasses/StringFunctions/StringFunctionsProvider.scala
+++ b/daffodil-udf/src/test/scala/org/sbadudfs/functionclasses/StringFunctions/StringFunctionsProvider.scala
@@ -26,7 +26,7 @@ import org.apache.daffodil.udf.UserDefinedFunctionProvider
  * Contains incorrect implementation of lookup function
  */
 class StringFunctionsProvider extends UserDefinedFunctionProvider {
-  override def getUserDefinedFunctionClasses = {
+  override def getUserDefinedFunctionClasses: Array[Class[?]] = {
     Array(classOf[ReverseWords], classOf[Reverse])
   }
 

--- a/daffodil-udf/src/test/scala/org/sbadudfs/functionclasses2/StringFunctions/StringFunctionsProvider.scala
+++ b/daffodil-udf/src/test/scala/org/sbadudfs/functionclasses2/StringFunctions/StringFunctionsProvider.scala
@@ -31,7 +31,7 @@ class StringFunctionsProvider extends UserDefinedFunctionProvider {
   val nonSerializable = new SomeNonSerializableClass
   val serializable = new SomeSerializableClass
 
-  override def getUserDefinedFunctionClasses = {
+  override def getUserDefinedFunctionClasses: Array[Class[?]] = {
     Array(classOf[GetNonSerializableState], classOf[GetSerializableState])
   }
 

--- a/daffodil-udf/src/test/scala/org/sbadudfs/udfexceptions/evaluating/StringFunctions/StringFunctionsProvider.scala
+++ b/daffodil-udf/src/test/scala/org/sbadudfs/udfexceptions/evaluating/StringFunctions/StringFunctionsProvider.scala
@@ -28,7 +28,7 @@ import org.apache.daffodil.udf.exceptions.UserDefinedFunctionProcessingError
  */
 class StringFunctionsProvider extends UserDefinedFunctionProvider {
 
-  override def getUserDefinedFunctionClasses = {
+  override def getUserDefinedFunctionClasses: Array[Class[?]] = {
     Array(classOf[ReverseWords], classOf[Reverse])
   }
 }

--- a/daffodil-udf/src/test/scala/org/sbadudfs/udfexceptions2/StringFunctions/StringFunctionsProvider.scala
+++ b/daffodil-udf/src/test/scala/org/sbadudfs/udfexceptions2/StringFunctions/StringFunctionsProvider.scala
@@ -27,7 +27,7 @@ import org.apache.daffodil.udf.UserDefinedFunctionProvider
  */
 class StringFunctionsProvider extends UserDefinedFunctionProvider {
 
-  override def getUserDefinedFunctionClasses = {
+  override def getUserDefinedFunctionClasses: Array[Class[?]] = {
     Array(classOf[ReverseWords], classOf[Reverse])
   }
 }

--- a/daffodil-udf/src/test/scala/org/sbadudfs/udfpexceptions/StringFunctions/StringFunctionsProvider.scala
+++ b/daffodil-udf/src/test/scala/org/sbadudfs/udfpexceptions/StringFunctions/StringFunctionsProvider.scala
@@ -31,7 +31,7 @@ class StringFunctionsProvider extends UserDefinedFunctionProvider {
     private val cause: Throwable = None.orNull
   ) extends Exception(message, cause)
 
-  override def getUserDefinedFunctionClasses = {
+  override def getUserDefinedFunctionClasses: Array[Class[?]] = {
     throw new CustomException("UDFP Error!")
     Array(classOf[ReverseWords], classOf[Reverse])
   }

--- a/daffodil-udf/src/test/scala/org/sbadudfs/udfpexceptions2/StringFunctions/StringFunctionsProvider.scala
+++ b/daffodil-udf/src/test/scala/org/sbadudfs/udfpexceptions2/StringFunctions/StringFunctionsProvider.scala
@@ -32,7 +32,7 @@ class StringFunctionsProvider extends UserDefinedFunctionProvider {
   ) extends Exception(message, cause)
 
   throw new CustomException("UDFP Error!")
-  override def getUserDefinedFunctionClasses = {
+  override def getUserDefinedFunctionClasses: Array[Class[?]] = {
     Array(classOf[ReverseWords], classOf[Reverse])
   }
 }

--- a/daffodil-udf/src/test/scala/org/sgoodudfs/example/IntegerFunctions/IntegerFunctionsProvider.scala
+++ b/daffodil-udf/src/test/scala/org/sgoodudfs/example/IntegerFunctions/IntegerFunctionsProvider.scala
@@ -25,7 +25,7 @@ import org.apache.daffodil.udf.UserDefinedFunctionProvider
  *
  */
 class IntegerFunctionsProvider extends UserDefinedFunctionProvider {
-  override def getUserDefinedFunctionClasses = {
+  override def getUserDefinedFunctionClasses: Array[Class[?]] = {
     Array(classOf[BoxedAddition], classOf[PrimitivesAddition])
   }
 }

--- a/daffodil-udf/src/test/scala/org/sgoodudfs/example/StringFunctions/StringFunctionsProvider.scala
+++ b/daffodil-udf/src/test/scala/org/sgoodudfs/example/StringFunctions/StringFunctionsProvider.scala
@@ -25,7 +25,7 @@ import org.apache.daffodil.udf.UserDefinedFunctionProvider
  *
  */
 class StringFunctionsProvider extends UserDefinedFunctionProvider {
-  override def getUserDefinedFunctionClasses = {
+  override def getUserDefinedFunctionClasses: Array[Class[?]] = {
     Array(classOf[ReverseWords], classOf[Reverse], classOf[SayHello])
   }
 }

--- a/daffodil-udf/src/test/scala/org/sgoodudfs/example/SupportedTypesFunctions/SupportedTypesFunctionsProvider.scala
+++ b/daffodil-udf/src/test/scala/org/sgoodudfs/example/SupportedTypesFunctions/SupportedTypesFunctionsProvider.scala
@@ -25,7 +25,7 @@ import org.apache.daffodil.udf.UserDefinedFunctionProvider
  *
  */
 class SupportedTypesFunctionsProvider extends UserDefinedFunctionProvider {
-  override def getUserDefinedFunctionClasses = {
+  override def getUserDefinedFunctionClasses: Array[Class[?]] = {
     Array(
       classOf[PrimByteFunc],
       classOf[BoxedByteFunc],


### PR DESCRIPTION
- specify types for overridden getUserDefinedFunctionClasses method
- remove empty namespace from xml literals
- specify longs for digits otherwise the assert fails on comparing an int and a long
- During NonEmptyString initialization, it requires TypeNode(String), which requires NodeInfo to be initialized, which tries to initialize the members of allTypes of which NonEmptyString is one. This results in NonEmptyString returning null. So we update the code to not force initialization of allType members during NodeInfo initialization. Instead, the members are initialized on an as needed basis
- Also we make parents call by name so they can also reference their children
- update scalafmt to format import selectors one per line. We already do this in code, but this is just to ensure newer code matches the format


DAFFODIL-2975