### PR TITLE
Review and Update Usage of .toSeq

### DIFF
--- a/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/AnnotatedSchemaComponent.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/AnnotatedSchemaComponent.scala
@@ -135,13 +135,12 @@ trait ResolvesScopedProperties extends FindPropertyMixin { self: Term =>
     val result = optFound match {
       case Some(f: Found) => f
       case None => {
-        val seq = str.toSeq
         // merge all the NotFound stuff.
-        val nonDefaults = seq.flatMap {
+        val nonDefaults = str.flatMap {
           case NotFound(nd, d, _) => nd
           case _: Found => Assert.invariantFailed()
         }
-        val defaults = seq.flatMap {
+        val defaults = str.flatMap {
           case NotFound(nd, d, _) => d
           case _: Found => Assert.invariantFailed()
         }

--- a/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/PropProviders.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/PropProviders.scala
@@ -126,7 +126,7 @@ final class ChainPropProvider(leafProvidersArg: Seq[LeafPropProvider], forAnnota
   /**
    * for debug/test only
    */
-  final lazy val properties: PropMap = leafProviders.flatMap { _.properties.toSeq }.toMap
+  final lazy val properties: PropMap = leafProviders.flatMap { _.properties }.toMap
 
   final lazy val leafProviders = leafProvidersArg
 

--- a/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/SchemaComponent.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/SchemaComponent.scala
@@ -74,7 +74,9 @@ trait SchemaComponent
     val optAttr =
       xml.attribute(XMLUtils.EXT_NS_APACHE, "suppressSchemaDefinitionWarnings").map { _.text }
     val warnStrs: Seq[String] =
-      optAttr.map { _.trim.split("\\s+").toSeq }.getOrElse { Seq.empty }
+      optAttr.map { w => w.trim.split("\\s+").toSeq }.getOrElse {
+        Seq.empty
+      }
     val warnIDs = warnStrs.map { warnStr =>
       // throws SDE if not valid warnID
       WarnID.stringToEnum("daf:suppressSchemaDefinitionWarnings", warnStr, this)

--- a/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/SchemaSet.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/SchemaSet.scala
@@ -217,7 +217,7 @@ final class SchemaSet private (
     val schemas = schemaGroups.map {
       case (ns, pairs) => {
         val sds = pairs.map { case (ns, s) => s }
-        val sch = Schema(ns, sds.toSeq, this)
+        val sch = Schema(ns, sds, this)
         sch
       }
     }

--- a/daffodil-core/src/main/scala/org/apache/daffodil/core/grammar/primitives/ChoiceCombinator.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/core/grammar/primitives/ChoiceCombinator.scala
@@ -155,7 +155,7 @@ case class ChoiceCombinator(ch: ChoiceTermBase, alternatives: Seq[Gram])
           // object that is the choice branch.
           //
           val isRepresentedTerm = alt.term.isRepresented
-          branchKeyRanges.toSeq.map(x => (x._1, x._2, alt.parser, isRepresentedTerm))
+          branchKeyRanges.map(x => (x._1, x._2, alt.parser, isRepresentedTerm))
         }
 
       // check for duplicate branch keys
@@ -316,7 +316,7 @@ case class ChoiceCombinator(ch: ChoiceTermBase, alternatives: Seq[Gram])
     val eventUnparserMap = eventRDMap.map { case (cbe, branchTerm) =>
       (cbe, branchTerm.termContentBody.unparser)
     }
-    val mapValues = eventUnparserMap.map { case (k, v) => v }.toSeq.filterNot(_.isEmpty)
+    val mapValues = eventUnparserMap.map { case (k, v) => v }.filterNot(_.isEmpty)
     if (mapValues.isEmpty) {
       if (branchForUnparse.isEmpty) {
         new NadaUnparser(null)

--- a/daffodil-core/src/main/scala/org/apache/daffodil/io/processors/charset/BitsCharset.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/io/processors/charset/BitsCharset.scala
@@ -154,7 +154,7 @@ trait BitsCharsetJava extends BitsCharset {
 
   private lazy val hasNameOrAliasContainingEBCDIC = {
     val allCharsetNames =
-      (javaCharset.aliases().asScala.toSeq :+ name :+ javaCharset.name()).map {
+      (javaCharset.aliases().asScala ++ Set(name, javaCharset.name())).map {
         _.toUpperCase
       }
     val res = allCharsetNames.exists(_.contains("EBCDIC"))

--- a/daffodil-core/src/main/scala/org/apache/daffodil/lib/exceptions/Assert.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/lib/exceptions/Assert.scala
@@ -55,7 +55,7 @@ abstract class ThinException protected (dummy: Int, cause: Throwable, fmt: Strin
   def this() = this(1, null, null)
   def this(msg: String) = this(1, null, msg)
   def this(fmt: String, args: Any*) =
-    this(1, null, fmt, args.toSeq*) // Fix varargs expansion
+    this(1, null, fmt, args*) // Fix varargs expansion
   def this(cause: Throwable) = this(1, cause, null)
 }
 

--- a/daffodil-core/src/main/scala/org/apache/daffodil/lib/util/Misc.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/lib/util/Misc.scala
@@ -624,7 +624,7 @@ object Misc {
   def isAsciiBased(csName: String): Boolean = isAsciiBased(JavaCharset.forName(csName))
 
   def isAsciiBased(cs: JavaCharset): Boolean = {
-    val aliases: Seq[String] = cs.aliases().asScala.toSeq.map { _.toUpperCase }
+    val aliases = cs.aliases().asScala.map { _.toUpperCase }
     val byName =
       aliases.exists { s =>
         !(s.contains("7-BIT")) &&

--- a/daffodil-core/src/main/scala/org/apache/daffodil/lib/util/Serialize.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/lib/util/Serialize.scala
@@ -75,7 +75,7 @@ trait PreSerialization extends Serializable {
 }
 
 private object PreSerialization {
-  private val classCache = new HashMap[Class[_], Boolean]
+  private val classCache = new HashMap[Class[?], Boolean]
 
   //
   // This private method ensures that any class (or any super class) that use this trait also implements the writeObject method

--- a/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/dpath/DPathRuntime.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/dpath/DPathRuntime.scala
@@ -170,7 +170,7 @@ abstract class RecipeOp extends Serializable {
 
   protected def toXML(s: String): scala.xml.Node = toXMLVarargs(new scala.xml.Text(s))
 
-  protected def toXMLVarargs(children: scala.xml.Node*): scala.xml.Node = toXML(children.toSeq)
+  protected def toXMLVarargs(children: scala.xml.Node*): scala.xml.Node = toXML(children)
 
   protected def toXML(children: scala.xml.NodeSeq): scala.xml.Node = {
     val name = Misc.getNameFromClass(this)

--- a/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/infoset/PartialNextElementResolver.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/infoset/PartialNextElementResolver.scala
@@ -190,7 +190,7 @@ sealed trait PartialNextElementResolver extends Serializable {
       hasNamespace
     )
 
-  def currentPossibleNextElements: Seq[ElementRuntimeData]
+  def currentPossibleNextElements: Iterable[ElementRuntimeData]
 
   final def currentPossibleNamedQNames = currentPossibleNextElements.map { _.namedQName }
 }
@@ -337,7 +337,7 @@ class SeveralPossibilitiesForNextElement(
           val localMatches = nextERDMap.view.filterKeys(_.local == local)
           if (localMatches.size > 1) {
             val sqn = StepQName(None, local, NS(namespace))
-            val keys = localMatches.keys.toSeq
+            val keys = localMatches.keys
             val errERD =
               new NamespaceAmbiguousElementErrorERD(Some(trd), local, namespace, keys)
             errERD.toUnparseError(false)
@@ -359,5 +359,5 @@ class SeveralPossibilitiesForNextElement(
 
   override def toString() = "Several(" + nextERDMap.keySet.mkString(", ") + ")"
 
-  override lazy val currentPossibleNextElements = nextERDMap.values.toSeq
+  override lazy val currentPossibleNextElements = nextERDMap.values
 }

--- a/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/processors/EvTextNumber.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/processors/EvTextNumber.scala
@@ -94,16 +94,16 @@ class TextNumberFormatEv(
     groupingSep: MaybeChar,
     exponentRep: Maybe[String]
   ): Unit = {
-    val bindings: Seq[(String, String)] = {
+    val bindings: Iterable[(String, String)] = {
       decimalSep.toOption.map { v => (v.toString, "textStandardDecimalSeparator") } ++
         groupingSep.toOption.map { v => (v.toString, "textStandardGroupingSeparator") } ++
         exponentRep.toOption.map { v => (v, "textStandardExponentRep") } ++
         infRep.toOption.map { v => (v, "textStandardInfinityRep") } ++
         nanRep.toOption.map { v => (v, "textStandardNaNRep") } ++
         zeroRepsRaw.map { zr => (zr, "textStandardZeroRep") }
-    }.toSeq
+    }
 
-    val mm: Map[String, Seq[String]] = bindings
+    val mm: Map[String, Iterable[String]] = bindings
       .groupBy(_._1)
       .view
       .mapValues(t => t.map(_._2))
@@ -113,7 +113,7 @@ class TextNumberFormatEv(
     val dupeStrings = dupes.map { case (k, s) =>
       "Non-distinct property '%s' found in: %s".format(k, s.mkString(", "))
     }
-    tci.schemaDefinitionUnless(dupeStrings.size == 0, dupeStrings.mkString("\n"))
+    tci.schemaDefinitionUnless(dupeStrings.isEmpty, dupeStrings.mkString("\n"))
   }
 
   /**

--- a/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/processors/RuntimeData.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/processors/RuntimeData.scala
@@ -865,7 +865,7 @@ final class UnexpectedElementErrorERD(
   optTRD: Option[TermRuntimeData],
   local: String,
   namespaceURI: String,
-  val allPossibleNQNs: Seq[QNameBase]
+  val allPossibleNQNs: Iterable[QNameBase]
 ) extends ErrorERD(local, namespaceURI) {}
 
 /**
@@ -877,7 +877,7 @@ final class NamespaceAmbiguousElementErrorERD(
   optTRD: Option[TermRuntimeData],
   local: String,
   namespaceURI: String,
-  val allPossibleNQNs: Seq[QNameBase]
+  val allPossibleNQNs: Iterable[QNameBase]
 ) extends ErrorERD(local, namespaceURI) {
 
   /**

--- a/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/DelimiterParsers.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/DelimiterParsers.scala
@@ -77,11 +77,11 @@ class DelimiterTextParser(
     foundLocalDFAIndex >= 0
   }
 
-  private def localDelimiters(state: PState): Seq[DFADelimiter] = {
+  private def localDelimiters(state: PState): ArrayBuffer[DFADelimiter] = {
     val localIndexStart = state.mpstate.delimitersLocalIndexStack.top
     val inScopeDelimiters = state.mpstate.delimiters
     val res = inScopeDelimiters.slice(localIndexStart, inScopeDelimiters.length)
-    res.toSeq
+    res
   }
 
   private def didNotFindExpectedDelimiter(foundDelimiter: ParseResult, start: PState): Unit = {

--- a/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/udf/UserDefinedFunctionService.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/udf/UserDefinedFunctionService.scala
@@ -52,7 +52,7 @@ object UserDefinedFunctionService {
   case class UserDefinedFunctionMethod(
     val decClass: Class[?],
     val methodName: String,
-    val paramTypes: Array[Class[_]]
+    val paramTypes: Array[Class[?]]
   ) extends Serializable {
 
     @transient lazy val method: Method = {
@@ -135,9 +135,9 @@ object UserDefinedFunctionService {
               Logger.log.warn(
                 s"User Defined Function Provider ignored: ${provider.getClass.getName}. No User Defined Functions found."
               )
-              Seq()
+              Array.empty[Class[?]]
             } else {
-              functionClasses.toSeq
+              functionClasses
             }
           } catch {
             /*
@@ -149,11 +149,11 @@ object UserDefinedFunctionService {
               Logger.log.warn(
                 s"User Defined Function Provider ignored: ${provider.getClass.getName}. Error loading User Defined Functions: ${e}"
               )
-              Seq()
+              Array.empty[Class[?]]
             }
           }
         }
-        .getOrElse(Seq())
+        .getOrElse(Array.empty[Class[?]])
 
       val goodFunctionClasses = providerFunctionClasses.filter { udfc =>
         val nonAnn = !udfc.isAnnotationPresent(classUserDefinedFunctionIdentification)

--- a/daffodil-core/src/main/scala/org/apache/daffodil/unparsers/runtime1/StringLiteralForUnparser.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/unparsers/runtime1/StringLiteralForUnparser.scala
@@ -41,7 +41,7 @@ class NilStringLiteralForUnparserEv(
     val rawWithEndMark = stringLiteralRaw + endMarker
     EntityReplacer { er =>
       val cookedWithEndMark = er.replaceForUnparse(rawWithEndMark)
-      val chunksSeparatedByNL = cookedWithEndMark.split(er.markerForNL).toSeq
+      val chunksSeparatedByNL = cookedWithEndMark.split(er.markerForNL)
       val last = chunksSeparatedByNL.last
       val butLast = chunksSeparatedByNL.take(chunksSeparatedByNL.length - 1)
       val chunks =

--- a/daffodil-core/src/test/scala/org/apache/daffodil/core/dsom/TestRefMap.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/core/dsom/TestRefMap.scala
@@ -244,7 +244,7 @@ class TestRefMap {
     val refMap = root.refMap
     val numEntries = refMap.size
     assertEquals(4, numEntries)
-    val refPairsMap = root.refPairsMap.toSeq
+    val refPairsMap = root.refPairsMap
     val numRefPairs = refPairsMap.map {
       _._2.length
     }.sum
@@ -302,7 +302,7 @@ class TestRefMap {
     val refMap = root.refMap
     val numEntries = refMap.size
     assertEquals(5, numEntries)
-    val refPairsMap = root.refPairsMap.toSeq
+    val refPairsMap = root.refPairsMap
     val numRefPairs = refPairsMap.map {
       _._2.length
     }.sum
@@ -356,7 +356,7 @@ class TestRefMap {
     val refMap = root.refMap
     val numEntries = refMap.size
     assertEquals(4, numEntries)
-    val refPairsMap = root.refPairsMap.toSeq
+    val refPairsMap = root.refPairsMap
     val numRefPairs = refPairsMap.map {
       _._2.length
     }.sum
@@ -418,7 +418,7 @@ class TestRefMap {
     val refMap = root.refMap
     val numEntries = refMap.size
     assertEquals(5, numEntries)
-    val refPairsMap = root.refPairsMap.toSeq
+    val refPairsMap = root.refPairsMap
     val numRefPairs = refPairsMap.map {
       _._2.length
     }.sum
@@ -488,7 +488,7 @@ class TestRefMap {
     val refMap = root.refMap
     val numEntries = refMap.size
     assertEquals(6, numEntries)
-    val refPairsMap = root.refPairsMap.toSeq
+    val refPairsMap = root.refPairsMap
     val numRefPairs = refPairsMap.map {
       _._2.length
     }.sum
@@ -566,7 +566,7 @@ class TestRefMap {
     val refMap = root.refMap
     val numEntries = refMap.size
     assertEquals(7, numEntries)
-    val refPairsMap = root.refPairsMap.toSeq
+    val refPairsMap = root.refPairsMap
     val numRefPairs = refPairsMap.map {
       _._2.length
     }.sum
@@ -652,7 +652,7 @@ class TestRefMap {
     val refMap = root.refMap
     val numEntries = refMap.size
     assertEquals(8, numEntries)
-    val refPairsMap = root.refPairsMap.toSeq
+    val refPairsMap = root.refPairsMap
     val numRefPairs = refPairsMap.map {
       _._2.length
     }.sum

--- a/daffodil-core/src/test/scala/org/apache/daffodil/layers/TestJavaIOStreams.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/layers/TestJavaIOStreams.scala
@@ -95,10 +95,10 @@ ZyBzb2x1dGlvbnMuCg=="""
       IOUtils.toInputStream(b64Text + additionalText, StandardCharsets.ISO_8859_1)
     val expected = text
     val decodedStream = java.util.Base64.getMimeDecoder().wrap(inputStream)
-    val lines = IOUtils.readLines(decodedStream, StandardCharsets.ISO_8859_1).asScala.toSeq
+    val lines = IOUtils.readLines(decodedStream, StandardCharsets.ISO_8859_1).asScala
     assertEquals(expected, lines(0))
     val additionalLines =
-      IOUtils.readLines(inputStream, StandardCharsets.ISO_8859_1).asScala.toSeq
+      IOUtils.readLines(inputStream, StandardCharsets.ISO_8859_1).asScala
     assertEquals(1, additionalLines.length)
     assertEquals(additionalText, additionalLines(0))
   }
@@ -114,11 +114,11 @@ ZyBzb2x1dGlvbnMuCg=="""
     val inputStream = IOUtils.toInputStream(b64Text + b64Text, StandardCharsets.ISO_8859_1)
     val expected = text
     val decodedStream = java.util.Base64.getMimeDecoder().wrap(inputStream)
-    val lines = IOUtils.readLines(decodedStream, StandardCharsets.ISO_8859_1).asScala.toSeq
+    val lines = IOUtils.readLines(decodedStream, StandardCharsets.ISO_8859_1).asScala
     assertEquals(expected, lines(0))
     val decodedStream2 = java.util.Base64.getMimeDecoder().wrap(inputStream)
     val additionalLines =
-      IOUtils.readLines(decodedStream2, StandardCharsets.ISO_8859_1).asScala.toSeq
+      IOUtils.readLines(decodedStream2, StandardCharsets.ISO_8859_1).asScala
     assertEquals(expected, additionalLines(0))
   }
 
@@ -160,11 +160,11 @@ ZyBzb2x1dGlvbnMuCg=="""
     //
     val gzipBufferSize = 1
     val decodedStream = new java.util.zip.GZIPInputStream(inputStream, gzipBufferSize)
-    val lines = IOUtils.readLines(decodedStream, StandardCharsets.ISO_8859_1).asScala.toSeq
+    val lines = IOUtils.readLines(decodedStream, StandardCharsets.ISO_8859_1).asScala
     assertEquals(1, lines.length)
     assertEquals(expected, lines(0))
     val additionalLines =
-      IOUtils.readLines(inputStream, StandardCharsets.ISO_8859_1).asScala.toSeq
+      IOUtils.readLines(inputStream, StandardCharsets.ISO_8859_1).asScala
     assertEquals(1, additionalLines.length)
     assertEquals(additionalText.drop(2), additionalLines(0))
   }
@@ -192,11 +192,11 @@ ZyBzb2x1dGlvbnMuCg=="""
     //
     val gzipBufferSize = 1
     val decodedStream = new java.util.zip.GZIPInputStream(inputStream, gzipBufferSize)
-    val lines = IOUtils.readLines(decodedStream, StandardCharsets.ISO_8859_1).asScala.toSeq
+    val lines = IOUtils.readLines(decodedStream, StandardCharsets.ISO_8859_1).asScala
     assertEquals(1, lines.length)
     assertEquals(expected, lines(0))
     val additionalLines =
-      IOUtils.readLines(inputStream, StandardCharsets.ISO_8859_1).asScala.toSeq
+      IOUtils.readLines(inputStream, StandardCharsets.ISO_8859_1).asScala
     assertEquals(1, additionalLines.length)
     assertEquals(additionalText.drop(2), additionalLines(0))
   }

--- a/daffodil-propgen/src/main/scala/org/apache/daffodil/propGen/PropertyGenerator.scala
+++ b/daffodil-propgen/src/main/scala/org/apache/daffodil/propGen/PropertyGenerator.scala
@@ -77,7 +77,7 @@ class PropertyGenerator(arg: Node) {
     res
   }
 
-  def genAll(): Seq[String] = {
+  def genAll() = {
     val allTopLevel = dfdlSchema.child
     val thunks = allTopLevel.map(node => {
       node.label match {
@@ -90,7 +90,7 @@ class PropertyGenerator(arg: Node) {
         }
       }
     })
-    thunks.toSeq
+    thunks
   }
 
   /**
@@ -744,7 +744,7 @@ import org.apache.daffodil.lib.exceptions.ThrowsSDE
 
 """
 
-  def writeGeneratedCode(thunks: Seq[String], ow: java.io.FileWriter): Unit = {
+  def writeGeneratedCode(thunks: Iterable[String], ow: java.io.FileWriter): Unit = {
     ow.write(preamble)
     for (thunk <- thunks) {
       ow.write(thunk)

--- a/daffodil-tdml-lib/src/main/scala/org/apache/daffodil/tdml/RunnerFactory.scala
+++ b/daffodil-tdml-lib/src/main/scala/org/apache/daffodil/tdml/RunnerFactory.scala
@@ -18,7 +18,6 @@
 package org.apache.daffodil.tdml
 
 import java.nio.file.Paths
-import scala.collection.immutable.ArraySeq
 
 import org.apache.daffodil.lib.iapi.TDMLImplementation
 import org.apache.daffodil.lib.iapi.URISchemaSource
@@ -50,8 +49,7 @@ object Runner {
     compileAllTopLevel: Boolean = false,
     defaultRoundTripDefault: RoundTrip = defaultRoundTripDefaultDefault,
     defaultValidationDefault: String = defaultValidationDefaultDefault,
-    defaultImplementationsDefault: Seq[String] =
-      ArraySeq.unsafeWrapArray(defaultImplementationsDefaultDefault)
+    defaultImplementationsDefault: Seq[String] = defaultImplementationsDefaultDefault
   ): Runner = {
 
     // Prepend forward slash to turn dir/file into classpath resource
@@ -115,7 +113,7 @@ object Runner {
    * A test or test suite can override this to specify more or different implementations
    * that the test should pass for.
    */
-  def defaultImplementationsDefaultDefault = TDMLImplementation.values.map(_.toString)
+  def defaultImplementationsDefaultDefault = TDMLImplementation.values.map(_.toString).toSeq
 
   /**
    * By default we don't run Daffodil negative TDML tests against cross-testers.
@@ -143,7 +141,7 @@ object Runner {
  * were a resource on the classpath. Otherwise it is treated as if it were a
  * URI.
  */
-final class Runner private (
+final class Runner private[tdml] (
   source: Either[scala.xml.Elem, String],
   optTDMLImplementation: Option[TDMLImplementation] = None,
   validateTDMLFile: Boolean = true,
@@ -151,8 +149,7 @@ final class Runner private (
   compileAllTopLevel: Boolean = false,
   defaultRoundTripDefault: RoundTrip = Runner.defaultRoundTripDefaultDefault,
   defaultValidationDefault: String = Runner.defaultValidationDefaultDefault,
-  defaultImplementationsDefault: Seq[String] =
-    ArraySeq.unsafeWrapArray(Runner.defaultImplementationsDefaultDefault),
+  defaultImplementationsDefault: Seq[String] = Runner.defaultImplementationsDefaultDefault,
   defaultIgnoreUnexpectedWarningsDefault: Boolean = true,
   defaultIgnoreUnexpectedValidationErrorsDefault: Boolean = true
 ) {

--- a/daffodil-tdml-lib/src/main/scala/org/apache/daffodil/tdml/TDMLRunner.scala
+++ b/daffodil-tdml-lib/src/main/scala/org/apache/daffodil/tdml/TDMLRunner.scala
@@ -373,7 +373,7 @@ class DFDLTestSuite private[tdml] (
   }
 
   def reportLoadingErrors(): Nothing = {
-    throw TDMLException(loadingExceptions.toSeq, None)
+    throw TDMLException(loadingExceptions, None)
   }
 
   var checkAllTopLevel: Boolean = compileAllTopLevel
@@ -414,7 +414,7 @@ class DFDLTestSuite private[tdml] (
     val str = (ts \ "@defaultConfig").text
     str
   }
-  lazy val defaultImplementations = {
+  lazy val defaultImplementations: Seq[String] = {
     val str = (ts \ "@defaultImplementations").text
     if (str == "") defaultImplementationsDefault
     else {
@@ -821,7 +821,7 @@ abstract class TestCase(testCaseXML: NodeSeq, val parent: DFDLTestSuite) {
           Some(XMLUtils.dafextURI)
         )
         if (node eq null)
-          throw TDMLException(parent.loadingExceptions.toSeq, None)
+          throw TDMLException(parent.loadingExceptions, None)
         val definedConfig = DefinedConfig(node, parent)
         Some(definedConfig)
       }
@@ -2831,7 +2831,7 @@ case class DFDLInfoset(di: Node, parent: Infoset) {
     val nAfter = testSuite.loadingExceptions.size
     val hasMoreExceptions = before.size < nAfter
     if (hasMoreExceptions) {
-      val newExceptions = (testSuite.loadingExceptions.diff(before)).toSeq
+      val newExceptions = (testSuite.loadingExceptions.diff(before))
       testCase.toss(TDMLException(newExceptions, None), None)
     }
     elem.asInstanceOf[Elem]

--- a/daffodil-tdml-processor/src/test/java/org/apache/daffodil/processor/tdml/TestRunnerFactory.java
+++ b/daffodil-tdml-processor/src/test/java/org/apache/daffodil/processor/tdml/TestRunnerFactory.java
@@ -21,8 +21,8 @@ import org.apache.daffodil.tdml.NoRoundTrip$;
 
 import org.apache.daffodil.tdml.Runner;
 
-import java.util.Arrays;
 import java.net.URI;
+import java.util.Arrays;
 
 import org.apache.daffodil.lib.util.Misc;
 import org.junit.Test;
@@ -43,16 +43,16 @@ public class TestRunnerFactory {
     URI tdmlUri = Misc.getRequiredResource("org/apache/daffodil/tdml/genericTdml.tdml");
     Right<scala.xml.Elem, String> rightURI = new Right<>(tdmlUri.toString());
     Runner runner = new Runner(
-      rightURI,
-      Option.apply(null),
-      true,
-      true,
-      false,
-      NoRoundTrip$.MODULE$,
-      "off",
-      CollectionConverters.asScala(Arrays.asList("daffodil", "ibm")).toSeq(),
-      false,
-      false);
+        rightURI,
+        Option.apply(null),
+        true,
+        true,
+        false,
+        NoRoundTrip$.MODULE$,
+        "off",
+        CollectionConverters.asScala(Arrays.asList("daffodil", "ibm")).toSeq(),
+        false,
+        false);
     runner.runOneTest("testPass");
     runner.reset();
   }


### PR DESCRIPTION
- we make use of .toSeq liberally within the code which can lead to unnecessary copies, so we review the code and update where possible to avoid .toSeq and replace with a more performant option
- ArraySeq.unsafeWrapArray wraps an array in a ArraySeq is a performant way to get a seq from an array
- use Arrays, Iterables or original collection in certain places instead of converting to Seq

DAFFODIL-2972