### PR TITLE
Restore previous behavior of Diagnostic.getMessage

### DIFF
--- a/daffodil-japi/src/main/scala/org/apache/daffodil/japi/Daffodil.scala
+++ b/daffodil-japi/src/main/scala/org/apache/daffodil/japi/Daffodil.scala
@@ -348,13 +348,23 @@ abstract class WithDiagnostics private[japi] (wd: SWithDiagnostics) extends Seri
 class Diagnostic private[japi] (d: SDiagnostic) {
 
   /**
-   * Get the diagnostic message.
+   * Get all diagnostic information, including mode name, schema context, and data location
+   *
+   * Future versions of Daffodil will change getMessage to return only the message portion of a
+   * diagnostic, matching the behavior of getMessageOnly--users should call toString() instead.
+   *
+   * @return diagnostic message in string form
+   */
+  def getMessage(): String = d.toString()
+
+  /**
+   * Get only the message part of a diagnostic.
    *
    * This does not include mode name, schema context, or data location information
    *
    * @return diagnostic message in string form
    */
-  def getMessage(): String = d.getMessage()
+  def getMessageOnly(): String = d.getMessage()
 
   /**
    * Get the diagnostic mode name

--- a/daffodil-sapi/src/main/scala/org/apache/daffodil/sapi/Daffodil.scala
+++ b/daffodil-sapi/src/main/scala/org/apache/daffodil/sapi/Daffodil.scala
@@ -314,13 +314,23 @@ abstract class WithDiagnostics private[sapi] (wd: SWithDiagnostics) extends Seri
 class Diagnostic private[sapi] (d: SDiagnostic) {
 
   /**
-   * Get the diagnostic message.
+   * Get all diagnostic information, including mode name, schema context, and data location
    *
-   * This does not include the mode name, schema context, or data location information
+   * Future versions of Daffodil will change getMessage to return only the message portion of a
+   * diagnostic, matching the behavior of getMessageOnly--users should call toString() instead.
    *
    * @return diagnostic message in string form
    */
-  def getMessage(): String = d.getMessage()
+  def getMessage(): String = d.toString()
+
+  /**
+   * Get only the message part of a diagnostic.
+   *
+   * This does not include mode name, schema context, or data location information
+   *
+   * @return diagnostic message in string form
+   */
+  def getMessageOnly(): String = d.getMessage()
 
   /**
    * Get the diagnostic mode name


### PR DESCRIPTION
Commit eff669344c modified Diagnostic.getMessage so that it only returned the message portion of a diagnostic, and not the mode, schema location, or data location information. However, it is possible that users relied on the previous behavior, which makes this a backwards incompatible change which should not happen during a minor release.

This restores the previous behavior of the Java/Scala APIs by changing Diagnostic.getMessage to call toString, which does return all diagnostic information as a string. For users that do want just the message, a new Diagnostic.getMessageOnly function is added to the Java/Scala APIs.

Documentation is added to suggest that API users should either call toString or getMessageOnly. We can revisit this Diagnostic API in the next major release and determine if we want to remove getMessageOnly and change getMessage to return just the message.

Note that this only changes the Scala/Java Diagnostic.getMessage API, the internal Diagnostic.getMessage function still returns just the message portion.

Deprecation/Compatibility:

A new Diagnostic.getMessageOnly() function is added to get just the message portion of a diagnostic, excluding mode, schema location, and data location portions. A future release of Daffodil may change Diagnostic.getMessage() to match this behavior, and getMessageOnly() may be removed. To ensure the current behavior is maintained with future releases, API users should call Diagnostic.toString() instead, which will always include the mode, message, schema location, and data location.

DAFFODIL-2984