### PR TITLE
Add support for full validation on a saved parser

### DIFF
--- a/daffodil-cli/src/main/scala/org/apache/daffodil/cli/Main.scala
+++ b/daffodil-cli/src/main/scala/org/apache/daffodil/cli/Main.scala
@@ -169,24 +169,12 @@ class CLIConf(arguments: Array[String], stdout: PrintStream, stderr: PrintStream
     singleArgConverter[(String, Option[URI])]((s: String) => {
       import ValidatorPatterns._
 
-      def doesNotSupportReloadableParsers(name: String): Boolean =
-        // TODO: DAFFODIL-1749, this will change once ticket is implemented
-        schema.isEmpty && parser.isDefined && !Seq("limited", "off").exists(_.contains(name))
-
       s match {
         case DefaultArgPattern(name, arg) =>
-          if (doesNotSupportReloadableParsers(name)) {
-            null // validateOpt will cause null to output an appropriate error message
-          } else {
-            val uri = fileResourceToURI(arg).uri
-            (name, Some(uri))
-          }
+          val uri = fileResourceToURI(arg).uri
+          (name, Some(uri))
         case NoArgsPattern(name) =>
-          if (doesNotSupportReloadableParsers(name)) {
-            null // validateOpt will cause null to output an appropriate error message
-          } else {
-            (name, schema.map(_.uri).toOption)
-          }
+          (name, schema.map(_.uri).toOption)
         case _ =>
           throw new Exception(
             "Unrecognized Validator name %s.  Must be 'xerces', 'limited', 'off', or name of spi validator."
@@ -427,8 +415,9 @@ class CLIConf(arguments: Array[String], stdout: PrintStream, stderr: PrintStream
       argName = "validator_name",
       descr =
         "Validator name. Use 'off', 'limited', 'xerces[=value]', 'schematron[=value]', or a " +
-          "custom validator_name[=value]. The optional value paramter provides a file to the " +
-          "validator (e.g. .xsd, .sch, .conf, .properties) used for validator configuration."
+          "custom validator_name[=value]. The optional value parameter provides a file to the " +
+          "validator (e.g. .xsd, .sch, .conf, .properties) used for validator configuration. " +
+          "If using --parser, some validators may require a config file specified."
     )(validateConverter(schema, parser))
     val debug = opt[Option[String]](
       argName = "file",
@@ -460,12 +449,6 @@ class CLIConf(arguments: Array[String], stdout: PrintStream, stderr: PrintStream
     validateOpt(debug, infile) {
       case (Some(_), Some("-")) | (Some(_), None) =>
         Left("Input must not be stdin during interactive debugging")
-      case _ => Right(())
-    }
-
-    validateOpt(parser, validate) {
-      case (Some(_), Some(null)) =>
-        Left("The validation name must be 'limited' or 'off' when using a saved parser.")
       case _ => Right(())
     }
 
@@ -557,8 +540,10 @@ class CLIConf(arguments: Array[String], stdout: PrintStream, stderr: PrintStream
       argName = "validator_name",
       descr =
         "Validator name. Use 'off', 'limited', 'xerces[=value]', 'schematron[=value]', or a " +
-          "custom validator_name[=value]. The optional value paramter provides a file to the " +
-          "validator (e.g. .xsd, .sch, .conf, .properties) used for validator configuration."
+          "custom validator_name[=value]. The optional value parameter provides a file to the " +
+          "validator (e.g. .xsd, .sch, .conf, .properties) used for validator configuration. " +
+          "If using --parser, some validators may require a config file specified. Note that " +
+          "using this flag doesn't use the created validator as unparse validation is currently unsupported."
     )(validateConverter(schema, parser))
     val debug = opt[Option[String]](
       argName = "file",
@@ -792,8 +777,9 @@ class CLIConf(arguments: Array[String], stdout: PrintStream, stderr: PrintStream
       argName = "validator_name",
       descr =
         "Validator name. Use 'off', 'limited', 'xerces[=value]', 'schematron[=value]', or a " +
-          "custom validator_name[=value]. The optional value paramter provides a file to the " +
-          "validator (e.g. .xsd, .sch, .conf, .properties) used for validator configuration."
+          "custom validator_name[=value]. The optional value parameter provides a file to the " +
+          "validator (e.g. .xsd, .sch, .conf, .properties) used for validator configuration. " +
+          "If using --parser, some validators may require a config file specified."
     )(validateConverter(schema, parser))
 
     val infile = trailArg[String](

--- a/daffodil-cli/src/test/scala/org/apache/daffodil/cli/cliTest/TestCLISaveParser.scala
+++ b/daffodil-cli/src/test/scala/org/apache/daffodil/cli/cliTest/TestCLISaveParser.scala
@@ -164,7 +164,7 @@ class TestCLISaveParser {
     }
   }
 
-  @Test def test_CLI_DFDL_1205_FullValidation_SavedParser_Incompatible(): Unit = {
+  @Test def test_CLI_DFDL_1205_FullValidation_SavedParser(): Unit = {
     val schema = path(
       "daffodil-cli/src/test/resources/org/apache/daffodil/cli/charClassEntities.dfdl.xsd"
     )
@@ -176,11 +176,16 @@ class TestCLISaveParser {
       )
 
       runCLI(args"parse --parser $parser --validate xerces $input") { cli =>
-        cli.expectErr("[error]")
-        cli.expectErr(
-          "The validation name must be 'limited' or 'off' when using a saved parser."
-        )
-      }(ExitCode.Usage)
+        cli.expectErr("xerces property is empty or not defined")
+      }(
+        ExitCode.UnableToCreateValidatorError
+      )
+
+      runCLI(args"parse --validate xerces $input --parser $parser") { cli =>
+        cli.expectErr("xerces property is empty or not defined")
+      }(
+        ExitCode.UnableToCreateValidatorError
+      )
     }
   }
 
@@ -231,8 +236,14 @@ class TestCLISaveParser {
 
       runCLI(args"parse --validate xerces -P $parser") { cli =>
         cli.send("test", inputDone = true)
-        cli.expectErr("validation name must be 'limited' or 'off' when using a saved parser.")
-      }(ExitCode.Usage)
+        cli.expectErr("xerces property is empty or not defined")
+      }(ExitCode.UnableToCreateValidatorError)
+
+      runCLI(args"parse --validate xerces=$schema -P $parser") { cli =>
+        cli.send("test", inputDone = true)
+        cli.expectErr("[error] Validation Error")
+        cli.expectErr("not valid")
+      }(ExitCode.ParseError)
     }
   }
 

--- a/daffodil-core/src/main/java/org/apache/daffodil/api/DataProcessor.java
+++ b/daffodil-core/src/main/java/org/apache/daffodil/api/DataProcessor.java
@@ -143,7 +143,8 @@ public interface DataProcessor extends WithDiagnostics, Serializable {
    * Save the DataProcessor
    * <p>
    * The resulting output can be reloaded by {@code Compiler.reload(savedParser:java\.nio\.channels\.ReadableByteChannel)* Compiler.reload}.
-   *
+   * Note that any changes due to withValidator, withDebugger, and any compile diagnostics are not saved
+   * 
    * @param output the byte channel to write the {@link DataProcessor} to. Note that external variable settings are not saved.
    */
   void save(WritableByteChannel output);

--- a/daffodil-core/src/main/scala/org/apache/daffodil/core/util/TestUtils.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/core/util/TestUtils.scala
@@ -115,8 +115,6 @@ object TestUtils {
     runSchemaOnRBC(testSchema, rbc, areTracing)
   }
 
-  private val useSerializedProcessor = true
-
   def testUnparsing(
     testSchema: scala.xml.Elem,
     infosetXML: Node,
@@ -182,21 +180,18 @@ object TestUtils {
     )
 
   private def saveAndReload(p: DataProcessor): DataProcessor = {
-    if (this.useSerializedProcessor) {
-      //
-      // We want to serialize/deserialize here, to avoid strange debug artifacts
-      // like where schema compilation is still happening at runtime (and
-      // therefore generating lots of Debug messages to the log)
-      //
-      val os = new java.io.ByteArrayOutputStream()
-      val output = Channels.newChannel(os)
-      p.save(output)
+    // We want to serialize/deserialize here, to avoid strange debug artifacts
+    // like where schema compilation is still happening at runtime (and
+    // therefore generating lots of Debug messages to the log)
+    //
+    val os = new java.io.ByteArrayOutputStream()
+    val output = Channels.newChannel(os)
+    p.save(output)
 
-      val is = new java.io.ByteArrayInputStream(os.toByteArray)
-      val input = Channels.newChannel(is)
-      val compiler_ = Compiler()
-      compiler_.reload(input).asInstanceOf[DataProcessor]
-    } else p
+    val is = new java.io.ByteArrayInputStream(os.toByteArray)
+    val input = Channels.newChannel(is)
+    val compiler_ = Compiler()
+    compiler_.reload(input).asInstanceOf[DataProcessor]
   }
 
   def compileSchema(testSchema: Node) = {

--- a/daffodil-core/src/test/java/org/apache/daffodil/jexample/TestAPI.java
+++ b/daffodil-core/src/test/java/org/apache/daffodil/jexample/TestAPI.java
@@ -20,6 +20,7 @@ package org.apache.daffodil.jexample;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -222,7 +223,7 @@ public class TestAPI {
   // This is a duplicate of test testAPI1 that serializes the parser
   // before executing the test.
   @Test
-  public void testAPI1_A_FullFails() throws Exception {
+  public void testAPI1_A_Full_SavedParser() throws Exception {
     DebuggerRunnerForAPITest debugger = new DebuggerRunnerForAPITest();
 
     org.apache.daffodil.api.Compiler c = Daffodil.compiler();
@@ -241,13 +242,9 @@ public class TestAPI {
     ReadableByteChannel input = Channels.newChannel(is);
     org.apache.daffodil.api.Compiler compiler = Daffodil.compiler();
     DataProcessor parser = compiler.reload(input);
-
-    try {
-      parser = parser.withValidation("xerces", schemaFile.toURI());
-      fail();
-    } catch (InvalidUsageException e) {
-      assertEquals("Only Limited/No validation allowed when using a restored parser.", e.getMessage());
-    }
+    assertNotNull(schemaFile);
+    parser = parser.withValidation("xerces", schemaFile.toURI());
+    assertNotNull(parser);
   }
 
   @Test

--- a/daffodil-core/src/test/scala/org/apache/daffodil/sexample/TestAPI.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/sexample/TestAPI.scala
@@ -41,7 +41,6 @@ import org.apache.daffodil.api.ParseResult
 import org.apache.daffodil.api.exceptions.DaffodilUnhandledSAXException
 import org.apache.daffodil.api.exceptions.DaffodilUnparseErrorSAXException
 import org.apache.daffodil.api.exceptions.ExternalVariableException
-import org.apache.daffodil.api.exceptions.InvalidUsageException
 import org.apache.daffodil.api.infoset.Infoset
 import org.apache.daffodil.api.infoset.XMLTextEscapeStyle
 import org.apache.daffodil.lib.exceptions.UsageException
@@ -51,8 +50,8 @@ import org.apache.commons.io.FileUtils
 import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
-import org.junit.Assert.fail
 import org.junit.Test
 import org.xml.sax.XMLReader
 
@@ -132,7 +131,7 @@ class TestAPI {
         try {
           Class.forName(desc.getName, false, getClass.getClassLoader)
         } catch {
-          case e: ClassNotFoundException => super.resolveClass(desc);
+          case e: ClassNotFoundException => super.resolveClass(desc)
         }
       }
     }
@@ -172,9 +171,9 @@ class TestAPI {
       val wbc = java.nio.channels.Channels.newChannel(bos)
       val inputter = Infoset.getScalaXMLInfosetInputter(outputter.getResult())
       val res2 = dp.unparse(inputter, wbc)
-      val err2 = res2.isError();
-      assertFalse(err2);
-      assertEquals("42", bos.toString());
+      val err2 = res2.isError()
+      assertFalse(err2)
+      assertEquals("42", bos.toString())
     }
   }
   // This is a duplicate of test testAPI1 that serializes the parser
@@ -225,9 +224,9 @@ class TestAPI {
       val wbc = java.nio.channels.Channels.newChannel(bos)
       val inputter = Infoset.getScalaXMLInfosetInputter(outputter.getResult())
       val res2 = dp.unparse(inputter, wbc)
-      val err2 = res2.isError();
-      assertFalse(err2);
-      assertEquals("42", bos.toString());
+      val err2 = res2.isError()
+      assertFalse(err2)
+      assertEquals("42", bos.toString())
     }
   }
   @Test
@@ -297,9 +296,9 @@ class TestAPI {
       val wbc = java.nio.channels.Channels.newChannel(bos)
       val inputter = Infoset.getScalaXMLInfosetInputter(outputter.getResult())
       val res2 = dp.unparse(inputter, wbc)
-      val err2 = res2.isError();
-      assertFalse(err2);
-      assertEquals("9", bos.toString());
+      val err2 = res2.isError()
+      assertFalse(err2)
+      assertEquals("9", bos.toString())
     }
   }
   // This is a duplicate of test testAPI3 that serializes the parser
@@ -338,9 +337,9 @@ class TestAPI {
       val wbc = java.nio.channels.Channels.newChannel(bos)
       val inputter = Infoset.getScalaXMLInfosetInputter(outputter.getResult())
       val res2 = dp.unparse(inputter, wbc)
-      val err2 = res2.isError();
-      assertFalse(err2);
-      assertEquals("9", bos.toString());
+      val err2 = res2.isError()
+      assertFalse(err2)
+      assertEquals("9", bos.toString())
     }
   }
   @Test
@@ -366,9 +365,9 @@ class TestAPI {
       val wbc = java.nio.channels.Channels.newChannel(bos)
       val inputter = Infoset.getScalaXMLInfosetInputter(outputter.getResult())
       val res2 = dp.unparse(inputter, wbc)
-      val err2 = res2.isError();
-      assertFalse(err2);
-      assertEquals("data", bos.toString());
+      val err2 = res2.isError()
+      assertFalse(err2)
+      assertEquals("data", bos.toString())
     }
   }
   @Test
@@ -400,9 +399,9 @@ class TestAPI {
       val wbc = java.nio.channels.Channels.newChannel(bos)
       val inputter = Infoset.getScalaXMLInfosetInputter(outputter.getResult())
       val res2 = dp.unparse(inputter, wbc)
-      val err2 = res2.isError();
-      assertFalse(err2);
-      assertEquals("data", bos.toString());
+      val err2 = res2.isError()
+      assertFalse(err2)
+      assertEquals("data", bos.toString())
     }
   }
 
@@ -492,8 +491,8 @@ class TestAPI {
       val wbc = java.nio.channels.Channels.newChannel(bos)
       val inputter = Infoset.getScalaXMLInfosetInputter(outputter.getResult())
       val res2 = dp.unparse(inputter, wbc)
-      val err2 = res2.isError();
-      assertFalse(err2);
+      val err2 = res2.isError()
+      assertFalse(err2)
       assertTrue(bos.toString().contains("Return-Path: <bob@smith.com>"))
     }
   }
@@ -525,8 +524,8 @@ class TestAPI {
       val wbc1 = java.nio.channels.Channels.newChannel(bos1)
       val inputter1 = Infoset.getScalaXMLInfosetInputter(node1)
       val res2 = dp.unparse(inputter1, wbc1)
-      val err2 = res2.isError();
-      assertFalse(err2);
+      val err2 = res2.isError()
+      assertFalse(err2)
       assertTrue(bos1.toString().contains("Return-Path: <bob@smith.com>"))
 
       val node2 = outputter.getResult()
@@ -535,8 +534,8 @@ class TestAPI {
       val wbc2 = java.nio.channels.Channels.newChannel(bos2)
       val inputter2 = Infoset.getScalaXMLInfosetInputter(node2)
       val res3 = dp.unparse(inputter2, wbc2)
-      val err3 = res3.isError();
-      assertFalse(err3);
+      val err3 = res3.isError()
+      assertFalse(err3)
       assertTrue(bos2.toString().contains("Return-Path: <bob@smith.com>"))
     }
   }
@@ -701,10 +700,11 @@ class TestAPI {
   }
   // This is a duplicate of test testAPI1 that serializes the parser
   // before executing the test.
-  // Demonstrates that setting validation to Full for a saved parser fails.
+  // Demonstrates that setting validation to xerces for a saved parser
+  // does not fail.
   //
   @Test
-  def testAPI1_A_FullFails(): Unit = {
+  def testAPI1_A_Full_SavedParser(): Unit = {
     val debugger = new DebuggerRunnerForAPITest()
 
     val c = Daffodil.compiler()
@@ -724,17 +724,8 @@ class TestAPI {
     val input = Channels.newChannel(is)
     val compiler = Daffodil.compiler()
     val parser = compiler.reload(input)
-
-    try {
-      parser.withValidation("xerces", schemaFile.toURI)
-      fail()
-    } catch {
-      case e: InvalidUsageException =>
-        assertEquals(
-          "Only Limited/No validation allowed when using a restored parser.",
-          e.getMessage
-        )
-    }
+    val p = parser.withValidation("xerces", schemaFile.toURI)
+    assertNotNull(p)
   }
 
   @Test
@@ -762,7 +753,7 @@ class TestAPI {
 
     val diags = res.getDiagnostics
     assertEquals(1, diags.size)
-    val d = diags.get(0);
+    val d = diags.get(0)
     assertTrue(d.getMessage.contains("wrong"))
     assertTrue(d.getMessage.contains("e2"))
   }
@@ -1368,9 +1359,9 @@ class TestAPI {
       val wbc = java.nio.channels.Channels.newChannel(bos)
       val inputter = Infoset.getScalaXMLInfosetInputter(outputter.getResult())
       val res2 = dp.unparse(inputter, wbc)
-      val err2 = res2.isError();
-      assertFalse(err2);
-      assertEquals("9100", bos.toString());
+      val err2 = res2.isError()
+      assertFalse(err2)
+      assertEquals("9100", bos.toString())
     }
   }
 

--- a/daffodil-tdml-lib/src/main/scala/org/apache/daffodil/tdml/TDMLRunner.scala
+++ b/daffodil-tdml-lib/src/main/scala/org/apache/daffodil/tdml/TDMLRunner.scala
@@ -553,7 +553,6 @@ class DFDLTestSuite private[tdml] (
   def getCompileResult(
     impl: AbstractTDMLDFDLProcessorFactory,
     suppliedSchema: DaffodilSchemaSource,
-    useSerializedProcessor: Boolean,
     optRootName: Option[String],
     optRootNamespace: Option[String],
     tunables: Map[String, String]
@@ -562,7 +561,6 @@ class DFDLTestSuite private[tdml] (
     val key = TDMLCompileResultCacheKey(
       impl.implementationName,
       suppliedSchema,
-      useSerializedProcessor,
       optRootName,
       optRootNamespace,
       tunables
@@ -934,18 +932,11 @@ abstract class TestCase(testCaseXML: NodeSeq, val parent: DFDLTestSuite) {
         _.nBits
       }
 
-      val useSerializedProcessor =
-        if (validation == "on") false
-        else if (defaultValidation == "on") false
-        else if (optExpectedWarnings.isDefined) false
-        else true
-
       val rootNamespaceString = getRootNamespaceString()
 
       val compileResult: TDML.CompileResult = parent.getCompileResult(
         impl,
         suppliedSchema,
-        useSerializedProcessor,
         Option(rootName),
         Option(rootNamespaceString),
         tunables
@@ -3014,7 +3005,6 @@ object UTF8Encoder {
 case class TDMLCompileResultCacheKey(
   impl: String,
   suppliedSchema: DaffodilSchemaSource,
-  useSerializedProcessor: Boolean,
   optRootName: Option[String],
   optRootNamespace: Option[String],
   tunables: Map[String, String]
@@ -3102,7 +3092,6 @@ case class TDMLCompileResultCache(entryExpireDurationSeconds: Option[Long]) {
     } else {
       val compileResult = impl.getProcessor(
         key.suppliedSchema,
-        key.useSerializedProcessor,
         key.optRootName,
         key.optRootNamespace,
         key.tunables

--- a/daffodil-tdml-lib/src/main/scala/org/apache/daffodil/tdml/processor/TDMLDFDLProcessor.scala
+++ b/daffodil-tdml-lib/src/main/scala/org/apache/daffodil/tdml/processor/TDMLDFDLProcessor.scala
@@ -57,7 +57,6 @@ trait AbstractTDMLDFDLProcessorFactory {
 
   def getProcessor(
     schemaSource: DaffodilSchemaSource,
-    useSerializedProcessor: Boolean,
     optRootName: Option[String] = None,
     optRootNamespace: Option[String] = None,
     tunables: Map[String, String]

--- a/daffodil-tdml-processor/src/main/scala/org/apache/daffodil/processor/tdml/DaffodilCTDMLDFDLProcessor.scala
+++ b/daffodil-tdml-processor/src/main/scala/org/apache/daffodil/processor/tdml/DaffodilCTDMLDFDLProcessor.scala
@@ -72,7 +72,6 @@ final class DaffodilCTDMLDFDLProcessorFactory(compiler: Compiler)
   // schema (only diagnostics on left, or processor too on right)
   override def getProcessor(
     schemaSource: DaffodilSchemaSource,
-    useSerializedProcessor: Boolean,
     optRootName: Option[String] = None,
     optRootNamespace: Option[String] = None,
     tunables: Map[String, String]

--- a/daffodil-tdml-processor/src/test/scala/org/apache/daffodil/processor/tdml/TestDaffodilC.scala
+++ b/daffodil-tdml-processor/src/test/scala/org/apache/daffodil/processor/tdml/TestDaffodilC.scala
@@ -214,13 +214,11 @@ class TestDaffodilC {
     val processorFactory = new DaffodilCTDMLDFDLProcessorFactory()
     val schemaSource =
       UnitTestSchemaSource(testSchema, nameHint = "getProcessor", Some(tempDir.toIO))
-    val useSerializedProcessor = false
     val optRootName = None
     val optRootNamespace = None
     val tunables = Map.empty[String, String]
     val cr = processorFactory.getProcessor(
       schemaSource,
-      useSerializedProcessor,
       optRootName,
       optRootNamespace,
       tunables

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import sbt.*
+import sbt._
 
 object Dependencies {
 


### PR DESCRIPTION
- add optSchemaURI arg to internal DataProcessor, and pass in from SchemaSetRuntime1Mixin
- add withValidatorName method to api DataProcessor
- remove errors on using with saved parser
- throw Exception if schemaURI isn't provided for xerces/schematron on reloadable parser
- add tests for reloadable parsers using schematron and xerces validation

DAFFODIL-3007