### PR TITLE
Fix issue with left side being narrower than right side

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ on:
   push:
     branches-ignore: [ 'dependabot/**' ]
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [ opened, synchronize, reopened ]
 
 # Cancel CI runs in progress when a pull request is updated.
 concurrency:
@@ -40,7 +40,7 @@ jobs:
       matrix:
         java_distribution: [ temurin ]
         java_version: [ 8, 11, 17, 21 ]
-        scala_version: [ 2.13.16 ]
+        scala_version: [ 3.3.6, 2.13.16 ]
         os: [ ubuntu-22.04, windows-2022, macos-14 ]
         exclude:
           # only run macos on java 17
@@ -88,13 +88,13 @@ jobs:
       LANG: ${{ matrix.lang }}.${{ matrix.encoding }}
       SBT: sbt -J-Xms1024m -J-Xmx5120m -J-XX:ReservedCodeCacheSize=512m -J-XX:MaxMetaspaceSize=1024m -J-Dfile.encoding=${{ matrix.encoding }} ++${{ matrix.scala_version }} coverage
       SONARSCAN: ${{
-                     matrix.os == 'ubuntu-22.04' &&
-                     matrix.java_version == '17' &&
-                     matrix.scala_version == '2.13.16' &&
-                     github.event_name == 'push' &&
-                     github.repository == 'apache/daffodil' &&
-                     github.ref == 'refs/heads/main'
-                  }}
+        matrix.os == 'ubuntu-22.04' &&
+        matrix.java_version == '17' &&
+        matrix.scala_version == '3.3.6' &&
+        github.event_name == 'push' &&
+        github.repository == 'apache/daffodil' &&
+        github.ref == 'refs/heads/main'
+        }}
       DAFFODIL_TDML_API_INFOSETS: all
 
     steps:
@@ -241,7 +241,7 @@ jobs:
       matrix:
         java_distribution: [ temurin ]
         java_version: [ 17 ]
-        scala_version: [ 2.13.16 ]
+        scala_version: [ 3.3.6 ]
         os: [ ubuntu-22.04 ]
     runs-on: ${{ matrix.os }}
     env:

--- a/build.sbt
+++ b/build.sbt
@@ -58,7 +58,7 @@ lazy val daffodil = project
 
 lazy val macroLib = Project("daffodil-macro-lib", file("daffodil-macro-lib"))
   .settings(commonSettings, nopublish)
-  .settings(libraryDependencies += "org.scala-lang" % "scala-reflect" % scalaVersion.value)
+  .settings(libraryDependencies += "org.scala-lang" % "scala-reflect" % "2.13.16")
   .disablePlugins(OsgiCheckPlugin)
 
 lazy val propgen = Project("daffodil-propgen", file("daffodil-propgen"))
@@ -191,8 +191,8 @@ val minSupportedJavaVersion: String =
 lazy val commonSettings = Seq(
   organization := "org.apache.daffodil",
   version := IO.read((ThisBuild / baseDirectory).value / "VERSION").trim,
-  scalaVersion := "2.13.16",
-  crossScalaVersions := Seq("2.13.16"),
+  scalaVersion := "3.3.6",
+  crossScalaVersions := Seq("3.3.6", "2.13.16"),
   scalacOptions ++= buildScalacOptions(scalaVersion.value),
   Test / scalacOptions ++= buildTestScalacOptions(scalaVersion.value),
   Compile / compile / javacOptions ++= buildJavacOptions(),
@@ -217,7 +217,7 @@ lazy val commonSettings = Seq(
   unmanagedBase := baseDirectory.value / "lib" / "jars",
   sourceManaged := baseDirectory.value / "src_managed",
   resourceManaged := baseDirectory.value / "resource_managed",
-  libraryDependencies ++= Dependencies.common,
+  libraryDependencies ++= Dependencies.common(scalaVersion.value),
   testOptions += Tests.Argument(TestFrameworks.JUnit, "-q", "--verbosity=1"),
   Compile / packageDoc / publishArtifact := false
 )
@@ -227,21 +227,27 @@ def buildScalacOptions(scalaVersion: String) = {
     s"-release:$minSupportedJavaVersion", // scala 2.12 can only do Java 8, regardless of this setting.
     "-feature",
     "-deprecation",
-    "-language:experimental.macros",
-    "-unchecked",
-    "-Xfatal-warnings",
-    "-Xxml:-coalescing",
-    "-Ywarn-unused:imports"
+    "-unchecked"
   )
 
   val scalaVersionSpecificOptions = CrossVersion.partialVersion(scalaVersion) match {
     case Some((2, 13)) =>
       Seq(
+        "-language:experimental.macros",
+        "-Xfatal-warnings",
+        "-Xxml:-coalescing",
+        "-Ywarn-unused:imports",
         "-Xlint:inaccessible",
         "-Xlint:infer-any",
         "-Xlint:nullary-unit",
         // suppress nullary-unit warning in the specific trait
         "-Wconf:cat=lint-nullary-unit:silent,site=org.apache.daffodil.junit.tdml.TdmlTests:silent"
+      )
+    case Some((3, _)) =>
+      Seq(
+        "-no-indent",
+        "-Werror",
+        "-Wunused:imports"
       )
     case _ => Seq.empty
   }

--- a/daffodil-cli/src/main/scala/org/apache/daffodil/cli/Main.scala
+++ b/daffodil-cli/src/main/scala/org/apache/daffodil/cli/Main.scala
@@ -97,6 +97,7 @@ import org.rogach.scallop
 import org.rogach.scallop.ArgType
 import org.rogach.scallop.ScallopOption
 import org.rogach.scallop.ValueConverter
+import org.rogach.scallop._
 import org.rogach.scallop.exceptions.GenericScallopException
 import org.slf4j.event.Level
 import org.xml.sax.InputSource

--- a/daffodil-core/src/main/scala/org/apache/daffodil/core/dpath/NodeInfoUtils.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/core/dpath/NodeInfoUtils.scala
@@ -113,7 +113,7 @@ object NodeInfoUtils {
       case _ => Assert.usageError("Unsupported return type: %s".format(resultType))
     }
 
-    val (argType: Numeric.Kind, resultType: Numeric.Kind) = {
+    val (argType, resultType) = {
       val lub = NodeInfoUtils.typeLeastUpperBound(leftArgType, rightArgType)
       //
       // For each abstract type that could be the least upper bound of the two
@@ -123,6 +123,9 @@ object NodeInfoUtils {
         case _ => lub
       }
       (lubImplementationType, lubImplementationType)
+    } match {
+      case (argType: Numeric.Kind, resultType: Numeric.Kind) => (argType, resultType)
+      case x => Assert.invariantFailed(s"Expected Numeric.Kind. Found ${x.getClass}")
     }
     val res = op match {
       case "div" => (argType, divResult(resultType))

--- a/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/ChoiceGroup.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/ChoiceGroup.scala
@@ -82,8 +82,10 @@ trait ChoiceDefMixin extends AnnotatedSchemaComponent with GroupDefLike {
       val ch = this match {
         case cgd: GlobalChoiceGroupDef => cgd.xml \ "choice"
       }
-      val Elem(_, "choice", _, _, c @ _*) = ch(0)
-      c
+      ch(0) match {
+        case Elem(_, "choice", _, _, c @ _*) => c
+        case x => SDE(s"Expected <choice> elem, found $x")
+      }
     }
   }
 }

--- a/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/ComplexTypes.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/ComplexTypes.scala
@@ -44,7 +44,10 @@ sealed abstract class ComplexTypeBase(xmlArg: Node, parentArg: SchemaComponent)
   final def sequence = group.asInstanceOf[LocalSequence]
   final def choice = group.asInstanceOf[Choice]
 
-  private lazy val Elem(_, "complexType", _, _, xmlChildren @ _*) = xml
+  private lazy val xmlChildren = xml match {
+    case Elem(_, "complexType", _, _, xc @ _*) => xc
+    case x => schemaDefinitionError(s"Expected <complexType> elem, found $x")
+  }
 
   final lazy val Seq(modelGroup) = {
     val s = smg

--- a/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/DFDLDefineVariable.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/DFDLDefineVariable.scala
@@ -137,7 +137,10 @@ final class DFDLNewVariableInstance(node: Node, decl: AnnotatedSchemaComponent)
 
   private lazy val attrValue = getAttributeOption("value")
 
-  private lazy val Elem("dfdl", "newVariableInstance", _, _, eltChildren @ _*) = node
+  private lazy val eltChildren = node match {
+    case Elem("dfdl", "newVariableInstance", _, _, ec @ _*) => ec
+    case x => schemaDefinitionError(s"Expected <dfdl:newVariableInstance> elem, found $x")
+  }
 
   private lazy val eltValue = eltChildren.text.trim
 
@@ -177,7 +180,10 @@ final class DFDLSetVariable(node: Node, decl: AnnotatedSchemaComponent)
   extends VariableReference(node, decl)
   with DFDLSetVariableRuntime1Mixin {
   private lazy val attrValue = getAttributeOption("value")
-  private lazy val Elem("dfdl", "setVariable", _, _, eltChildren @ _*) = node
+  private lazy val eltChildren = node match {
+    case Elem("dfdl", "setVariable", _, _, ec @ _*) => ec
+    case x => schemaDefinitionError(s"Expected <dfdl:setVariable> elem, found $x")
+  }
   private lazy val eltValue = eltChildren.text.trim
   final lazy val value = (attrValue, eltValue) match {
     case (None, v) if (v != "") => v

--- a/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/SchemaComponent.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/SchemaComponent.scala
@@ -243,7 +243,10 @@ trait SchemaComponent
   /**
    * the easiest way to get an empty metadata object.
    */
-  private val scala.xml.Elem(_, _, emptyXMLMetadata, _, _*) = <foo/>
+  private val emptyXMLMetadata = <foo/> match {
+    case scala.xml.Elem(_, _, exm, _, _*) => exm
+    case x => schemaDefinitionError(s"Expected elem, found $x")
+  }
 
   /**
    * Used as factory for the XML Node with the right namespace and prefix etc.

--- a/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/SequenceGroup.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/SequenceGroup.scala
@@ -299,7 +299,10 @@ trait SequenceDefMixin
   }
 
   final lazy val hiddenGroupRefXML = LV(Symbol("hiddenGroupRefXML")) {
-    val Found(qname, _, _, _) = hiddenGroupRefOption
+    val qname = hiddenGroupRefOption match {
+      case Found(qn, _, _, _) => qn
+      case x => Assert.invariantFailed(s"Expected Found class, got ${x.getClass}")
+    }
     // synthesize a group reference here.
     val contextScope = xml.asInstanceOf[Elem].scope
     val hgr = {

--- a/daffodil-core/src/main/scala/org/apache/daffodil/core/grammar/RepTypeMixin.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/core/grammar/RepTypeMixin.scala
@@ -85,8 +85,8 @@ trait RepTypeMixin { self: ElementBase =>
     }.value
 
   lazy val (
-    repTypeCompareLT: NumberCompareOp,
-    repTypeCompareLE: NumberCompareOp
+    repTypeCompareLT,
+    repTypeCompareLE
   ) = LV(Symbol("repTypeComparers")) {
     Assert.invariant(
       repTypeElementDecl.primType.isSubtypeOf(NodeInfo.Integer),
@@ -94,7 +94,17 @@ trait RepTypeMixin { self: ElementBase =>
     )
     val comparisonOps = ComparisonOps.forType(repTypeElementDecl.primType)
     (comparisonOps.lt, comparisonOps.le)
-  }.value
+  }.value match {
+    case (
+          repTypeCompareLT: NumberCompareOp,
+          repTypeCompareLE: NumberCompareOp
+        ) =>
+      (repTypeCompareLT, repTypeCompareLE)
+    case x =>
+      Assert.invariantFailed(
+        s"Expected NumberCompareOp tuple, found (${x._1.getClass}, ${x._2.getClass}) tuple "
+      )
+  }
 
   lazy val (
     repTypeParseValuesMap: Map[DataValueNumber, DataValueString],

--- a/daffodil-core/src/main/scala/org/apache/daffodil/core/grammar/primitives/DelimiterAndEscapeRelated.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/core/grammar/primitives/DelimiterAndEscapeRelated.scala
@@ -24,8 +24,7 @@ import org.apache.daffodil.lib.exceptions.Assert
 import org.apache.daffodil.lib.util.Maybe._
 import org.apache.daffodil.lib.util.Misc
 import org.apache.daffodil.lib.xml.XMLUtils
-import org.apache.daffodil.runtime1.processors.parsers._
-import org.apache.daffodil.runtime1.processors.parsers.{ Parser => DaffodilParser }
+import org.apache.daffodil.runtime1.processors.parsers.{ Parser => DaffodilParser, _ }
 import org.apache.daffodil.runtime1.processors.unparsers.{ Unparser => DaffodilUnparser }
 import org.apache.daffodil.unparsers.runtime1._
 

--- a/daffodil-core/src/main/scala/org/apache/daffodil/core/grammar/primitives/SequenceCombinator.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/core/grammar/primitives/SequenceCombinator.scala
@@ -26,8 +26,7 @@ import org.apache.daffodil.lib.util.MaybeInt
 import org.apache.daffodil.lib.util.Misc
 import org.apache.daffodil.runtime1.processors.parsers._
 import org.apache.daffodil.runtime1.processors.unparsers._
-import org.apache.daffodil.unparsers.runtime1._
-import org.apache.daffodil.unparsers.runtime1.{ Separated => SeparatedUnparser }
+import org.apache.daffodil.unparsers.runtime1.{ Separated => SeparatedUnparser, _ }
 
 /**
  * Base class for all kinds of sequences.

--- a/daffodil-core/src/main/scala/org/apache/daffodil/lib/calendar/DFDLCalendar.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/lib/calendar/DFDLCalendar.scala
@@ -134,25 +134,26 @@ trait OrderedCalendar { self: DFDLCalendar =>
     Assert.invariant(!p.hasTimeZone || p.calendar.getTimeZone == TimeZone.GMT_ZONE)
     Assert.invariant(!q.hasTimeZone || q.calendar.getTimeZone == TimeZone.GMT_ZONE)
 
-    val length = fieldsForComparison.length
-    for (i <- 0 until length) {
-      val field = fieldsForComparison(i)
+    fieldsForComparison
+      .map { field =>
+        val hasP = p.calendar.isSet(field)
+        val hasQ = q.calendar.isSet(field)
 
-      val hasPSubI = p.calendar.isSet(field)
-      val hasQSubI = q.calendar.isSet(field)
-
-      if (!hasPSubI && !hasQSubI) { /* continue */ }
-      else if (hasPSubI ^ hasQSubI) return DFDLCalendarOrder.P_NOT_EQUAL_Q
-      else {
-        val pSubI = p.calendar.get(field)
-        val qSubI = q.calendar.get(field)
-
-        if (pSubI < qSubI) { return DFDLCalendarOrder.P_LESS_THAN_Q }
-        else if (pSubI > qSubI) { return DFDLCalendarOrder.P_GREATER_THAN_Q }
-        else { /* continue */ }
+        if (!hasP && !hasQ) {
+          None
+        } else if (hasP ^ hasQ) {
+          Some(DFDLCalendarOrder.P_NOT_EQUAL_Q)
+        } else {
+          val pVal = p.calendar.get(field)
+          val qVal = q.calendar.get(field)
+          if (pVal < qVal) Some(DFDLCalendarOrder.P_LESS_THAN_Q)
+          else if (pVal > qVal) Some(DFDLCalendarOrder.P_GREATER_THAN_Q)
+          else None
+        }
       }
-    }
-    DFDLCalendarOrder.P_EQUAL_Q
+      .find(_.isDefined) // lazily stops at first Some(...)
+      .flatten
+      .getOrElse(DFDLCalendarOrder.P_EQUAL_Q)
   }
 }
 

--- a/daffodil-core/src/main/scala/org/apache/daffodil/lib/oolag/OOLAG.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/lib/oolag/OOLAG.scala
@@ -350,7 +350,9 @@ object OOLAG {
       }
     }
 
-    private sealed trait ActivityStatus
+    // scala 3.3.6 complains about this being private (MissingType error). So as a
+    // workaround to that, we make it protected instead
+    protected sealed trait ActivityStatus
     private case object Active extends ActivityStatus
     private case object Inactive extends ActivityStatus
 

--- a/daffodil-core/src/main/scala/org/apache/daffodil/lib/xml/XMLUtils.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/lib/xml/XMLUtils.scala
@@ -891,7 +891,10 @@ Differences were (path, expected, actual):
   }
 
   def childArrayCounters(e: Elem) = {
-    val Elem(_, _, _, _, children @ _*) = e
+    val children = e match {
+      case Elem(_, _, _, _, c @ _*) => c
+      case x => Assert.invariantFailed(s"Expected elem with children, found $x")
+    }
     val labels = children.map { _.label }
     val groups = labels.groupBy { x => x }
     val counts = groups.map { case (label, labelList) => (label, labelList.length) }
@@ -926,8 +929,16 @@ Differences were (path, expected, actual):
     lazy val zPath = parentPathSteps.reverse.mkString("/")
     (an, bn) match {
       case (a: Elem, b: Elem) => {
-        val Elem(prefixA, labelA, attribsA, nsbA, childrenA @ _*) = a
-        val Elem(prefixB, labelB, attribsB, nsbB, childrenB @ _*) = b
+        val (prefixA, labelA, attribsA, nsbA, childrenA) = a match {
+          case Elem(prefixA, labelA, attribsA, nsbA, childrenA @ _*) =>
+            (prefixA, labelA, attribsA, nsbA, childrenA)
+          case x => Assert.invariantFailed(s"Expected elem, found $x")
+        }
+        val (prefixB, labelB, attribsB, nsbB, childrenB) = b match {
+          case Elem(prefixB, labelB, attribsB, nsbB, childrenB @ _*) =>
+            (prefixB, labelB, attribsB, nsbB, childrenB)
+          case x => Assert.invariantFailed(s"Expected elem, found $x")
+        }
         val typeA: Option[String] = getXSIType(a)
         val typeB: Option[String] = getXSIType(b)
         val maybeType: Option[String] = Option(typeA.getOrElse(typeB.getOrElse(null)))

--- a/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/debugger/InteractiveDebugger.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/debugger/InteractiveDebugger.scala
@@ -1347,7 +1347,10 @@ class InteractiveDebugger(
             } else {
               // Not a recognized info subcommand. Assume it is an arg to the
               // most recent command we've seen and prepend it to that list.
-              val head :: tail = infoCmds
+              val (head, tail) = infoCmds match {
+                case head :: tail => (head, tail)
+                case Nil => Assert.invariantFailed("infoCmds is empty")
+              }
               (arg +: head) +: tail
             }
         }
@@ -1364,7 +1367,10 @@ class InteractiveDebugger(
         }
         val infocmds = buildInfoCommands(args)
         infocmds.foreach { cmds =>
-          val cmd :: args = cmds
+          val (cmd, args) = cmds match {
+            case cmd :: args => (cmd, args)
+            case Nil => Assert.invariantFailed("cmds was empty")
+          }
           subcommands.find(_.matches(cmd)) match {
             case Some(c) => c.validate(args)
             case None => throw new DebugException("undefined info command: %s".format(cmd))
@@ -1379,7 +1385,10 @@ class InteractiveDebugger(
       ): DebugState.Type = {
         val infocmds = buildInfoCommands(args)
         infocmds.foreach { cmds =>
-          val cmd :: args = cmds
+          val (cmd, args) = cmds match {
+            case cmd :: args => (cmd, args)
+            case Nil => Assert.invariantFailed("cmds was empty")
+          }
           val action = subcommands.find(_.matches(cmd)).get
           action.act(args, state, processor)
         }

--- a/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/processors/RuntimeData.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/processors/RuntimeData.scala
@@ -357,57 +357,74 @@ final class SimpleTypeRuntimeData(
       }
     }
     // Check length
-    e.length.foreach { length =>
-      if (!checkLength(currentElement, length, e, primType))
+    if (e.length.isDefined) {
+      val length = e.length.get
+      if (!checkLength(currentElement, length, e, primType)) {
         return Error("facet length (%s)".format(length))
+      }
     }
+
     // Check minLength
-    e.minLength.foreach { minLength =>
-      if (!checkMinLength(currentElement, minLength, e, primType))
+    if (e.minLength.isDefined) {
+      val minLength = e.minLength.get
+      if (!checkMinLength(currentElement, minLength, e, primType)) {
         return Error("facet minLength (%s)".format(minLength))
+      }
     }
+
     // Check maxLength
-    e.maxLength.foreach { maxLength =>
-      if (!checkMaxLength(currentElement, maxLength, e, primType))
+    if (e.maxLength.isDefined) {
+      val maxLength = e.maxLength.get
+      if (!checkMaxLength(currentElement, maxLength, e, primType)) {
         return Error("facet maxLength (%s)".format(maxLength))
+      }
     }
+
     // Check minInclusive
-    e.minInclusive.foreach { minInclusive =>
-      if (!checkMinInc(currentElement, minInclusive, primType, e))
+    if (e.minInclusive.isDefined) {
+      val minInclusive = e.minInclusive.get
+      if (!checkMinInc(currentElement, minInclusive, primType, e)) {
         return Error("facet minInclusive (%s)".format(minInclusive))
+      }
     }
+
     // Check maxInclusive
-    e.maxInclusive.foreach { maxInclusive =>
-      if (!checkMaxInc(currentElement, maxInclusive, primType, e))
+    if (e.maxInclusive.isDefined) {
+      val maxInclusive = e.maxInclusive.get
+      if (!checkMaxInc(currentElement, maxInclusive, primType, e)) {
         return Error("facet maxInclusive (%s)".format(maxInclusive))
+      }
     }
+
     // Check minExclusive
-    e.minExclusive.foreach { minExclusive =>
-      if (!checkMinExc(currentElement, minExclusive, primType, e))
+    if (e.minExclusive.isDefined) {
+      val minExclusive = e.minExclusive.get
+      if (!checkMinExc(currentElement, minExclusive, primType, e)) {
         return Error("facet minExclusive (%s)".format(minExclusive))
+      }
     }
+
     // Check maxExclusive
-    e.maxExclusive.foreach { maxExclusive =>
-      if (!checkMaxExc(currentElement, maxExclusive, primType, e))
+    if (e.maxExclusive.isDefined) {
+      val maxExclusive = e.maxExclusive.get
+      if (!checkMaxExc(currentElement, maxExclusive, primType, e)) {
         return Error("facet maxExclusive (%s)".format(maxExclusive))
+      }
     }
 
     // Check totalDigits
-    e.totalDigits.foreach { totalDigits =>
-      val tdLong = totalDigits.longValue()
-      val isTotalDigitsGreaterThanEqToZero = tdLong.compareTo(0L) >= 0
-      if (isTotalDigitsGreaterThanEqToZero) {
-        if (!checkTotalDigits(currentElement, tdLong))
-          return Error("facet totalDigits (%s)".format(totalDigits))
+    if (e.totalDigits.isDefined) {
+      val totalDigits = e.totalDigits.get.longValue()
+      if (totalDigits >= 0 && !checkTotalDigits(currentElement, totalDigits)) {
+        return Error("facet totalDigits (%s)".format(totalDigits))
       }
     }
+
     // Check fractionDigits
-    e.fractionDigits.foreach { fractionDigits =>
-      val fdLong = fractionDigits.longValue()
-      val isFractionDigitsGreaterThanEqToZero = fdLong.compareTo(0L) >= 0
-      if (isFractionDigitsGreaterThanEqToZero) {
-        if (!checkFractionDigits(currentElement, fdLong))
-          return Error("facet fractionDigits (%s)".format(fractionDigits))
+    if (e.fractionDigits.isDefined) {
+      val fractionDigits = e.fractionDigits.get.longValue()
+      if (fractionDigits >= 0 && !checkFractionDigits(currentElement, fractionDigits)) {
+        return Error("facet fractionDigits (%s)".format(fractionDigits))
       }
     }
 

--- a/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/udf/UserDefinedFunctionService.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/udf/UserDefinedFunctionService.scala
@@ -30,6 +30,7 @@ import java.util.ServiceLoader
 import scala.collection.immutable.{ ArraySeq => IArraySeq }
 import scala.collection.mutable._
 
+import org.apache.daffodil.lib.exceptions.Assert
 import org.apache.daffodil.lib.util.Logger
 import org.apache.daffodil.lib.util.Misc
 import org.apache.daffodil.runtime1.dpath.NodeInfo
@@ -219,7 +220,10 @@ object UserDefinedFunctionService {
             val evaluateParamTypes: List[NodeInfo.Kind] = initParamTypeConv.flatMap {
               _._1
             }.toList
-            val Some(evaluateReturnType: NodeInfo.Kind) = initRetTypeConv
+            val evaluateReturnType: NodeInfo.Kind = initRetTypeConv match {
+              case Some(evt: NodeInfo.Kind) => evt
+              case x => Assert.invariantFailed(s"Expected Some, found $x")
+            }
 
             val key = s"{$fns}$fname"
             if (udfInfoLookup.contains(key)) {

--- a/daffodil-core/src/main/scala/org/apache/daffodil/unparsers/runtime1/DelimitedUnparsers.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/unparsers/runtime1/DelimitedUnparsers.scala
@@ -84,12 +84,7 @@ sealed class StringDelimitedUnparser(
                 val theScheme = scheme.asInstanceOf[EscapeSchemeBlockUnparserHelper]
 
                 def hasInscopeTerminatingDelimiters(): Boolean = {
-                  // Need to do this so we can 'break' the loop early
-                  //
-                  for (d <- terminatingMarkup) {
-                    if (valueString.contains(d.lookingFor)) return true
-                  }
-                  false
+                  terminatingMarkup.exists(d => valueString.contains(d.lookingFor))
                 }
 
                 val generateEscapeBlock =

--- a/daffodil-core/src/test/scala/org/apache/daffodil/core/dpath/TestDFDLExpressionTree.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/core/dpath/TestDFDLExpressionTree.scala
@@ -110,22 +110,35 @@ class TestDFDLExpressionTree extends Parsers {
 
   @Test def test_a() = {
     testExpr2(aSchema, "{ /tns:a }") { (ce, erd) =>
-      val WholeExpression(
-        _,
-        RootPathExpression(Some(RelativePathExpression(steps, _))),
-        _,
-        _,
-        _,
-        _
-      ) = ce
-      val List(n1: DownStepExpression) = steps
-      val n1p @ NamedStep("tns:a", None) = n1;
+      val steps = ce match {
+        case WholeExpression(
+              _,
+              RootPathExpression(Some(RelativePathExpression(steps, _))),
+              _,
+              _,
+              _,
+              _
+            ) =>
+          steps
+        case _ => fail(); null
+      }
+      val n1: DownStepExpression = steps match {
+        case List(n1: DownStepExpression) => n1
+        case _ => fail(); null
+      }
+      val n1p = n1 match {
+        case n1p @ NamedStep("tns:a", None) => n1p
+        case _ => fail(); null
+      }
       assertNotNull(n1p)
       assertFalse(n1.isArray)
       assertEquals(NodeInfo.AnyType, n1.targetType)
       assertEquals(NodeInfo.String, n1.inherentType)
       assertTrue(n1.isLastStep)
-      val List(DownElement(nqn: NamedQName)) = n1.compiledDPath.ops.toList
+      val nqn = n1.compiledDPath.ops.toList match {
+        case List(DownElement(nqn: NamedQName)) => nqn
+        case _ => fail(); null
+      }
       assertEquals(nqn, n1.stepElements.head.namedQName)
     }
   }
@@ -145,48 +158,100 @@ class TestDFDLExpressionTree extends Parsers {
 
   @Test def test_a_pred(): Unit = {
     testExpr2(bSchema, "{ /tns:b/a[/tns:b/i] }") { (ce, erd) =>
-      val w @ WholeExpression(
-        _,
-        RootPathExpression(Some(RelativePathExpression(steps, _))),
-        _,
-        _,
-        _,
-        _
-      ) = ce
+      val (w, steps) = ce match {
+        case w @ WholeExpression(
+              _,
+              RootPathExpression(Some(RelativePathExpression(steps, _))),
+              _,
+              _,
+              _,
+              _
+            ) =>
+          (w, steps)
+        case _ => fail(); null
+      }
       val List(b, a) = steps
-      val bp @ NamedStep("tns:b", None) = b; assertNotNull(bp)
-      val NamedStep("a", Some(PredicateExpression(i))) = a
-      val RootPathExpression(Some(RelativePathExpression(List(_, istep), _))) = i
-      val isp @ NamedStep("i", None) = istep; assertNotNull(isp)
+      val bp = b match {
+        case bp @ NamedStep("tns:b", None) => bp
+        case _ => fail(); null
+      }; assertNotNull(bp)
+      val i = a match {
+        case NamedStep("a", Some(PredicateExpression(i))) => i
+        case _ => fail(); null
+      }
+      val istep = i match {
+        case RootPathExpression(Some(RelativePathExpression(List(_, istep), _))) => istep
+        case _ => fail(); null
+      }
+      val isp = istep match {
+        case isp @ NamedStep("i", None) => isp
+        case _ => fail(); null
+      }; assertNotNull(isp)
       val ops = i.compiledDPath.ops.toList
-      val List(ToRoot, DownElement(berd), DownElement(_), IntToLong, LongToArrayIndex) = ops
-      val List(ToRoot, DownElement(berd2), DownArrayOccurrence(_, _)) =
-        w.compiledDPath.ops.toList
+      val berd = ops match {
+        case List(ToRoot, DownElement(berd), DownElement(_), IntToLong, LongToArrayIndex) =>
+          berd
+        case _ => fail(); null
+      }
+      val berd2 =
+        w.compiledDPath.ops.toList match {
+          case List(ToRoot, DownElement(berd2), DownArrayOccurrence(_, _)) => berd2
+          case _ => fail(); null
+        }
       assertEquals(berd, berd2)
     }
   }
 
   @Test def test_a_predPred(): Unit = {
     testExpr(dummySchema, "{ a[i[j]] }") { actual =>
-      val WholeExpression(_, RelativePathExpression(steps, _), _, _, _, _) = actual
+      val steps = actual match {
+        case WholeExpression(_, RelativePathExpression(steps, _), _, _, _, _) => steps
+        case _ => fail(); null
+      }
       val List(n1) = steps
-      val NamedStep("a", Some(PredicateExpression(rel))) = n1
-      val RelativePathExpression(List(n2), _) = rel
-      val NamedStep("i", Some(PredicateExpression(j))) = n2
-      val RelativePathExpression(List(n3), _) = j
-      val n3p @ NamedStep("j", None) = n3; assertNotNull(n3p)
+      val rel = n1 match {
+        case NamedStep("a", Some(PredicateExpression(rel))) => rel
+        case _ => fail(); null
+      }
+      val n2 = rel match {
+        case RelativePathExpression(List(n2), _) => n2
+        case _ => fail(); null
+      }
+      val j = n2 match {
+        case NamedStep("i", Some(PredicateExpression(j))) => j
+        case _ => fail(); null
+      }
+      val n3 = j match {
+        case RelativePathExpression(List(n3), _) => n3
+        case _ => fail(); null
+      }
+      val n3p = n3 match {
+        case n3p @ NamedStep("j", None) => n3p
+        case _ => fail(); null
+      }; assertNotNull(n3p)
     }
   }
 
   @Test def test_relativePath() = {
     testExpr(dummySchema, "{ ../..[2]/bookstore }") { actual =>
-      val WholeExpression(_, RelativePathExpression(steps, _), _, _, _, _) = actual
+      val steps = actual match {
+        case WholeExpression(_, RelativePathExpression(steps, _), _, _, _, _) => steps
+        case _ => fail(); null
+      }
       val List(n1, n2, n3) = steps
-      val u @ Up(None) = n1; assertNotNull(u)
-      val u2 @ Up(Some(PredicateExpression(LiteralExpression(two: JBigInt)))) = n2;
-      assertNotNull(u2)
+      val u = n1 match {
+        case u @ Up(None) => u
+        case _ => fail(); null
+      }; assertNotNull(u)
+      val (u2, two) = n2 match {
+        case u2 @ Up(Some(PredicateExpression(LiteralExpression(two: JBigInt)))) => (u2, two)
+        case _ => fail(); null
+      }; assertNotNull(u2)
       assertEquals(JBigInt.valueOf(2), two)
-      val n3p @ NamedStep("bookstore", None) = n3; assertNotNull(n3p)
+      val n3p = n3 match {
+        case n3p @ NamedStep("bookstore", None) => n3p
+        case _ => fail(); null
+      }; assertNotNull(n3p)
     }
   }
 
@@ -211,16 +276,23 @@ class TestDFDLExpressionTree extends Parsers {
 
   @Test def test_absolutePath() = {
     testExpr2(testSchema, "{ /tns:bookstore/book/title }") { (actual, erd) =>
-      val WholeExpression(
-        _,
-        RootPathExpression(Some(RelativePathExpression(steps, _))),
-        _,
-        _,
-        _,
-        _
-      ) = actual
+      val steps = actual match {
+        case WholeExpression(
+              _,
+              RootPathExpression(Some(RelativePathExpression(steps, _))),
+              _,
+              _,
+              _,
+              _
+            ) =>
+          steps
+        case _ => fail(); null
+      }
       val List(n1, n2, n3) = steps.asInstanceOf[List[NamedStep]]
-      val n1p @ NamedStep("tns:bookstore", None) = n1; assertNotNull(n1p)
+      val n1p = n1 match {
+        case n1p @ NamedStep("tns:bookstore", None) => n1p
+        case _ => fail(); null
+      }; assertNotNull(n1p)
       assertTrue(n1.isFirstStep)
       assertFalse(n1.isLastStep)
       assertEquals(0, n1.positionInStepsSequence)
@@ -240,7 +312,10 @@ class TestDFDLExpressionTree extends Parsers {
       assertEquals(erd.dpathElementCompileInfo, n1.stepElements.head)
       assertEquals(NS("http://example.com"), erd.targetNamespace)
 
-      val n2p @ NamedStep("book", None) = n2; assertNotNull(n2p)
+      val n2p = n2 match {
+        case n2p @ NamedStep("book", None) => n2p
+        case _ => fail(); null
+      }; assertNotNull(n2p)
       assertFalse(n2.isFirstStep)
       assertFalse(n2.isLastStep)
       assertEquals(1, n2.positionInStepsSequence) // zero based
@@ -248,7 +323,10 @@ class TestDFDLExpressionTree extends Parsers {
       assertEquals(StepQName(None, "book", NoNamespace), n2.stepQName)
       val bookERD = erd.childERDs.find { _.name == "book" }.get
       assertEquals(bookERD.dpathElementCompileInfo, n2.stepElements.head)
-      val n3p @ NamedStep("title", None) = n3; assertNotNull(n3p)
+      val n3p = n3 match {
+        case n3p @ NamedStep("title", None) => n3p
+        case _ => fail(); null
+      }; assertNotNull(n3p)
       assertFalse(n3.isFirstStep)
       assertTrue(n3.isLastStep)
       assertEquals(2, n3.positionInStepsSequence) // zero based
@@ -261,14 +339,18 @@ class TestDFDLExpressionTree extends Parsers {
 
   @Test def test_pathNoSuchElement1(): Unit = {
     testExpr2(testSchema, "{ /thereIsNoElementWithThisName }") { (actual, erd) =>
-      val WholeExpression(
-        _,
-        RootPathExpression(Some(RelativePathExpression(List(step: NamedStep), _))),
-        _,
-        _,
-        _,
-        _
-      ) = actual
+      val step = actual match {
+        case WholeExpression(
+              _,
+              RootPathExpression(Some(RelativePathExpression(List(step: NamedStep), _))),
+              _,
+              _,
+              _,
+              _
+            ) =>
+          step
+        case _ => fail(); null
+      }
       val exc = intercept[Exception] {
         step.stepElements
       }
@@ -282,37 +364,57 @@ class TestDFDLExpressionTree extends Parsers {
 
   @Test def test_predPath() = {
     testExpr(dummySchema, "{ /bookstore[$i]/book/title }") { actual =>
-      val WholeExpression(
-        _,
-        RootPathExpression(Some(RelativePathExpression(steps, _))),
-        _,
-        _,
-        _,
-        _
-      ) = actual
+      val steps = actual match {
+        case WholeExpression(
+              _,
+              RootPathExpression(Some(RelativePathExpression(steps, _))),
+              _,
+              _,
+              _,
+              _
+            ) =>
+          steps
+        case _ => fail(); null
+      }
       val List(n1, n2, n3) = steps
-      val NamedStep("bookstore", pred) = n1
+      val pred = n1 match {
+        case NamedStep("bookstore", pred) => pred
+        case _ => fail(); null
+      }
       // println(pred)
       NS("http://example.com")
-      val p @ Some(PredicateExpression(VariableRef("i"))) = pred; assertNotNull(p)
-      val n2p @ NamedStep("book", None) = n2; assertNotNull(n2p)
-      val n3p @ NamedStep("title", None) = n3; assertNotNull(n3p)
+      val p = pred match {
+        case p @ Some(PredicateExpression(VariableRef("i"))) => p
+        case _ => fail(); null
+      }; assertNotNull(p)
+      val n2p = n2 match {
+        case n2p @ NamedStep("book", None) => n2p
+        case _ => fail(); null
+      }; assertNotNull(n2p)
+      val n3p = n3 match {
+        case n3p @ NamedStep("title", None) => n3p
+        case _ => fail(); null
+      }; assertNotNull(n3p)
     }
   }
 
   @Test def testAddConstants(): Unit = {
     testExpr(dummySchema, "{ 1 + 2 }") { actual =>
-      val a @ WholeExpression(
-        _,
-        AdditiveExpression(
-          "+",
-          List(LiteralExpression(one: JBigInt), LiteralExpression(two: JBigInt))
-        ),
-        _,
-        _,
-        _,
-        _
-      ) = actual; assertNotNull(a)
+      val (a, one, two) = actual match {
+        case a @ WholeExpression(
+              _,
+              AdditiveExpression(
+                "+",
+                List(LiteralExpression(one: JBigInt), LiteralExpression(two: JBigInt))
+              ),
+              _,
+              _,
+              _,
+              _
+            ) =>
+          (a, one, two)
+        case _ => fail(); null
+      }; assertNotNull(a)
       assertEquals(JBigInt.valueOf(1), one)
       assertEquals(JBigInt.valueOf(2), two)
     }
@@ -320,17 +422,22 @@ class TestDFDLExpressionTree extends Parsers {
 
   @Test def testFnTrue(): Unit = {
     testExpr(dummySchema, "{ fn:true() }") { actual =>
-      val a @ WholeExpression(_, FunctionCallExpression("fn:true", Nil), _, _, _, _) = actual;
-      assertNotNull(a)
+      val a = actual match {
+        case a @ WholeExpression(_, FunctionCallExpression("fn:true", Nil), _, _, _, _) => a
+        case _ => fail(); null
+      }; assertNotNull(a)
     }
   }
 
   @Test def test_numbers1() = {
     testExpr(dummySchema, "{ 0. }") { (actual: Expression) =>
       val res = JBigDecimal.ZERO
-      val a @ WholeExpression(_, LiteralExpression(actualRes: JBigDecimal), _, _, _, _) =
-        actual;
-      assertNotNull(a)
+      val (a, actualRes) =
+        actual match {
+          case a @ WholeExpression(_, LiteralExpression(actualRes: JBigDecimal), _, _, _, _) =>
+            (a, actualRes)
+          case _ => fail(); null
+        }; assertNotNull(a)
       assertEquals(res, actualRes)
     }
   }
@@ -359,8 +466,10 @@ class TestDFDLExpressionTree extends Parsers {
     //    }
     testExpr(dummySchema, "{ .1 }") { actual =>
       val res = new JBigDecimal("0.1")
-      val a @ WholeExpression(_, LiteralExpression(`res`), _, _, _, _) = actual;
-      assertNotNull(a)
+      val a = actual match {
+        case a @ WholeExpression(_, LiteralExpression(`res`), _, _, _, _) => a
+        case _ => fail(); null
+      }; assertNotNull(a)
     }
     testExpr(
       dummySchema,
@@ -368,21 +477,30 @@ class TestDFDLExpressionTree extends Parsers {
     ) { actual =>
       val res =
         new JBigDecimal("982304892038409234982304892038409234.0909808908982304892038409234")
-      val WholeExpression(_, LiteralExpression(r: JBigDecimal), _, _, _, _) = actual
+      val r = actual match {
+        case WholeExpression(_, LiteralExpression(r: JBigDecimal), _, _, _, _) => r
+        case _ => fail(); null
+      }
       assertEquals(res, r)
     }
 
     testExpr(dummySchema, "{ 0 }") { actual =>
       val res = JBigInt.ZERO
-      val a @ WholeExpression(_, LiteralExpression(actualRes: JBigInt), _, _, _, _) = actual;
-      assertNotNull(a)
+      val (a, actualRes) = actual match {
+        case a @ WholeExpression(_, LiteralExpression(actualRes: JBigInt), _, _, _, _) =>
+          (a, actualRes)
+        case _ => fail(); null
+      }; assertNotNull(a)
       assertEquals(res, actualRes)
     }
     testExpr(dummySchema, "{ 9817239872193792873982173948739879128370982398723897921370 }") {
       actual =>
         val res = new JBigInt("9817239872193792873982173948739879128370982398723897921370")
-        val a @ WholeExpression(_, LiteralExpression(actualRes: JBigInt), _, _, _, _) = actual;
-        assertNotNull(a)
+        val (a, actualRes) = actual match {
+          case a @ WholeExpression(_, LiteralExpression(actualRes: JBigInt), _, _, _, _) =>
+            (a, actualRes)
+          case _ => fail(); null
+        }; assertNotNull(a)
         assertEquals(res, actualRes)
     }
 
@@ -413,7 +531,10 @@ class TestDFDLExpressionTree extends Parsers {
 
     def testFn(expr: String)(body: FunctionCallExpression => Unit): Unit = {
       testExpr(dummySchema, expr) { actual =>
-        val WholeExpression(_, fnExpr: FunctionCallExpression, _, _, _, _) = actual
+        val fnExpr = actual match {
+          case WholeExpression(_, fnExpr: FunctionCallExpression, _, _, _, _) => fnExpr
+          case _ => fail(); null
+        }
         body(fnExpr)
       }
     }
@@ -436,53 +557,72 @@ class TestDFDLExpressionTree extends Parsers {
   else +i
         }"""
     ) { actual =>
-      val WholeExpression(_, IfExpression(Seq(pred, thenPart, elsePart)), _, _, _, _) = actual
-      val p @ OrExpression(
-        List(
-          RelativePathExpression(List(NamedStep("a", None)), _),
-          AndExpression(
-            List(
-              RelativePathExpression(List(NamedStep("b", None)), _),
-              ComparisonExpression(
-                "gt",
-                List(
-                  RelativePathExpression(List(NamedStep("c", None)), _),
-                  RelativePathExpression(List(NamedStep("d", None)), _)
+      val (pred, thenPart, elsePart) = actual match {
+        case WholeExpression(_, IfExpression(Seq(pred, thenPart, elsePart)), _, _, _, _) =>
+          (pred, thenPart, elsePart)
+        case _ => fail(); null
+      }
+      val p = pred match {
+        case p @ OrExpression(
+              List(
+                RelativePathExpression(List(NamedStep("a", None)), _),
+                AndExpression(
+                  List(
+                    RelativePathExpression(List(NamedStep("b", None)), _),
+                    ComparisonExpression(
+                      "gt",
+                      List(
+                        RelativePathExpression(List(NamedStep("c", None)), _),
+                        RelativePathExpression(List(NamedStep("d", None)), _)
+                      )
+                    )
+                  )
                 )
               )
-            )
-          )
-        )
-      ) = pred
+            ) =>
+          p
+        case _ => fail(); null
+      }
       assertNotNull(p)
-      val th @ IfExpression(
-        List(
-          ComparisonExpression(
-            "gt",
-            List(
-              RelativePathExpression(List(NamedStep("c", None)), _),
-              RelativePathExpression(List(NamedStep("d", None)), _)
-            )
-          ),
-          AdditiveExpression(
-            "+",
-            List(
-              RelativePathExpression(List(NamedStep("e", None)), _),
-              MultiplicativeExpression(
-                "*",
-                List(
-                  RelativePathExpression(List(NamedStep("f", None)), _),
-                  RelativePathExpression(List(NamedStep("g", None)), _)
-                )
+      val th = thenPart match {
+        case th @ IfExpression(
+              List(
+                ComparisonExpression(
+                  "gt",
+                  List(
+                    RelativePathExpression(List(NamedStep("c", None)), _),
+                    RelativePathExpression(List(NamedStep("d", None)), _)
+                  )
+                ),
+                AdditiveExpression(
+                  "+",
+                  List(
+                    RelativePathExpression(List(NamedStep("e", None)), _),
+                    MultiplicativeExpression(
+                      "*",
+                      List(
+                        RelativePathExpression(List(NamedStep("f", None)), _),
+                        RelativePathExpression(List(NamedStep("g", None)), _)
+                      )
+                    )
+                  )
+                ),
+                UnaryExpression("-", RelativePathExpression(List(NamedStep("h", None)), _))
               )
-            )
-          ),
-          UnaryExpression("-", RelativePathExpression(List(NamedStep("h", None)), _))
-        )
-      ) = thenPart
+            ) =>
+          th
+        case _ => fail(); null
+      }
       assertNotNull(th)
-      val el @ UnaryExpression("+", RelativePathExpression(List(NamedStep("i", None)), _)) =
-        elsePart
+      val el =
+        elsePart match {
+          case el @ UnaryExpression(
+                "+",
+                RelativePathExpression(List(NamedStep("i", None)), _)
+              ) =>
+            el
+          case _ => fail(); null
+        }
       assertNotNull(el)
     }
   }

--- a/daffodil-core/src/test/scala/org/apache/daffodil/core/dsom/TestAppinfoSyntax.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/core/dsom/TestAppinfoSyntax.scala
@@ -63,8 +63,14 @@ class TestAppinfoSyntax {
     val sset = compiler.compileNode(sc).sset
     val Seq(sch) = sset.schemas
     val a = sch.schemaDocuments.head
-    val Seq(ao: Elem) = a.dfdlAppInfos
-    val Some(ns) = ao.attribute(nnURI, "nonNativeAttribute1")
+    val ao = a.dfdlAppInfos match {
+      case Seq(ao: Elem) => ao
+      case _ => fail(); null
+    }
+    val ns = ao.attribute(nnURI, "nonNativeAttribute1") match {
+      case Some(ns) => ns
+      case _ => fail(); null
+    }
     assertEquals(expected, ns.toString())
     val (_, actual) = TestUtils.testString(sc, "5")
     val expectedParseInfoset = <root>5</root>
@@ -104,9 +110,18 @@ class TestAppinfoSyntax {
     val sset = compiler.compileNode(sc).sset
     val Seq(sch) = sset.schemas
     val a = sch.schemaDocuments.head
-    val Seq(ao: Elem, bo: Elem) = a.dfdlAppInfos
-    val Some(anna) = ao.attribute(nnURI, "nonNativeAttribute1")
-    val Some(bnna) = bo.attribute(nnURI, "nonNativeAttribute2")
+    val (ao, bo) = a.dfdlAppInfos match {
+      case Seq(ao: Elem, bo: Elem) => (ao, bo)
+      case _ => fail(); null
+    }
+    val anna = ao.attribute(nnURI, "nonNativeAttribute1") match {
+      case Some(anna) => anna
+      case _ => fail(); null
+    }
+    val bnna = bo.attribute(nnURI, "nonNativeAttribute2") match {
+      case Some(bnna) => bnna
+      case _ => fail(); null
+    }
     assertEquals(expected, anna.toString())
     assertEquals(expected, bnna.toString())
     val e = intercept[Exception] {
@@ -147,8 +162,14 @@ class TestAppinfoSyntax {
     val sset = compiler.compileNode(sc).sset
     val Seq(sch) = sset.schemas
     val a = sch.schemaDocuments.head
-    val Seq(ao: Elem) = a.dfdlAppInfos
-    val Some(anna) = ao.attribute(nnURI, "nonNativeAttribute1")
+    val ao = a.dfdlAppInfos match {
+      case Seq(ao: Elem) => ao
+      case _ => fail(); null
+    }
+    val anna = ao.attribute(nnURI, "nonNativeAttribute1") match {
+      case Some(anna) => anna
+      case _ => fail(); null
+    }
     assertEquals(expected, anna.toString())
     val e = intercept[Exception] {
       TestUtils.testString(sc, "5")
@@ -193,8 +214,14 @@ class TestAppinfoSyntax {
     val sset = compiler.compileNode(sc).sset
     val Seq(sch) = sset.schemas
     val a = sch.schemaDocuments.head
-    val Seq(ao: Elem) = a.dfdlAppInfos
-    val Some(anna) = ao.attribute(nnURI, "nonNativeAttribute1")
+    val ao = a.dfdlAppInfos match {
+      case Seq(ao: Elem) => ao
+      case _ => fail(); null
+    }
+    val anna = ao.attribute(nnURI, "nonNativeAttribute1") match {
+      case Some(anna) => anna
+      case _ => fail(); null
+    }
     assertEquals(expected, anna.toString())
     val (_, actual) = TestUtils.testString(sc, "5")
     val expectedParseInfoset = <root>5</root>
@@ -243,8 +270,14 @@ class TestAppinfoSyntax {
     val sset = compiler.compileNode(sc).sset
     val Seq(sch) = sset.schemas
     val a = sch.schemaDocuments.head
-    val Seq(ao: Elem) = a.dfdlAppInfos
-    val Some(anna) = ao.attribute(nnURI, "nonNativeAttribute1")
+    val ao = a.dfdlAppInfos match {
+      case Seq(ao: Elem) => ao
+      case _ => fail(); null
+    }
+    val anna = ao.attribute(nnURI, "nonNativeAttribute1") match {
+      case Some(anna) => anna
+      case _ => fail(); null
+    }
     assertEquals(expected, anna.toString())
     val (_, actual) = TestUtils.testString(sc, "5")
     val expectedParseInfoset = <root>5</root>

--- a/daffodil-core/src/test/scala/org/apache/daffodil/core/dsom/TestDsomCompiler.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/core/dsom/TestDsomCompiler.scala
@@ -269,7 +269,10 @@ class TestDsomCompiler {
     seq.formatAnnotation.asInstanceOf[DFDLSequence] // ...annotated with...
     assertEquals(YesNo.No, seq.initiatedContent) // initiatedContent="no"
 
-    val Seq(e1a: DFDLElement) = e1d.annotationObjs
+    val e1a = e1d.annotationObjs match {
+      case Seq(e1a: DFDLElement) => e1a
+      case _ => fail(); null
+    }
     assertEquals("UTF-8", e1a.getPropertyForUnitTest("encoding"))
 
     // Explore global simple type defs
@@ -311,20 +314,30 @@ class TestDsomCompiler {
     ) // has escapeCharacter="%%" (note: string literals not digested yet, so %% is %%, not %.
 
     // Explore global group defs
-    val Seq(_, root, _*) = sd.globalElementDecls
+    val root = sd.globalElementDecls match {
+      case Seq(_, root, _*) => root
+      case _ => fail(); null
+    }
     val seq1 = root.complexType.modelGroup.asInstanceOf[SequenceGroupRef]
 
-    val Seq(e1r: ElementRef, cgr: ChoiceGroupRef) = seq1.groupMembers
+    val (e1r, cgr) = seq1.groupMembers match {
+      case Seq(e1r: ElementRef, cgr: ChoiceGroupRef) => (e1r, cgr)
+      case _ => fail(); null
+    }
 
     val Seq(ggd1, ggd2, _, _, _) = sd.globalGroupDefs // there are two
     assertEquals("gr", ggd1.namedQName.local)
     assertEquals("hiddenGroup", ggd2.namedQName.local)
 
     // Explore LocalSimpleTypeDef
-    val Seq(c1: LocalElementDecl, _: LocalElementDecl, c3: LocalElementDecl, rest @ _*) =
-      cgr.groupMembers
+    val (c1, c3) =
+      cgr.groupMembers match {
+        case Seq(c1: LocalElementDecl, _: LocalElementDecl, c3: LocalElementDecl, rest @ _*) =>
+          (c1, c3)
+        case _ => fail(); null
+      }
     val ist =
-      c3.asInstanceOf[LocalElementDecl].immediateType.get.asInstanceOf[LocalSimpleTypeDef]
+      c3.immediateType.get.asInstanceOf[LocalSimpleTypeDef]
     val istBase = ist.optRestriction.get.baseQName.toQNameString
     assertEquals("tns:aType", istBase)
 
@@ -334,7 +347,10 @@ class TestDsomCompiler {
     assertEquals("{ $myVar1 eq (+47 mod 4) }", c1a.asInstanceOf[DFDLDiscriminator].testBody.get)
 
     // Explore sequence
-    val Seq(ann: DFDLGroup) = seq1.annotationObjs // one format annotation with a property
+    val ann = seq1.annotationObjs match {
+      case Seq(ann: DFDLGroup) => ann // one format annotation with a property
+      case _ => fail(); null
+    }
     assertNotNull(ann)
     assertEquals(SeparatorPosition.Infix, seq1.separatorPosition)
     assertEquals(2, e1r.maxOccurs)
@@ -350,13 +366,23 @@ class TestDsomCompiler {
     val sd = sch.schemaDocuments.head
 
     // Explore global group defs
-    val Seq(_, root, _*) = sd.globalElementDecls
+    val root = sd.globalElementDecls match {
+      case Seq(_, root, _*) => root
+      case _ => fail(); null
+    }
     val seq1 = root.complexType.modelGroup.asInstanceOf[SequenceGroupRef]
 
-    val Seq(_: ElementRef, cgr: ChoiceGroupRef) = seq1.groupMembers
+    val cgr = seq1.groupMembers match {
+      case Seq(_: ElementRef, cgr: ChoiceGroupRef) => cgr
+      case _ => fail(); null
+    }
     val cgd = cgr.groupDef
-    val Seq(_, cd2: LocalElementDecl, rest @ _*) =
-      cgd.groupMembersNotShared // Children nodes of Choice-node, there are 3
+    val cd2 =
+      cgd.groupMembersNotShared match {
+        case Seq(_, cd2: LocalElementDecl, rest @ _*) =>
+          cd2 // Children nodes of Choice-node, there are 3
+        case _ => fail(); null
+      }
 
     // val Seq(a1: DFDLChoice) = ch1.annotationObjs // Obtain the annotation object that is a child
     // of the group node.
@@ -364,8 +390,12 @@ class TestDsomCompiler {
     assertEquals(AlignmentType.Implicit, cgr.alignment)
     assertEquals(ChoiceLengthKind.Implicit, cgr.choiceLengthKind)
 
-    val Seq(asrt1: DFDLAssert) = cd2.annotationObjs // Obtain Annotation object that is child
+    // Obtain Annotation object that is child
     // of cd2.
+    val asrt1 = cd2.annotationObjs match {
+      case Seq(asrt1: DFDLAssert) => asrt1
+      case _ => fail(); null
+    }
 
     assertEquals("{ $myVar1 eq xs:int(xs:string(fn:round-half-to-even(8.5))) }", asrt1.testTxt)
   }
@@ -578,7 +608,10 @@ class TestDsomCompiler {
     val ct = ge1.complexType
     val seq = ct.sequence
 
-    val Seq(e1: ElementBase, _: ElementBase) = seq.groupMembers
+    val e1 = seq.groupMembers match {
+      case Seq(e1: ElementBase, _: ElementBase) => e1
+      case _ => fail(); null
+    }
     //
     assertTrue(e1.verifyPropValue("initiator", ""))
     assertTrue(e1.verifyPropValue("representation", "text"))
@@ -664,7 +697,10 @@ class TestDsomCompiler {
 
     val seq = ge1.sequence
 
-    val Seq(e1: LocalElementDecl, e2: LocalElementDecl) = seq.groupMembers
+    val (e1, e2) = seq.groupMembers match {
+      case Seq(e1: LocalElementDecl, e2: LocalElementDecl) => (e1, e2)
+      case _ => fail(); null
+    }
     e1.formatAnnotation.asInstanceOf[DFDLElement]
     // val props = e1.properties
 
@@ -688,11 +724,17 @@ class TestDsomCompiler {
     val Seq(sch) = sset.schemas
     val sd = sch.schemaDocuments.head
 
-    val Seq(_, gedf, _*) = sd.globalElementDecls
+    val gedf = sd.globalElementDecls match {
+      case Seq(_, gedf, _*) => gedf
+      case _ => fail(); null
+    }
     val root = gedf.asRoot
     val sgr = root.complexType.modelGroup.asInstanceOf[SequenceGroupRef]
 
-    val Seq(e1r: ElementRef, cgr: ChoiceGroupRef) = sgr.groupMembers
+    val (e1r, cgr) = sgr.groupMembers match {
+      case Seq(e1r: ElementRef, cgr: ChoiceGroupRef) => (e1r, cgr)
+      case _ => fail(); null
+    }
 
     assertEquals("hiddenGroup", cgr.groupDef.namedQName.local)
     assertEquals(AlignmentType.Implicit, cgr.alignment)

--- a/daffodil-core/src/test/scala/org/apache/daffodil/core/dsom/TestExternalVariables.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/core/dsom/TestExternalVariables.scala
@@ -24,7 +24,6 @@ import scala.xml.Node
 import org.apache.daffodil.core.compiler.Compiler
 import org.apache.daffodil.io.InputSourceDataInputStream
 import org.apache.daffodil.lib.Implicits._
-import org.apache.daffodil.lib.Implicits.ns2String
 import org.apache.daffodil.lib.iapi.UnitTestSchemaSource
 import org.apache.daffodil.lib.util.Misc
 import org.apache.daffodil.lib.util.SchemaUtils
@@ -38,8 +37,6 @@ import org.apache.daffodil.runtime1.processors.ExternalVariableException
 import org.apache.daffodil.runtime1.processors.VariableMap
 
 import org.junit.Assert._
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
 import org.junit.Test
 
 /**

--- a/daffodil-core/src/test/scala/org/apache/daffodil/core/dsom/TestMiddleEndAttributes.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/core/dsom/TestMiddleEndAttributes.scala
@@ -179,7 +179,10 @@ class TestMiddleEndAttributes {
     val mems = seq.groupMembers
     val Seq(t1: Term) = mems
     val e1ref = t1.asInstanceOf[ElementRef]
-    val Some(nes: LocalSequence) = e1ref.optLexicalParent
+    val nes = e1ref.optLexicalParent match {
+      case Some(nes: LocalSequence) => nes
+      case _ => fail(); null
+    }
     assertEquals(seq, nes)
   }
 

--- a/daffodil-core/src/test/scala/org/apache/daffodil/core/dsom/TestMiddleEndAttributes3.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/core/dsom/TestMiddleEndAttributes3.scala
@@ -59,12 +59,18 @@ class TestMiddleEndAttributes3 {
     val ect = e.complexType
     val seq = ect.sequence
     val mems = seq.groupMembers
-    val Seq(ile: ElementBase, _: ElementBase) = mems
+    val ile = mems match {
+      case Seq(ile: ElementBase, _: ElementBase) => ile
+      case _ => fail(); null
+    }
     val ile_nextSibling = ile.nextSibling
     assertNotNull(ile_nextSibling)
     val ilct = ile.complexType
     val ilseq = ilct.sequence
-    val Seq(_: ElementBase, ipsrcle: ElementBase) = ilseq.groupMembers
+    val ipsrcle = ilseq.groupMembers match {
+      case Seq(_: ElementBase, ipsrcle: ElementBase) => ipsrcle
+      case _ => fail(); null
+    }
     val nextSiblings = ipsrcle.nextSibling
     assertNotNull(nextSiblings)
   }
@@ -108,12 +114,18 @@ class TestMiddleEndAttributes3 {
     val ect = e.complexType
     val seq = ect.sequence
     val mems = seq.groupMembers
-    val Seq(ile: ElementBase, _: ElementBase, _: Choice) = mems
+    val ile = mems match {
+      case Seq(ile: ElementBase, _: ElementBase, _: Choice) => ile
+      case _ => fail(); null
+    }
     val ile_nextSibling = ile.nextSibling
     assertNotNull(ile_nextSibling)
     val ilct = ile.complexType
     val ilseq = ilct.sequence
-    val Seq(_: ElementBase, _: SequenceGroupRef, ipsrcle: ElementBase) = ilseq.groupMembers
+    val ipsrcle = ilseq.groupMembers match {
+      case Seq(_: ElementBase, _: SequenceGroupRef, ipsrcle: ElementBase) => ipsrcle
+      case _ => fail(); null
+    }
     val nextSiblings = ipsrcle.nextSibling
     assertNotNull(nextSiblings)
   }

--- a/daffodil-core/src/test/scala/org/apache/daffodil/core/dsom/TestRefMap.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/core/dsom/TestRefMap.scala
@@ -73,7 +73,10 @@ class TestRefMap {
     val numRefPairs = root.refPairsMap.size
     assertEquals(2, numRefPairs) // good proxy for schema size
     val ctDef = root.complexType.asInstanceOf[GlobalComplexTypeDef]
-    val Some(Seq((edecl, ctRefSpecs))) = refMap.get(ctDef)
+    val (edecl, ctRefSpecs) = refMap.get(ctDef) match {
+      case Some(Seq((edecl, ctRefSpecs))) => (edecl, ctRefSpecs)
+      case _ => fail(); null
+    }
     assertEquals(root.referencedElement.shortSchemaComponentDesignator, edecl)
   }
 
@@ -103,7 +106,10 @@ class TestRefMap {
     assertEquals(3, numRefPairs) // good proxy for schema size
     val rootDecl = root.referencedElement
     val ctDef = root.complexType.asInstanceOf[GlobalComplexTypeDef]
-    val Some(Seq((edecl, ctRefSpecs))) = refMap.get(ctDef)
+    val edecl = refMap.get(ctDef) match {
+      case Some(Seq((edecl, ctRefSpecs))) => edecl
+      case _ => fail(); null
+    }
     assertEquals(rootDecl.shortSchemaComponentDesignator, edecl)
     val gref = rootDecl.complexType.modelGroup.asInstanceOf[SequenceGroupRef]
     val Seq((grefSSCD, gdRefSpecs)) = refMap.get(gref.groupDef).get
@@ -139,7 +145,10 @@ class TestRefMap {
     assertEquals(3, numRefPairs) // good proxy for schema size
     val rootDecl = root.referencedElement
     val ctDef = root.complexType.asInstanceOf[GlobalComplexTypeDef]
-    val Some(Seq((edecl, ctRefSpecs))) = refMap.get(ctDef)
+    val edecl = refMap.get(ctDef) match {
+      case Some(Seq((edecl, ctRefSpecs))) => edecl
+      case _ => fail(); null
+    }
     assertEquals(rootDecl.shortSchemaComponentDesignator, edecl)
     val gref = rootDecl.complexType.modelGroup.asInstanceOf[ChoiceGroupRef]
     val Seq((grefSSCD, gdRefSpecs)) = refMap.get(gref.groupDef).get
@@ -188,7 +197,10 @@ class TestRefMap {
     assertEquals(6, numRefPairs) // good proxy for schema size
     val rootDecl = root.referencedElement
     val ctDef = root.complexType.asInstanceOf[GlobalComplexTypeDef]
-    val Some(Seq((edecl, ctRefSpecs))) = refMap.get(ctDef)
+    val edecl = refMap.get(ctDef) match {
+      case Some(Seq((edecl, ctRefSpecs))) => edecl
+      case _ => fail(); null
+    }
     assertEquals(rootDecl.shortSchemaComponentDesignator, edecl)
     val gref = rootDecl.complexType.modelGroup.asInstanceOf[ChoiceGroupRef]
     val Seq((grefSSCD, gdRefSpecs)) = refMap.get(gref.groupDef).get
@@ -691,7 +703,10 @@ class TestRefMap {
     val numRefPairs = root.refPairsMap.size
     val rootDecl = root.referencedElement
     val ctDef = root.complexType.asInstanceOf[GlobalComplexTypeDef]
-    val Some(Seq((edecl, ctRefSpecs))) = refMap.get(ctDef)
+    val _ = refMap.get(ctDef) match {
+      case Some(Seq((edecl, ctRefSpecs))) => edecl
+      case _ => fail(); null
+    }
     val gref = rootDecl.complexType.modelGroup.asInstanceOf[SequenceGroupRef]
     val g_gDef = gref.groupDef
     val eDecl = g_gDef.groupMembers(0)

--- a/daffodil-core/src/test/scala/org/apache/daffodil/core/externalvars/TestExternalVariables.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/core/externalvars/TestExternalVariables.scala
@@ -37,9 +37,18 @@ class TestExternalVariables {
     val varNoNS = "{}varNoNS"
     val varGuessNS = "varGuessNS"
 
-    val Success(qWithNS) = QName.refQNameFromExtendedSyntax(varWithNS)
-    val Success(qNoNS) = QName.refQNameFromExtendedSyntax(varNoNS)
-    val Success(qGuessNS) = QName.refQNameFromExtendedSyntax(varGuessNS)
+    val qWithNS = QName.refQNameFromExtendedSyntax(varWithNS) match {
+      case Success(qWithNS) => qWithNS
+      case _ => fail(); null
+    }
+    val qNoNS = QName.refQNameFromExtendedSyntax(varNoNS) match {
+      case Success(qNoNS) => qNoNS
+      case _ => fail(); null
+    }
+    val qGuessNS = QName.refQNameFromExtendedSyntax(varGuessNS) match {
+      case Success(qGuessNS) => qGuessNS
+      case _ => fail(); null
+    }
 
     assertEquals(NS("someNS"), qWithNS.namespace)
     assertEquals("varWithNS", qWithNS.local)

--- a/daffodil-core/src/test/scala/org/apache/daffodil/core/iapi/TestParseIndividualMessages.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/core/iapi/TestParseIndividualMessages.scala
@@ -26,11 +26,12 @@ import scala.concurrent.TimeoutException
 import scala.concurrent.duration.Duration
 import scala.xml.Node
 
+import org.apache.daffodil.api
 import org.apache.daffodil.core.util.TestUtils
 import org.apache.daffodil.io.SocketPairTestRig
 import org.apache.daffodil.lib.Implicits.intercept
 import org.apache.daffodil.lib.util.SchemaUtils
-import org.apache.daffodil.runtime1.iapi._
+import org.apache.daffodil.runtime1.iapi.DFDL
 
 import org.junit.Assert._
 import org.junit.Test
@@ -73,12 +74,11 @@ class TestParseIndividualMessages {
         //
         // If we need more than 4 bytes to successfully parse (we shouldn't for this schema)
         // then this will hang, because only 4 bytes are in fact available.
-        val (pr: DFDL.ParseResult, xml: Node) =
+        val (pr: api.ParseResult, xml: Node) =
           TestUtils.runDataProcessorOnInputStream(dp, cis, areTracing = false)
-
         assertFalse(pr.isError)
         assertEquals("1234", xml.text)
-        assertEquals(33, pr.resultState.currentLocation.bitPos1b)
+        assertEquals(33, pr.asInstanceOf[DFDL.ParseResult].resultState.currentLocation.bitPos1b)
       }
     }
     sptr.run()

--- a/daffodil-core/src/test/scala/org/apache/daffodil/core/infoset/TestInfoset.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/core/infoset/TestInfoset.scala
@@ -130,7 +130,10 @@ class TestInfoset1 {
 
     val xmlInfoset = <list xmlns={ex}><w>4</w></list>
 
-    val (infoset: DIComplex, _, tunable) = testInfoset(testSchema, xmlInfoset)
+    val (infoset, tunable) = testInfoset(testSchema, xmlInfoset) match {
+      case (infoset: DIComplex, _, tunable) => (infoset, tunable)
+      case _ => fail(); null
+    }
     val list_erd = infoset.erd
     assertEquals(list_erd, infoset.runtimeData)
     val Seq(w_erd) = list_erd.childERDs
@@ -189,7 +192,10 @@ class TestInfoset1 {
     )
 
     val xmlInfoset = <list xmlns={ex}><w>4</w><w>5</w></list>
-    val (infoset: DIComplex, _, tunable) = testInfoset(testSchema, xmlInfoset)
+    val (infoset, tunable) = testInfoset(testSchema, xmlInfoset) match {
+      case (infoset: DIComplex, _, tunable) => (infoset, tunable)
+      case _ => fail(); null
+    }
     val Seq(w_erd) = infoset.erd.childERDs
     infoset.getChildArray(w_erd, tunable) match {
       case arr: InfosetArray => {
@@ -226,7 +232,10 @@ class TestInfoset1 {
 
     val xmlInfoset = <list xmlns={ex}><w>4</w><w>5</w><c>7</c></list>
 
-    val (infoset: DIComplex, _, tunable) = testInfoset(testSchema, xmlInfoset)
+    val (infoset, tunable) = testInfoset(testSchema, xmlInfoset) match {
+      case (infoset: DIComplex, _, tunable) => (infoset, tunable)
+      case _ => fail(); null
+    }
     val list_erd = infoset.erd
     val Seq(w_erd, _, _, c_erd) = list_erd.childERDs
     infoset.getChildArray(w_erd, tunable) match {
@@ -264,7 +273,10 @@ class TestInfoset1 {
 
     val xmlInfoset = <list xmlns={ex} xmlns:xsi={xsi}><x xsi:nil='true'/></list>
 
-    val (infoset: DIComplex, _, tunable) = testInfoset(testSchema, xmlInfoset)
+    val (infoset, tunable) = testInfoset(testSchema, xmlInfoset) match {
+      case (infoset: DIComplex, _, tunable) => (infoset, tunable)
+      case _ => fail(); null
+    }
     val list_erd = infoset.erd
     val Seq(x_erd) = list_erd.childERDs
     assertTrue(x_erd.isArray)
@@ -303,7 +315,10 @@ class TestInfoset1 {
 
     val xmlInfoset = <list xmlns={ex} xmlns:xsi={xsi}><x xsi:nil='true'/></list>
 
-    val (infoset: DIComplex, _, tunable) = testInfoset(testSchema, xmlInfoset)
+    val (infoset, tunable) = testInfoset(testSchema, xmlInfoset) match {
+      case (infoset: DIComplex, _, tunable) => (infoset, tunable)
+      case _ => fail(); null
+    }
     val list_erd = infoset.erd
     val Seq(x_erd) = list_erd.childERDs
     infoset.getChildArray(x_erd, tunable) match {
@@ -340,11 +355,17 @@ class TestInfoset1 {
       xsi
     }><w>4</w><w>5</w><x xsi:nil='true'/><x><c>7</c></x></list>
 
-    val (infoset: DIComplex, rootTerm, tunable) = testInfoset(testSchema, xmlInfoset)
+    val (infoset, rootTerm, tunable) = testInfoset(testSchema, xmlInfoset) match {
+      case (infoset: DIComplex, rootTerm, tunable) => (infoset, rootTerm, tunable)
+      case _ => fail(); null
+    }
     val list_erd = infoset.erd
     val rootPossibles = rootTerm.possibleNextLexicalSiblingStreamingUnparserElements
-    val Seq(wTerm: ElementBase, xTerm: ElementBase) =
-      rootTerm.complexType.modelGroup.groupMembers
+    val (wTerm, xTerm) =
+      rootTerm.complexType.modelGroup.groupMembers match {
+        case Seq(wTerm: ElementBase, xTerm: ElementBase) => (wTerm, xTerm)
+        case _ => fail(); null
+      }
     val xPossibles = xTerm.possibleNextLexicalSiblingStreamingUnparserElements
     val Seq(w_erd, x_erd) = list_erd.childERDs
     val Seq(a_erd, b_erd, c_erd) = x_erd.childERDs
@@ -387,7 +408,10 @@ class TestInfoset1 {
 
     val xmlInfoset = <list xmlns={ex}><x><c>7</c></x><x><b>8</b></x></list>
 
-    val (infoset: DIComplex, _, tunable) = testInfoset(testSchema, xmlInfoset)
+    val (infoset, tunable) = testInfoset(testSchema, xmlInfoset) match {
+      case (infoset: DIComplex, _, tunable) => (infoset, tunable)
+      case _ => fail(); null
+    }
     val list_erd = infoset.erd
     val Seq(w_erd, x_erd) = list_erd.childERDs
     val Seq(a_erd, b_erd, c_erd) = x_erd.childERDs
@@ -440,7 +464,10 @@ class TestInfoset1 {
       ex
     }><enum>EQUAL_TO_OR_&lt;_0.0001_SQUARE_DATA_MILES</enum></root>
 
-    val (infoset: DIComplex, _, tunable) = testInfoset(testSchema, xmlInfoset)
+    val (infoset, tunable) = testInfoset(testSchema, xmlInfoset) match {
+      case (infoset: DIComplex, _, tunable) => (infoset, tunable)
+      case _ => fail(); null
+    }
     val enumElt: DISimple = infoset.child(0).asInstanceOf[DISimple]
     val value = enumElt.dataValueAsString
     assertEquals("EQUAL_TO_OR_<_0.0001_SQUARE_DATA_MILES", value)

--- a/daffodil-core/src/test/scala/org/apache/daffodil/core/infoset/TestInfosetCursor.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/core/infoset/TestInfosetCursor.scala
@@ -115,15 +115,24 @@ class TestInfosetInputter {
     val iicc: InfosetAccessor = ic.inspectAccessor
 
     assertTrue(ic.advance)
-    val Start(foo: DISimple) = aacc
+    val foo = aacc match {
+      case Start(foo: DISimple) => foo
+      case _ => fail(); null
+    }
     assertEquals("Hello", foo.dataValueAsString)
 
     assertTrue(ic.inspect)
-    val End(foo_i: DISimple) = iicc
+    val foo_i = iicc match {
+      case End(foo_i: DISimple) => foo_i
+      case _ => fail(); null
+    }
     assertTrue(foo_i eq foo)
 
     assertTrue(ic.advance)
-    val End(foo_e: DISimple) = aacc
+    val foo_e = aacc match {
+      case End(foo_e: DISimple) => foo_e
+      case _ => fail(); null
+    }
     assertTrue(foo_e eq foo)
 
     assertFalse(ic.inspect)
@@ -145,15 +154,24 @@ class TestInfosetInputter {
     val iicc: InfosetAccessor = ic.inspectAccessor
 
     assertTrue(ic.advance)
-    val Start(foo: DISimple) = aacc
+    val foo = aacc match {
+      case Start(foo: DISimple) => foo
+      case _ => fail(); null
+    }
     assertTrue(foo.isNilled)
 
     assertTrue(ic.inspect)
-    val End(foo_i: DISimple) = iicc
+    val foo_i = iicc match {
+      case End(foo_i: DISimple) => foo_i
+      case _ => fail(); null
+    }
     assertTrue(foo_i eq foo)
 
     assertTrue(ic.advance)
-    val End(foo_e: DISimple) = aacc
+    val foo_e = aacc match {
+      case End(foo_e: DISimple) => foo_e
+      case _ => fail(); null
+    }
     assertTrue(foo_e eq foo)
 
     assertFalse(ic.inspect)
@@ -180,32 +198,53 @@ class TestInfosetInputter {
     val iacc = ic.inspectAccessor
 
     val barERD = rootERD
-    val Some(barSeqTRD) = barERD.optComplexTypeModelGroupRuntimeData
+    val barSeqTRD = barERD.optComplexTypeModelGroupRuntimeData match {
+      case Some(barSeqTRD) => barSeqTRD
+      case _ => fail(); null
+    }
     val Seq(fooERD) = barERD.childERDs
     ic.pushTRD(barERD)
     assertTrue(ic.advance)
-    val Start(bar: DIComplex) = aacc
+    val bar = aacc match {
+      case Start(bar: DIComplex) => bar
+      case _ => fail(); null
+    }
     ic.pushTRD(barSeqTRD)
     ic.pushTRD(fooERD)
     assertTrue(ic.advance)
-    val Start(foo: DISimple) = aacc
+    val foo = aacc match {
+      case Start(foo: DISimple) => foo
+      case _ => fail(); null
+    }
     assertEquals("Hello", foo.dataValue.getAnyRef)
 
     assertTrue(ic.inspect)
-    val End(ifoo: DISimple) = iacc
+    val ifoo = iacc match {
+      case End(ifoo: DISimple) => ifoo
+      case _ => fail(); null
+    }
     assertTrue(foo eq ifoo)
 
     assertTrue(ic.advance)
-    val End(eFoo: DISimple) = aacc
+    val eFoo = aacc match {
+      case End(eFoo: DISimple) => eFoo
+      case _ => fail(); null
+    }
     assertTrue(foo eq eFoo)
 
     ic.popTRD()
     assertTrue(ic.inspect)
-    val End(ibar: DIComplex) = iacc
+    val ibar = iacc match {
+      case End(ibar: DIComplex) => ibar
+      case _ => fail(); null
+    }
     assertTrue(bar eq ibar)
 
     assertTrue(ic.advance)
-    val End(bar_e: DIComplex) = aacc
+    val bar_e = aacc match {
+      case End(bar_e: DIComplex) => bar_e
+      case _ => fail(); null
+    }
     assertTrue(bar eq bar_e)
     ic.popTRD()
     ic.popTRD()
@@ -231,22 +270,43 @@ class TestInfosetInputter {
     }><foo>Hello</foo><baz>World</baz></bar>
     val (ic, rootERD) = infosetInputter(sch, infosetXML)
     val aacc = ic.advanceAccessor
-    val Start(bar_s: DIComplex) = { assertTrue(ic.advance); aacc }
+    val bar_s = { assertTrue(ic.advance); aacc } match {
+      case Start(bar_s: DIComplex) => bar_s
+      case _ => fail(); null
+    }
     val barERD = bar_s.erd
-    val Some(barSeqTRD) = barERD.optComplexTypeModelGroupRuntimeData
+    val barSeqTRD = barERD.optComplexTypeModelGroupRuntimeData match {
+      case Some(barSeqTRD) => barSeqTRD
+      case _ => fail(); null
+    }
     val Seq(fooERD, bazERD) = barERD.childERDs
 
     ic.pushTRD(barSeqTRD)
     ic.pushTRD(fooERD)
-    val Start(foo_s: DISimple) = { assertTrue(ic.advance); aacc }
-    val End(foo_e: DISimple) = { assertTrue(ic.advance); aacc }
+    val foo_s = { assertTrue(ic.advance); aacc } match {
+      case Start(foo_s: DISimple) => foo_s
+      case _ => fail(); null
+    }
+    val foo_e = { assertTrue(ic.advance); aacc } match {
+      case End(foo_e: DISimple) => foo_e
+      case _ => fail(); null
+    }
     ic.popTRD()
     ic.pushTRD(bazERD)
-    val Start(baz_s: DISimple) = { assertTrue(ic.advance); aacc }
-    val End(baz_e: DISimple) = { assertTrue(ic.advance); aacc };
+    val baz_s = { assertTrue(ic.advance); aacc } match {
+      case Start(baz_s: DISimple) => baz_s
+      case _ => fail(); null
+    }
+    val baz_e = { assertTrue(ic.advance); aacc } match {
+      case End(baz_e: DISimple) => baz_e
+      case _ => fail(); null
+    }
     assertNotNull(baz_e)
     ic.popTRD()
-    val End(bar_e: DIComplex) = { assertTrue(ic.advance); aacc }
+    val bar_e = { assertTrue(ic.advance); aacc } match {
+      case End(bar_e: DIComplex) => bar_e
+      case _ => fail(); null
+    }
     ic.popTRD()
     ic.popTRD()
     assertFalse(ic.inspect)
@@ -291,43 +351,95 @@ class TestInfosetInputter {
                      </quux>
     val (ic, rootERD) = infosetInputter(sch, infosetXML)
     val aacc = ic.advanceAccessor
-    val Start(quux_s: DIComplex) = { assertTrue(ic.advance); aacc }
+    val quux_s = { assertTrue(ic.advance); aacc } match {
+      case Start(quux_s: DIComplex) => quux_s
+      case _ => fail(); null
+    }
     val quuxERD = quux_s.erd
-    val Some(quuxSeqTRD: SequenceRuntimeData) = quuxERD.optComplexTypeModelGroupRuntimeData
+    val quuxSeqTRD = quuxERD.optComplexTypeModelGroupRuntimeData match {
+      case Some(quuxSeqTRD: SequenceRuntimeData) => quuxSeqTRD
+      case _ => fail(); null
+    }
     val Seq(bar1ERD, bar2ERD) = quuxERD.childERDs
-    val Some(bar1SeqTRD: SequenceRuntimeData) = bar1ERD.optComplexTypeModelGroupRuntimeData
-    val Some(bar2SeqTRD: SequenceRuntimeData) = bar2ERD.optComplexTypeModelGroupRuntimeData
+    val bar1SeqTRD = bar1ERD.optComplexTypeModelGroupRuntimeData match {
+      case Some(bar1SeqTRD: SequenceRuntimeData) => bar1SeqTRD
+      case _ => fail(); null
+    }
+    val bar2SeqTRD = bar2ERD.optComplexTypeModelGroupRuntimeData match {
+      case Some(bar2SeqTRD: SequenceRuntimeData) => bar2SeqTRD
+      case _ => fail(); null
+    }
     val Seq(foo1ERD, baz1ERD) = bar1ERD.childERDs
     val Seq(foo2ERD, baz2ERD) = bar2ERD.childERDs
     ic.pushTRD(quuxSeqTRD)
     ic.pushTRD(bar1ERD)
-    val Start(bar1_s: DIComplex) = { assertTrue(ic.advance); aacc }
+    val bar1_s = { assertTrue(ic.advance); aacc } match {
+      case Start(bar1_s: DIComplex) => bar1_s
+      case _ => fail(); null
+    }
     ic.pushTRD(bar1SeqTRD)
     ic.pushTRD(foo1ERD)
-    val Start(foo1_s: DISimple) = { assertTrue(ic.advance); aacc }
-    val End(foo1_e: DISimple) = { assertTrue(ic.advance); aacc }
+    val foo1_s = { assertTrue(ic.advance); aacc } match {
+      case Start(foo1_s: DISimple) => foo1_s
+      case _ => fail(); null
+    }
+    val foo1_e = { assertTrue(ic.advance); aacc } match {
+      case End(foo1_e: DISimple) => foo1_e
+      case _ => fail(); null
+    }
     ic.popTRD()
     ic.pushTRD(baz1ERD)
-    val Start(baz1_s: DISimple) = { assertTrue(ic.advance); aacc }
-    val End(baz1_e: DISimple) = { assertTrue(ic.advance); aacc }; assertNotNull(baz1_e)
+    val baz1_s = { assertTrue(ic.advance); aacc } match {
+      case Start(baz1_s: DISimple) => baz1_s
+      case _ => fail(); null
+    }
+    val baz1_e = { assertTrue(ic.advance); aacc } match {
+      case End(baz1_e: DISimple) => baz1_e
+      case _ => fail(); null
+    };
+    assertNotNull(baz1_e)
     ic.popTRD()
     ic.popTRD()
-    val End(bar1_e: DIComplex) = { assertTrue(ic.advance); aacc }
+    val bar1_e = { assertTrue(ic.advance); aacc } match {
+      case End(bar1_e: DIComplex) => bar1_e
+      case _ => fail(); null
+    }
     ic.pushTRD(bar2ERD)
-    val Start(bar2_s: DIComplex) = { assertTrue(ic.advance); aacc }
+    val bar2_s = { assertTrue(ic.advance); aacc } match {
+      case Start(bar2_s: DIComplex) => bar2_s
+      case _ => fail(); null
+    }
     ic.pushTRD(bar2SeqTRD)
     ic.pushTRD(foo2ERD)
-    val Start(foo2_s: DISimple) = { assertTrue(ic.advance); aacc }
-    val End(foo2_e: DISimple) = { assertTrue(ic.advance); aacc }
+    val foo2_s = { assertTrue(ic.advance); aacc } match {
+      case Start(foo2_s: DISimple) => foo2_s
+      case _ => fail(); null
+    }
+    val foo2_e = { assertTrue(ic.advance); aacc } match {
+      case End(foo2_e: DISimple) => foo2_e
+      case _ => fail(); null
+    }
     ic.popTRD()
     ic.pushTRD(baz2ERD)
-    val Start(baz2_s: DISimple) = { assertTrue(ic.advance); aacc }
-    val End(baz2_e: DISimple) = { assertTrue(ic.advance); aacc }; assertNotNull(baz2_e)
+    val baz2_s = { assertTrue(ic.advance); aacc } match {
+      case Start(baz2_s: DISimple) => baz2_s
+      case _ => fail(); null
+    }
+    val baz2_e = { assertTrue(ic.advance); aacc } match {
+      case End(baz2_e: DISimple) => baz2_e
+      case _ => fail(); null
+    }; assertNotNull(baz2_e)
     ic.popTRD()
     ic.popTRD()
-    val End(bar2_e: DIComplex) = { assertTrue(ic.advance); aacc }
+    val bar2_e = { assertTrue(ic.advance); aacc } match {
+      case End(bar2_e: DIComplex) => bar2_e
+      case _ => fail(); null
+    }
     ic.popTRD()
-    val End(quux_e: DIComplex) = { assertTrue(ic.advance); aacc }
+    val quux_e = { assertTrue(ic.advance); aacc } match {
+      case End(quux_e: DIComplex) => quux_e
+      case _ => fail(); null
+    }
     assertFalse(ic.inspect)
     assertTrue(bar1_s eq bar1_e) // exact same object
     assertTrue(foo1_s eq foo1_e)
@@ -362,20 +474,47 @@ class TestInfosetInputter {
     val (ic, rootERD) = infosetInputter(sch, infosetXML)
     val aacc = ic.advanceAccessor
     val barERD = rootERD
-    val Some(barSeqTRD: SequenceRuntimeData) = barERD.optComplexTypeModelGroupRuntimeData
+    val barSeqTRD = barERD.optComplexTypeModelGroupRuntimeData match {
+      case Some(barSeqTRD: SequenceRuntimeData) => barSeqTRD
+      case _ => fail(); null
+    }
     val Seq(fooERD) = barERD.childERDs
     ic.pushTRD(barERD)
-    val Start(bar_s: DIComplex) = { assertTrue(ic.advance); aacc }
+    val bar_s = { assertTrue(ic.advance); aacc } match {
+      case Start(bar_s: DIComplex) => bar_s
+      case _ => fail(); null
+    }
     ic.pushTRD(barSeqTRD)
     ic.pushTRD(fooERD)
-    val StartArray(foo_arr_s) = { assertTrue(ic.advance); aacc }
-    val Start(foo_1_s: DISimple) = { assertTrue(ic.advance); aacc }
-    val End(foo_1_e: DISimple) = { assertTrue(ic.advance); aacc }
-    val Start(foo_2_s: DISimple) = { assertTrue(ic.advance); aacc }
-    val End(foo_2_e: DISimple) = { assertTrue(ic.advance); aacc }
-    val EndArray(foo_arr_e) = { assertTrue(ic.advance); aacc }
+    val foo_arr_s = { assertTrue(ic.advance); aacc } match {
+      case StartArray(foo_arr_s) => foo_arr_s
+      case _ => fail(); null
+    }
+    val foo_1_s = { assertTrue(ic.advance); aacc } match {
+      case Start(foo_1_s: DISimple) => foo_1_s
+      case _ => fail(); null
+    }
+    val foo_1_e = { assertTrue(ic.advance); aacc } match {
+      case End(foo_1_e: DISimple) => foo_1_e
+      case _ => fail(); null
+    }
+    val foo_2_s = { assertTrue(ic.advance); aacc } match {
+      case Start(foo_2_s: DISimple) => foo_2_s
+      case _ => fail(); null
+    }
+    val foo_2_e = { assertTrue(ic.advance); aacc } match {
+      case End(foo_2_e: DISimple) => foo_2_e
+      case _ => fail(); null
+    }
+    val foo_arr_e = { assertTrue(ic.advance); aacc } match {
+      case EndArray(foo_arr_e) => foo_arr_e
+      case _ => fail(); null
+    }
     ic.popTRD()
-    val End(bar_e: DIComplex) = { assertTrue(ic.advance); aacc }
+    val bar_e = { assertTrue(ic.advance); aacc } match {
+      case End(bar_e: DIComplex) => bar_e
+      case _ => fail(); null
+    }
     ic.popTRD()
     ic.popTRD()
     assertFalse(ic.inspect)
@@ -407,24 +546,57 @@ class TestInfosetInputter {
     }><foo>Hello</foo><foo>World</foo><baz>Yadda</baz></bar>
     val (ic, rootERD) = infosetInputter(sch, infosetXML)
     val aacc = ic.advanceAccessor
-    val Start(bar_s: DIComplex) = { assertTrue(ic.advance); aacc }
+    val bar_s = { assertTrue(ic.advance); aacc } match {
+      case Start(bar_s: DIComplex) => bar_s
+      case _ => fail(); null
+    }
     val barERD = bar_s.erd
-    val Some(barSeqTRD: SequenceRuntimeData) = barERD.optComplexTypeModelGroupRuntimeData
+    val barSeqTRD = barERD.optComplexTypeModelGroupRuntimeData match {
+      case Some(barSeqTRD: SequenceRuntimeData) => barSeqTRD
+      case _ => fail(); null
+    }
     val Seq(fooERD, bazERD) = barERD.childERDs
     ic.pushTRD(barSeqTRD)
     ic.pushTRD(fooERD)
-    val StartArray(foo_arr_s) = { assertTrue(ic.advance); aacc }
-    val Start(foo_1_s: DISimple) = { assertTrue(ic.advance); aacc }
-    val End(foo_1_e: DISimple) = { assertTrue(ic.advance); aacc }
-    val Start(foo_2_s: DISimple) = { assertTrue(ic.advance); aacc }
-    val End(foo_2_e: DISimple) = { assertTrue(ic.advance); aacc }
-    val EndArray(foo_arr_e) = { assertTrue(ic.advance); aacc }
+    val foo_arr_s = { assertTrue(ic.advance); aacc } match {
+      case StartArray(foo_arr_s) => foo_arr_s
+      case _ => fail(); null
+    }
+    val foo_1_s = { assertTrue(ic.advance); aacc } match {
+      case Start(foo_1_s: DISimple) => foo_1_s
+      case _ => fail(); null
+    }
+    val foo_1_e = { assertTrue(ic.advance); aacc } match {
+      case End(foo_1_e: DISimple) => foo_1_e
+      case _ => fail(); null
+    }
+    val foo_2_s = { assertTrue(ic.advance); aacc } match {
+      case Start(foo_2_s: DISimple) => foo_2_s
+      case _ => fail(); null
+    }
+    val foo_2_e = { assertTrue(ic.advance); aacc } match {
+      case End(foo_2_e: DISimple) => foo_2_e
+      case _ => fail(); null
+    }
+    val foo_arr_e = { assertTrue(ic.advance); aacc } match {
+      case EndArray(foo_arr_e) => foo_arr_e
+      case _ => fail(); null
+    }
     ic.popTRD()
     ic.pushTRD(bazERD)
-    val Start(baz_s: DISimple) = { assertTrue(ic.advance); aacc }
-    val End(baz_e: DISimple) = { assertTrue(ic.advance); aacc }
+    val baz_s = { assertTrue(ic.advance); aacc } match {
+      case Start(baz_s: DISimple) => baz_s
+      case _ => fail(); null
+    }
+    val baz_e = { assertTrue(ic.advance); aacc } match {
+      case End(baz_e: DISimple) => baz_e
+      case _ => fail(); null
+    }
     assertNotNull(baz_e)
-    val End(bar_e: DIComplex) = { assertTrue(ic.advance); aacc }
+    val bar_e = { assertTrue(ic.advance); aacc } match {
+      case End(bar_e: DIComplex) => bar_e
+      case _ => fail(); null
+    }
     ic.popTRD()
     ic.popTRD()
     assertFalse(ic.inspect)
@@ -459,25 +631,58 @@ class TestInfosetInputter {
     val (ic, rootERD) = infosetInputter(sch, infosetXML)
     val aacc = ic.advanceAccessor
     val barERD = rootERD
-    val Some(barSeqTRD: SequenceRuntimeData) = barERD.optComplexTypeModelGroupRuntimeData
+    val barSeqTRD = barERD.optComplexTypeModelGroupRuntimeData match {
+      case Some(barSeqTRD: SequenceRuntimeData) => barSeqTRD
+      case _ => fail(); null
+    }
     ic.pushTRD(barERD)
-    val Start(bar_s: DIComplex) = { assertTrue(ic.advance); aacc }
+    val bar_s = { assertTrue(ic.advance); aacc } match {
+      case Start(bar_s: DIComplex) => bar_s
+      case _ => fail(); null
+    }
     val Seq(bazERD, fooERD) = barERD.childERDs
     ic.pushTRD(barSeqTRD)
     ic.pushTRD(bazERD)
-    val Start(baz_s: DISimple) = { assertTrue(ic.advance); aacc }
-    val End(baz_e: DISimple) = { assertTrue(ic.advance); aacc }
+    val baz_s = { assertTrue(ic.advance); aacc } match {
+      case Start(baz_s: DISimple) => baz_s
+      case _ => fail(); null
+    }
+    val baz_e = { assertTrue(ic.advance); aacc } match {
+      case End(baz_e: DISimple) => baz_e
+      case _ => fail(); null
+    }
     assertNotNull(baz_e)
     ic.popTRD()
     ic.pushTRD(fooERD)
-    val StartArray(foo_arr_s) = { assertTrue(ic.advance); aacc }
-    val Start(foo_1_s: DISimple) = { assertTrue(ic.advance); aacc }
-    val End(foo_1_e: DISimple) = { assertTrue(ic.advance); aacc }
-    val Start(foo_2_s: DISimple) = { assertTrue(ic.advance); aacc }
-    val End(foo_2_e: DISimple) = { assertTrue(ic.advance); aacc }
-    val EndArray(foo_arr_e) = { assertTrue(ic.advance); aacc }
+    val foo_arr_s = { assertTrue(ic.advance); aacc } match {
+      case StartArray(foo_arr_s) => foo_arr_s
+      case _ => fail(); null
+    }
+    val foo_1_s = { assertTrue(ic.advance); aacc } match {
+      case Start(foo_1_s: DISimple) => foo_1_s
+      case _ => fail(); null
+    }
+    val foo_1_e = { assertTrue(ic.advance); aacc } match {
+      case End(foo_1_e: DISimple) => foo_1_e
+      case _ => fail(); null
+    }
+    val foo_2_s = { assertTrue(ic.advance); aacc } match {
+      case Start(foo_2_s: DISimple) => foo_2_s
+      case _ => fail(); null
+    }
+    val foo_2_e = { assertTrue(ic.advance); aacc } match {
+      case End(foo_2_e: DISimple) => foo_2_e
+      case _ => fail(); null
+    }
+    val foo_arr_e = { assertTrue(ic.advance); aacc } match {
+      case EndArray(foo_arr_e) => foo_arr_e
+      case _ => fail(); null
+    }
     ic.popTRD()
-    val End(bar_e: DIComplex) = { assertTrue(ic.advance); aacc }
+    val bar_e = { assertTrue(ic.advance); aacc } match {
+      case End(bar_e: DIComplex) => bar_e
+      case _ => fail(); null
+    }
     ic.popTRD()
     ic.popTRD()
     assertFalse(ic.inspect)
@@ -512,27 +717,66 @@ class TestInfosetInputter {
     val (ic, rootERD) = infosetInputter(sch, infosetXML)
     val aacc = ic.advanceAccessor
     val barERD = rootERD
-    val Some(barSeqTRD: SequenceRuntimeData) = barERD.optComplexTypeModelGroupRuntimeData
+    val barSeqTRD = barERD.optComplexTypeModelGroupRuntimeData match {
+      case Some(barSeqTRD: SequenceRuntimeData) => barSeqTRD
+      case _ => fail(); null
+    }
     val Seq(bazERD, fooERD) = barERD.childERDs
     ic.pushTRD(barERD)
-    val Start(bar_s: DIComplex) = { assertTrue(ic.advance); aacc }
+    val bar_s = { assertTrue(ic.advance); aacc } match {
+      case Start(bar_s: DIComplex) => bar_s
+      case _ => fail(); null
+    }
     ic.pushTRD(barSeqTRD)
     ic.pushTRD(bazERD)
-    val StartArray(baz_arr_s) = { assertTrue(ic.advance); aacc }
-    val Start(baz_s: DISimple) = { assertTrue(ic.advance); aacc }
-    val End(baz_e: DISimple) = { assertTrue(ic.advance); aacc }
+    val baz_arr_s = { assertTrue(ic.advance); aacc } match {
+      case StartArray(baz_arr_s) => baz_arr_s
+      case _ => fail(); null
+    }
+    val baz_s = { assertTrue(ic.advance); aacc } match {
+      case Start(baz_s: DISimple) => baz_s
+      case _ => fail(); null
+    }
+    val baz_e = { assertTrue(ic.advance); aacc } match {
+      case End(baz_e: DISimple) => baz_e
+      case _ => fail(); null
+    }
     assertNotNull(baz_e)
-    val EndArray(baz_arr_e) = { assertTrue(ic.advance); aacc }
+    val baz_arr_e = { assertTrue(ic.advance); aacc } match {
+      case EndArray(baz_arr_e) => baz_arr_e
+      case _ => fail(); null
+    }
     ic.popTRD()
     ic.pushTRD(fooERD)
-    val StartArray(foo_arr_s) = { assertTrue(ic.advance); aacc }
-    val Start(foo_1_s: DISimple) = { assertTrue(ic.advance); aacc }
-    val End(foo_1_e: DISimple) = { assertTrue(ic.advance); aacc }
-    val Start(foo_2_s: DISimple) = { assertTrue(ic.advance); aacc }
-    val End(foo_2_e: DISimple) = { assertTrue(ic.advance); aacc }
-    val EndArray(foo_arr_e) = { assertTrue(ic.advance); aacc }
+    val foo_arr_s = { assertTrue(ic.advance); aacc } match {
+      case StartArray(foo_arr_s) => foo_arr_s
+      case _ => fail(); null
+    }
+    val foo_1_s = { assertTrue(ic.advance); aacc } match {
+      case Start(foo_1_s: DISimple) => foo_1_s
+      case _ => fail(); null
+    }
+    val foo_1_e = { assertTrue(ic.advance); aacc } match {
+      case End(foo_1_e: DISimple) => foo_1_e
+      case _ => fail(); null
+    }
+    val foo_2_s = { assertTrue(ic.advance); aacc } match {
+      case Start(foo_2_s: DISimple) => foo_2_s
+      case _ => fail(); null
+    }
+    val foo_2_e = { assertTrue(ic.advance); aacc } match {
+      case End(foo_2_e: DISimple) => foo_2_e
+      case _ => fail(); null
+    }
+    val foo_arr_e = { assertTrue(ic.advance); aacc } match {
+      case EndArray(foo_arr_e) => foo_arr_e
+      case _ => fail(); null
+    }
     ic.popTRD()
-    val End(bar_e: DIComplex) = { assertTrue(ic.advance); aacc }
+    val bar_e = { assertTrue(ic.advance); aacc } match {
+      case End(bar_e: DIComplex) => bar_e
+      case _ => fail(); null
+    }
     ic.popTRD()
     ic.popTRD()
     assertFalse(ic.inspect)
@@ -566,21 +810,48 @@ class TestInfosetInputter {
     val aacc = ic.advanceAccessor
     val iacc = ic.inspectAccessor
     val barERD = rootERD
-    val Some(barSeqTRD: SequenceRuntimeData) = barERD.optComplexTypeModelGroupRuntimeData
+    val barSeqTRD = barERD.optComplexTypeModelGroupRuntimeData match {
+      case Some(barSeqTRD: SequenceRuntimeData) => barSeqTRD
+      case _ => fail(); null
+    }
     val Seq(fooERD) = barERD.childERDs
     ic.pushTRD(barERD)
-    val Start(bar_s1: DIComplex) = { assertTrue(ic.inspect); iacc }
-    val Start(bar_s2: DIComplex) = { assertTrue(ic.inspect); iacc }
-    val Start(bar_s3: DIComplex) = { assertTrue(ic.advance); aacc }
+    val bar_s1 = { assertTrue(ic.inspect); iacc } match {
+      case Start(bar_s1: DIComplex) => bar_s1
+      case _ => fail(); null
+    }
+    val bar_s2 = { assertTrue(ic.inspect); iacc } match {
+      case Start(bar_s2: DIComplex) => bar_s2
+      case _ => fail(); null
+    }
+    val bar_s3 = { assertTrue(ic.advance); aacc } match {
+      case Start(bar_s3: DIComplex) => bar_s3
+      case _ => fail(); null
+    }
     ic.pushTRD(barSeqTRD)
     ic.pushTRD(fooERD)
-    val Start(foo_s1: DISimple) = { assertTrue(ic.inspect); iacc }
-    val Start(foo_s2: DISimple) = { assertTrue(ic.advance); aacc }
-    val End(foo_e: DISimple) = { assertTrue(ic.advance); aacc }
-    val End(bar_e1: DIComplex) = { assertTrue(ic.inspect); iacc }
+    val foo_s1 = { assertTrue(ic.inspect); iacc } match {
+      case Start(foo_s1: DISimple) => foo_s1
+      case _ => fail(); null
+    }
+    val foo_s2 = { assertTrue(ic.advance); aacc } match {
+      case Start(foo_s2: DISimple) => foo_s2
+      case _ => fail(); null
+    }
+    val foo_e = { assertTrue(ic.advance); aacc } match {
+      case End(foo_e: DISimple) => foo_e
+      case _ => fail(); null
+    }
+    val bar_e1 = { assertTrue(ic.inspect); iacc } match {
+      case End(bar_e1: DIComplex) => bar_e1
+      case _ => fail(); null
+    }
     assertTrue(ic.inspect)
     ic.popTRD()
-    val End(bar_e2: DIComplex) = { assertTrue(ic.advance); aacc }
+    val bar_e2 = { assertTrue(ic.advance); aacc } match {
+      case End(bar_e2: DIComplex) => bar_e2
+      case _ => fail(); null
+    }
     ic.popTRD()
     ic.popTRD()
     assertFalse(ic.inspect)
@@ -618,29 +889,71 @@ class TestInfosetInputter {
     }><s><c1>Hello</c1></s><s><c2>World</c2></s></e>
     val (ic, rootERD) = infosetInputter(sch, infosetXML)
     val aacc = ic.advanceAccessor
-    val Start(e: DIComplex) = { assertTrue(ic.advance); aacc }
+    val e = { assertTrue(ic.advance); aacc } match {
+      case Start(e: DIComplex) => e
+      case _ => fail(); null
+    }
     val eERD = e.erd
-    val Some(eSeqTRD: SequenceRuntimeData) = eERD.optComplexTypeModelGroupRuntimeData
+    val eSeqTRD = eERD.optComplexTypeModelGroupRuntimeData match {
+      case Some(eSeqTRD: SequenceRuntimeData) => eSeqTRD
+      case _ => fail(); null
+    }
     val Seq(sERD) = eERD.childERDs
-    val Some(sChoTRD: ChoiceRuntimeData) = sERD.optComplexTypeModelGroupRuntimeData
+    val sChoTRD = sERD.optComplexTypeModelGroupRuntimeData match {
+      case Some(sChoTRD: ChoiceRuntimeData) => sChoTRD
+      case _ => fail(); null
+    }
     val Seq(c1ERD, c2ERD) = sERD.childERDs
     ic.pushTRD(eSeqTRD)
     ic.pushTRD(sERD)
-    val StartArray(as) = { assertTrue(ic.advance); aacc }
-    val Start(s1: DIComplex) = { assertTrue(ic.advance); aacc }; assertNotNull(s1)
+    val as = { assertTrue(ic.advance); aacc } match {
+      case StartArray(as) => as
+      case _ => fail(); null
+    }
+    val s1 = { assertTrue(ic.advance); aacc } match {
+      case Start(s1: DIComplex) => s1
+      case _ => fail(); null
+    }; assertNotNull(s1)
     ic.pushTRD(sChoTRD)
-    val Start(c1: DISimple) = { assertTrue(ic.advance); aacc }
-    val End(c1e: DISimple) = { assertTrue(ic.advance); aacc }; assertNotNull(c1e)
-    val End(s1e: DIComplex) = { assertTrue(ic.advance); aacc }; assertNotNull(s1e)
+    val c1 = { assertTrue(ic.advance); aacc } match {
+      case Start(c1: DISimple) => c1
+      case _ => fail(); null
+    }
+    val c1e = { assertTrue(ic.advance); aacc } match {
+      case End(c1e: DISimple) => c1e
+      case _ => fail(); null
+    }; assertNotNull(c1e)
+    val s1e = { assertTrue(ic.advance); aacc } match {
+      case End(s1e: DIComplex) => s1e
+      case _ => fail(); null
+    }; assertNotNull(s1e)
     ic.popTRD()
-    val Start(s2: DIComplex) = { assertTrue(ic.advance); aacc }; assertNotNull(s2)
+    val s2 = { assertTrue(ic.advance); aacc } match {
+      case Start(s2: DIComplex) => s2
+      case _ => fail(); null
+    }; assertNotNull(s2)
     ic.pushTRD(sChoTRD)
-    val Start(c2: DISimple) = { assertTrue(ic.advance); aacc }
-    val End(c2e: DISimple) = { assertTrue(ic.advance); aacc };; assertNotNull(c2e)
-    val End(s2e: DIComplex) = { assertTrue(ic.advance); aacc }; assertNotNull(s2e)
+    val c2 = { assertTrue(ic.advance); aacc } match {
+      case Start(c2: DISimple) => c2
+      case _ => fail(); null
+    }
+    val c2e = { assertTrue(ic.advance); aacc } match {
+      case End(c2e: DISimple) => c2e
+      case _ => fail(); null
+    }; assertNotNull(c2e)
+    val s2e = { assertTrue(ic.advance); aacc } match {
+      case End(s2e: DIComplex) => s2e
+      case _ => fail(); null
+    }; assertNotNull(s2e)
     ic.popTRD()
-    val EndArray(ase) = { assertTrue(ic.advance); aacc }
-    val End(ee: DIComplex) = { assertTrue(ic.advance); aacc }
+    val ase = { assertTrue(ic.advance); aacc } match {
+      case EndArray(ase) => ase
+      case _ => fail(); null
+    }
+    val ee = { assertTrue(ic.advance); aacc } match {
+      case End(ee: DIComplex) => ee
+      case _ => fail(); null
+    }
     ic.popTRD()
     ic.popTRD()
     assertFalse(ic.inspect)

--- a/daffodil-core/src/test/scala/org/apache/daffodil/core/infoset/TestInfosetCursorFromReader.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/core/infoset/TestInfosetCursorFromReader.scala
@@ -86,7 +86,10 @@ class TestInfosetInputterFromReader {
     val infosetXML = <foo xmlns={XMLUtils.EXAMPLE_NAMESPACE}>Hello</foo>
     val (ii, _, _, _) = infosetInputter(sch, infosetXML)
     val is = ii.to(LazyList).toList
-    val List(Start(s: DISimple), End(e: DISimple)) = is
+    val (s, e) = is match {
+      case List(Start(s: DISimple), End(e: DISimple)) => (s, e)
+      case _ => fail(); null
+    }
     assertTrue(s eq e) // exact same object
     assertTrue(s.dataValue.getAnyRef.isInstanceOf[String])
     assertTrue(s.dataValueAsString =:= "Hello")
@@ -103,7 +106,10 @@ class TestInfosetInputterFromReader {
     }/>
     val (ii, _, _, _) = infosetInputter(sch, infosetXML)
     val is = ii.to(LazyList).toList
-    val List(Start(s: DISimple), End(e: DISimple)) = is
+    val (s, e) = is match {
+      case List(Start(s: DISimple), End(e: DISimple)) => (s, e)
+      case _ => fail(); null
+    }
     assertTrue(s eq e) // exact same object
     assertTrue(s.isNilled)
   }
@@ -123,15 +129,27 @@ class TestInfosetInputterFromReader {
     val infosetXML = <bar xmlns={XMLUtils.EXAMPLE_NAMESPACE}><foo>Hello</foo></bar>
     val (is, rootERD, inp, tunable) = infosetInputter(sch, infosetXML)
     val Seq(fooERD) = rootERD.childERDs
-    val Start(bar_s: DIComplex) = is.next()
+    val bar_s = is.next() match {
+      case Start(bar_s: DIComplex) => bar_s
+      case _ => fail(); null
+    }
 
     inp.pushTRD(fooERD)
-    val Start(foo_s: DISimple) = is.next()
+    val foo_s = is.next() match {
+      case Start(foo_s: DISimple) => foo_s
+      case _ => fail(); null
+    }
     bar_s.addChild(foo_s, tunable)
-    val End(foo_e: DISimple) = is.next()
+    val foo_e = is.next() match {
+      case End(foo_e: DISimple) => foo_e
+      case _ => fail(); null
+    }
     val poppedERD = inp.popTRD()
     assertEquals(fooERD, poppedERD)
-    val End(bar_e: DIComplex) = is.next()
+    val bar_e = is.next() match {
+      case End(bar_e: DIComplex) => bar_e
+      case _ => fail(); null
+    }
     assertFalse(is.hasNext)
     assertTrue(bar_s eq bar_e) // exact same object
     assertTrue(foo_s eq foo_e)
@@ -156,17 +174,35 @@ class TestInfosetInputterFromReader {
       XMLUtils.EXAMPLE_NAMESPACE
     }><foo>Hello</foo><baz>World</baz></bar>
     val (is, rootERD, inp, tunable) = infosetInputter(sch, infosetXML)
-    val Start(bar_s: DIComplex) = is.next()
+    val bar_s = is.next() match {
+      case Start(bar_s: DIComplex) => bar_s
+      case _ => fail(); null
+    }
     val Seq(fooERD, bazERD) = rootERD.childERDs
     inp.pushTRD(fooERD)
-    val Start(foo_s: DISimple) = is.next()
-    val End(foo_e: DISimple) = is.next()
+    val foo_s = is.next() match {
+      case Start(foo_s: DISimple) => foo_s
+      case _ => fail(); null
+    }
+    val foo_e = is.next() match {
+      case End(foo_e: DISimple) => foo_e
+      case _ => fail(); null
+    }
     assertEquals(fooERD, inp.popTRD())
     inp.pushTRD(bazERD)
-    val Start(baz_s: DISimple) = is.next()
-    val End(baz_e: DISimple) = is.next(); assertNotNull(baz_e)
+    val baz_s = is.next() match {
+      case Start(baz_s: DISimple) => baz_s
+      case _ => fail(); null
+    }
+    val baz_e = is.next() match {
+      case End(baz_e: DISimple) => baz_e
+      case _ => fail(); null
+    }; assertNotNull(baz_e)
     assertEquals(bazERD, inp.popTRD())
-    val End(bar_e: DIComplex) = is.next()
+    val bar_e = is.next() match {
+      case End(bar_e: DIComplex) => bar_e
+      case _ => fail(); null
+    }
     assertFalse(is.hasNext)
     assertTrue(bar_s eq bar_e) // exact same object
     assertTrue(foo_s eq foo_e)
@@ -211,30 +247,65 @@ class TestInfosetInputterFromReader {
     //
     // Get all the ERDs and Sequence TRDs
     //
-    val Some(seq1TRD: SequenceRuntimeData) = rootERD.optComplexTypeModelGroupRuntimeData
-    val Seq(bar1ERD: ElementRuntimeData, bar2ERD: ElementRuntimeData) = seq1TRD.groupMembers
-    val Some(bar1SeqTRD: SequenceRuntimeData) = bar1ERD.optComplexTypeModelGroupRuntimeData
-    val Seq(foo1ERD: ElementRuntimeData, baz1ERD: ElementRuntimeData) = bar1SeqTRD.groupMembers
-    val Some(bar2SeqTRD: SequenceRuntimeData) = bar2ERD.optComplexTypeModelGroupRuntimeData
-    val Seq(foo2ERD: ElementRuntimeData, baz2ERD: ElementRuntimeData) = bar2SeqTRD.groupMembers
+    val seq1TRD = rootERD.optComplexTypeModelGroupRuntimeData match {
+      case Some(seq1TRD: SequenceRuntimeData) => seq1TRD
+      case _ => fail(); null
+    }
+    val (bar1ERD, bar2ERD) = seq1TRD.groupMembers match {
+      case Seq(bar1ERD: ElementRuntimeData, bar2ERD: ElementRuntimeData) => (bar1ERD, bar2ERD)
+      case _ => fail(); null
+    }
+    val bar1SeqTRD = bar1ERD.optComplexTypeModelGroupRuntimeData match {
+      case Some(bar1SeqTRD: SequenceRuntimeData) => bar1SeqTRD
+      case _ => fail(); null
+    }
+    val (foo1ERD, baz1ERD) = bar1SeqTRD.groupMembers match {
+      case Seq(foo1ERD: ElementRuntimeData, baz1ERD: ElementRuntimeData) => (foo1ERD, baz1ERD)
+      case _ => fail(); null
+    }
+    val bar2SeqTRD = bar2ERD.optComplexTypeModelGroupRuntimeData match {
+      case Some(bar2SeqTRD: SequenceRuntimeData) => bar2SeqTRD
+      case _ => fail(); null
+    }
+    val (foo2ERD, baz2ERD) = bar2SeqTRD.groupMembers match {
+      case Seq(foo2ERD: ElementRuntimeData, baz2ERD: ElementRuntimeData) => (foo2ERD, baz2ERD)
+      case _ => fail(); null
+    }
 
     inp.pushTRD(rootERD)
-    val Start(quux_s: DIComplex) = is.next()
+    val quux_s = is.next() match {
+      case Start(quux_s: DIComplex) => quux_s
+      case _ => fail(); null
+    }
     inp.pushTRD(seq1TRD)
     inp.pushTRD(bar1ERD)
-    val Start(bar1_s: DIComplex) = is.next()
+    val bar1_s = is.next() match {
+      case Start(bar1_s: DIComplex) => bar1_s
+      case _ => fail(); null
+    }
     //
     // When the unparser for the bar1 element does eventually run, it will push the bar1ERD
     // and when it runs the model group unparser it will push that sequence's TRD.
     inp.pushTRD(bar1SeqTRD)
     inp.pushTRD(foo1ERD)
-    val Start(foo1_s: DISimple) = is.next()
-    val End(foo1_e: DISimple) = is.next()
+    val foo1_s = is.next() match {
+      case Start(foo1_s: DISimple) => foo1_s
+      case _ => fail(); null
+    }
+    val foo1_e = is.next() match {
+      case End(foo1_e: DISimple) => foo1_e
+      case _ => fail(); null
+    }
     assertEquals(foo1ERD, inp.popTRD())
     inp.pushTRD(baz1ERD)
-    val Start(baz1_s: DISimple) = is.next()
-    val End(baz1_e: DISimple) = is.next();
-    assertNotNull(baz1_e)
+    val baz1_s = is.next() match {
+      case Start(baz1_s: DISimple) => baz1_s
+      case _ => fail(); null
+    }
+    val baz1_e = is.next() match {
+      case End(baz1_e: DISimple) => baz1_e
+      case _ => fail(); null
+    }; assertNotNull(baz1_e)
     assertEquals(baz1ERD, inp.popTRD())
     //
     // At the end of a complex element, it should not be expecting
@@ -243,25 +314,49 @@ class TestInfosetInputterFromReader {
     val badERD = inp.nextElement("notFound", XMLUtils.EXAMPLE_NAMESPACE, true)
     assertTrue(badERD.isInstanceOf[ErrorERD])
 
-    val End(bar1_e: DIComplex) = is.next()
+    val bar1_e = is.next() match {
+      case End(bar1_e: DIComplex) => bar1_e
+      case _ => fail(); null
+    }
     assertEquals(bar1SeqTRD, inp.popTRD())
     assertEquals(bar1ERD, inp.popTRD())
     inp.pushTRD(bar2ERD)
-    val Start(bar2_s: DIComplex) = is.next()
+    val bar2_s = is.next() match {
+      case Start(bar2_s: DIComplex) => bar2_s
+      case _ => fail(); null
+    }
     inp.pushTRD(bar2SeqTRD)
     inp.pushTRD(foo2ERD)
-    val Start(foo2_s: DISimple) = is.next()
-    val End(foo2_e: DISimple) = is.next()
+    val foo2_s = is.next() match {
+      case Start(foo2_s: DISimple) => foo2_s
+      case _ => fail(); null
+    }
+    val foo2_e = is.next() match {
+      case End(foo2_e: DISimple) => foo2_e
+      case _ => fail(); null
+    }
     assertEquals(foo2ERD, inp.popTRD())
     inp.pushTRD(baz2ERD)
-    val Start(baz2_s: DISimple) = is.next()
-    val End(baz2_e: DISimple) = is.next();
+    val baz2_s = is.next() match {
+      case Start(baz2_s: DISimple) => baz2_s
+      case _ => fail(); null
+    }
+    val baz2_e = is.next() match {
+      case End(baz2_e: DISimple) => baz2_e
+      case _ => fail(); null
+    }
     assertNotNull(baz2_e)
     assertEquals(baz2ERD, inp.popTRD())
     assertEquals(bar2SeqTRD, inp.popTRD())
     assertEquals(bar2ERD, inp.popTRD())
-    val End(bar2_e: DIComplex) = is.next()
-    val End(quux_e: DIComplex) = is.next()
+    val bar2_e = is.next() match {
+      case End(bar2_e: DIComplex) => bar2_e
+      case _ => fail(); null
+    }
+    val quux_e = is.next() match {
+      case End(quux_e: DIComplex) => quux_e
+      case _ => fail(); null
+    }
     assertFalse(is.hasNext)
     assertTrue(bar1_s eq bar1_e) // exact same object
     assertTrue(foo1_s eq foo1_e)
@@ -294,24 +389,54 @@ class TestInfosetInputterFromReader {
       XMLUtils.EXAMPLE_NAMESPACE
     }><foo>Hello</foo><foo>World</foo></bar>
     val (is, rootERD, inp, tunable) = infosetInputter(sch, infosetXML)
-    val Some(barSeqTRD: SequenceRuntimeData) = rootERD.optComplexTypeModelGroupRuntimeData
-    val Seq(fooERD: ElementRuntimeData) = barSeqTRD.groupMembers
+    val barSeqTRD = rootERD.optComplexTypeModelGroupRuntimeData match {
+      case Some(barSeqTRD: SequenceRuntimeData) => barSeqTRD
+      case _ => fail(); null
+    }
+    val fooERD = barSeqTRD.groupMembers match {
+      case Seq(fooERD: ElementRuntimeData) => fooERD
+      case _ => fail(); null
+    }
     val doc = inp.documentElement
-    val Start(bar_s: DIComplex) = is.next()
+    val bar_s = is.next() match {
+      case Start(bar_s: DIComplex) => bar_s
+      case _ => fail(); null
+    }
     doc.addChild(bar_s, tunable)
     inp.pushTRD(barSeqTRD)
     inp.pushTRD(fooERD)
-    val StartArray(foo_arr_s) = is.next()
-    val Start(foo_1_s: DISimple) = is.next()
+    val foo_arr_s = is.next() match {
+      case StartArray(foo_arr_s) => foo_arr_s
+      case _ => fail(); null
+    }
+    val foo_1_s = is.next() match {
+      case Start(foo_1_s: DISimple) => foo_1_s
+      case _ => fail(); null
+    }
     bar_s.addChild(foo_1_s, tunable)
-    val End(foo_1_e: DISimple) = is.next()
-    val Start(foo_2_s: DISimple) = is.next()
+    val foo_1_e = is.next() match {
+      case End(foo_1_e: DISimple) => foo_1_e
+      case _ => fail(); null
+    }
+    val foo_2_s = is.next() match {
+      case Start(foo_2_s: DISimple) => foo_2_s
+      case _ => fail(); null
+    }
     bar_s.addChild(foo_2_s, tunable)
-    val End(foo_2_e: DISimple) = is.next()
-    val EndArray(foo_arr_e) = is.next()
+    val foo_2_e = is.next() match {
+      case End(foo_2_e: DISimple) => foo_2_e
+      case _ => fail(); null
+    }
+    val foo_arr_e = is.next() match {
+      case EndArray(foo_arr_e) => foo_arr_e
+      case _ => fail(); null
+    }
     assertEquals(fooERD, inp.popTRD())
     assertEquals(barSeqTRD, inp.popTRD())
-    val End(bar_e: DIComplex) = is.next()
+    val bar_e = is.next() match {
+      case End(bar_e: DIComplex) => bar_e
+      case _ => fail(); null
+    }
     assertFalse(is.hasNext)
     assertTrue(bar_s eq bar_e) // exact same object
     assertTrue(foo_arr_s eq foo_arr_e)
@@ -340,29 +465,65 @@ class TestInfosetInputterFromReader {
       XMLUtils.EXAMPLE_NAMESPACE
     }><foo>Hello</foo><foo>World</foo><baz>Yadda</baz></bar>
     val (is, rootERD, inp, tunable) = infosetInputter(sch, infosetXML)
-    val Some(barSeqTRD: SequenceRuntimeData) = rootERD.optComplexTypeModelGroupRuntimeData
-    val Seq(fooERD: ElementRuntimeData, bazERD: ElementRuntimeData) = barSeqTRD.groupMembers
-    val Start(bar_s: DIComplex) = is.next()
+    val barSeqTRD = rootERD.optComplexTypeModelGroupRuntimeData match {
+      case Some(barSeqTRD: SequenceRuntimeData) => barSeqTRD
+      case _ => fail(); null
+    }
+    val (fooERD, bazERD) = barSeqTRD.groupMembers match {
+      case Seq(fooERD: ElementRuntimeData, bazERD: ElementRuntimeData) => (fooERD, bazERD)
+      case _ => fail(); null
+    }
+    val bar_s = is.next() match {
+      case Start(bar_s: DIComplex) => bar_s
+      case _ => fail(); null
+    }
     inp.pushTRD(barSeqTRD)
     inp.pushTRD(fooERD)
-    val StartArray(foo_arr_s) = is.next()
-    val Start(foo_1_s: DISimple) = is.next()
-    val End(foo_1_e: DISimple) = is.next()
-    val Start(foo_2_s: DISimple) = is.next()
-    val End(foo_2_e: DISimple) = is.next()
-    val EndArray(foo_arr_e) = is.next()
+    val foo_arr_s = is.next() match {
+      case StartArray(foo_arr_s) => foo_arr_s
+      case _ => fail(); null
+    }
+    val foo_1_s = is.next() match {
+      case Start(foo_1_s: DISimple) => foo_1_s
+      case _ => fail(); null
+    }
+    val foo_1_e = is.next() match {
+      case End(foo_1_e: DISimple) => foo_1_e
+      case _ => fail(); null
+    }
+    val foo_2_s = is.next() match {
+      case Start(foo_2_s: DISimple) => foo_2_s
+      case _ => fail(); null
+    }
+    val foo_2_e = is.next() match {
+      case End(foo_2_e: DISimple) => foo_2_e
+      case _ => fail(); null
+    }
+    val foo_arr_e = is.next() match {
+      case EndArray(foo_arr_e) => foo_arr_e
+      case _ => fail(); null
+    }
     //
     // While fooERD is still on the stack, we should be able to resolve baz element since
     // foo is optional
     //
-    val Start(baz_s: DISimple) = is.next()
+    val baz_s = is.next() match {
+      case Start(baz_s: DISimple) => baz_s
+      case _ => fail(); null
+    }
     assertEquals(fooERD, inp.popTRD())
     inp.pushTRD(bazERD)
-    val End(baz_e: DISimple) = is.next()
+    val baz_e = is.next() match {
+      case End(baz_e: DISimple) => baz_e
+      case _ => fail(); null
+    }
     assertNotNull(baz_e)
     assertEquals(bazERD, inp.popTRD())
     assertEquals(barSeqTRD, inp.popTRD())
-    val End(bar_e: DIComplex) = is.next()
+    val bar_e = is.next() match {
+      case End(bar_e: DIComplex) => bar_e
+      case _ => fail(); null
+    }
     assertFalse(is.hasNext)
     assertTrue(bar_s eq bar_e) // exact same object
     assertTrue(foo_arr_s eq foo_arr_e)
@@ -393,29 +554,65 @@ class TestInfosetInputterFromReader {
       XMLUtils.EXAMPLE_NAMESPACE
     }><baz>Yadda</baz><foo>Hello</foo><foo>World</foo></bar>
     val (is, rootERD, inp, tunable) = infosetInputter(sch, infosetXML)
-    val Some(barSeqTRD: SequenceRuntimeData) = rootERD.optComplexTypeModelGroupRuntimeData
-    val Seq(bazERD: ElementRuntimeData, fooERD: ElementRuntimeData) = barSeqTRD.groupMembers
+    val barSeqTRD = rootERD.optComplexTypeModelGroupRuntimeData match {
+      case Some(barSeqTRD: SequenceRuntimeData) => barSeqTRD
+      case _ => fail(); null
+    }
+    val (bazERD, fooERD) = barSeqTRD.groupMembers match {
+      case Seq(bazERD: ElementRuntimeData, fooERD: ElementRuntimeData) => (bazERD, fooERD)
+      case _ => fail(); null
+    }
 
-    val Start(bar_s: DIComplex) = is.next()
+    val bar_s = is.next() match {
+      case Start(bar_s: DIComplex) => bar_s
+      case _ => fail(); null
+    }
 
     inp.pushTRD(barSeqTRD)
     inp.pushTRD(bazERD)
 
-    val Start(baz_s: DISimple) = is.next()
-    val End(baz_e: DISimple) = is.next()
+    val baz_s = is.next() match {
+      case Start(baz_s: DISimple) => baz_s
+      case _ => fail(); null
+    }
+    val baz_e = is.next() match {
+      case End(baz_e: DISimple) => baz_e
+      case _ => fail(); null
+    }
     assertNotNull(baz_e)
     inp.popTRD()
     inp.pushTRD(fooERD)
-    val StartArray(foo_arr_s) = is.next()
-    val Start(foo_1_s: DISimple) = is.next()
-    val End(foo_1_e: DISimple) = is.next()
-    val Start(foo_2_s: DISimple) = is.next()
-    val End(foo_2_e: DISimple) = is.next()
+    val foo_arr_s = is.next() match {
+      case StartArray(foo_arr_s) => foo_arr_s
+      case _ => fail(); null
+    }
+    val foo_1_s = is.next() match {
+      case Start(foo_1_s: DISimple) => foo_1_s
+      case _ => fail(); null
+    }
+    val foo_1_e = is.next() match {
+      case End(foo_1_e: DISimple) => foo_1_e
+      case _ => fail(); null
+    }
+    val foo_2_s = is.next() match {
+      case Start(foo_2_s: DISimple) => foo_2_s
+      case _ => fail(); null
+    }
+    val foo_2_e = is.next() match {
+      case End(foo_2_e: DISimple) => foo_2_e
+      case _ => fail(); null
+    }
     inp.popTRD()
     inp.popTRD()
-    val EndArray(foo_arr_e) = is.next()
+    val foo_arr_e = is.next() match {
+      case EndArray(foo_arr_e) => foo_arr_e
+      case _ => fail(); null
+    }
 
-    val End(bar_e: DIComplex) = is.next()
+    val bar_e = is.next() match {
+      case End(bar_e: DIComplex) => bar_e
+      case _ => fail(); null
+    }
     assertFalse(is.hasNext)
     assertTrue(bar_s eq bar_e) // exact same object
     assertTrue(foo_arr_s eq foo_arr_e)
@@ -446,25 +643,67 @@ class TestInfosetInputterFromReader {
       XMLUtils.EXAMPLE_NAMESPACE
     }><baz>Yadda</baz><foo>Hello</foo><foo>World</foo></bar>
     val (is, rootERD, inp, tunable) = infosetInputter(sch, infosetXML)
-    val Some(barSeqTRD: SequenceRuntimeData) = rootERD.optComplexTypeModelGroupRuntimeData
-    val Seq(bazERD: ElementRuntimeData, fooERD: ElementRuntimeData) = barSeqTRD.groupMembers
+    val barSeqTRD = rootERD.optComplexTypeModelGroupRuntimeData match {
+      case Some(barSeqTRD: SequenceRuntimeData) => barSeqTRD
+      case _ => fail(); null
+    }
+    val (bazERD, fooERD) = barSeqTRD.groupMembers match {
+      case Seq(bazERD: ElementRuntimeData, fooERD: ElementRuntimeData) => (bazERD, fooERD)
+      case _ => fail(); null
+    }
 
-    val Start(bar_s: DIComplex) = is.next()
+    val bar_s = is.next() match {
+      case Start(bar_s: DIComplex) => bar_s
+      case _ => fail(); null
+    }
     inp.pushTRD(barSeqTRD)
     inp.pushTRD(bazERD)
-    val StartArray(baz_arr_s) = is.next()
-    val Start(baz_s: DISimple) = is.next()
-    val End(baz_e: DISimple) = is.next()
+    val baz_arr_s = is.next() match {
+      case StartArray(baz_arr_s) => baz_arr_s
+      case _ => fail(); null
+    }
+    val baz_s = is.next() match {
+      case Start(baz_s: DISimple) => baz_s
+      case _ => fail(); null
+    }
+    val baz_e = is.next() match {
+      case End(baz_e: DISimple) => baz_e
+      case _ => fail(); null
+    }
     assertNotNull(baz_e)
-    val EndArray(baz_arr_e) = is.next()
-    val StartArray(foo_arr_s) = is.next()
-    val Start(foo_1_s: DISimple) = is.next()
-    val End(foo_1_e: DISimple) = is.next()
-    val Start(foo_2_s: DISimple) = is.next()
-    val End(foo_2_e: DISimple) = is.next()
-    val EndArray(foo_arr_e) = is.next()
+    val baz_arr_e = is.next() match {
+      case EndArray(baz_arr_e) => baz_arr_e
+      case _ => fail(); null
+    }
+    val foo_arr_s = is.next() match {
+      case StartArray(foo_arr_s) => foo_arr_s
+      case _ => fail(); null
+    }
+    val foo_1_s = is.next() match {
+      case Start(foo_1_s: DISimple) => foo_1_s
+      case _ => fail(); null
+    }
+    val foo_1_e = is.next() match {
+      case End(foo_1_e: DISimple) => foo_1_e
+      case _ => fail(); null
+    }
+    val foo_2_s = is.next() match {
+      case Start(foo_2_s: DISimple) => foo_2_s
+      case _ => fail(); null
+    }
+    val foo_2_e = is.next() match {
+      case End(foo_2_e: DISimple) => foo_2_e
+      case _ => fail(); null
+    }
+    val foo_arr_e = is.next() match {
+      case EndArray(foo_arr_e) => foo_arr_e
+      case _ => fail(); null
+    }
     inp.popTRD()
-    val End(bar_e: DIComplex) = is.next()
+    val bar_e = is.next() match {
+      case End(bar_e: DIComplex) => bar_e
+      case _ => fail(); null
+    }
     assertFalse(is.hasNext)
     assertTrue(bar_s eq bar_e) // exact same object
     assertTrue(foo_arr_s eq foo_arr_e)
@@ -493,22 +732,52 @@ class TestInfosetInputterFromReader {
     )
     val infosetXML = <bar xmlns={XMLUtils.EXAMPLE_NAMESPACE}><foo>Hello</foo></bar>
     val (is, rootERD, inp, tunable) = infosetInputter(sch, infosetXML)
-    val Some(barSeqTRD: SequenceRuntimeData) = rootERD.optComplexTypeModelGroupRuntimeData
-    val Seq(fooERD: ElementRuntimeData) = barSeqTRD.groupMembers
+    val barSeqTRD = rootERD.optComplexTypeModelGroupRuntimeData match {
+      case Some(barSeqTRD: SequenceRuntimeData) => barSeqTRD
+      case _ => fail(); null
+    }
+    val fooERD = barSeqTRD.groupMembers match {
+      case Seq(fooERD: ElementRuntimeData) => fooERD
+      case _ => fail(); null
+    }
 
-    val Start(bar_s1: DIComplex) = is.peek
-    val Start(bar_s2: DIComplex) = is.peek
-    val Start(bar_s: DIComplex) = is.next()
+    val bar_s1 = is.peek match {
+      case Start(bar_s1: DIComplex) => bar_s1
+      case _ => fail(); null
+    }
+    val bar_s2 = is.peek match {
+      case Start(bar_s2: DIComplex) => bar_s2
+      case _ => fail(); null
+    }
+    val bar_s = is.next() match {
+      case Start(bar_s: DIComplex) => bar_s
+      case _ => fail(); null
+    }
     inp.pushTRD(barSeqTRD)
     inp.pushTRD(fooERD)
-    val Start(foo_s1: DISimple) = is.peek
-    val Start(foo_s2: DISimple) = is.next()
-    val End(foo_e: DISimple) = is.next()
+    val foo_s1 = is.peek match {
+      case Start(foo_s1: DISimple) => foo_s1
+      case _ => fail(); null
+    }
+    val foo_s2 = is.next() match {
+      case Start(foo_s2: DISimple) => foo_s2
+      case _ => fail(); null
+    }
+    val foo_e = is.next() match {
+      case End(foo_e: DISimple) => foo_e
+      case _ => fail(); null
+    }
     inp.popTRD()
     inp.popTRD()
-    val End(bar_e1: DIComplex) = is.peek
+    val bar_e1 = is.peek match {
+      case End(bar_e1: DIComplex) => bar_e1
+      case _ => fail(); null
+    }
     assertTrue(is.hasNext)
-    val End(bar_e2: DIComplex) = is.next()
+    val bar_e2 = is.next() match {
+      case End(bar_e2: DIComplex) => bar_e2
+      case _ => fail(); null
+    }
     assertFalse(is.hasNext)
     assertTrue(bar_s1 eq bar_s2)
     assertTrue(bar_e1 eq bar_e2)
@@ -542,31 +811,79 @@ class TestInfosetInputterFromReader {
       XMLUtils.EXAMPLE_NAMESPACE
     }><s><c1>Hello</c1></s><s><c2>World</c2></s></e>
     val (is, eERD, inp, tunable) = infosetInputter(sch, infosetXML)
-    val Some(eSeqTRD: SequenceRuntimeData) = eERD.optComplexTypeModelGroupRuntimeData
-    val Seq(sERD: ElementRuntimeData) = eSeqTRD.groupMembers
-    val Some(sChoTRD: ChoiceRuntimeData) = sERD.optComplexTypeModelGroupRuntimeData
-    val Seq(c1ERD: ElementRuntimeData, c2ERD: ElementRuntimeData) = sChoTRD.groupMembers
-    val Start(e: DIComplex) = is.next()
+    val eSeqTRD = eERD.optComplexTypeModelGroupRuntimeData match {
+      case Some(eSeqTRD: SequenceRuntimeData) => eSeqTRD
+      case _ => fail(); null
+    }
+    val sERD = eSeqTRD.groupMembers match {
+      case Seq(sERD: ElementRuntimeData) => sERD
+      case _ => fail(); null
+    }
+    val sChoTRD = sERD.optComplexTypeModelGroupRuntimeData match {
+      case Some(sChoTRD: ChoiceRuntimeData) => sChoTRD
+      case _ => fail(); null
+    }
+    val _ = sChoTRD.groupMembers match {
+      case Seq(c1ERD: ElementRuntimeData, c2ERD: ElementRuntimeData) => c1ERD
+      case _ => fail(); null
+    }
+    val e = is.next() match {
+      case Start(e: DIComplex) => e
+      case _ => fail(); null
+    }
     inp.pushTRD(eSeqTRD)
     inp.pushTRD(sERD)
-    val StartArray(as) = is.next()
-    val Start(s1: DIComplex) = is.next(); assertNotNull(s1)
+    val as = is.next() match {
+      case StartArray(as) => as
+      case _ => fail(); null
+    }
+    val s1 = is.next() match {
+      case Start(s1: DIComplex) => s1
+      case _ => fail(); null
+    }; assertNotNull(s1)
     inp.pushTRD(sChoTRD)
-    val Start(c1: DISimple) = is.next()
-    val End(c1e: DISimple) = is.next(); assertNotNull(c1e)
+    val c1 = is.next() match {
+      case Start(c1: DISimple) => c1
+      case _ => fail(); null
+    }
+    val c1e = is.next() match {
+      case End(c1e: DISimple) => c1e
+      case _ => fail(); null
+    }; assertNotNull(c1e)
     inp.popTRD()
     inp.popTRD()
-    val End(s1e: DIComplex) = is.next(); assertNotNull(s1e)
+    val s1e = is.next() match {
+      case End(s1e: DIComplex) => s1e
+      case _ => fail(); null
+    }; assertNotNull(s1e)
     inp.pushTRD(sERD)
-    val Start(s2: DIComplex) = is.next(); assertNotNull(s2)
+    val s2 = is.next() match {
+      case Start(s2: DIComplex) => s2
+      case _ => fail(); null
+    }; assertNotNull(s2)
     inp.pushTRD(sChoTRD)
-    val Start(c2: DISimple) = is.next()
-    val End(c2e: DISimple) = is.next();; assertNotNull(c2e)
+    val c2 = is.next() match {
+      case Start(c2: DISimple) => c2
+      case _ => fail(); null
+    }
+    val c2e = is.next() match {
+      case End(c2e: DISimple) => c2e
+      case _ => fail(); null
+    };; assertNotNull(c2e)
     inp.popTRD()
-    val End(s2e: DIComplex) = is.next(); assertNotNull(s2e)
-    val EndArray(ase) = is.next()
+    val s2e = is.next() match {
+      case End(s2e: DIComplex) => s2e
+      case _ => fail(); null
+    }; assertNotNull(s2e)
+    val ase = is.next() match {
+      case EndArray(ase) => ase
+      case _ => fail(); null
+    }
     inp.popTRD()
-    val End(ee: DIComplex) = is.next()
+    val ee = is.next() match {
+      case End(ee: DIComplex) => ee
+      case _ => fail(); null
+    }
     assertFalse(is.hasNext)
     assertTrue(as eq ase) // exact same object
     assertTrue(e eq ee)

--- a/daffodil-core/src/test/scala/org/apache/daffodil/core/infoset/TestInfosetCursorFromReader2.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/core/infoset/TestInfosetCursorFromReader2.scala
@@ -99,24 +99,48 @@ class TestInfosetInputterFromReader2 {
 
   def doTest(count: Int): Unit = {
     val (is, rootERD, inp) = infosetUnlimitedSource(count)
-    val Some(barSeqTRD: SequenceRuntimeData) = rootERD.optComplexTypeModelGroupRuntimeData
-    val Seq(fooERD: ElementRuntimeData) = barSeqTRD.groupMembers
+    val barSeqTRD = rootERD.optComplexTypeModelGroupRuntimeData match {
+      case Some(barSeqTRD: SequenceRuntimeData) => barSeqTRD
+      case _ => fail(); null
+    }
+    val fooERD = barSeqTRD.groupMembers match {
+      case Seq(fooERD: ElementRuntimeData) => fooERD
+      case _ => fail(); null
+    }
     inp.pushTRD(rootERD)
-    val Start(bar_s: DIComplex) = is.next()
+    val bar_s = is.next() match {
+      case Start(bar_s: DIComplex) => bar_s
+      case _ => fail(); null
+    }
     inp.pushTRD(barSeqTRD)
     inp.pushTRD(fooERD)
-    val StartArray(foo_arr_s) = is.next()
+    val foo_arr_s = is.next() match {
+      case StartArray(foo_arr_s) => foo_arr_s
+      case _ => fail(); null
+    }
     (1 to count).foreach { i =>
-      val Start(foo_1_s: DISimple) = is.next()
-      val End(foo_1_e: DISimple) = is.next()
+      val foo_1_s = is.next() match {
+        case Start(foo_1_s: DISimple) => foo_1_s
+        case _ => fail(); null
+      }
+      val foo_1_e = is.next() match {
+        case End(foo_1_e: DISimple) => foo_1_e
+        case _ => fail(); null
+      }
       assertTrue(foo_1_s eq foo_1_e)
       assertTrue(foo_1_s.dataValue.getAnyRef.isInstanceOf[String])
       assertEquals("Hello", foo_1_s.dataValueAsString)
     }
-    val EndArray(foo_arr_e) = is.next()
+    val foo_arr_e = is.next() match {
+      case EndArray(foo_arr_e) => foo_arr_e
+      case _ => fail(); null
+    }
     inp.popTRD()
     inp.popTRD()
-    val End(bar_e: DIComplex) = is.next()
+    val bar_e = is.next() match {
+      case End(bar_e: DIComplex) => bar_e
+      case _ => fail(); null
+    }
     inp.popTRD()
     assertFalse(is.hasNext)
     assertTrue(bar_s eq bar_e) // exact same object

--- a/daffodil-core/src/test/scala/org/apache/daffodil/core/runtime1/TestStreamingUnparserCompilerAttributes.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/core/runtime1/TestStreamingUnparserCompilerAttributes.scala
@@ -26,6 +26,7 @@ import org.apache.daffodil.core.dsom.SequenceGroupRef
 import org.apache.daffodil.core.dsom.Term
 import org.apache.daffodil.core.util.TestUtils.getRoot
 
+import org.junit.Assert.fail
 import org.junit.Test
 
 class TestStreamingUnparserCompilerAttributes {
@@ -52,11 +53,26 @@ class TestStreamingUnparserCompilerAttributes {
       </xs:element>
     }
     val rg: S = r.complexType.sequence
-    val Seq(a: LE, b: LE) = rg.groupMembers
-    val Closed(Seq(PNE(`r`, true))) = poss(r)
-    val Closed(Nil) = poss(rg)
-    val Closed(Seq(PNE(`a`, true))) = poss(a)
-    val Closed(Seq(PNE(`b`, true))) = poss(b)
+    val (a, b) = rg.groupMembers match {
+      case Seq(a: LE, b: LE) => (a, b)
+      case _ => fail(); null
+    }
+    poss(r) match {
+      case Closed(Seq(PNE(`r`, true))) =>
+      case _ => fail()
+    }
+    poss(rg) match {
+      case Closed(Nil) =>
+      case _ => fail()
+    }
+    poss(a) match {
+      case Closed(Seq(PNE(`a`, true))) =>
+      case _ => fail()
+    }
+    poss(b) match {
+      case Closed(Seq(PNE(`b`, true))) =>
+      case _ => fail()
+    }
   }
 
   @Test def testPossibleNextStreamingUnparserEvent2() = {
@@ -71,11 +87,27 @@ class TestStreamingUnparserCompilerAttributes {
       </xs:element>
     }
     val rg: S = r.complexType.sequence
-    val Seq(a: LE, b: LE) = rg.groupMembers
-    val Closed(Seq(PNE(`r`, true))) = poss(r)
-    val Closed(Nil) = poss(rg)
-    val Closed(Seq(PNE(`a`, false), PNE(`b`, true))) = poss(a)
-    val Closed(Seq(PNE(`b`, true))) = poss(b)
+    val (a, b) = rg.groupMembers match {
+      case Seq(a: LE, b: LE) => (a, b)
+      case _ => fail(); null
+
+    }
+    poss(r) match {
+      case Closed(Seq(PNE(`r`, true))) =>
+      case _ => fail()
+    }
+    poss(rg) match {
+      case Closed(Nil) =>
+      case _ => fail()
+    }
+    poss(a) match {
+      case Closed(Seq(PNE(`a`, false), PNE(`b`, true))) =>
+      case _ => fail()
+    }
+    poss(b) match {
+      case Closed(Seq(PNE(`b`, true))) =>
+      case _ => fail()
+    }
   }
 
   @Test def testPossibleNextStreamingUnparserEvent2OVC() = {
@@ -90,11 +122,26 @@ class TestStreamingUnparserCompilerAttributes {
       </xs:element>
     }
     val rg: S = r.complexType.sequence
-    val Seq(a: LE, b: LE) = rg.groupMembers
-    val Closed(Seq(PNE(`r`, true))) = poss(r)
-    val Closed(Nil) = poss(rg)
-    val Closed(Seq(PNE(`a`, false), PNE(`b`, true))) = poss(a)
-    val Closed(Seq(PNE(`b`, true))) = poss(b)
+    val (a, b) = rg.groupMembers match {
+      case Seq(a: LE, b: LE) => (a, b)
+      case _ => fail(); null
+    }
+    poss(r) match {
+      case Closed(Seq(PNE(`r`, true))) =>
+      case _ => fail()
+    }
+    poss(rg) match {
+      case Closed(Nil) =>
+      case _ => fail()
+    }
+    poss(a) match {
+      case Closed(Seq(PNE(`a`, false), PNE(`b`, true))) =>
+      case _ => fail()
+    }
+    poss(b) match {
+      case Closed(Seq(PNE(`b`, true))) =>
+      case _ => fail()
+    }
   }
 
   @Test def testPossibleNextStreamingUnparserEvent3() = {
@@ -115,13 +162,34 @@ class TestStreamingUnparserCompilerAttributes {
       </xs:group>
     }
     val rg: S = r.complexType.sequence
-    val Seq(a: LE, b: LE, gr: SGR) = rg.groupMembers
-    val Seq(c: LE) = gr.groupMembers
-    val Closed(Seq(PNE(`r`, true))) = poss(r)
-    val Closed(Nil) = poss(rg)
-    val Closed(Seq(PNE(`a`, false), PNE(`b`, false), PNE(`c`, true))) = poss(a)
-    val Closed(Seq(PNE(`b`, false), PNE(`c`, true))) = poss(b)
-    val Closed(Seq(PNE(`c`, true))) = poss(c)
+    val (a: LE, b: LE, gr: SGR) = rg.groupMembers match {
+      case Seq(a: LE, b: LE, gr: SGR) => (a: LE, b: LE, gr: SGR)
+      case _ => fail(); null
+    }
+    val (c: LE) = gr.groupMembers match {
+      case Seq(c: LE) => (c: LE)
+      case _ => fail(); null
+    }
+    poss(r) match {
+      case Closed(Seq(PNE(`r`, true))) =>
+      case _ => fail()
+    }
+    poss(rg) match {
+      case Closed(Nil) =>
+      case _ => fail()
+    }
+    poss(a) match {
+      case Closed(Seq(PNE(`a`, false), PNE(`b`, false), PNE(`c`, true))) =>
+      case _ => fail()
+    }
+    poss(b) match {
+      case Closed(Seq(PNE(`b`, false), PNE(`c`, true))) =>
+      case _ => fail()
+    }
+    poss(c) match {
+      case Closed(Seq(PNE(`c`, true))) =>
+      case _ => fail()
+    }
   }
 
   @Test def testPossibleNextStreamingUnparserEvent4() = {
@@ -143,15 +211,34 @@ class TestStreamingUnparserCompilerAttributes {
       </xs:group>
     }
     val rg: S = r.complexType.sequence
-    val Seq(a: LE, b: LE, gr: CGR) = rg.groupMembers
-    val Seq(c: LE, d: LE) = gr.groupMembers
-    val Closed(Seq(PNE(`a`, false), PNE(`b`, false), PNE(`c`, false), PNE(`d`, false))) = poss(
-      a
-    )
-    val Closed(Seq(PNE(`b`, false), PNE(`c`, false), PNE(`d`, false))) = poss(b)
-    val Closed(Seq(PNE(`c`, false), PNE(`d`, false))) = poss(gr)
-    val Closed(Seq(PNE(`c`, true))) = poss(c)
-    val Closed(Seq(PNE(`d`, true))) = poss(d)
+    val (a: LE, b: LE, gr: CGR) = rg.groupMembers match {
+      case Seq(a: LE, b: LE, gr: CGR) => (a: LE, b: LE, gr: CGR)
+      case _ => fail(); null
+    }
+    val (c: LE, d: LE) = gr.groupMembers match {
+      case Seq(c: LE, d: LE) => (c: LE, d: LE)
+      case _ => fail(); null
+    }
+    poss(a) match {
+      case Closed(Seq(PNE(`a`, false), PNE(`b`, false), PNE(`c`, false), PNE(`d`, false))) =>
+      case _ => fail()
+    }
+    poss(b) match {
+      case Closed(Seq(PNE(`b`, false), PNE(`c`, false), PNE(`d`, false))) =>
+      case _ => fail()
+    }
+    poss(gr) match {
+      case Closed(Seq(PNE(`c`, false), PNE(`d`, false))) =>
+      case _ => fail()
+    }
+    poss(c) match {
+      case Closed(Seq(PNE(`c`, true))) =>
+      case _ => fail()
+    }
+    poss(d) match {
+      case Closed(Seq(PNE(`d`, true))) =>
+      case _ => fail()
+    }
   }
 
   @Test def testPossibleNextStreamingUnparserEvent5() = {
@@ -178,15 +265,42 @@ class TestStreamingUnparserCompilerAttributes {
       </xs:group>
     }
     val rg: S = r.complexType.sequence
-    val Seq(sgr: SGR, cgr: CGR) = rg.groupMembers
-    val Seq(a: LE, b: LE) = sgr.groupMembers
-    val Seq(c: LE, d: LE) = cgr.groupMembers
-    val Closed(Seq(PNE(`c`, false), PNE(`d`, false))) = poss(sgr)
-    val Open(Seq(PNE(`a`, false), PNE(`b`, false))) = poss(a)
-    val Open(Seq(PNE(`b`, false))) = poss(b)
-    val Closed(Seq(PNE(`c`, false), PNE(`d`, false))) = poss(cgr)
-    val Closed(Seq(PNE(`c`, true))) = poss(c)
-    val Closed(Seq(PNE(`d`, true))) = poss(d)
+    val (sgr: SGR, cgr: CGR) = rg.groupMembers match {
+      case Seq(sgr: SGR, cgr: CGR) => (sgr: SGR, cgr: CGR)
+      case _ => fail(); null
+    }
+    val (a: LE, b: LE) = sgr.groupMembers match {
+      case Seq(a: LE, b: LE) => (a: LE, b: LE)
+      case _ => fail(); null
+    }
+    val (c: LE, d: LE) = cgr.groupMembers match {
+      case Seq(c: LE, d: LE) => (c: LE, d: LE)
+      case _ => fail(); null
+    }
+    poss(sgr) match {
+      case Closed(Seq(PNE(`c`, false), PNE(`d`, false))) =>
+      case _ => fail()
+    }
+    poss(a) match {
+      case Open(Seq(PNE(`a`, false), PNE(`b`, false))) =>
+      case _ => fail()
+    }
+    poss(b) match {
+      case Open(Seq(PNE(`b`, false))) =>
+      case _ => fail()
+    }
+    poss(cgr) match {
+      case Closed(Seq(PNE(`c`, false), PNE(`d`, false))) =>
+      case _ => fail()
+    }
+    poss(c) match {
+      case Closed(Seq(PNE(`c`, true))) =>
+      case _ => fail()
+    }
+    poss(d) match {
+      case Closed(Seq(PNE(`d`, true))) =>
+      case _ => fail()
+    }
   }
 
   @Test def testPossibleNextStreamingUnparserEvent6() = {
@@ -201,10 +315,22 @@ class TestStreamingUnparserCompilerAttributes {
       </xs:element>
     }
     val rg: C = r.complexType.choice
-    val Seq(c: LE, d: LE) = rg.groupMembers
-    val Closed(Seq(PNE(`c`, false), PNE(`d`, false))) = poss(rg)
-    val Closed(Seq(PNE(`c`, true))) = poss(c)
-    val Closed(Seq(PNE(`d`, true))) = poss(d)
+    val (c: LE, d: LE) = rg.groupMembers match {
+      case Seq(c: LE, d: LE) => (c: LE, d: LE)
+      case _ => fail(); null
+    }
+    poss(rg) match {
+      case Closed(Seq(PNE(`c`, false), PNE(`d`, false))) =>
+      case _ => fail()
+    }
+    poss(c) match {
+      case Closed(Seq(PNE(`c`, true))) =>
+      case _ => fail()
+    }
+    poss(d) match {
+      case Closed(Seq(PNE(`d`, true))) =>
+      case _ => fail()
+    }
   }
 
   @Test def testPossibleNextStreamingUnparserEvent7() = {
@@ -220,11 +346,26 @@ class TestStreamingUnparserCompilerAttributes {
       </xs:element>
     }
     val rg: C = r.complexType.choice
-    val Seq(c: LE, d: LE, es: S) = rg.groupMembers
-    val Open(Nil) = poss(es)
-    val Open(Seq(PNE(`c`, false), PNE(`d`, false))) = poss(rg)
-    val Closed(Seq(PNE(`c`, true))) = poss(c)
-    val Closed(Seq(PNE(`d`, true))) = poss(d)
+    val (c: LE, d: LE, es: S) = rg.groupMembers match {
+      case Seq(c: LE, d: LE, es: S) => (c: LE, d: LE, es: S)
+      case _ => fail(); null
+    }
+    poss(es) match {
+      case Open(Nil) =>
+      case _ => fail()
+    }
+    poss(rg) match {
+      case Open(Seq(PNE(`c`, false), PNE(`d`, false))) =>
+      case _ => fail()
+    }
+    poss(c) match {
+      case Closed(Seq(PNE(`c`, true))) =>
+      case _ => fail()
+    }
+    poss(d) match {
+      case Closed(Seq(PNE(`d`, true))) =>
+      case _ => fail()
+    }
   }
 
   @Test def testPossibleNextStreamingUnparserEvent8() = {
@@ -243,11 +384,26 @@ class TestStreamingUnparserCompilerAttributes {
       </xs:group>
     }
     val rg: C = r.complexType.choice
-    val Seq(c: LE, d: LE, gr: SGR) = rg.groupMembers
-    val Open(Nil) = poss(gr)
-    val Open(Seq(PNE(`c`, false), PNE(`d`, false))) = poss(rg)
-    val Closed(Seq(PNE(`c`, true))) = poss(c)
-    val Closed(Seq(PNE(`d`, true))) = poss(d)
+    val (c: LE, d: LE, gr: SGR) = rg.groupMembers match {
+      case Seq(c: LE, d: LE, gr: SGR) => (c: LE, d: LE, gr: SGR)
+      case _ => fail(); null
+    }
+    poss(gr) match {
+      case Open(Nil) =>
+      case _ => fail()
+    }
+    poss(rg) match {
+      case Open(Seq(PNE(`c`, false), PNE(`d`, false))) =>
+      case _ => fail()
+    }
+    poss(c) match {
+      case Closed(Seq(PNE(`c`, true))) =>
+      case _ => fail()
+    }
+    poss(d) match {
+      case Closed(Seq(PNE(`d`, true))) =>
+      case _ => fail()
+    }
   }
 
   @Test def testPossibleNextStreamingUnparserEvent9() = {
@@ -268,12 +424,30 @@ class TestStreamingUnparserCompilerAttributes {
       </xs:group>
     }
     val rg: C = r.complexType.choice
-    val Seq(c: LE, d: LE, gr: SGR) = rg.groupMembers
-    val Seq(e: LE) = gr.groupMembers
-    val Open(Nil) = poss(gr)
-    val Open(Seq(PNE(`c`, false), PNE(`d`, false), PNE(`e`, false))) = poss(rg)
-    val Closed(Seq(PNE(`c`, true))) = poss(c)
-    val Closed(Seq(PNE(`d`, true))) = poss(d)
+    val (c: LE, d: LE, gr: SGR) = rg.groupMembers match {
+      case Seq(c: LE, d: LE, gr: SGR) => (c: LE, d: LE, gr: SGR)
+      case _ => fail(); null
+    }
+    val (e: LE) = gr.groupMembers match {
+      case Seq(e: LE) => (e: LE)
+      case _ => fail(); null
+    }
+    poss(gr) match {
+      case Open(Nil) =>
+      case _ => fail()
+    }
+    poss(rg) match {
+      case Open(Seq(PNE(`c`, false), PNE(`d`, false), PNE(`e`, false))) =>
+      case _ => fail()
+    }
+    poss(c) match {
+      case Closed(Seq(PNE(`c`, true))) =>
+      case _ => fail()
+    }
+    poss(d) match {
+      case Closed(Seq(PNE(`d`, true))) =>
+      case _ => fail()
+    }
   }
 
   @Test def testPossibleNextStreamingUnparserEvent9OVC() = {
@@ -294,12 +468,30 @@ class TestStreamingUnparserCompilerAttributes {
       </xs:group>
     }
     val rg: C = r.complexType.choice
-    val Seq(c: LE, d: LE, gr: SGR) = rg.groupMembers
-    val Seq(e: LE) = gr.groupMembers
-    val Open(Nil) = poss(gr)
-    val Open(Seq(PNE(`c`, false), PNE(`d`, false), PNE(`e`, false))) = poss(rg)
-    val Closed(Seq(PNE(`c`, true))) = poss(c)
-    val Closed(Seq(PNE(`d`, true))) = poss(d)
+    val (c: LE, d: LE, gr: SGR) = rg.groupMembers match {
+      case Seq(c: LE, d: LE, gr: SGR) => (c: LE, d: LE, gr: SGR)
+      case _ => fail(); null
+    }
+    val (e: LE) = gr.groupMembers match {
+      case Seq(e: LE) => (e: LE)
+      case _ => fail(); null
+    }
+    poss(gr) match {
+      case Open(Nil) =>
+      case _ => fail()
+    }
+    poss(rg) match {
+      case Open(Seq(PNE(`c`, false), PNE(`d`, false), PNE(`e`, false))) =>
+      case _ => fail()
+    }
+    poss(c) match {
+      case Closed(Seq(PNE(`c`, true))) =>
+      case _ => fail()
+    }
+    poss(d) match {
+      case Closed(Seq(PNE(`d`, true))) =>
+      case _ => fail()
+    }
   }
 
   @Test def testPossibleNextStreamingUnparserEvent9OVCIVC() = {
@@ -320,12 +512,30 @@ class TestStreamingUnparserCompilerAttributes {
       </xs:group>
     }
     val rg: C = r.complexType.choice
-    val Seq(c: LE, d: LE, gr: SGR) = rg.groupMembers
-    val Seq(e: LE) = gr.groupMembers
-    val Open(Nil) = poss(gr)
-    val Open(Seq(PNE(`c`, false), PNE(`d`, false), PNE(`e`, false))) = poss(rg)
-    val Closed(Seq(PNE(`c`, true))) = poss(c)
-    val Closed(Seq(PNE(`d`, true))) = poss(d)
+    val (c: LE, d: LE, gr: SGR) = rg.groupMembers match {
+      case Seq(c: LE, d: LE, gr: SGR) => (c: LE, d: LE, gr: SGR)
+      case _ => fail(); null
+    }
+    val (e: LE) = gr.groupMembers match {
+      case Seq(e: LE) => (e: LE)
+      case _ => fail(); null
+    }
+    poss(gr) match {
+      case Open(Nil) =>
+      case _ => fail()
+    }
+    poss(rg) match {
+      case Open(Seq(PNE(`c`, false), PNE(`d`, false), PNE(`e`, false))) =>
+      case _ => fail()
+    }
+    poss(c) match {
+      case Closed(Seq(PNE(`c`, true))) =>
+      case _ => fail()
+    }
+    poss(d) match {
+      case Closed(Seq(PNE(`d`, true))) =>
+      case _ => fail()
+    }
   }
 
   @Test def testPossibleNextStreamingUnparserEvent10() = {
@@ -353,16 +563,46 @@ class TestStreamingUnparserCompilerAttributes {
       </xs:group>
     }
     val rg: S = r.complexType.sequence
-    val Seq(s: S) = rg.groupMembers
-    val Seq(cgr: CGR) = s.groupMembers
-    val Seq(c: LE, d: LE, gr: SGR) = cgr.groupMembers
-    val Seq(e: LE) = gr.groupMembers
-    val Closed(Nil) = poss(rg)
-    val Open(Nil) = poss(s)
-    val Open(Seq(PNE(`c`, false), PNE(`d`, false), PNE(`e`, false))) = poss(cgr)
-    val Open(Nil) = poss(gr)
-    val Closed(Seq(PNE(`c`, true))) = poss(c)
-    val Closed(Seq(PNE(`d`, true))) = poss(d)
+    val (s: S) = rg.groupMembers match {
+      case Seq(s: S) => (s: S)
+      case _ => fail(); null
+    }
+    val (cgr: CGR) = s.groupMembers match {
+      case Seq(cgr: CGR) => (cgr: CGR)
+      case _ => fail(); null
+    }
+    val (c: LE, d: LE, gr: SGR) = cgr.groupMembers match {
+      case Seq(c: LE, d: LE, gr: SGR) => (c: LE, d: LE, gr: SGR)
+      case _ => fail(); null
+    }
+    val (e: LE) = gr.groupMembers match {
+      case Seq(e: LE) => (e: LE)
+      case _ => fail(); null
+    }
+    poss(rg) match {
+      case Closed(Nil) =>
+      case _ => fail()
+    }
+    poss(s) match {
+      case Open(Nil) =>
+      case _ => fail()
+    }
+    poss(cgr) match {
+      case Open(Seq(PNE(`c`, false), PNE(`d`, false), PNE(`e`, false))) =>
+      case _ => fail()
+    }
+    poss(gr) match {
+      case Open(Nil) =>
+      case _ => fail()
+    }
+    poss(c) match {
+      case Closed(Seq(PNE(`c`, true))) =>
+      case _ => fail()
+    }
+    poss(d) match {
+      case Closed(Seq(PNE(`d`, true))) =>
+      case _ => fail()
+    }
   }
 
   @Test def testPossibleNextStreamingUnparserEvent11() = {
@@ -378,10 +618,22 @@ class TestStreamingUnparserCompilerAttributes {
       </xs:element>
     }
     val rg: S = r.complexType.sequence
-    val Seq(a: LE, b: LE, c: LE) = rg.groupMembers
-    val Closed(Seq(PNE(`a`, true))) = poss(a)
-    val Closed(Seq(PNE(`b`, false), PNE(`c`, true))) = poss(b)
-    val Closed(Seq(PNE(`c`, true))) = poss(c)
+    val (a: LE, b: LE, c: LE) = rg.groupMembers match {
+      case Seq(a: LE, b: LE, c: LE) => (a: LE, b: LE, c: LE)
+      case _ => fail(); null
+    }
+    poss(a) match {
+      case Closed(Seq(PNE(`a`, true))) =>
+      case _ => fail()
+    }
+    poss(b) match {
+      case Closed(Seq(PNE(`b`, false), PNE(`c`, true))) =>
+      case _ => fail()
+    }
+    poss(c) match {
+      case Closed(Seq(PNE(`c`, true))) =>
+      case _ => fail()
+    }
   }
 
 // DAFFODIL-2937
@@ -419,14 +671,32 @@ class TestStreamingUnparserCompilerAttributes {
         </xs:group>
     }
     val rg: SGR = r.complexType.group.asInstanceOf[SequenceGroupRef]
-    val Seq(g2c1: LE, g2c2: LE, g2c3: LE, hg: CGR, vg: CGR) = rg.groupMembers
-    val Closed(Seq(PNE(`g2c1`, true))) = poss(g2c1)
-    val Closed(Seq(PNE(`g2c2`, true))) = poss(g2c2)
-    val Closed(Seq(PNE(`g2c3`, false), PNE(vg_inty, false), PNE(vg_stringy, false))) = poss(
-      g2c3
-    )
-    val Open(Seq(PNE(`vg_inty`, false), PNE(`vg_stringy`, false))) = poss(hg)
-    val Closed(Seq(PNE(`vg_inty`, false), PNE(`vg_stringy`, false))) = poss(vg)
+    val (g2c1: LE, g2c2: LE, g2c3: LE, hg: CGR, vg: CGR) = rg.groupMembers match {
+      case Seq(g2c1: LE, g2c2: LE, g2c3: LE, hg: CGR, vg: CGR) =>
+        (g2c1: LE, g2c2: LE, g2c3: LE, hg: CGR, vg: CGR)
+      case _ => fail(); null
+    }
+    poss(g2c1) match {
+      case Closed(Seq(PNE(`g2c1`, true))) =>
+      case _ => fail()
+    }
+    poss(g2c2) match {
+      case Closed(Seq(PNE(`g2c2`, true))) =>
+      case _ => fail()
+    }
+    val (vg_inty, vg_stringy) = poss(g2c3) match {
+      case Closed(Seq(PNE(`g2c3`, false), PNE(vg_inty, false), PNE(vg_stringy, false))) =>
+        (vg_inty, vg_stringy)
+      case _ => fail(); null
+    }
+    poss(hg) match {
+      case Open(Seq(PNE(`vg_inty`, false), PNE(`vg_stringy`, false))) =>
+      case _ => fail()
+    }
+    poss(vg) match {
+      case Closed(Seq(PNE(`vg_inty`, false), PNE(`vg_stringy`, false))) =>
+      case _ => fail()
+    }
   }
 
   @Test def testPossibleNextStreamingUnparserEventHidden1() = {
@@ -447,12 +717,30 @@ class TestStreamingUnparserCompilerAttributes {
       </xs:group>
     }
     val rg: S = r.complexType.sequence
-    val Seq(a: LE, hgr: SGR, b: LE) = rg.groupMembers
-    val Seq(e: LE) = hgr.groupMembers
-    val Closed(Seq(PNE(`a`, true))) = poss(a)
-    val Closed(Seq(PNE(`b`, true))) = poss(b)
-    val Closed(Seq(PNE(`b`, true))) = poss(hgr)
-    val Open(Seq(PNE(`e`, false))) = poss(e)
+    val (a: LE, hgr: SGR, b: LE) = rg.groupMembers match {
+      case Seq(a: LE, hgr: SGR, b: LE) => (a: LE, hgr: SGR, b: LE)
+      case _ => fail(); null
+    }
+    val (e: LE) = hgr.groupMembers match {
+      case Seq(e: LE) => (e: LE)
+      case _ => fail(); null
+    }
+    poss(a) match {
+      case Closed(Seq(PNE(`a`, true))) =>
+      case _ => fail()
+    }
+    poss(b) match {
+      case Closed(Seq(PNE(`b`, true))) =>
+      case _ => fail()
+    }
+    poss(hgr) match {
+      case Closed(Seq(PNE(`b`, true))) =>
+      case _ => fail()
+    }
+    poss(e) match {
+      case Open(Seq(PNE(`e`, false))) =>
+      case _ => fail()
+    }
   }
 
   @Test def testPossibleNextStreamingUnparserEventHidden2() = {
@@ -484,20 +772,62 @@ class TestStreamingUnparserCompilerAttributes {
       </xs:group>
     }
     val rg: S = r.complexType.sequence
-    val Seq(a: LE, cg: C, c: LE) = rg.groupMembers
-    val Seq(s1: S, s2: SGR) = cg.groupMembers
-    val Seq(pg: SGR, b: LE) = s1.groupMembers
-    val Seq(aflag: LE) = s2.groupMembers
-    val Seq(pflag: LE) = pg.groupMembers
-    val Closed(Seq(PNE(`a`, true))) = poss(a)
-    val Closed(Seq(PNE(`b`, false), PNE(`c`, true))) = poss(cg)
-    val Closed(Seq(PNE(`c`, true))) = poss(c)
-    val Open(Nil) = poss(s1)
-    val Open(Nil) = poss(s2)
-    val Closed(Seq(PNE(`b`, true))) = poss(pg)
-    val Open(Seq(PNE(`pflag`, false))) = poss(pflag)
-    val Closed(Seq(PNE(`b`, true))) = poss(b)
-    val Open(Seq(PNE(`aflag`, false))) = poss(aflag)
+    val (a: LE, cg: C, c: LE) = rg.groupMembers match {
+      case Seq(a: LE, cg: C, c: LE) => (a: LE, cg: C, c: LE)
+      case _ => fail(); null
+    }
+    val (s1: S, s2: SGR) = cg.groupMembers match {
+      case Seq(s1: S, s2: SGR) => (s1: S, s2: SGR)
+      case _ => fail(); null
+    }
+    val (pg: SGR, b: LE) = s1.groupMembers match {
+      case Seq(pg: SGR, b: LE) => (pg: SGR, b: LE)
+      case _ => fail(); null
+    }
+    val (aflag: LE) = s2.groupMembers match {
+      case Seq(aflag: LE) => (aflag: LE)
+      case _ => fail(); null
+    }
+    val (pflag: LE) = pg.groupMembers match {
+      case Seq(pflag: LE) => (pflag: LE)
+      case _ => fail(); null
+    }
+    poss(a) match {
+      case Closed(Seq(PNE(`a`, true))) =>
+      case _ => fail()
+    }
+    poss(cg) match {
+      case Closed(Seq(PNE(`b`, false), PNE(`c`, true))) =>
+      case _ => fail()
+    }
+    poss(c) match {
+      case Closed(Seq(PNE(`c`, true))) =>
+      case _ => fail()
+    }
+    poss(s1) match {
+      case Open(Nil) =>
+      case _ => fail()
+    }
+    poss(s2) match {
+      case Open(Nil) =>
+      case _ => fail()
+    }
+    poss(pg) match {
+      case Closed(Seq(PNE(`b`, true))) =>
+      case _ => fail()
+    }
+    poss(pflag) match {
+      case Open(Seq(PNE(`pflag`, false))) =>
+      case _ => fail()
+    }
+    poss(b) match {
+      case Closed(Seq(PNE(`b`, true))) =>
+      case _ => fail()
+    }
+    poss(aflag) match {
+      case Open(Seq(PNE(`aflag`, false))) =>
+      case _ => fail()
+    }
   }
 
   @Test def testPossibleNextStreamingUnparserEventHidden3() = {
@@ -536,36 +866,114 @@ class TestStreamingUnparserCompilerAttributes {
       </xs:group>
     }
     val rg: S = r.complexType.sequence
-    val Seq(a: LE, cg1: C, cg2: C, d: LE) = rg.groupMembers
-    val Seq(s1a: S, s1b: SGR) = cg1.groupMembers
-    val Seq(pg1: SGR, b: LE) = s1a.groupMembers
-    val Seq(aflag1: LE) = s1b.groupMembers
-    val Seq(pflag1: LE) = pg1.groupMembers
+    val (a: LE, cg1: C, cg2: C, d: LE) = rg.groupMembers match {
+      case Seq(a: LE, cg1: C, cg2: C, d: LE) => (a: LE, cg1: C, cg2: C, d: LE)
+      case _ => fail(); null
+    }
+    val (s1a: S, s1b: SGR) = cg1.groupMembers match {
+      case Seq(s1a: S, s1b: SGR) => (s1a: S, s1b: SGR)
+      case _ => fail(); null
+    }
+    val (pg1: SGR, b: LE) = s1a.groupMembers match {
+      case Seq(pg1: SGR, b: LE) => (pg1: SGR, b: LE)
+      case _ => fail(); null
+    }
+    val (aflag1: LE) = s1b.groupMembers match {
+      case Seq(aflag1: LE) => (aflag1: LE)
+      case _ => fail(); null
+    }
+    val (pflag1: LE) = pg1.groupMembers match {
+      case Seq(pflag1: LE) => (pflag1: LE)
+      case _ => fail(); null
+    }
 
-    val Seq(s2a: S, s2b: SGR) = cg2.groupMembers
-    val Seq(pg2: SGR, c: LE) = s2a.groupMembers
-    val Seq(aflag2: LE) = s2b.groupMembers
-    val Seq(pflag2: LE) = pg2.groupMembers
+    val (s2a: S, s2b: SGR) = cg2.groupMembers match {
+      case Seq(s2a: S, s2b: SGR) => (s2a: S, s2b: SGR)
+      case _ => fail(); null
+    }
+    val (pg2: SGR, c: LE) = s2a.groupMembers match {
+      case Seq(pg2: SGR, c: LE) => (pg2: SGR, c: LE)
+      case _ => fail(); null
+    }
+    val (aflag2: LE) = s2b.groupMembers match {
+      case Seq(aflag2: LE) => (aflag2: LE)
+      case _ => fail(); null
+    }
+    val (pflag2: LE) = pg2.groupMembers match {
+      case Seq(pflag2: LE) => (pflag2: LE)
+      case _ => fail(); null
+    }
 
-    val Closed(Seq(PNE(`a`, true))) = poss(a)
+    poss(a) match {
+      case Closed(Seq(PNE(`a`, true))) =>
+      case _ => fail()
+    }
 
-    val Closed(Seq(PNE(`b`, false), PNE(`c`, false), PNE(`d`, true))) = poss(cg1)
-    val Closed(Seq(PNE(`c`, true))) = poss(c)
-    val Open(Nil) = poss(s1a)
-    val Open(Nil) = poss(s1b)
-    val Closed(Seq(PNE(`b`, true))) = poss(pg1)
-    val Open(Seq(PNE(`pflag1`, false))) = poss(pflag1)
-    val Closed(Seq(PNE(`b`, true))) = poss(b)
-    val Open(Seq(PNE(`aflag1`, false))) = poss(aflag1)
+    poss(cg1) match {
+      case Closed(Seq(PNE(`b`, false), PNE(`c`, false), PNE(`d`, true))) =>
+      case _ => fail()
+    }
+    poss(c) match {
+      case Closed(Seq(PNE(`c`, true))) =>
+      case _ => fail()
+    }
+    poss(s1a) match {
+      case Open(Nil) =>
+      case _ => fail()
+    }
+    poss(s1b) match {
+      case Open(Nil) =>
+      case _ => fail()
+    }
+    poss(pg1) match {
+      case Closed(Seq(PNE(`b`, true))) =>
+      case _ => fail()
+    }
+    poss(pflag1) match {
+      case Open(Seq(PNE(`pflag1`, false))) =>
+      case _ => fail()
+    }
+    poss(b) match {
+      case Closed(Seq(PNE(`b`, true))) =>
+      case _ => fail()
+    }
+    poss(aflag1) match {
+      case Open(Seq(PNE(`aflag1`, false))) =>
+      case _ => fail()
+    }
 
-    val Closed(Seq(PNE(`c`, false), PNE(`d`, true))) = poss(cg2)
-    val Closed(Seq(PNE(`c`, true))) = poss(c)
-    val Open(Nil) = poss(s2a)
-    val Open(Nil) = poss(s2b)
-    val Closed(Seq(PNE(`c`, true))) = poss(pg2)
-    val Open(Seq(PNE(`pflag2`, false))) = poss(pflag2)
-    val Closed(Seq(PNE(`c`, true))) = poss(c)
-    val Open(Seq(PNE(`aflag2`, false))) = poss(aflag2)
+    poss(cg2) match {
+      case Closed(Seq(PNE(`c`, false), PNE(`d`, true))) =>
+      case _ => fail()
+    }
+    poss(c) match {
+      case Closed(Seq(PNE(`c`, true))) =>
+      case _ => fail()
+    }
+    poss(s2a) match {
+      case Open(Nil) =>
+      case _ => fail()
+    }
+    poss(s2b) match {
+      case Open(Nil) =>
+      case _ => fail()
+    }
+    poss(pg2) match {
+      case Closed(Seq(PNE(`c`, true))) =>
+      case _ => fail()
+    }
+    poss(pflag2) match {
+      case Open(Seq(PNE(`pflag2`, false))) =>
+      case _ => fail()
+    }
+    poss(c) match {
+      case Closed(Seq(PNE(`c`, true))) =>
+      case _ => fail()
+    }
+    poss(aflag2) match {
+      case Open(Seq(PNE(`aflag2`, false))) =>
+      case _ => fail()
+    }
   }
 
   val schemaX =
@@ -605,18 +1013,54 @@ class TestStreamingUnparserCompilerAttributes {
       getRoot(schemaX, topLevels = <dfdl:format ref="tns:GeneralFormat" lengthKind="explicit"/>)
 
     val rg: S = r.complexType.sequence
-    val Seq(ch: C, y: LE) = rg.groupMembers
-    val Seq(s1: S, ag: SGR) = ch.groupMembers
-    val Seq(pg: SGR, b: LE) = s1.groupMembers
-    val Seq(p: LE) = pg.groupMembers
-    val Seq(a: LE) = ag.groupMembers
+    val (ch: C, y: LE) = rg.groupMembers match {
+      case Seq(ch: C, y: LE) => (ch: C, y: LE)
+      case _ => fail(); null
+    }
+    val (s1: S, ag: SGR) = ch.groupMembers match {
+      case Seq(s1: S, ag: SGR) => (s1: S, ag: SGR)
+      case _ => fail(); null
+    }
+    val (pg: SGR, b: LE) = s1.groupMembers match {
+      case Seq(pg: SGR, b: LE) => (pg: SGR, b: LE)
+      case _ => fail(); null
+    }
+    val (p: LE) = pg.groupMembers match {
+      case Seq(p: LE) => (p: LE)
+      case _ => fail(); null
+    }
+    val (a: LE) = ag.groupMembers match {
+      case Seq(a: LE) => (a: LE)
+      case _ => fail(); null
+    }
 
-    val Open(Seq(PNE(`b`, false), PNE(`y`, false))) = poss(ch)
-    val Open(Nil) = poss(s1)
-    val Open(Seq(PNE(`y`, false))) = poss(y)
-    val Open(Seq(PNE(`b`, false))) = poss(pg)
-    val Open(Nil) = poss(ag)
-    val Open(Seq(PNE(`p`, false))) = poss(p)
-    val Open(Seq(PNE(`a`, false))) = poss(a)
+    poss(ch) match {
+      case Open(Seq(PNE(`b`, false), PNE(`y`, false))) =>
+      case _ => fail()
+    }
+    poss(s1) match {
+      case Open(Nil) =>
+      case _ => fail()
+    }
+    poss(y) match {
+      case Open(Seq(PNE(`y`, false))) =>
+      case _ => fail()
+    }
+    poss(pg) match {
+      case Open(Seq(PNE(`b`, false))) =>
+      case _ => fail()
+    }
+    poss(ag) match {
+      case Open(Nil) =>
+      case _ => fail()
+    }
+    poss(p) match {
+      case Open(Seq(PNE(`p`, false))) =>
+      case _ => fail()
+    }
+    poss(a) match {
+      case Open(Seq(PNE(`a`, false))) =>
+      case _ => fail()
+    }
   }
 }

--- a/daffodil-core/src/test/scala/org/apache/daffodil/lib/iapi/TestTunables.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/lib/iapi/TestTunables.scala
@@ -15,14 +15,13 @@
  * limitations under the License.
  */
 
-package org.apache.daffodil.core.general
+package org.apache.daffodil.lib.iapi
 
 import org.apache.daffodil.lib.Implicits.ImplicitsSuppressUnusedImportWarning
 
 import org.junit.Test; object INoWarnDSOM1 { ImplicitsSuppressUnusedImportWarning() }
 
 import org.apache.daffodil.core.util.Fakes
-import org.apache.daffodil.lib.iapi.DaffodilTunables
 import org.apache.daffodil.lib.xml.XMLUtils
 
 import org.junit.Assert.assertEquals

--- a/daffodil-core/src/test/scala/org/apache/daffodil/lib/xml/test/unit/TestQName.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/lib/xml/test/unit/TestQName.scala
@@ -29,7 +29,6 @@ import org.apache.daffodil.lib.xml.RefQName
 import org.apache.daffodil.lib.xml.UnspecifiedNamespace
 
 import org.junit.Assert._
-import org.junit.Assert.assertEquals
 import org.junit.Test
 
 class TestQName {

--- a/daffodil-core/src/test/scala/org/apache/daffodil/lib/xml/test/unit/TestXMLUtils.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/lib/xml/test/unit/TestXMLUtils.scala
@@ -160,8 +160,11 @@ class TestXMLUtils {
 
   @Test def testWalkUnicodeString1(): Unit = {
     val s = "abc"
-    val Seq((ab, 'a', 'b'), ('a', 'b', 'c'), ('b', 'c', ca)) =
-      XMLUtils.walkUnicodeString(s)((p, c, n) => (p, c, n))
+    val (ab, ca) =
+      XMLUtils.walkUnicodeString(s)((p, c, n) => (p, c, n)) match {
+        case Seq((ab, 'a', 'b'), ('a', 'b', 'c'), ('b', 'c', ca)) => (ab, ca)
+        case _ => fail(); null
+      }
     assertEquals(0.toChar, ab)
     assertEquals(0.toChar, ca)
   }

--- a/daffodil-propgen/src/main/scala/org/apache/daffodil/propGen/PropertyGenerator.scala
+++ b/daffodil-propgen/src/main/scala/org/apache/daffodil/propGen/PropertyGenerator.scala
@@ -105,7 +105,10 @@ class PropertyGenerator(arg: Node) {
   }
 
   def genElement(e: Node): String = {
-    val Some(name) = attr(e, "name")
+    val name = attr(e, "name") match {
+      case Some(name) => name
+      case _ => throw new IllegalStateException("Expected attribute, found none")
+    }
     val typeName = attr(e, "type")
     typeName match {
       case None => genElementImmediateType(e, name)

--- a/daffodil-propgen/src/main/scala/org/apache/daffodil/propGen/TunableGenerator.scala
+++ b/daffodil-propgen/src/main/scala/org/apache/daffodil/propGen/TunableGenerator.scala
@@ -88,7 +88,7 @@ class TunableGenerator(schemaRootConfig: scala.xml.Node, schemaRootExt: scala.xm
     |  }
     |}
     |
-    |case class DaffodilTunables private (
+    |case class DaffodilTunables private[iapi] (
     """.trim.stripMargin
 
   val middle = """

--- a/daffodil-schematron/src/main/scala/org/apache/daffodil/validation/schematron/SchematronValidator.scala
+++ b/daffodil-schematron/src/main/scala/org/apache/daffodil/validation/schematron/SchematronValidator.scala
@@ -39,8 +39,8 @@ final class SchematronValidator(
     handler: api.validation.ValidationHandler
   ): Unit = {
     val svrl = XML.loadString(engine.validate(document))
-    for (f @ Elem("svrl", "failed-assert", _, _, msg @ _*) <- svrl.child) yield {
-      handler.validationError(msg.text.trim, { f \\ "@location" }.text)
+    svrl.child.collect { case f @ Elem("svrl", "failed-assert", _, _, msg @ _*) =>
+      handler.validationError(msg.text.trim, (f \ "@location").text)
     }
 
     val svrlString = svrl.mkString

--- a/daffodil-tdml-lib/src/main/scala/org/apache/daffodil/tdml/TDMLRunner.scala
+++ b/daffodil-tdml-lib/src/main/scala/org/apache/daffodil/tdml/TDMLRunner.scala
@@ -2283,7 +2283,10 @@ case class Document(d: NodeSeq, parent: TestCase) {
     }
   }
 
-  private lazy val Seq(Elem(_, "document", _, _, children @ _*)) = d
+  private lazy val children = d match {
+    case Seq(Elem(_, "document", _, _, children @ _*)) => children
+    case x => Assert.invariantFailed(s"Expected <document>, found $x")
+  }
 
   private val actualDocumentPartElementChildren = children.toList.flatMap { child =>
     child match {

--- a/daffodil-test/src/test/scala/org/apache/daffodil/infoset/TestStringAsXml.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/infoset/TestStringAsXml.scala
@@ -96,7 +96,10 @@ class TestStringAsXml {
       )
       .toURL
       .openStream
-    val (parseDiags, Some(parseInfosetActual)) = doParse(dp, parseData)
+    val (parseDiags, Some(parseInfosetActual)) = doParse(dp, parseData) match {
+      case (parseDiags, Some(parseInfosetActual)) => (parseDiags, Some(parseInfosetActual))
+      case _ => fail(); null
+    }
     val parseInfosetExpected = {
       val is = Misc
         .getRequiredResource(
@@ -126,7 +129,10 @@ class TestStringAsXml {
       )
       .toURL
       .openStream
-    val (parseDiags, Some(parseInfosetActual)) = doParse(dp, parseData)
+    val (parseDiags, Some(parseInfosetActual)) = doParse(dp, parseData) match {
+      case (parseDiags, Some(parseInfosetActual)) => (parseDiags, Some(parseInfosetActual))
+      case _ => fail(); null
+    }
     val parseInfosetExpected = {
       val is = Misc
         .getRequiredResource(
@@ -153,7 +159,10 @@ class TestStringAsXml {
       )
       .toURL
       .openStream
-    val (_, Some(unparseDataActual)) = doUnparse(dp, unparseInfoset)
+    val unparseDataActual = doUnparse(dp, unparseInfoset) match {
+      case (_, Some(unparseDataActual)) => unparseDataActual
+      case _ => fail(); null
+    }
     val unparseDataExpected = {
       val is = Misc
         .getRequiredResource(
@@ -177,12 +186,21 @@ class TestStringAsXml {
         .openStream
       IOUtils.toString(is, StandardCharsets.UTF_8)
     }
-    val (_, Some(data1)) =
-      doUnparse(dp, new ByteArrayInputStream(infoset1.getBytes(StandardCharsets.UTF_8)))
-    val (_, Some(infoset2)) =
-      doParse(dp, new ByteArrayInputStream(data1.getBytes(StandardCharsets.UTF_8)))
-    val (_, Some(data2)) =
-      doUnparse(dp, new ByteArrayInputStream(infoset2.getBytes(StandardCharsets.UTF_8)))
+    val data1 =
+      doUnparse(dp, new ByteArrayInputStream(infoset1.getBytes(StandardCharsets.UTF_8))) match {
+        case (_, Some(data1)) => data1
+        case _ => fail(); null
+      }
+    val infoset2 =
+      doParse(dp, new ByteArrayInputStream(data1.getBytes(StandardCharsets.UTF_8))) match {
+        case (_, Some(infoset2)) => infoset2
+        case _ => fail(); null
+      }
+    val data2 =
+      doUnparse(dp, new ByteArrayInputStream(infoset2.getBytes(StandardCharsets.UTF_8))) match {
+        case (_, Some(data2)) => data2
+        case _ => fail(); null
+      }
     // unparsing canonicalizes the XML infoset payload. The original infoset is
     // not canoncialized, so the parsed infoset should not match the original.
     // But both unprsed data should match because the first unparse
@@ -287,7 +305,10 @@ class TestStringAsXml {
       )
       .toURL
       .openStream
-    val (parseDiags, Some(parseInfosetActual)) = doParse(dp, parseData)
+    val (parseDiags, Some(parseInfosetActual)) = doParse(dp, parseData) match {
+      case (parseDiags, Some(parseInfosetActual)) => (parseDiags, Some(parseInfosetActual))
+      case _ => fail(); null
+    }
     val parseInfosetExpected = {
       val is = Misc
         .getRequiredResource(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -19,7 +19,12 @@ import sbt.*
 
 object Dependencies {
 
-  lazy val common = core ++ infoset ++ test
+  def common(scalaVersion: String) = core ++ infoset ++ test ++ {
+    CrossVersion.partialVersion(scalaVersion) match {
+      case Some((2, 13)) => Seq("org.scala-lang" % "scala-reflect" % "2.13.16")
+      case _ => Seq.empty
+    }
+  }
 
   lazy val core = Seq(
     "com.lihaoyi" %% "os-lib" % "0.11.4", // for writing/compiling C source files


### PR DESCRIPTION
- Scala 3 is stricter than Scala 2 about type narrowing, this was a result of removing the 3.0 migration tag and having it default to LTS 3.3 source tag
- fixed pattern binding uses refutable extractor `scala.xml.Elem` which allows using a pattern than might fail in a val assignment in scala 2 but not scala 3
- Since Non local returns are no longer supported in Scala 3, we refactor code to support 3.3.6 and 2.13.16
- fix unused import errors (and issue in Main where certain converters were no longer auto imported)

DAFFODIL-2975