### PR TITLE
Revert back to fedora 40 in /contains/release-candidate

### DIFF
--- a/containers/release-candidate/Dockerfile
+++ b/containers/release-candidate/Dockerfile
@@ -15,7 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM registry.fedoraproject.org/fedora:41
+FROM registry.fedoraproject.org/fedora:40
 
 WORKDIR /root
 


### PR DESCRIPTION
Revert back to fedora 40 in /contains/release-candidate

- fedora 41 doesn't have a wine package that can be installed.
  - when trying to build the containers there is errors:
    - No match for argument: wine
    - Problem: conflicting requests
      - nothing provides wine-common needed by winetricks-20230212-4.fc41.noarch from fedora