### PR TITLE
Correct release-candidate dependency installation

### DIFF
--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -58,7 +58,9 @@ jobs:
 
       - name: Install Dependencies
         run: |
-          sudo apt-get install -y libmxml-dev rpm wine winetricks
+          sudo dpkg --add-architecture i386
+          sudo apt-get update
+          sudo apt-get install -y libmxml-dev rpm wine32 winetricks
           sudo locale-gen $LANG
 
           INNO_SETUP_EXE="innosetup-6.4.1.exe"


### PR DESCRIPTION
- It seems the GitHub action ubuntu image has an outdated package index relative to the mirrors so some dependencies cannot be found. This adds apt-get update to ensure the package index is correct
- We also need to install wine32 instead of wine, this requires the i386 architecture is added

DAFFODIL-2971

I forgot to copy some changes from the daffodil-infrastructure build-release docker image to the new github actions release-candidate workflow. 