### PR TITLE
Fix unreachable pattern match except null warning

### DIFF
--- a/daffodil-core/src/main/scala/org/apache/daffodil/core/dpath/Expression.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/core/dpath/Expression.scala
@@ -1040,7 +1040,6 @@ sealed abstract class SelfStepExpression(s: String, predArg: Option[PredicateExp
       priorStep.get match {
         case priorUp: UpStepExpression => SDE("Path '../.' is not allowed.")
         case priorDown: DownStepExpression => priorDown.stepElements
-        case x => Assert.invariantFailed("Not recognized: " + x)
       }
   }
 }

--- a/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/Root.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/Root.scala
@@ -91,7 +91,7 @@ final class Root private (
   private def refsTo(g: GlobalComponent): Seq[SchemaComponent] =
     refMap.get(g).toSeq.flatMap { refSpec =>
       refSpec.flatMap { case (_, seqRS) =>
-        seqRS.map { rs: RefSpec => rs.from }
+        seqRS.map { (rs: RefSpec) => rs.from }
       }
     }
 

--- a/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/SchemaComponent.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/SchemaComponent.scala
@@ -198,7 +198,6 @@ trait SchemaComponent
         case ct: GlobalComplexTypeDef => "ct=" + ct.namedQName.toQNameString
         case ct: ComplexTypeBase => "ct"
         case st: SimpleTypeDefBase => "st=" + st.namedQName.toQNameString
-        case st: SimpleTypeBase => "st=" + st.primType.globalQName.toQNameString
         case cgr: ChoiceGroupRef =>
           "cgr" + (if (cgr.isHidden) "h" else "") + (if (cgr.position > 1) cgr.position
                                                      else

--- a/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/SchemaSet.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/SchemaSet.scala
@@ -402,7 +402,6 @@ final class SchemaSet private (
           }
           firstElement
         }
-        case _ => Assert.invariantFailed("illegal combination of root element specifications")
       }
     re.asRoot
   }.value
@@ -649,11 +648,11 @@ final class SchemaSet private (
       // constructing the complete object graph. By just always obtaining all the simple types
       // defs we insure the quasi-elements used by them are always constructed, and names are
       // resolvable.
-      allSchemaDocuments.flatMap { sd: SchemaDocument =>
+      allSchemaDocuments.flatMap { (sd: SchemaDocument) =>
         sd.globalSimpleTypeDefs
       } ++ {
         if (this.checkAllTopLevel)
-          allSchemaDocuments.flatMap { sd: SchemaDocument =>
+          allSchemaDocuments.flatMap { (sd: SchemaDocument) =>
             sd.defaultFormat // just demand this since it should be possible to create it.
             sd.globalElementDecls ++
               sd.globalComplexTypeDefs ++

--- a/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/SequenceGroup.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/SequenceGroup.scala
@@ -75,7 +75,7 @@ abstract class SequenceTermBase(
   def isLayered: Boolean = layerOption.isDefined
 
   lazy val optionLayerRuntimeData: Option[LayerRuntimeData] =
-    layerOption.map { layerProperty: RefQName =>
+    layerOption.map { (layerProperty: RefQName) =>
       val layerVars = variableMap.vrds.filter { vrd =>
         vrd.globalQName.namespace == layerProperty.namespace
       }

--- a/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/SimpleTypes.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/SimpleTypes.scala
@@ -104,7 +104,6 @@ object PrimitiveType {
       case PrimType.Date => Date
       case PrimType.Time => Time
       case PrimType.AnyURI => AnyURI
-      case _ => Assert.usageError("Not a primitive type node: " + typeNode)
     }
   }
 

--- a/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/TermEncodingMixin.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/TermEncodingMixin.scala
@@ -88,7 +88,6 @@ trait TermEncodingMixin extends KnownEncodingMixin { self: Term =>
       val encName = encodingEv.optConstant.get.toUpperCase()
       if (encName.startsWith("UTF-16")) {
         utf16Width // demand this so checking is done
-        true
       }
     }
     isKnown

--- a/daffodil-core/src/main/scala/org/apache/daffodil/core/grammar/ElementBaseGrammarMixin.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/core/grammar/ElementBaseGrammarMixin.scala
@@ -642,7 +642,6 @@ trait ElementBaseGrammarMixin
         notYetImplemented("lengthKind='endOfParent' for complex type")
       case LengthKind.EndOfParent =>
         notYetImplemented("lengthKind='endOfParent' for simple type")
-      case _ => SDE("Unimplemented lengthKind %s", lengthKind)
     }
   }
 
@@ -673,7 +672,6 @@ trait ElementBaseGrammarMixin
         notYetImplemented("lengthKind='endOfParent' for complex type")
       case LengthKind.EndOfParent =>
         notYetImplemented("lengthKind='endOfParent' for simple type")
-      case _ => SDE("Unimplemented lengthKind %s", lengthKind)
     }
   }
 

--- a/daffodil-core/src/main/scala/org/apache/daffodil/core/grammar/RepTypeMixin.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/core/grammar/RepTypeMixin.scala
@@ -128,22 +128,22 @@ trait RepTypeMixin { self: ElementBase =>
     // This is Seq of attributes extracted from each enumeration, where each item in the
     // sequence is a 3-tuple containing the cooked repValues, repValueRanges, and enum value
     // from the associated enum
-    val enumAttributes = restriction.enumerations.map { enum =>
-      enum.schemaDefinitionWhen(
-        enum.repValuesRaw.isEmpty && enum.repValueRangesRaw.isEmpty,
+    val enumAttributes = restriction.enumerations.map { enumVal =>
+      enumVal.schemaDefinitionWhen(
+        enumVal.repValuesRaw.isEmpty && enumVal.repValueRangesRaw.isEmpty,
         "All enumerations must define dfdlx:repValues and/or dfdlx:repValueRanges when dfdlx:repType (%s) is defined",
         repType
       )
 
       val repValues: Seq[DataValueNumber] =
-        enum.repValuesRaw
+        enumVal.repValuesRaw
           .map(repTypeElementDecl.primType.fromXMLString(_).asInstanceOf[DataValueNumber])
       val repValueRanges: Seq[(DataValueNumber, DataValueNumber)] =
-        enum.repValueRangesRaw
+        enumVal.repValueRangesRaw
           .map(repTypeElementDecl.primType.fromXMLString(_).asInstanceOf[DataValueNumber])
           .sliding(2, 2)
           .map { case Seq(low, high) =>
-            enum.schemaDefinitionUnless(
+            enumVal.schemaDefinitionUnless(
               lt.operate(low, high).getBoolean,
               "dfdlx:repValueRanges low value (%s) must be less than high value (%s)",
               low.value,
@@ -152,7 +152,7 @@ trait RepTypeMixin { self: ElementBase =>
             (low, high)
           }
           .toSeq
-      val enumValue = enum.enumValueCooked.asInstanceOf[DataValueString]
+      val enumValue = enumVal.enumValueCooked.asInstanceOf[DataValueString]
       (repValues, repValueRanges, enumValue)
     }
 

--- a/daffodil-core/src/main/scala/org/apache/daffodil/core/grammar/SequenceGrammarMixin.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/core/grammar/SequenceGrammarMixin.scala
@@ -172,19 +172,6 @@ trait SequenceGrammarMixin extends GrammarMixin with SequenceTermRuntime1Mixin {
         )
       case (e: EB, Ordered__, Never______, Implicit__, ___, max) =>
         new RepOrderedWithMinMaxSequenceChild(this, e, groupIndex)
-      case (
-            e: EB,
-            Ordered__,
-            Never______,
-            ock
-            /****/
-            ,
-            ___,
-            __2
-          ) if (ock ne null) =>
-        e.SDE(
-          "separatorSuppressionPolicy='never' not allowed in combination with occursCountKind='" + ock + "'."
-        )
       case (e: EB, Ordered__, Trailing___, Implicit__, ___, max) =>
         new RepOrderedWithMinMaxSequenceChild(this, e, groupIndex)
       case (e: EB, Ordered__, TrailingStr, Implicit__, ___, UNB) =>

--- a/daffodil-core/src/main/scala/org/apache/daffodil/core/runtime1/ModelGroupRuntime1Mixin.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/core/runtime1/ModelGroupRuntime1Mixin.scala
@@ -33,15 +33,9 @@ trait ModelGroupRuntime1Mixin { self: ModelGroup =>
   final override lazy val termRuntimeData: TermRuntimeData = modelGroupRuntimeData
 
   protected lazy val groupMembersRuntimeData = {
-    val res = this match {
-      case mg: ModelGroup =>
-        mg.groupMembers.map {
-          _ match {
-            case eb: ElementBase => eb.erd
-            case t: Term => t.termRuntimeData
-          }
-        }
-      case _ => Nil
+    val res = self.groupMembers.map {
+      case eb: ElementBase => eb.erd
+      case t: Term => t.termRuntimeData
     }
     res
   }

--- a/daffodil-core/src/test/scala/org/apache/daffodil/core/dpath/TestDFDLExpressionTree.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/core/dpath/TestDFDLExpressionTree.scala
@@ -328,7 +328,7 @@ class TestDFDLExpressionTree extends Parsers {
   }
 
   @Test def test_numbers1() = {
-    testExpr(dummySchema, "{ 0. }") { actual: Expression =>
+    testExpr(dummySchema, "{ 0. }") { (actual: Expression) =>
       val res = JBigDecimal.ZERO
       val a @ WholeExpression(_, LiteralExpression(actualRes: JBigDecimal), _, _, _, _) =
         actual;

--- a/daffodil-japi/src/main/scala/org/apache/daffodil/japi/Daffodil.scala
+++ b/daffodil-japi/src/main/scala/org/apache/daffodil/japi/Daffodil.scala
@@ -94,7 +94,6 @@ object Daffodil {
    * @return new object to compile DFDL schemas
    */
   def compiler(): Compiler = {
-    new Daffodil // silence warning about unused private constructor
     new Compiler(SCompiler())
   }
 

--- a/daffodil-japi/src/main/scala/org/apache/daffodil/japi/packageprivate/Utils.scala
+++ b/daffodil-japi/src/main/scala/org/apache/daffodil/japi/packageprivate/Utils.scala
@@ -51,7 +51,7 @@ private[japi] object XMLTextEscapeStyleConversions {
     val sxmlTextEscapeStyle: SXMLTextEscapeStyle.Value = style match {
       case XMLTextEscapeStyle.Standard => SXMLTextEscapeStyle.Standard
       case XMLTextEscapeStyle.CDATA => SXMLTextEscapeStyle.CDATA
-      case _ =>
+      case null =>
         throw new Exception(
           "Unrecognized value: %s for parameter: xmlTextEscapeStyle. Must be 'Standard' or 'CDATA'."
             .format(style)

--- a/daffodil-lib/src/main/scala/org/apache/daffodil/lib/util/MStack.scala
+++ b/daffodil-lib/src/main/scala/org/apache/daffodil/lib/util/MStack.scala
@@ -117,7 +117,7 @@ final class MStackOfMaybe[T <: AnyRef] {
   @inline final def isEmpty = delegate.isEmpty
 
   def clear() = delegate.clear()
-  def toListMaybe = delegate.toList.map { x: AnyRef =>
+  def toListMaybe = delegate.toList.map { (x: AnyRef) =>
     Maybe(x) // Scala compiler bug without this cast
   }
 }

--- a/daffodil-lib/src/test/scala/org/apache/daffodil/lib/oolag/TestOOLAG.scala
+++ b/daffodil-lib/src/test/scala/org/apache/daffodil/lib/oolag/TestOOLAG.scala
@@ -221,13 +221,8 @@ class TestOOLAG {
     val e = intercept[AlreadyTried] {
       h.a2_.value
     }
-    e match {
-      case at: AlreadyTried => {
-        val m = e.getMessage()
-        assertTrue(m.contains("a2"))
-      }
-      case _ => fail()
-    }
+    val m = e.getMessage()
+    assertTrue(m.contains("a2"))
   }
 
   @Test def testThrowToTopLevel(): Unit = {

--- a/daffodil-lib/src/test/scala/passera/test/UnsignedCheck.scala
+++ b/daffodil-lib/src/test/scala/passera/test/UnsignedCheck.scala
@@ -52,7 +52,7 @@ class UnsignedCheck {
 
   @Test def testIntToString() = {
     assertTrue(
-      forAll { n: Int => n >= 0 ==> (n.toUInt.toString == n.toString) }
+      forAll { (n: Int) => n >= 0 ==> (n.toUInt.toString == n.toString) }
     )
   }
 

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/debugger/InteractiveDebugger.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/debugger/InteractiveDebugger.scala
@@ -338,11 +338,7 @@ class InteractiveDebugger(
       // Evaluatable is really designed to be called from parsers/unparsers.
       //
       try {
-        val res = compiledExpr.evaluate(state)
-        res match {
-          case b: java.lang.Boolean => b.booleanValue()
-          case _ => false
-        }
+        compiledExpr.evaluate(state).booleanValue()
       } catch {
         case s: scala.util.control.ControlThrowable => throw s
         case u: UnsuppressableException => throw u

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/infoset/InfosetImpl.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/infoset/InfosetImpl.scala
@@ -1853,7 +1853,6 @@ sealed class DIComplex(override val erd: ElementRuntimeData)
         addChildToFastLookup(ia)
         childNodes += ia
         _numChildren = childNodes.length
-        ia
       }
       // Array is now always last, add the new child to it
       childNodes.last.asInstanceOf[DIArray].append(e)

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/layers/LayerRuntimeCompiler.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/layers/LayerRuntimeCompiler.scala
@@ -158,10 +158,10 @@ class LayerRuntimeCompiler {
         )
         // at this point we know each variable that was not a parameter of the setter
         // has a getter with matching name.
-        val resultVarPairs = resultGettersNames.map { rgn: String =>
+        val resultVarPairs = resultGettersNames.map { (rgn: String) =>
           val getter: Method =
             allVarResultGetters
-              .find { g: Method => g.getName == varResultPrefix + rgn }
+              .find { (g: Method) => g.getName == varResultPrefix + rgn }
               .getOrElse {
                 Assert.invariantFailed("no getter for getter name.")
               }

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/Evaluatable.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/Evaluatable.scala
@@ -73,10 +73,7 @@ trait InfosetCachedEvaluatable[T <: AnyRef] { self: Evaluatable[T] =>
         // is more memory efficient to just recalculate any evaluatables
         Assert.invariant(state.currentNode.isDefined)
         val cn = state.infoset
-        val termNode = cn match {
-          case t: DITerm => t
-          case _ => Assert.invariantFailed("current node was not a term.")
-        }
+        val termNode = cn.asInstanceOf[DITerm]
         val cache = termNode.evalCache(state)
         val optHit = cache.get(this)
         if (optHit.isDefined) optHit.get

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/MetadataWalker.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/MetadataWalker.scala
@@ -43,9 +43,6 @@ class MetadataWalker(private val dp: DataProcessor) {
       case erd: ElementRuntimeData => walkElement(handler, erd)
       case srd: SequenceRuntimeData => walkSequence(handler, srd)
       case crd: ChoiceRuntimeData => walkChoice(handler, crd)
-      // $COVERAGE-OFF$
-      case _ => Assert.invariantFailed(s"unrecognized TermRuntimeData subtype: $trd")
-      // $COVERAGE-ON$
     }
   }
 

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/ElementCombinator1.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/ElementCombinator1.scala
@@ -263,9 +263,6 @@ class ElementParser(
         // a simple element.
         currentElement.setParent(st.parent)
       }
-      case _ => {
-        Assert.invariantFailed("Unknown priorElement: " + priorElement)
-      }
     }
     Logger.log.debug(s"priorElement = ${priorElement}")
     pstate.setInfoset(currentElement, Nope)

--- a/daffodil-sapi/src/main/scala/org/apache/daffodil/sapi/Daffodil.scala
+++ b/daffodil-sapi/src/main/scala/org/apache/daffodil/sapi/Daffodil.scala
@@ -90,7 +90,6 @@ object Daffodil {
 
   /** Create a new object used to compiled DFDL schemas */
   def compiler(): Compiler = {
-    new Daffodil // silence warning about unused private constructor above.
     new Compiler(SCompiler())
   }
 

--- a/daffodil-test/src/test/scala/org/apache/daffodil/runtime1/layers/SimpleBombOutLayer.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/runtime1/layers/SimpleBombOutLayer.scala
@@ -114,8 +114,6 @@ final class STL_BombOutLayer() extends Layer("stlBombOutLayer", "urn:STL") {
             // ok
             case Abort =>
               Assert.abort(msg)
-            case _ =>
-              Assert.invariantFailed(s"Not recognized bombHow value: $bombHow")
           }
         }
       }


### PR DESCRIPTION
- fix unused symbols warning
- fix deprecated do while
- fix lambda needs paren warning (warning: parentheses are required around the parameter of a lambda)
- rename enum -> enumVal now that the latter is a keyword

DAFFODIL-2975