### PR TITLE
Change Diagnostic.getMessage to only return the message portion

### DIFF
--- a/daffodil-cli/src/main/scala/org/apache/daffodil/cli/Main.scala
+++ b/daffodil-cli/src/main/scala/org/apache/daffodil/cli/Main.scala
@@ -1001,9 +1001,9 @@ class Main(
   def displayDiagnostics(pr: WithDiagnostics): Unit = {
     pr.getDiagnostics.foreach { d =>
       if (d.isError) {
-        Logger.log.error(d.getMessage())
+        Logger.log.error(d.toString())
       } else {
-        Logger.log.warn(d.getMessage())
+        Logger.log.warn(d.toString())
       }
     }
   }

--- a/daffodil-codegen-c/src/main/scala/org/apache/daffodil/codegen/c/DaffodilCExamplesGenerator.scala
+++ b/daffodil-codegen-c/src/main/scala/org/apache/daffodil/codegen/c/DaffodilCExamplesGenerator.scala
@@ -34,11 +34,11 @@ object DaffodilCExamplesGenerator {
   ): Unit = {
     // Generate example code from the sample schema
     val pf = Compiler().compileFile(schemaFile.toIO, optRootName)
-    assert(!pf.isError, pf.getDiagnostics.map(_.getMessage()).mkString("\n"))
+    assert(!pf.isError, pf.getDiagnostics.map(_.toString()).mkString("\n"))
     val cg = pf.forLanguage("c")
     val tempDir = os.temp.dir(dir = null, prefix = TDMLImplementation.DaffodilC.toString)
     val codeDir = cg.generateCode(tempDir.toString)
-    assert(!cg.isError, cg.getDiagnostics.map(_.getMessage()).mkString("\n"))
+    assert(!cg.isError, cg.getDiagnostics.map(_.toString()).mkString("\n"))
 
     // Replace the example generated files with the newly generated files
     val generatedCodeHeader = codeDir / "libruntime" / "generated_code.h"

--- a/daffodil-core/src/test/scala/org/apache/daffodil/core/dsom/TestPolymorphicUpwardRelativeExpressions.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/core/dsom/TestPolymorphicUpwardRelativeExpressions.scala
@@ -142,7 +142,7 @@ class TestPolymorphicUpwardRelativeExpressions {
     val e = intercept[Exception] {
       TestUtils.testString(testSchema, "e2;1961-02-01;6;", areTracing = false)
     }
-    val msg = e.getMessage()
+    val msg = e.toString()
     val hasSDE = msg.contains("Schema Definition Error")
     val hasPolyInt = msg.contains("../../poly eq 5 with xs:int")
     val hasPolyDate = msg.contains("../../poly eq 5 with xs:date")

--- a/daffodil-core/src/test/scala/org/apache/daffodil/core/general/TestRuntimeProperties.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/core/general/TestRuntimeProperties.scala
@@ -155,7 +155,7 @@ class TestRuntimeProperties {
     val ex = intercept[Exception] {
       TestUtils.compileSchema(testSchemaBad1)
     }
-    val msg = ex.getMessage()
+    val msg = ex.toString()
 
     assertTrue(msg.contains("Schema Definition Error"))
     assertTrue(msg.contains("dfdlx:runtimeProperties"))
@@ -179,7 +179,7 @@ class TestRuntimeProperties {
     val ex = intercept[Exception] {
       TestUtils.compileSchema(testSchemaBad2)
     }
-    val msg = ex.getMessage()
+    val msg = ex.toString()
 
     assertTrue(msg.contains("Schema Definition Error"))
     assertTrue(msg.contains("dfdlx:runtimeProperties"))

--- a/daffodil-core/src/test/scala/org/apache/daffodil/core/outputValueCalc/TestOutputValueCalcAndAlignment.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/core/outputValueCalc/TestOutputValueCalcAndAlignment.scala
@@ -18,7 +18,6 @@
 package org.apache.daffodil.core.outputValueCalc
 
 import org.apache.daffodil.core.util.TestUtils
-import org.apache.daffodil.lib.util.Misc
 import org.apache.daffodil.lib.util.SchemaUtils
 import org.apache.daffodil.lib.xml.XMLUtils
 
@@ -142,7 +141,7 @@ class TestOutputValueCalcAndAlignment {
       // Some test utilities, given multiple diagnostics from a run, will just
       // concatenate their messages, and throw a vanilla Exception object.
       case e: Exception => {
-        val msg = Misc.getSomeMessage(e).get.toLowerCase
+        val msg = e.toString.toLowerCase
         if (!msg.contains("Schema Definition Error".toLowerCase))
           fail(msg + " did not contain Schema Definition Error")
 

--- a/daffodil-core/src/test/scala/org/apache/daffodil/core/outputValueCalc/TestOutputValueCalcForwardReference.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/core/outputValueCalc/TestOutputValueCalcForwardReference.scala
@@ -118,7 +118,7 @@ class TestOutputValueCalcForwardReference {
       fail("Expected SuspendedExpressionsDeadlockException")
     } catch {
       case e: Exception => {
-        val msg = e.getMessage().toLowerCase()
+        val msg = e.toString().toLowerCase()
         assertTrue(msg.contains("deadlocked"))
         assertTrue(msg.contains("runtime schema definition error"))
       }

--- a/daffodil-japi/src/main/scala/org/apache/daffodil/japi/Daffodil.scala
+++ b/daffodil-japi/src/main/scala/org/apache/daffodil/japi/Daffodil.scala
@@ -348,12 +348,27 @@ abstract class WithDiagnostics private[japi] (wd: SWithDiagnostics) extends Seri
 class Diagnostic private[japi] (d: SDiagnostic) {
 
   /**
-   * Get the diagnostic message
+   * Get the diagnostic message.
+   *
+   * This does not include mode name, schema context, or data location information
    *
    * @return diagnostic message in string form
    */
   def getMessage(): String = d.getMessage()
 
+  /**
+   * Get the diagnostic mode name
+   *
+   * @return diagnostic mode name in string form
+   */
+  def getModeName(): String = d.getModeName()
+
+  /**
+   * Get a string containing the mode name, message, schema location, and data location combined
+   * into a single string
+   *
+   * @return all diagnostic information as a string
+   */
   override def toString() = d.toString
 
   /**

--- a/daffodil-japi/src/test/java/org/apache/daffodil/example/TestJavaAPI.java
+++ b/daffodil-japi/src/test/java/org/apache/daffodil/example/TestJavaAPI.java
@@ -259,7 +259,7 @@ public class TestJavaAPI {
             java.util.List<Diagnostic> diags = res.getDiagnostics();
             assertEquals(1, diags.size());
             Diagnostic d = diags.get(0);
-            // System.err.println(d.getMessage());
+            assertEquals("Parse Error", d.getModeName());
             assertTrue(d.getMessage().contains("int"));
             assertTrue(d.getMessage().contains("Not an int"));
             assertTrue(d.getDataLocations().toString().contains("10"));

--- a/daffodil-japi/src/test/java/org/apache/daffodil/example/ValidatorApiExample.java
+++ b/daffodil-japi/src/test/java/org/apache/daffodil/example/ValidatorApiExample.java
@@ -79,7 +79,7 @@ public class ValidatorApiExample {
         java.io.File schemaFile = getResource("/test/japi/alwaysInvalid.dfdl.xsd");
         ProcessorFactory pf = c.compileFile(schemaFile);
         for (Diagnostic d: pf.getDiagnostics()) {
-            System.err.println(d.getMessage());
+            System.err.println(d.toString());
         }
         DataProcessor dp = pf.onPath("/").withValidationMode(ValidationMode.Full);
 
@@ -92,8 +92,8 @@ public class ValidatorApiExample {
 
             for (Diagnostic d : res.getDiagnostics()) {
                 // doublecheck - all the errors are validation errors.
-                // System.err.println(d.getMessage());
-                assertTrue(d.getMessage().contains("Validation Error"));
+                // System.err.println(d.toString());
+                assertTrue(d.toString().contains("Validation Error"));
             }
             assertTrue(res.isError());
             // XMLOutputter xout = new XMLOutputter();

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/debugger/InteractiveDebugger.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/debugger/InteractiveDebugger.scala
@@ -200,7 +200,7 @@ class InteractiveDebugger(
 
       if (state.processorStatus ne Success) {
         debugPrintln("failure:")
-        debugPrintln("%s".format(state.diagnostics.head.getMessage()), "  ")
+        debugPrintln("%s".format(state.diagnostics.head.toString()), "  ")
       }
 
       if (debugState == DebugState.Trace) {
@@ -360,7 +360,7 @@ class InteractiveDebugger(
       case u: UnsuppressableException => throw u
       case e: Throwable => {
         debugPrintln(
-          "caught throwable " + Misc.getNameFromClass(e) + ": " + Misc.getSomeMessage(e).get
+          "caught throwable " + e.toString
         )
         state.setSuccess()
         false
@@ -1145,7 +1145,7 @@ class InteractiveDebugger(
             if (!newDiags.isEmpty) {
               val ex = new ErrorsNotYetRecorded(newDiags)
               throw new DebugException(
-                "expression evaluation failed: %s".format(Misc.getSomeMessage(ex).get)
+                "expression evaluation failed: %s".format(ex.toString)
               )
             }
           }
@@ -1172,7 +1172,7 @@ class InteractiveDebugger(
           case e: Throwable => {
             val ex = e // just so we can see it in the debugger.
             throw new DebugException(
-              "expression evaluation failed: %s".format(Misc.getSomeMessage(ex).get)
+              "expression evaluation failed: %s".format(ex.toString)
             )
           }
         }

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/dpath/DPathRuntime.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/dpath/DPathRuntime.scala
@@ -124,9 +124,19 @@ class CompiledDPath(val ops: RecipeOp*) extends Serializable {
         case e: java.lang.IllegalArgumentException => false
         case e: FNErrorException => false
         case e: SchemaDefinitionDiagnosticBase =>
-          throw new SchemaDefinitionError(Some(sfl), None, e.getMessage())
+          // include the mode name of the original diagnostic for a more clear diagnostic
+          throw new SchemaDefinitionError(
+            Some(sfl),
+            None,
+            e.getModeName() + ": " + e.getMessage()
+          )
         case e: ProcessingError =>
-          throw new SchemaDefinitionError(Some(sfl), None, e.getMessage())
+          // include the mode name of the original diagnostic for a more clear diagnostic
+          throw new SchemaDefinitionError(
+            Some(sfl),
+            None,
+            e.getModeName() + ": " + e.getMessage()
+          )
       }
     val res =
       if (isConstant) dstate.currentValue else DataValue.NoValue

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/ParseErrors.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/ParseErrors.scala
@@ -58,16 +58,8 @@ final class CharsetNotByteAlignedError(
 class AssertionFailed(
   rd: SchemaFileLocation,
   state: PState,
-  msg: String,
-  details: Maybe[String] = Nope
-) extends ParseError(One(rd), One(state.currentLocation), "Assertion failed: %s", msg) {
-  override def componentText: String = {
-
-    if (details.isDefined) "\nDetails: " + details.get
-    else ""
-
-  }
-}
+  msg: String
+) extends ParseError(One(rd), One(state.currentLocation), "Assertion failed: %s", msg)
 
 class ChoiceBranchFailed(rd: SchemaFileLocation, state: PState, val errors: Seq[Diagnostic])
   extends ParseError(

--- a/daffodil-runtime1/src/test/scala/org/apache/daffodil/runtime1/dsom/TestSDW.scala
+++ b/daffodil-runtime1/src/test/scala/org/apache/daffodil/runtime1/dsom/TestSDW.scala
@@ -31,7 +31,9 @@ class TestSDW {
       None,
       "test message"
     )
-    val expected = "Schema Definition Warning: test message (id: deprecatedBuiltInFormats)"
+    val expected = "test message (id: deprecatedBuiltInFormats)"
     assertEquals(expected, sdw.getMessage)
+    assertEquals("Schema Definition Warning", sdw.getModeName())
+    assertEquals("Schema Definition Warning: " + expected, sdw.toString)
   }
 }

--- a/daffodil-sapi/src/main/scala/org/apache/daffodil/sapi/Daffodil.scala
+++ b/daffodil-sapi/src/main/scala/org/apache/daffodil/sapi/Daffodil.scala
@@ -314,12 +314,27 @@ abstract class WithDiagnostics private[sapi] (wd: SWithDiagnostics) extends Seri
 class Diagnostic private[sapi] (d: SDiagnostic) {
 
   /**
-   * Get the diagnostic message
+   * Get the diagnostic message.
+   *
+   * This does not include the mode name, schema context, or data location information
    *
    * @return diagnostic message in string form
    */
   def getMessage(): String = d.getMessage()
 
+  /**
+   * Get the diagnostic mode name
+   *
+   * @return diagnostic mode name in string form
+   */
+  def getModeName(): String = d.getModeName()
+
+  /**
+   * Get a string containing the mode name, message, schema location, and data location combined
+   * into a single string
+   *
+   * @return all diagnostic information as a string
+   */
   override def toString() = d.toString
 
   /**

--- a/daffodil-sapi/src/test/scala/org/apache/daffodil/example/TestScalaAPI.scala
+++ b/daffodil-sapi/src/test/scala/org/apache/daffodil/example/TestScalaAPI.scala
@@ -259,6 +259,7 @@ class TestScalaAPI {
       val diags = res.getDiagnostics
       assertEquals(1, diags.size)
       val d = diags(0)
+      assertEquals("Parse Error", d.getModeName())
       assertTrue(d.getMessage().contains("int"))
       assertTrue(d.getMessage().contains("Not an int"))
       assertTrue(d.getDataLocations.toString().contains("10"))

--- a/daffodil-tdml-lib/src/main/scala/org/apache/daffodil/tdml/TDMLRunner.scala
+++ b/daffodil-tdml-lib/src/main/scala/org/apache/daffodil/tdml/TDMLRunner.scala
@@ -1231,7 +1231,7 @@ case class ParserTestCase(ptc: NodeSeq, parentArg: DFDLTestSuite)
     if (actual.isProcessingError) {
       // Means there was an error, not just warnings.
       if (diagObjs.length == 1) throw TDMLException(diagObjs.head, implString)
-      val diags = actual.getDiagnostics.map(_.getMessage()).mkString("\n")
+      val diags = actual.getDiagnostics.map(_.toString()).mkString("\n")
       throw TDMLException(diags, implString)
     } else {
       // If we think we've succeeded, verify there are no errors
@@ -1686,7 +1686,7 @@ case class UnparserTestCase(ptc: NodeSeq, parentArg: DFDLTestSuite)
         // Means there was an error, not just warnings.
         val diagObjs = parseActual.getDiagnostics
         if (diagObjs.length == 1) throw diagObjs.head
-        val diags = parseActual.getDiagnostics.map(_.getMessage()).mkString("\n")
+        val diags = parseActual.getDiagnostics.map(_.toString()).mkString("\n")
         throw TDMLException(diags, implString)
       }
       val loc: DataLocation = parseActual.currentLocation

--- a/daffodil-tdml-processor/src/main/scala/org/apache/daffodil/processor/tdml/DaffodilTDMLDFDLProcessor.scala
+++ b/daffodil-tdml-processor/src/main/scala/org/apache/daffodil/processor/tdml/DaffodilTDMLDFDLProcessor.scala
@@ -311,8 +311,8 @@ class DaffodilTDMLDFDLProcessor private (private var dp: DataProcessor)
           if (!actual.isError && !errorHandler.isError) {
             verifySameParseOutput(outputter.xmlStream, saxOutputStream)
           }
-          val dpParseDiag = actual.getDiagnostics.map(_.getMessage())
-          val saxParseDiag = errorHandler.getDiagnostics.map(_.getMessage())
+          val dpParseDiag = actual.getDiagnostics.map(_.toString())
+          val saxParseDiag = errorHandler.getDiagnostics.map(_.toString())
           verifySameDiagnostics(dpParseDiag, saxParseDiag)
         }
       }
@@ -364,8 +364,8 @@ class DaffodilTDMLDFDLProcessor private (private var dp: DataProcessor)
           VerifyTestCase.verifyBinaryOrMixedData(dpis, saxOutputStream, None)
         }
       }
-      val dpUnparseDiag = actualDP.getDiagnostics.map(_.getMessage())
-      val saxUnparseDiag = actualSAX.getDiagnostics.map(_.getMessage())
+      val dpUnparseDiag = actualDP.getDiagnostics.map(_.toString())
+      val saxUnparseDiag = actualSAX.getDiagnostics.map(_.toString())
       verifySameDiagnostics(dpUnparseDiag, saxUnparseDiag)
     }
 


### PR DESCRIPTION
- The Diagnostic.getMessage function no longer includes the schema context and mode name. This allows API users to retrieve just the message if they don't care about the other information or if they want to get it separately.
- Adds a new Diagnostic.getModeName function to get the mode (e.g. Schema Definition Warning, Parse Error)
- The Diagnostic.toString() function is not changed, returning the combined mode name, message and context information as one string.
- The Diagnostic.componentText is removed. The only Diagnostic that changed this from the empty string default was the "AssertionFailed" diagnostic via the "details" parameter, but nothing ever set this paramter, so componentText was always empty

Deprecation/Compatibility:

The Diagnostic.getMessage() function no longer returns the diagnostic mode, schema location, or data location. It only returns the actual message portion of a diagnostic. To get the previous behavior, call Diagnostic.toString() instead. A new Diagnostic.getModeName() function is added to return just the mode (Schema Definition Warning, Parse Error, etc).

DAFFODIL-2984