### PR TITLE
Fix old release candidate container to get version correctly

### DIFF
--- a/containers/release-candidate/src/daffodil-release-candidate
+++ b/containers/release-candidate/src/daffodil-release-candidate
@@ -231,16 +231,7 @@ svn checkout https://dist.apache.org/repos/dist/dev/daffodil/$PROJECT_DIST_DIR $
 
 pushd $REPO_ROOT/$DAFFODIL_CODE_REPO &> /dev/null
 
-case $PROJECT_REPO in
-  "daffodil" | "daffodil-sbt")
-    VERSION=$(grep 'version :=' build.sbt | cut -d\" -f2)
-    SCALA_BINARY_VERSION=$(grep 'scalaVersion :=' build.sbt | cut -d\" -f2 | cut -d. -f1,2)
-    ;;
-  "daffodil-vscode")
-    VERSION=$(grep '"version"' package.json | cut -d\" -f4)
-    ;;
-esac
-
+VERSION=$(cat VERSION)
 if [[ $VERSION == *SNAPSHOT* ]]; then
   echo -e "\n!!! $PROJECT_NAME version ($VERSION) should not contain SNAPSHOT for a release !!!\n";
   if [ "$DRY_RUN" = true ]; then
@@ -316,7 +307,7 @@ case $PROJECT_REPO in
     rm -rf $DAFFODIL_DOCS_DIR
     mkdir -p $DAFFODIL_DOCS_DIR/{javadoc,scaladoc}/
     cp -R target/javaunidoc/* $DAFFODIL_DOCS_DIR/javadoc/
-    cp -R target/scala-$SCALA_BINARY_VERSION/unidoc/* $DAFFODIL_DOCS_DIR/scaladoc/
+    cp -R target/scala-*/unidoc/* $DAFFODIL_DOCS_DIR/scaladoc/
     cp target/tunables.md $DAFFODIL_SITE_DIR/site/
 
     echo "Installing Site Tutorials..."


### PR DESCRIPTION
The new release candidate workflow expects version information to come from the VERSION file instead of grepping through build.sbt or package.json files. We still need the old container to work as a backup until we fully switch over to the new release workflow, so this fixes it to use the right files. This also uses a to find unidoc so we don't have to figure out which scala version is used for docs.

DAFFODIL-2971