### PR TITLE
Remove unused imports

### DIFF
--- a/daffodil-core/src/main/scala/org/apache/daffodil/core/dpath/Expression.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/core/dpath/Expression.scala
@@ -29,11 +29,9 @@ import org.apache.daffodil.lib.exceptions._
 import org.apache.daffodil.lib.oolag.OOLAG.OOLAGHost
 import org.apache.daffodil.lib.oolag.OOLAG.OOLAGHostImpl
 import org.apache.daffodil.lib.util.Numbers
-import org.apache.daffodil.lib.xml.RefQName
 import org.apache.daffodil.lib.xml._
 import org.apache.daffodil.runtime1.BasicComponent
 import org.apache.daffodil.runtime1.dpath._
-import org.apache.daffodil.runtime1.dsom.RelativePathPastRootError
 import org.apache.daffodil.runtime1.dsom._
 import org.apache.daffodil.runtime1.infoset.DataValue.DataValuePrimitive
 import org.apache.daffodil.runtime1.udf.UserDefinedFunctionService

--- a/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/DFDLSchemaFile.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/DFDLSchemaFile.scala
@@ -21,7 +21,6 @@ import java.io.File
 import scala.xml.Elem
 
 import org.apache.daffodil.core.dsom.IIUtils._
-import org.apache.daffodil.lib.api.Diagnostic
 import org.apache.daffodil.lib.api._
 import org.apache.daffodil.lib.exceptions.Assert
 import org.apache.daffodil.lib.exceptions.SchemaFileLocation

--- a/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/NamedMixin.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/NamedMixin.scala
@@ -22,7 +22,6 @@ import scala.xml.Node
 import org.apache.daffodil.lib.api.DaffodilTunables
 import org.apache.daffodil.lib.util.Misc
 import org.apache.daffodil.lib.util.NamedMixinBase
-import org.apache.daffodil.lib.xml.GetAttributesMixin
 import org.apache.daffodil.lib.xml._
 
 /**

--- a/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/SchemaSet.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/SchemaSet.scala
@@ -31,9 +31,6 @@ import org.apache.daffodil.lib.exceptions.Assert
 import org.apache.daffodil.lib.oolag.OOLAG
 import org.apache.daffodil.lib.schema.annotation.props.LookupLocation
 import org.apache.daffodil.lib.util.TransitiveClosure
-import org.apache.daffodil.lib.xml.DFDLCatalogResolver
-import org.apache.daffodil.lib.xml.NS
-import org.apache.daffodil.lib.xml.XMLUtils
 import org.apache.daffodil.lib.xml._
 
 object SchemaSet {

--- a/daffodil-core/src/main/scala/org/apache/daffodil/core/grammar/ChoiceGrammarMixin.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/core/grammar/ChoiceGrammarMixin.scala
@@ -28,6 +28,13 @@ trait ChoiceGrammarMixin extends GrammarMixin with ChoiceTermRuntime1Mixin {
     ChoiceCombinator(this, alternatives)
   }
 
+  /**
+   * The members of the choice group with special treatment given to some kinds of members.
+   *
+   * An invariant is that if a direct child member is an array element, the child
+   * will have been encapsulated as a sequence, so that arrays always live within
+   * sequences.
+   */
   final protected lazy val alternatives: Seq[Gram] =
     groupMembers.map { _.termContentBody }
 

--- a/daffodil-core/src/main/scala/org/apache/daffodil/core/grammar/ElementBaseGrammarMixin.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/core/grammar/ElementBaseGrammarMixin.scala
@@ -23,10 +23,6 @@ import org.apache.daffodil.core.dsom.ElementBase
 import org.apache.daffodil.core.dsom.ExpressionCompilers
 import org.apache.daffodil.core.dsom.InitiatedTerminatedMixin
 import org.apache.daffodil.core.dsom.PrefixLengthQuasiElementDecl
-import org.apache.daffodil.core.grammar.primitives.ConvertTextBooleanPrim
-import org.apache.daffodil.core.grammar.primitives.LeadingSkipRegion
-import org.apache.daffodil.core.grammar.primitives.LiteralValueNilOfSpecifiedLength
-import org.apache.daffodil.core.grammar.primitives.SimpleNilOrValue
 import org.apache.daffodil.core.grammar.primitives._
 import org.apache.daffodil.core.runtime1.ElementBaseRuntime1Mixin
 import org.apache.daffodil.lib.api.WarnID

--- a/daffodil-core/src/main/scala/org/apache/daffodil/core/grammar/SequenceGrammarMixin.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/core/grammar/SequenceGrammarMixin.scala
@@ -18,8 +18,6 @@
 package org.apache.daffodil.core.grammar
 
 import org.apache.daffodil.core.dsom._
-import org.apache.daffodil.core.grammar.primitives.OrderedSequence
-import org.apache.daffodil.core.grammar.primitives.UnorderedSequence
 import org.apache.daffodil.core.grammar.primitives._
 import org.apache.daffodil.core.runtime1.SequenceTermRuntime1Mixin
 import org.apache.daffodil.lib.exceptions.Assert

--- a/daffodil-core/src/main/scala/org/apache/daffodil/core/grammar/primitives/ChoiceCombinator.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/core/grammar/primitives/ChoiceCombinator.scala
@@ -22,7 +22,6 @@ import scala.util.Failure
 import scala.util.Success
 import scala.util.Try
 
-import org.apache.daffodil.core.dsom.ChoiceTermBase
 import org.apache.daffodil.core.dsom._
 import org.apache.daffodil.core.grammar.Gram
 import org.apache.daffodil.core.grammar.Terminal

--- a/daffodil-core/src/main/scala/org/apache/daffodil/core/grammar/primitives/PrimitivesExpressions.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/core/grammar/primitives/PrimitivesExpressions.scala
@@ -18,10 +18,6 @@
 package org.apache.daffodil.core.grammar.primitives
 
 import org.apache.daffodil.core.compiler.ForParser
-import org.apache.daffodil.core.dsom.DFDLNewVariableInstance
-import org.apache.daffodil.core.dsom.DFDLSetVariable
-import org.apache.daffodil.core.dsom.ElementBase
-import org.apache.daffodil.core.dsom.ExpressionCompilers
 import org.apache.daffodil.core.dsom._
 import org.apache.daffodil.core.grammar._
 import org.apache.daffodil.lib.exceptions.Assert

--- a/daffodil-core/src/main/scala/org/apache/daffodil/core/grammar/primitives/SpecifiedLength.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/core/grammar/primitives/SpecifiedLength.scala
@@ -25,12 +25,8 @@ import org.apache.daffodil.core.grammar.Terminal
 import org.apache.daffodil.lib.exceptions.Assert
 import org.apache.daffodil.lib.schema.annotation.props.gen.LengthUnits
 import org.apache.daffodil.runtime1.dpath.NodeInfo.PrimType
-import org.apache.daffodil.runtime1.processors.parsers.Parser
-import org.apache.daffodil.runtime1.processors.parsers.SpecifiedLengthExplicitParser
-import org.apache.daffodil.runtime1.processors.parsers.SpecifiedLengthImplicitParser
 import org.apache.daffodil.runtime1.processors.parsers._
 import org.apache.daffodil.runtime1.processors.unparsers._
-import org.apache.daffodil.unparsers.runtime1.SpecifiedLengthExplicitImplicitUnparser
 import org.apache.daffodil.unparsers.runtime1._
 
 abstract class SpecifiedLengthCombinatorBase(val e: ElementBase, eGramArg: => Gram)

--- a/daffodil-core/src/main/scala/org/apache/daffodil/core/runtime1/ChoiceTermRuntime1Mixin.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/core/runtime1/ChoiceTermRuntime1Mixin.scala
@@ -22,7 +22,6 @@ import org.apache.daffodil.core.dsom.ElementBase
 import org.apache.daffodil.core.dsom.ExpressionCompilers
 import org.apache.daffodil.core.dsom.SequenceTermBase
 import org.apache.daffodil.core.dsom.Term
-import org.apache.daffodil.core.grammar.Gram
 import org.apache.daffodil.lib.api.WarnID
 import org.apache.daffodil.lib.exceptions.Assert
 import org.apache.daffodil.lib.util.Delay
@@ -34,15 +33,6 @@ import org.apache.daffodil.runtime1.processors.ChoiceDispatchKeyEv
 import org.apache.daffodil.runtime1.processors.ChoiceRuntimeData
 
 trait ChoiceTermRuntime1Mixin { self: ChoiceTermBase =>
-
-  /**
-   * The members of the choice group with special treatment given to some kinds of members.
-   *
-   * An invariant is that if a direct child member is an array element, the child
-   * will have been encapsulated as a sequence, so that arrays always live within
-   * sequences.
-   */
-  protected def alternatives: Seq[Gram]
 
   final protected lazy val choiceDispatchKeyExpr = {
     val qn = this.qNameForProperty("choiceDispatchKey")

--- a/daffodil-core/src/test/scala/org/apache/daffodil/core/dpath/TestDFDLExpressionTree.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/core/dpath/TestDFDLExpressionTree.scala
@@ -23,9 +23,7 @@ import scala.util.parsing.combinator.Parsers
 import org.apache.daffodil.core.compiler._
 import org.apache.daffodil.lib.Implicits._
 import org.apache.daffodil.lib.util.SchemaUtils
-import org.apache.daffodil.lib.xml.StepQName
 import org.apache.daffodil.lib.xml._
-import org.apache.daffodil.runtime1.dpath.NodeInfo
 import org.apache.daffodil.runtime1.dpath._
 import org.apache.daffodil.runtime1.processors.ElementRuntimeData
 

--- a/daffodil-core/src/test/scala/org/apache/daffodil/core/dsom/TestDsomCompiler.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/core/dsom/TestDsomCompiler.scala
@@ -43,7 +43,6 @@ import org.apache.daffodil.lib.schema.annotation.props.gen.Representation
 import org.apache.daffodil.lib.schema.annotation.props.gen.SeparatorPosition
 import org.apache.daffodil.lib.schema.annotation.props.gen.TextNumberRep
 import org.apache.daffodil.lib.schema.annotation.props.gen.YesNo
-import org.apache.daffodil.lib.util.Misc
 import org.apache.daffodil.lib.util._
 import org.apache.daffodil.lib.xml.DaffodilXMLLoader
 import org.apache.daffodil.lib.xml.XMLUtils

--- a/daffodil-core/src/test/scala/org/apache/daffodil/core/infoset/TestInfosetCursor1.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/core/infoset/TestInfosetCursor1.scala
@@ -17,8 +17,9 @@
 
 package org.apache.daffodil.core.infoset
 
-import javax.xml.stream.XMLInputFactory
-import javax.xml.stream.XMLStreamConstants
+// workaround for scala 3 bug where there are false positives with
+// unused imports: https://github.com/scala/scala3/issues/22692
+import javax.xml.stream._
 
 import org.apache.daffodil.core.compiler.Compiler
 import org.apache.daffodil.lib.Implicits.intercept

--- a/daffodil-lib/src/main/scala-3/org/apache/daffodil/lib/exceptions/AssertsUsingMacrosMixin.scala
+++ b/daffodil-lib/src/main/scala-3/org/apache/daffodil/lib/exceptions/AssertsUsingMacrosMixin.scala
@@ -64,8 +64,6 @@ trait AssertsUsingMacrosMixin {
  * they need access to Assert which is lib class and is not accessible from macro-lib
  */
 object AssertMacros {
-
-  import org.apache.daffodil.lib.exceptions.Assert
   /*
    * Note that in macro definitions, the argument names here must match the argument names
    * in the macro implementations.

--- a/daffodil-lib/src/main/scala/org/apache/daffodil/lib/oolag/OOLAG.scala
+++ b/daffodil-lib/src/main/scala/org/apache/daffodil/lib/oolag/OOLAG.scala
@@ -24,9 +24,7 @@ import org.apache.daffodil.lib.api.WithDiagnostics
 import org.apache.daffodil.lib.exceptions.Assert
 import org.apache.daffodil.lib.exceptions.ThinException
 import org.apache.daffodil.lib.exceptions.UnsuppressableException
-import org.apache.daffodil.lib.util.Logger
 import org.apache.daffodil.lib.util.Maybe._
-import org.apache.daffodil.lib.util.Misc
 import org.apache.daffodil.lib.util._
 
 /**

--- a/daffodil-lib/src/main/scala/org/apache/daffodil/lib/xml/XMLUtils.scala
+++ b/daffodil-lib/src/main/scala/org/apache/daffodil/lib/xml/XMLUtils.scala
@@ -31,7 +31,6 @@ import scala.collection.mutable
 import scala.collection.mutable.ArrayBuilder
 import scala.math.abs
 import scala.util.matching.Regex
-import scala.xml.NamespaceBinding
 import scala.xml._
 
 import org.apache.daffodil.lib.api.DaffodilSchemaSource

--- a/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/unparsers/runtime1/ChoiceAndOtherVariousUnparsers.scala
+++ b/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/unparsers/runtime1/ChoiceAndOtherVariousUnparsers.scala
@@ -24,7 +24,6 @@ import org.apache.daffodil.lib.util.Maybe._
 import org.apache.daffodil.lib.util.MaybeInt
 import org.apache.daffodil.lib.util.ProperlySerializableMap._
 import org.apache.daffodil.runtime1.infoset._
-import org.apache.daffodil.runtime1.processors.RuntimeData
 import org.apache.daffodil.runtime1.processors._
 import org.apache.daffodil.runtime1.processors.unparsers._
 

--- a/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/unparsers/runtime1/ConvertTextStandardNumberUnparser.scala
+++ b/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/unparsers/runtime1/ConvertTextStandardNumberUnparser.scala
@@ -24,7 +24,6 @@ import java.math.{ BigDecimal => JBigDecimal }
 import org.apache.daffodil.lib.util.Maybe
 import org.apache.daffodil.lib.util.Numbers.isZero
 import org.apache.daffodil.runtime1.dpath.NodeInfo
-import org.apache.daffodil.runtime1.processors.TextNumberFormatEv
 import org.apache.daffodil.runtime1.processors._
 import org.apache.daffodil.runtime1.processors.parsers.TextDecimalVirtualPointMixin
 import org.apache.daffodil.runtime1.processors.unparsers._

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/api/DFDLParserUnparser.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/api/DFDLParserUnparser.scala
@@ -20,7 +20,6 @@ package org.apache.daffodil.runtime1.api
 import java.io.File
 
 import org.apache.daffodil.io.InputSourceDataInputStream
-import org.apache.daffodil.lib.api.WithDiagnostics
 import org.apache.daffodil.lib.api._
 import org.apache.daffodil.lib.externalvars.Binding
 import org.apache.daffodil.runtime1.infoset.InfosetInputter

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/debugger/InteractiveDebugger.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/debugger/InteractiveDebugger.scala
@@ -41,10 +41,8 @@ import org.apache.daffodil.runtime1.dpath.NodeInfo
 import org.apache.daffodil.runtime1.dsom.ExpressionCompilerClass
 import org.apache.daffodil.runtime1.dsom.RelativePathPastRootError
 import org.apache.daffodil.runtime1.dsom.RuntimeSchemaDefinitionError
-import org.apache.daffodil.runtime1.infoset.XMLTextInfosetOutputter
 import org.apache.daffodil.runtime1.infoset._
 import org.apache.daffodil.runtime1.processors._
-import org.apache.daffodil.runtime1.processors.parsers.ConvertTextCombinatorParser
 import org.apache.daffodil.runtime1.processors.parsers._
 import org.apache.daffodil.runtime1.processors.unparsers.UState
 import org.apache.daffodil.runtime1.processors.unparsers.UStateForSuspension

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/dsom/SDE.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/dsom/SDE.scala
@@ -20,7 +20,6 @@ package org.apache.daffodil.runtime1.dsom
 import org.apache.daffodil.lib.api.DaffodilTunables
 import org.apache.daffodil.lib.api.Diagnostic
 import org.apache.daffodil.lib.api.WarnID
-import org.apache.daffodil.lib.exceptions.SchemaFileLocation
 import org.apache.daffodil.lib.exceptions._
 import org.apache.daffodil.lib.util.Maybe
 import org.apache.daffodil.lib.util.Maybe._

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/DataProcessor.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/DataProcessor.scala
@@ -46,7 +46,6 @@ import org.apache.daffodil.lib.api.WithDiagnostics
 import org.apache.daffodil.lib.equality._
 import org.apache.daffodil.runtime1.api.DFDL
 import org.apache.daffodil.runtime1.debugger.Debugger
-import org.apache.daffodil.runtime1.dsom.TunableLimitExceededError
 import org.apache.daffodil.runtime1.dsom._
 object EqualityNoWarn3 {
   EqualitySuppressUnusedImportWarning()

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/unparsers/Unparser.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/unparsers/Unparser.scala
@@ -22,9 +22,6 @@ import org.apache.daffodil.lib.exceptions.Assert;
 object INoWarn { ImplicitsSuppressUnusedImportWarning() }
 import org.apache.daffodil.lib.util.Maybe._
 import org.apache.daffodil.runtime1.dsom.RuntimeSchemaDefinitionError
-import org.apache.daffodil.runtime1.processors.PrimProcessor
-import org.apache.daffodil.runtime1.processors.Processor
-import org.apache.daffodil.runtime1.processors.ToBriefXMLImpl
 import org.apache.daffodil.runtime1.processors._
 
 sealed trait Unparser extends Processor {

--- a/daffodil-tdml-processor/src/test/scala/org/apache/daffodil/processor/tdml/TestTDMLCrossTest.scala
+++ b/daffodil-tdml-processor/src/test/scala/org/apache/daffodil/processor/tdml/TestTDMLCrossTest.scala
@@ -19,7 +19,6 @@ package org.apache.daffodil.processor.tdml
 
 import org.apache.daffodil.lib.Implicits._
 import org.apache.daffodil.lib.xml.XMLUtils
-import org.apache.daffodil.tdml.Runner
 import org.apache.daffodil.tdml._
 
 import org.junit.Assert._

--- a/daffodil-tdml-processor/src/test/scala/org/apache/daffodil/processor/tdml/TestTDMLRoundTrips.scala
+++ b/daffodil-tdml-processor/src/test/scala/org/apache/daffodil/processor/tdml/TestTDMLRoundTrips.scala
@@ -19,7 +19,6 @@ package org.apache.daffodil.processor.tdml
 
 import org.apache.daffodil.lib.Implicits._
 import org.apache.daffodil.lib.xml.XMLUtils
-import org.apache.daffodil.tdml.Runner
 import org.apache.daffodil.tdml._
 
 import org.junit.Assert._

--- a/daffodil-tdml-processor/src/test/scala/org/apache/daffodil/processor/tdml/TestTDMLRunner.scala
+++ b/daffodil-tdml-processor/src/test/scala/org/apache/daffodil/processor/tdml/TestTDMLRunner.scala
@@ -25,7 +25,6 @@ import org.apache.daffodil.lib.Implicits._
 import org.apache.daffodil.lib.exceptions.UsageException
 import org.apache.daffodil.lib.util._
 import org.apache.daffodil.lib.xml.XMLUtils
-import org.apache.daffodil.tdml.Runner
 import org.apache.daffodil.tdml._
 
 import org.junit.Assert.assertEquals


### PR DESCRIPTION
- scala 3 emits a false positive warning about XMLStreamConstants being an usused import even though it is very much in use. We are able to rid ourselves of the error by using underscore import for the entire package
- remove other unused imports

DAFFODIL-2975