### PR TITLE
Fix overriding non-lazy val with lazy val

### DIFF
--- a/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/Nesting.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/Nesting.scala
@@ -30,9 +30,6 @@ case class EnclosingComponentDef(encloser: SchemaComponent, lexicalPosition: Int
 
 trait NestingLexicalMixin { self: SchemaComponent =>
 
-  /** The lexically enclosing schema component */
-  def optLexicalParent: Option[SchemaComponent]
-
   def shortSchemaComponentDesignator: String
 
   private def usageErr(sc: SchemaComponent) =

--- a/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/ParticleMixin.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/ParticleMixin.scala
@@ -22,10 +22,6 @@ import org.apache.daffodil.lib.exceptions.Assert
 import org.apache.daffodil.lib.schema.annotation.props.gen._
 
 trait RequiredOptionalMixin { self: ElementBase =>
-
-  def minOccurs: Int
-  def maxOccurs: Int
-
   final override lazy val isScalar = minOccurs == 1 && maxOccurs == 1
 
   /**

--- a/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/SchemaComponentFactory.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/SchemaComponentFactory.scala
@@ -27,8 +27,6 @@ import org.apache.daffodil.lib.xml.XMLUtils
 
 trait SchemaFileLocatableImpl extends SchemaFileLocatable { self: SchemaComponent =>
 
-  def xml: scala.xml.Node
-  def schemaFile: Option[DFDLSchemaFile]
   def optLexicalParent: Option[SchemaComponent]
 
   /**
@@ -61,8 +59,6 @@ trait SchemaFileLocatableImpl extends SchemaFileLocatable { self: SchemaComponen
 trait CommonContextMixin extends NestingLexicalMixin with CommonContextView {
   self: SchemaComponent =>
 
-  def optLexicalParent: Option[SchemaComponent]
-
   lazy val schemaFile: Option[DFDLSchemaFile] = optLexicalParent.flatMap { _.schemaFile }
   lazy val schemaSet: SchemaSet = optLexicalParent.get.schemaSet
   lazy val optSchemaDocument: Option[SchemaDocument] = optLexicalParent.flatMap {
@@ -75,8 +71,6 @@ trait CommonContextMixin extends NestingLexicalMixin with CommonContextView {
   final def xmlSchemaDocument: XMLSchemaDocument = optXMLSchemaDocument.get
   def uriString: String = optLexicalParent.get.uriString
   def diagnosticFile: File = optLexicalParent.get.diagnosticFile
-
-  def xml: scala.xml.Node
 
   /**
    * Namespace scope for resolving QNames.

--- a/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/SchemaDocIncludesAndImportsMixin.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/SchemaDocIncludesAndImportsMixin.scala
@@ -188,8 +188,6 @@ trait SchemaDocIncludesAndImportsMixin { self: XMLSchemaDocument =>
     self.schemaSet.diagnosticFile
   }
 
-  protected def seenBefore: IIMap
-
   // val iiXML: Node = xml // override in SchemaSet
 
   lazy val impNodes = (xml \ "import")

--- a/daffodil-core/src/main/scala/org/apache/daffodil/core/runtime1/ElementBaseRuntime1Mixin.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/core/runtime1/ElementBaseRuntime1Mixin.scala
@@ -36,7 +36,7 @@ trait ElementBaseRuntime1Mixin { self: ElementBase =>
 
   // initialize cyclic structure
   requiredEvaluationsIfActivated(
-    dpathElementCompileInfo.initialize
+    dpathElementCompileInfo.initialize()
   )
 
   // initialize cyclic structure

--- a/daffodil-io/src/main/scala/org/apache/daffodil/io/processors/charset/BitsCharsetNonByteSize.scala
+++ b/daffodil-io/src/main/scala/org/apache/daffodil/io/processors/charset/BitsCharsetNonByteSize.scala
@@ -51,9 +51,9 @@ import org.apache.daffodil.lib.util.MaybeInt
 
 trait BitsCharsetNonByteSize extends BitsCharset {
 
-  protected val decodeString: String
+  protected def decodeString: String
 
-  val replacementCharCode: Int
+  def replacementCharCode: Int
 
   def averageCharsPerByte() = averageCharsPerBit() * 8.0f
   def averageCharsPerBit() = 1.0f / bitWidthOfACodeUnit

--- a/daffodil-lib/src/main/scala/org/apache/daffodil/lib/api/Validator.scala
+++ b/daffodil-lib/src/main/scala/org/apache/daffodil/lib/api/Validator.scala
@@ -59,8 +59,8 @@ trait ValidatorFactory extends SimpleNamedLoadableService {
  * Results of a validation execution
  */
 trait ValidationResult {
-  def warnings(): java.util.Collection[ValidationWarning]
-  def errors(): java.util.Collection[ValidationFailure]
+  val warnings: java.util.Collection[ValidationWarning]
+  val errors: java.util.Collection[ValidationFailure]
 }
 
 object ValidationResult {

--- a/daffodil-lib/src/main/scala/org/apache/daffodil/lib/exceptions/SchemaFileLocatable.scala
+++ b/daffodil-lib/src/main/scala/org/apache/daffodil/lib/exceptions/SchemaFileLocatable.scala
@@ -127,12 +127,11 @@ class XercesSchemaFileLocation(
     (if (xercesError.getColumnNumber > 0) Some(xercesError.getColumnNumber.toString) else None),
     schemaFileLocation.diagnosticFile,
     schemaFileLocation.toString,
-    schemaFileLocation.diagnosticDebugName
+    // we set this to blank string instead of "Schema File" since we don't have access to the element
+    // that causes this error from Xerces and "Schema File" doesn't really add much more info compared
+    // to the blank string
+    ""
   ) {
-  // we set this to blank string instead of "Schema File" since we don't have access to the element
-  // that causes this error from Xerces and "Schema File" doesn't really add much more info compared
-  // to the blank string
-  override val diagnosticDebugName = ""
 
   // we have to override equals and hashCode because the OOlag error checks for duplicates in its error list
   override def equals(obj: Any): Boolean = {

--- a/daffodil-lib/src/main/scala/org/apache/daffodil/lib/schema/annotation/props/Properties.scala
+++ b/daffodil-lib/src/main/scala/org/apache/daffodil/lib/schema/annotation/props/Properties.scala
@@ -86,7 +86,7 @@ abstract class EnumValueBase extends Serializable
 abstract class Enum[A] extends EnumBase with Converter[String, A] {
   def toPropName(prop: A) = prop.toString
 
-  val values: Array[A]
+  def values: Array[A]
 
   /**
    * This is invoked at runtime to compare expression results to see if they

--- a/daffodil-lib/src/test/scala/org/apache/daffodil/lib/validation/TestValidatorsSPI.scala
+++ b/daffodil-lib/src/test/scala/org/apache/daffodil/lib/validation/TestValidatorsSPI.scala
@@ -53,8 +53,8 @@ class TestValidatorsSPI {
     val v = f.make(XercesValidatorFactory.makeConfig(Seq(schema)))
     val r = v.validateXML(infoset)
 
-    assertTrue(r.warnings().isEmpty)
-    assertTrue(r.errors().isEmpty)
+    assertTrue(r.warnings.isEmpty)
+    assertTrue(r.errors.isEmpty)
   }
 
   @Test def testFailingValidator(): Unit = {
@@ -62,9 +62,9 @@ class TestValidatorsSPI {
     val v = f.make(XercesValidatorFactory.makeConfig(Seq(schema)))
     val r = v.validateXML(infoset)
 
-    assertTrue(r.warnings().isEmpty)
-    assertFalse(r.errors().isEmpty)
+    assertTrue(r.warnings.isEmpty)
+    assertFalse(r.errors.isEmpty)
 
-    assertEquals(r.errors().iterator().next().getMessage, "boom")
+    assertEquals(r.errors.iterator().next().getMessage, "boom")
   }
 }

--- a/daffodil-lib/src/test/scala/org/apache/daffodil/lib/validation/TestXercesValidator.scala
+++ b/daffodil-lib/src/test/scala/org/apache/daffodil/lib/validation/TestXercesValidator.scala
@@ -29,7 +29,7 @@ class TestXercesValidator {
     val v = f.make(XercesValidatorFactory.makeConfig(Seq(schema)))
     val r = v.validateXML(infoset)
 
-    assertTrue(r.warnings().isEmpty)
-    assertTrue(r.errors().isEmpty)
+    assertTrue(r.warnings.isEmpty)
+    assertTrue(r.errors.isEmpty)
   }
 }

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/api/DFDLParserUnparser.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/api/DFDLParserUnparser.scala
@@ -245,7 +245,7 @@ object DFDL {
 
   trait ParseResult extends Result with WithDiagnostics {
     def resultState: State
-    def validationResult(): Option[ValidationResult]
+    val validationResult: Option[ValidationResult]
   }
 
   trait UnparseResult extends Result with WithDiagnostics {

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/debugger/InteractiveDebugger.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/debugger/InteractiveDebugger.scala
@@ -496,7 +496,7 @@ class InteractiveDebugger(
   /**********************************/
 
   abstract class DebugCommand {
-    val name: String
+    def name: String
     lazy val short: String = name(0).toString
     val desc: String
     val longDesc: String

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/dsom/CompiledExpression1.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/dsom/CompiledExpression1.scala
@@ -367,10 +367,11 @@ class DPathElementCompileInfo(
   /**
    * Cyclic objects require initialization
    */
-  override lazy val initialize: Unit = {
+  private lazy val init_ : Unit = {
     parents
     elementChildrenCompileInfo
   }
+  override def initialize(): Unit = init_
 
   override def serializeParents(oos: java.io.ObjectOutputStream): Unit = {
     super.serializeParents(oos)

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/infoset/InfosetInputter.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/infoset/InfosetInputter.scala
@@ -149,7 +149,7 @@ abstract class InfosetInputter
    * some infoset representations may fail to unparse if the schema depends on
    * namespace information to differentiate between elements.
    */
-  val supportsNamespaces: Boolean
+  def supportsNamespaces: Boolean
 
   final override lazy val advanceAccessor = InfosetAccessor()
   final override lazy val inspectAccessor = InfosetAccessor()

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/DataProcessor.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/DataProcessor.scala
@@ -413,8 +413,8 @@ class DataProcessor(
       val vr = maybeValidationBytes.toOption.map { bytes =>
         val bis = new java.io.ByteArrayInputStream(bytes.toByteArray)
         val res = validator.validateXML(bis)
-        res.warnings().forEach { w => state.validationError(w.getMessage) }
-        res.errors().forEach {
+        res.warnings.forEach { w => state.validationError(w.getMessage) }
+        res.errors.forEach {
           case e: ValidationException =>
             state.validationErrorNoContext(e.getCause)
           case f: ValidationFailure =>

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/ExpressionEvaluatingParsers.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/ExpressionEvaluatingParsers.scala
@@ -37,8 +37,10 @@ import org.apache.daffodil.runtime1.processors.VariableRuntimeData
  */
 abstract class ExpressionEvaluationParser(
   expr: CompiledExpression[AnyRef],
-  override val context: RuntimeData
+  contextParam: RuntimeData
 ) extends PrimParserNoData {
+
+  override val context: RuntimeData = contextParam
 
   override def runtimeDependencies = Vector()
 

--- a/daffodil-schematron/src/test/scala/org/apache/daffodil/validation/schematron/TestBasicValidation.scala
+++ b/daffodil-schematron/src/test/scala/org/apache/daffodil/validation/schematron/TestBasicValidation.scala
@@ -44,7 +44,7 @@ class TestBasicValidation {
       )
 
     val result = p.validateXML(new ByteArrayInputStream(xml.getBytes))
-    assert(result.errors().isEmpty)
+    assert(result.errors.isEmpty)
   }
 
   @Test def testInvalidXML(): Unit = {
@@ -59,8 +59,8 @@ class TestBasicValidation {
       )
 
     val result = p.validateXML(new ByteArrayInputStream(xml.getBytes))
-    result.errors().forEach(e => println(s"Fail: ${e.getMessage}"))
-    assert(result.errors().size() == 2)
+    result.errors.forEach(e => println(s"Fail: ${e.getMessage}"))
+    assert(result.errors.size() == 2)
   }
 
   @Test def testInvalidXML2(): Unit = {
@@ -75,8 +75,8 @@ class TestBasicValidation {
       )
 
     val result = p.validateXML(new ByteArrayInputStream(xml.getBytes))
-    result.errors().forEach(e => println(s"Fail: ${e.getMessage}"))
-    assert(result.errors().size() == 1)
+    result.errors.forEach(e => println(s"Fail: ${e.getMessage}"))
+    assert(result.errors.size() == 1)
   }
 
   @Test def testInstantiateAnInstanceOfTemplates(): Unit = {

--- a/daffodil-schematron/src/test/scala/org/apache/daffodil/validation/schematron/TestSpiLoading.scala
+++ b/daffodil-schematron/src/test/scala/org/apache/daffodil/validation/schematron/TestSpiLoading.scala
@@ -34,7 +34,7 @@ class TestSpiLoading {
     val xml = Source.fromResource("xml/article-2.xml").mkString
 
     val result = v.validateXML(new ByteArrayInputStream(xml.getBytes))
-    result.errors().forEach(e => println(s"Fail: ${e.getMessage}"))
-    assert(result.errors().size() == 2)
+    result.errors.forEach(e => println(s"Fail: ${e.getMessage}"))
+    assert(result.errors.size() == 2)
   }
 }

--- a/daffodil-tdml-junit/src/main/scala/org/apache/daffodil/junit/tdml/TdmlSuite.scala
+++ b/daffodil-tdml-junit/src/main/scala/org/apache/daffodil/junit/tdml/TdmlSuite.scala
@@ -33,7 +33,7 @@ trait TdmlSuite {
   /**
    * Resource path to the TDML file to use for this JUnit suite
    */
-  val tdmlResource: String
+  def tdmlResource: String
 
   /**
    * Function to get the directory containing tdmlResource. Useful if createRunner is overridden


### PR DESCRIPTION
- make non-lazy val a def since lazy vals cannot be abstract
- scala 3 no longer allows a lazy value of type Unit to override a def of type unit (warning: lazy value X of type Unit no longer has compatible type scala)
- scala 3 no longer allows overriding a val parameter (warning: overriding val parameter value X in class Y is deprecated, will be illegal in a future version)
- remove ambiguity causing abstract definitions

DAFFODIL-2975