### PR TITLE
Workaround to possible scala 3 infinite loop bug

### DIFF
--- a/daffodil-core/src/main/scala/org/apache/daffodil/core/dpath/Expression.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/core/dpath/Expression.scala
@@ -49,9 +49,9 @@ import org.apache.daffodil.runtime1.udf.UserDefinedFunctionService
  */
 abstract class Expression extends OOLAGHostImpl() with BasicComponent {
 
-  override lazy val tunable: DaffodilTunables = parent.tunable
+  override lazy val tunable: DaffodilTunables = wholeExpression.tunable
   override lazy val localSuppressSchemaDefinitionWarnings: Seq[WarnID] =
-    parent.localSuppressSchemaDefinitionWarnings
+    wholeExpression.localSuppressSchemaDefinitionWarnings
 
   /**
    * Override where we traverse/access elements.
@@ -123,10 +123,10 @@ abstract class Expression extends OOLAGHostImpl() with BasicComponent {
     }
   }
 
-  final lazy val wholeExpression: Expression = {
+  final lazy val wholeExpression: WholeExpression = {
     parent match {
       case w: WholeExpression => w
-      case null => this
+      case null => this.asInstanceOf[WholeExpression]
       case _ => parent.wholeExpression
     }
   }
@@ -134,7 +134,7 @@ abstract class Expression extends OOLAGHostImpl() with BasicComponent {
   final lazy val wholeExpressionText = wholeExpression.text
 
   lazy val compileInfo: DPathCompileInfo = // override in WholeExpression
-    parent.compileInfo
+    wholeExpression.compileInfo
 
   final lazy val enclosingElementCompileInfos: Seq[DPathElementCompileInfo] =
     compileInfo.enclosingElementCompileInfos
@@ -147,9 +147,9 @@ abstract class Expression extends OOLAGHostImpl() with BasicComponent {
     ecis.head.rootElement
   }
 
-  lazy val namespaces: NamespaceBinding = parent.namespaces
+  lazy val namespaces: NamespaceBinding = wholeExpression.namespaces
 
-  lazy val noPrefixNamespace: NS = parent.noPrefixNamespace
+  lazy val noPrefixNamespace: NS = wholeExpression.noPrefixNamespace
 
   def children: Seq[Expression]
 

--- a/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/SchemaComponent.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/SchemaComponent.scala
@@ -84,7 +84,7 @@ trait SchemaComponent
 
   override def oolagContextViaArgs = optLexicalParent
 
-  override lazy val tunable: DaffodilTunables = optLexicalParent.get.tunable
+  override lazy val tunable: DaffodilTunables = schemaSet.tunable
   final override lazy val unqualifiedPathStepPolicy = tunable.unqualifiedPathStepPolicy
 
   // FIXME: I think this should be abstract. We never need this actual object.
@@ -304,8 +304,6 @@ final class Schema private (
 ) extends SchemaComponentImpl(<fake/>, Option(schemaSetArg)) {
 
   override def targetNamespace: NS = namespace
-
-  override lazy val schemaSet = schemaSetArg
 
   lazy val schemaDocuments = schemaDocs
 

--- a/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/SchemaComponentFactory.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/SchemaComponentFactory.scala
@@ -64,7 +64,10 @@ trait CommonContextMixin extends NestingLexicalMixin with CommonContextView {
   def optLexicalParent: Option[SchemaComponent]
 
   lazy val schemaFile: Option[DFDLSchemaFile] = optLexicalParent.flatMap { _.schemaFile }
-  lazy val schemaSet: SchemaSet = optLexicalParent.get.schemaSet
+  final lazy val schemaSet: SchemaSet = optLexicalParent match {
+    case Some(s) => s.schemaSet
+    case None => this.asInstanceOf[SchemaSet]
+  }
   lazy val optSchemaDocument: Option[SchemaDocument] = optLexicalParent.flatMap {
     _.optSchemaDocument
   }

--- a/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/SchemaSet.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/SchemaSet.scala
@@ -122,8 +122,6 @@ final class SchemaSet private (
 
   lazy val resolver = DFDLCatalogResolver.get
 
-  override lazy val schemaSet = this
-
   override lazy val optSchemaDocument = None
   override lazy val optXMLSchemaDocument = None
 


### PR DESCRIPTION
- Our pattern of `val x = parent.x` no longer works in Scala 3 because it can't detect that parent.x can be overridden to end the recursion, so it thinks we're stuck in an infinite loop because parent and `this` are the same type. Even though parent will eventually resolve to Root, which has a different overridden x. To trick it into seeing there will be no infinite loop, we need a new pattern where we do `parent match { case r: RootType => r; case _ => parent.x }` or if possible/known `val x = root.x`. This might actually allow scala to convert the recursion to a while loop, so it might be more efficient.

DAFFODIL-2975