### PR TITLE
Only mmap regular files in the CLI

### DIFF
--- a/daffodil-cli/src/main/scala/org/apache/daffodil/cli/Main.scala
+++ b/daffodil-cli/src/main/scala/org/apache/daffodil/cli/Main.scala
@@ -1225,18 +1225,24 @@ class Main(
             val input = parseOpts.infile.toOption match {
               case Some("-") | None => InputSourceDataInputStream(STDIN)
               case Some(file) => {
-                // for files <= 2GB, use a mapped byte buffer to avoid the overhead related to
-                // the BucketingInputSource. Larger files cannot be mapped so we cannot avoid it
+                // Try to use a memory mapped byte buffer for input files since it is
+                // significantly more efficient, especially for large files. Files larger than
+                // 2GB and non-regular files (e.g. fifo files, devices, unix sockets) cannot be
+                // mapped--in these cases we use use a normal input stream which is less
+                // efficient.
                 val path = Paths.get(file)
-                val size = Files.size(path)
-                if (size <= Int.MaxValue) {
-                  val fc = FileChannel.open(path, StandardOpenOption.READ)
-                  val bb = fc.map(FileChannel.MapMode.READ_ONLY, 0, size)
-                  fc.close() // we no longer need the channel now that we've mapped it
-                  InputSourceDataInputStream(bb)
-                } else {
-                  val is = Files.newInputStream(path, StandardOpenOption.READ)
-                  InputSourceDataInputStream(is)
+                val optSize = if (Files.isRegularFile(path)) Some(Files.size(path)) else None
+                optSize match {
+                  case Some(size) if size <= Int.MaxValue => {
+                    val fc = FileChannel.open(path, StandardOpenOption.READ)
+                    val bb = fc.map(FileChannel.MapMode.READ_ONLY, 0, size)
+                    fc.close() // we no longer need the channel now that we've mapped it
+                    InputSourceDataInputStream(bb)
+                  }
+                  case _ => {
+                    val is = Files.newInputStream(path, StandardOpenOption.READ)
+                    InputSourceDataInputStream(is)
+                  }
                 }
               }
             }

--- a/daffodil-cli/src/test/scala/org/apache/daffodil/cli/cliTest/Util.scala
+++ b/daffodil-cli/src/test/scala/org/apache/daffodil/cli/cliTest/Util.scala
@@ -50,7 +50,7 @@ import org.junit.Assert.assertEquals
 
 object Util {
 
-  private val isWindows = System.getProperty("os.name").toLowerCase().startsWith("windows")
+  val isWindows = System.getProperty("os.name").toLowerCase().startsWith("windows")
 
   private val daffodilBinPath = {
     val ext = if (isWindows) ".bat" else ""


### PR DESCRIPTION
When an input file for the CLI is not stdin, it currently maps the file to a MappedByteBuffer, which gives significant performance gains, especially for large files. However, for non-regular files like fifo files, devices, sockets, the map functions are undefined. In practice, we get a byte buffer but the result is a buffer with zero bytes, leading to the CLI parse/unparse seeing no data.

To fix this, the CLI now checks if a file is regular, and only if it is regular will it consider mapping the file. Non-regular files use the existing fallback streaming behavior.

DAFFODIL-3002