### PR TITLE
Only set elements as final if their parse succeeds

### DIFF
--- a/daffodil-cli/src/test/resources/org/apache/daffodil/cli/cli_schema_05.dfdl.xsd
+++ b/daffodil-cli/src/test/resources/org/apache/daffodil/cli/cli_schema_05.dfdl.xsd
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<schema
+  xmlns="http://www.w3.org/2001/XMLSchema"
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/"
+  xmlns:ex="http://example.com"
+  targetNamespace="http://example.com" >
+
+  <include schemaLocation="/org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+
+  <annotation>
+    <appinfo source="http://www.ogf.org/dfdl/">
+      <dfdl:format ref="ex:GeneralFormat" representation="binary" />
+    </appinfo>
+  </annotation>
+
+  <element name="root">
+    <complexType>
+      <sequence>
+        <element name="dispatch" type="xs:int" />
+        <choice dfdl:choiceDispatchKey="{ xs:string(./dispatch) }">
+          <sequence dfdl:choiceBranchKey="1">
+            <element name="i1" type="xs:int" />
+            <element name="i2" type="xs:int" />
+          </sequence>
+          <sequence dfdl:choiceBranchKey="2">
+            <element name="l1" type="xs:long" />
+            <element name="l2" type="xs:long" />
+          </sequence>
+        </choice>
+      </sequence>
+    </complexType>
+  </element>
+
+</schema>

--- a/daffodil-cli/src/test/scala/org/apache/daffodil/cli/cliTest/TestCLIParsing.scala
+++ b/daffodil-cli/src/test/scala/org/apache/daffodil/cli/cliTest/TestCLIParsing.scala
@@ -969,4 +969,29 @@ class TestCLIParsing {
       e.getMessage.contains("""Input Buffer: <?xml version="1.0" encoding="UTF-8"?>""")
     )
   }
+
+  @Test def test_CLI_Parsing_parse_error_infoset_walker_jdom(): Unit = {
+    val schema = path(
+      "daffodil-cli/src/test/resources/org/apache/daffodil/cli/cli_schema_05.dfdl.xsd"
+    )
+
+    runCLI(args"parse -s $schema -I jdom -TinfosetWalkerSkipMin=0 -TinfosetWalkerSkipMax=0") {
+      cli =>
+        // this is not enough data for the scema, which leads to a parse error about insufficient bits
+        cli.sendBytes(Array[Byte](0, 0, 0, 1), inputDone = true)
+
+        // there was a bug Daffodil that is most easily observed using the jdom infoset outputter
+        // with a non skipping infoset walker. With this setup, when an element fails to parse
+        // inside a choice dispatch (and no surrounding points of uncertainty) the infoset walker
+        // could walk into the failed element, which leads to an SDE when using the JDOM infoset
+        // outputter. This SDE prevents backtracking so we do not see a diagnostic about the
+        // choice dispatch branch failing. If the bug is fixed, we should never walk into the
+        // invalid element, we should not get an SDE, and we should get a diagnostic about choice
+        // dispatch.
+        cli.expectErr("Parse Error: Choice dispatch branch failed")
+
+        // this is the core failure diagnostic, which we see regardless of bug
+        cli.expectErr("Parse Error: Insufficient bits in data.")
+    }(ExitCode.ParseError)
+  }
 }


### PR DESCRIPTION
Currently, the sequence parser unconditionally sets an element as final after the elements parser has completed, even if that parser completed with a parse error. And because it is marked as final, there is a chance an InfosetWalker can walk into it, which means InfosetOutputters would see a potentially invalid infoset element and can lead to unexpected errors that could lead to missing diagnostics. Note that invalid data will still lead to a parse error and we will see a diagnostic for the core error, but it does mean that some complementary diagnostics could be lost.

Some InfosetOutputters, like the XMLTextInfosetOutputter and ScalaInfosetOutputter gracefully handle invalid infostes, but that is only because they can be used for debugging where the infoset might only be partially created. It is not a requirement that InfosetOutputters need to support invalid infosets--in fact, the JDOM and SAX infoset outputters do not support them and can be used to trigger the issue.

To fix this, this modifies the sequence parser so it only sets isFinal to true if a parser succeeded and we know we have a valid element. This ensures we never walk into invalid infoset elements that some InfosetOutputters might not expect.

DAFFODIL-3006