### PR TITLE
Fix short names in CLI debugger

### DIFF
--- a/daffodil-test-integration/src/test/scala/org/apache/daffodil/cliTest/TestCLIDebugger.scala
+++ b/daffodil-test-integration/src/test/scala/org/apache/daffodil/cliTest/TestCLIDebugger.scala
@@ -225,7 +225,7 @@ class TestCLIDebugger {
     runCLI(args"parse -d -s $schema -r e $input", fork = true, envs = envs) { cli =>
       cli.expect("(debug)")
       cli.sendLine("set removeHidden false")
-      cli.sendLine("display info infoset")
+      cli.sendLine("di i i") // short form of "display info infoset"
       cli.sendLine("step")
       cli.sendLine("step")
       // intentionally look for a newline to make sure normally hidden elements


### PR DESCRIPTION
Removes all remaining uses of the name parameter when doing things like filtering or searching subcommands. Instead, we now always uses the "matches" function, which takes into account both short and long name. This fixes the "info" command and the "diffExcludes" setting.

The name variable is now only used when when outputting the name of a debugger command that was run.

This also always enables debugger command name conflict detection. It doesn't really need to always be run, but we never uncomment this to actually check for conflicts, and it's fast enough that it's not noticable.

DAFFODIL-2991