### PR TITLE
Use Seqs internally for BlobPaths/Diagnostics

### DIFF
--- a/daffodil-codegen-c/src/main/scala/org/apache/daffodil/codegen/c/DaffodilCCodeGenerator.scala
+++ b/daffodil-codegen-c/src/main/scala/org/apache/daffodil/codegen/c/DaffodilCCodeGenerator.scala
@@ -81,7 +81,7 @@ import org.apache.daffodil.runtime1.dsom.SchemaDefinitionWarning
 class DaffodilCCodeGenerator(root: Root) extends api.CodeGenerator {
   // Note this class is not thread-safe due to mutable state needed to
   // implement WithDiagnostics trait
-  private var diagnostics: java.util.List[api.Diagnostic] = java.util.Collections.emptyList()
+  private var diagnostics: Seq[api.Diagnostic] = Nil
   private var errorStatus: Boolean = false
 
   /**
@@ -123,8 +123,7 @@ class DaffodilCCodeGenerator(root: Root) extends api.CodeGenerator {
     // while appending any warnings to our diagnostics
     val cgState = new CodeGeneratorState(root)
     DaffodilCCodeGenerator.generateCode(root.document, cgState)
-    diagnostics = new java.util.LinkedList[api.Diagnostic](diagnostics)
-    diagnostics.addAll(root.warnings.asJava)
+    diagnostics = diagnostics ++ root.warnings
     val versionHeaderText = cgState.generateVersionHeader
     val codeHeaderText = cgState.generateCodeHeader
     val codeFileText = cgState.generateCodeFile
@@ -228,8 +227,7 @@ class DaffodilCCodeGenerator(root: Root) extends api.CodeGenerator {
   private def warning(formatString: String, args: Any*): Unit = {
     val sde =
       new SchemaDefinitionWarning(WarnID.CodeGenerator, None, None, formatString, args: _*)
-    diagnostics = new java.util.LinkedList[api.Diagnostic](diagnostics)
-    diagnostics.add(sde)
+    diagnostics = diagnostics :+ sde
   }
 
   /**
@@ -237,13 +235,12 @@ class DaffodilCCodeGenerator(root: Root) extends api.CodeGenerator {
    */
   private def error(formatString: String, args: Any*): Unit = {
     val sde = new SchemaDefinitionError(None, None, formatString, args: _*)
-    diagnostics = new java.util.LinkedList[api.Diagnostic](diagnostics)
-    diagnostics.add(sde)
+    diagnostics = diagnostics :+ sde
     errorStatus = true
   }
 
   // Implements the WithDiagnostics trait
-  override def getDiagnostics: java.util.List[api.Diagnostic] = diagnostics
+  override def getDiagnostics: java.util.List[api.Diagnostic] = diagnostics.asJava
   override def isError: Boolean = errorStatus
 }
 

--- a/daffodil-core/src/main/scala/org/apache/daffodil/core/compiler/Compiler.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/core/compiler/Compiler.scala
@@ -103,7 +103,7 @@ final class ProcessorFactory private (
 
   def elementBaseInstanceCount: Long = sset.elementBaseInstanceCount
 
-  def diagnostics: java.util.List[api.Diagnostic] = {
+  def diagnostics: Seq[api.Diagnostic] = {
     // The work to compile a schema and build diagnostics is triggered by the user calling
     // isError. But if a user gets diagnostics before doing so, then no work will have been done
     // and the diagnostics will be empty. Technically this is incorrect usage--a user should
@@ -117,7 +117,7 @@ final class ProcessorFactory private (
     sset.diagnostics
   }
 
-  def getDiagnostics: java.util.List[api.Diagnostic] = diagnostics
+  def getDiagnostics: java.util.List[api.Diagnostic] = diagnostics.asJava
 
   override def onPath(xpath: String): api.DataProcessor = sset.onPath(xpath)
 

--- a/daffodil-core/src/main/scala/org/apache/daffodil/core/util/TestUtils.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/core/util/TestUtils.scala
@@ -127,7 +127,7 @@ object TestUtils {
   ): Unit = {
     val compiler = Compiler()
     val pf = compiler.compileNode(testSchema)
-    if (pf.isError) throwDiagnostics(pf.diagnostics)
+    if (pf.isError) throwDiagnostics(pf.getDiagnostics)
     var u = pf.onPath("/").asInstanceOf[DataProcessor]
     if (u.isError) throwDiagnostics(u.getDiagnostics)
     val outputStream = new java.io.ByteArrayOutputStream()

--- a/daffodil-core/src/main/scala/org/apache/daffodil/lib/oolag/OOLAG.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/lib/oolag/OOLAG.scala
@@ -450,7 +450,7 @@ object OOLAG {
     final def warnings: Seq[api.Diagnostic] = oolagRoot.warnings_.toSeq
 
     override def getDiagnostics: java.util.List[api.Diagnostic] =
-      diagnostics
+      diagnostics.asJava
 
     def warn(th: Diagnostic): Unit = {
       oolagRoot.oolagWarn(th)
@@ -493,7 +493,7 @@ object OOLAG {
       errorCount > 0
     }
 
-    def diagnostics: java.util.List[api.Diagnostic] = (errors ++ warnings).asJava
+    def diagnostics: Seq[api.Diagnostic] = errors ++ warnings
   }
 
   /**

--- a/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/debugger/InteractiveDebugger.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/debugger/InteractiveDebugger.scala
@@ -195,7 +195,7 @@ class InteractiveDebugger(
 
       if (state.processorStatus ne Success) {
         debugPrintln("failure:")
-        debugPrintln("%s".format(state.diagnostics.get(0).toString), "  ")
+        debugPrintln("%s".format(state.diagnostics.head.toString), "  ")
       }
 
       if (debugState == DebugState.Trace) {

--- a/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/iapi/DFDLParserUnparser.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/iapi/DFDLParserUnparser.scala
@@ -184,7 +184,7 @@ object DFDL {
     /**
      * @return list of diagnostics
      */
-    def diagnostics: java.util.List[Diagnostic]
+    def diagnostics: Seq[Diagnostic]
 
     /**
      * @return current data location
@@ -197,7 +197,7 @@ object DFDL {
    */
   abstract class Result extends api.Result {
     def resultState: State
-    var diagnostics: java.util.List[api.Diagnostic] = java.util.Collections.emptyList()
+    var diagnostics: Seq[api.Diagnostic] = Nil
 
     private def resultStatusDiagnostics: Seq[api.Diagnostic] = {
       resultState.processorStatus match {
@@ -207,12 +207,11 @@ object DFDL {
     }
 
     override def getDiagnostics: java.util.List[api.Diagnostic] = {
-      (diagnostics.asScala ++ resultState.diagnostics.asScala ++ resultStatusDiagnostics).distinct.asJava
+      (diagnostics ++ resultState.diagnostics ++ resultStatusDiagnostics).distinct.asJava
     }
 
     override def addDiagnostic(d: api.Diagnostic): Unit = {
-      diagnostics = new java.util.LinkedList[api.Diagnostic](diagnostics)
-      diagnostics.add(0, d)
+      diagnostics = d +: diagnostics
     }
 
     override def isError = isProcessingError || isValidationError

--- a/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/processors/DataProcessor.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/processors/DataProcessor.scala
@@ -27,9 +27,9 @@ import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.nio.file.Path
 import java.util.zip.GZIPOutputStream
+import scala.jdk.CollectionConverters._
 
 import org.apache.daffodil.api
-import org.apache.daffodil.api.Diagnostic
 import org.apache.daffodil.api.debugger.Debugger
 import org.apache.daffodil.api.metadata.MetadataHandler
 import org.apache.daffodil.lib.Implicits._
@@ -133,8 +133,7 @@ class DataProcessor(
   val validator: api.validation.Validator = NoValidator,
   protected val areDebugging: Boolean = false,
   protected val optDebugger: Option[api.debugger.Debugger] = None,
-  protected val diagnostics: java.util.List[api.Diagnostic] =
-    new java.util.LinkedList[api.Diagnostic]()
+  protected val diagnostics: Seq[api.Diagnostic] = Seq.empty
 ) extends DFDL.DataProcessor
   with Serializable
   with MultipleEventHandler {
@@ -167,7 +166,7 @@ class DataProcessor(
     validator: api.validation.Validator = validator,
     areDebugging: Boolean = areDebugging,
     optDebugger: Option[api.debugger.Debugger] = optDebugger,
-    diagnostics: java.util.List[api.Diagnostic] = diagnostics
+    diagnostics: Seq[api.Diagnostic] = diagnostics
   ) = new DataProcessor(
     ssrd,
     tunables,
@@ -239,7 +238,7 @@ class DataProcessor(
   override def isError = false
 
   override def getDiagnostics: java.util.List[api.Diagnostic] =
-    diagnostics
+    diagnostics.asJava
 
   override def newXMLReaderInstance: api.DaffodilParseXMLReader = {
     val xrdr = new DaffodilParseXMLReader(this)
@@ -274,7 +273,7 @@ class DataProcessor(
       variableMap = ssrd.originalVariables,
       validator = NoValidator,
       // don't save any warnings that were generated
-      diagnostics = new java.util.ArrayList[Diagnostic]()
+      diagnostics = Seq.empty
     )
 
     try {
@@ -364,11 +363,11 @@ class DataProcessor(
         validator.validateXML(bis, state)
       }
       // copy the blob paths we created to the users infoset outputter
-      output.setBlobPaths(state.blobPaths)
+      output.setBlobPaths(state.blobPaths.asJava)
       new ParseResult(state)
     } else {
       // failed, so delete all blobs that were created
-      state.blobPaths.forEach { path =>
+      state.blobPaths.foreach { path =>
         Files.delete(path)
       }
       // ensure the blob paths on the users infoset outputter are empty in case of reuse

--- a/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/ElementCombinator1.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/ElementCombinator1.scala
@@ -18,7 +18,6 @@
 package org.apache.daffodil.runtime1.processors.parsers
 
 import org.apache.daffodil.api
-import org.apache.daffodil.api.Diagnostic
 import org.apache.daffodil.lib.exceptions.Assert
 import org.apache.daffodil.lib.util.Logger
 import org.apache.daffodil.lib.util.Maybe
@@ -143,9 +142,7 @@ abstract class ElementParserBase(
 
       Assert.invariant(pstate.hasInfoset)
 
-      var setVarFailureDiags: java.util.List[api.Diagnostic] =
-        new java.util.LinkedList[Diagnostic]()
-
+      var setVarFailureDiags: Seq[api.Diagnostic] = Nil
       if (pstate.processorStatus eq Success) {
         var i: Int = 0
         while (i < setVarParser.length) {
@@ -175,8 +172,8 @@ abstract class ElementParserBase(
       // We're done with the discriminator, so now we revisit the set variable statements.
       // If a failure occurred there, then now we can fail out right here.
       //
-      if (!setVarFailureDiags.isEmpty) {
-        pstate.setFailed(setVarFailureDiags.get(0))
+      if (setVarFailureDiags.nonEmpty) {
+        pstate.setFailed(setVarFailureDiags.head)
         return
       }
 

--- a/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/ParseErrors.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/ParseErrors.scala
@@ -65,7 +65,7 @@ class AssertionFailed(
 class ChoiceBranchFailed(
   rd: SchemaFileLocation,
   state: PState,
-  val errors: java.util.List[api.Diagnostic]
+  val errors: Seq[api.Diagnostic]
 ) extends ParseError(
     One(rd),
     One(state.currentLocation),
@@ -76,7 +76,7 @@ class ChoiceBranchFailed(
 class EntireChoiceFailed(
   rd: SchemaFileLocation,
   state: PState,
-  diags: java.util.List[api.Diagnostic]
+  diags: Seq[api.Diagnostic]
 ) extends ParseError(
     One(rd),
     One(state.currentLocation),
@@ -85,13 +85,13 @@ class EntireChoiceFailed(
   ) {
 
   override def getLocationsInSchemaFiles: java.util.List[api.LocationInSchemaFile] = {
-    val locs = diags.asScala.flatMap { d => d.getLocationsInSchemaFiles.asScala }
+    val locs = diags.flatMap { d => d.getLocationsInSchemaFiles.asScala }
     locs.toList.asJava
   }
 
   override def getDataLocations: java.util.List[api.DataLocation] = {
     // all should have the same starting location if they are alternatives.
-    val dataLocs = diags.asScala.flatMap { _.getDataLocations.asScala }
+    val dataLocs = diags.flatMap { _.getDataLocations.asScala }
     // TBD: what is the idiom for "insert a equals sign between all the elements of the list...??"
     // Well, this works, but isn't there a one-liner for this idiom.
     val allAreSame = dataLocs match {
@@ -99,7 +99,7 @@ class EntireChoiceFailed(
       case _ => true
     }
     Assert.invariant(allAreSame)
-    diags.get(0).getDataLocations
+    diags.head.getDataLocations
   }
 }
 
@@ -114,7 +114,7 @@ class ChoiceDispatchNoMatch(rd: SchemaFileLocation, state: PState, val key: Stri
 class ChoiceDispatchFailed(
   rd: SchemaFileLocation,
   state: PState,
-  val errors: java.util.List[api.Diagnostic]
+  val errors: Seq[api.Diagnostic]
 ) extends ParseError(
     One(rd),
     One(state.currentLocation),

--- a/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/Parser.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/Parser.scala
@@ -17,8 +17,6 @@
 
 package org.apache.daffodil.runtime1.processors.parsers
 
-import java.util.Collections
-
 import org.apache.daffodil.api
 import org.apache.daffodil.api.DataLocation
 import org.apache.daffodil.io.BacktrackingException
@@ -260,7 +258,7 @@ class ChoiceParser(ctxt: RuntimeData, val childParsers: Array[Parser])
 
   def parse(pstate: PState): Unit = {
 
-    var diagnostics: java.util.List[api.Diagnostic] = Collections.emptyList()
+    var diagnostics: Seq[api.Diagnostic] = Nil
     var i = 0
     val numAlternatives = childParsers.length
 
@@ -295,8 +293,7 @@ class ChoiceParser(ctxt: RuntimeData, val childParsers: Array[Parser])
 
           val diag =
             new ChoiceBranchFailed(context.schemaFileLocation, pstate, pstate.diagnostics)
-          diagnostics = new java.util.LinkedList[api.Diagnostic](diagnostics)
-          diagnostics.add(0, diag)
+          diagnostics = diag +: diagnostics
 
           if (pstate.isPointOfUncertaintyResolved(pou)) {
             // A discriminator resolved the point of uncertainty associated with
@@ -318,10 +315,8 @@ class ChoiceParser(ctxt: RuntimeData, val childParsers: Array[Parser])
     }
 
     if (!successfullyParsedChildBranch) {
-      diagnostics = new java.util.LinkedList[api.Diagnostic](diagnostics)
-      Collections.reverse(diagnostics)
       val allDiags =
-        new EntireChoiceFailed(context.schemaFileLocation, pstate, diagnostics)
+        new EntireChoiceFailed(context.schemaFileLocation, pstate, diagnostics.reverse)
       pstate.setFailed(allDiags)
     }
   }

--- a/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/processors/unparsers/UState.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/processors/unparsers/UState.scala
@@ -71,7 +71,7 @@ object ENoWarn { EqualitySuppressUnusedImportWarning() }
 
 abstract class UState(
   vbox: VariableBox,
-  diagnosticsArg: java.util.List[api.Diagnostic],
+  diagnosticsArg: Seq[api.Diagnostic],
   dataProcArg: Maybe[DataProcessor],
   tunable: DaffodilTunables,
   areDebugging: Boolean
@@ -220,8 +220,7 @@ abstract class UState(
   }
 
   def addUnparseError(ue: UnparseError): Unit = {
-    diagnostics = new java.util.LinkedList[api.Diagnostic](diagnostics)
-    diagnostics.add(0, ue)
+    diagnostics = ue +: diagnostics
     _processorStatus = new Failure(ue)
   }
 
@@ -507,7 +506,7 @@ final class UStateMain private (
   private val inputter: InfosetInputter,
   outStream: java.io.OutputStream,
   vbox: VariableBox,
-  diagnosticsArg: java.util.List[api.Diagnostic],
+  diagnosticsArg: Seq[api.Diagnostic],
   dataProcArg: DataProcessor,
   tunable: DaffodilTunables,
   areDebugging: Boolean
@@ -519,7 +518,7 @@ final class UStateMain private (
     inputter: InfosetInputter,
     outputStream: java.io.OutputStream,
     vmap: VariableMap,
-    diagnosticsArg: java.util.List[api.Diagnostic],
+    diagnosticsArg: Seq[api.Diagnostic],
     dataProcArg: DataProcessor,
     tunable: DaffodilTunables,
     areDebugging: Boolean
@@ -761,7 +760,7 @@ object UState {
      */
     val variables = dataProc.variableMap.copy()
 
-    val diagnostics = new java.util.LinkedList[api.Diagnostic]()
+    val diagnostics = Nil
     val newState = new UStateMain(
       inputter,
       outStream,

--- a/daffodil-core/src/test/scala/org/apache/daffodil/core/dsom/TestExternalVariables.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/core/dsom/TestExternalVariables.scala
@@ -218,7 +218,7 @@ class TestExternalVariables {
     val c = Compiler(validateDFDLSchemas = false)
     val pf = c.compileSource(source)
     pf.isError
-    pf.diagnostics.forEach { d => println(d) }
+    pf.diagnostics.foreach { d => println(d) }
     assertFalse(pf.isError)
     val dp = pf.onPath("/").asInstanceOf[DataProcessor].withExternalVariables(variables)
 

--- a/daffodil-core/src/test/scala/org/apache/daffodil/lib/oolag/TestOOLAG.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/lib/oolag/TestOOLAG.scala
@@ -256,7 +256,7 @@ class TestOOLAG {
     assertTrue(h.divZero_.isError)
 
     val d = h.diagnostics
-    d.forEach { System.err.println(_) }
+    d.foreach { System.err.println(_) }
     // Division by zero is not caught by oolag anymore, so there will be
     // no diagnostic message.
     // assertTrue(d.length == 1)

--- a/daffodil-tdml-processor/src/main/scala/org/apache/daffodil/processor/tdml/DaffodilCTDMLDFDLProcessor.scala
+++ b/daffodil-tdml-processor/src/main/scala/org/apache/daffodil/processor/tdml/DaffodilCTDMLDFDLProcessor.scala
@@ -229,20 +229,14 @@ final class DaffodilCTDMLParseResult(
   messages: String = ""
 ) extends TDMLParseResult {
 
-  private var diagnostics: java.util.List[api.Diagnostic] = processorResult match {
+  private var diagnostics: Seq[api.Diagnostic] = processorResult match {
     case Success =>
-      if (messages.nonEmpty)
-        new java.util.LinkedList[api.Diagnostic](
-          java.util.Arrays.asList(DaffodilCTDMLMessages(messages))
-        )
-      else java.util.Arrays.asList()
-    case Failure(cause) =>
-      new java.util.LinkedList[api.Diagnostic](java.util.Arrays.asList(cause))
+      if (messages.nonEmpty) List(DaffodilCTDMLMessages(messages)) else Nil
+    case Failure(cause) => List(cause)
   }
 
   override def addDiagnostic(diagnostic: Diagnostic): Unit = {
-    diagnostics = new java.util.LinkedList[api.Diagnostic](diagnostics)
-    diagnostics.add(diagnostic)
+    diagnostics = diagnostic +: diagnostics
   }
 
   // We must read outFile right away (def or lazy val will not work) because the parse
@@ -260,9 +254,9 @@ final class DaffodilCTDMLParseResult(
   }
 
   override def currentLocation: DataLocation = DaffodilCTDMLDataLocation(finalBitPos0b)
-  override def isValidationError: Boolean = diagnostics.asScala.exists(_.isValidation)
+  override def isValidationError: Boolean = diagnostics.exists(_.isValidation)
   override def isProcessingError: Boolean = processorResult.isFailure
-  override def getDiagnostics: java.util.List[api.Diagnostic] = diagnostics
+  override def getDiagnostics: java.util.List[api.Diagnostic] = diagnostics.asJava
 }
 
 /**
@@ -297,18 +291,16 @@ final class DaffodilCTDMLUnparseResult(
   messages: String = ""
 ) extends TDMLUnparseResult {
 
-  private val diagnostics: java.util.List[api.Diagnostic] = processorResult match {
+  private val diagnostics: Seq[api.Diagnostic] = processorResult match {
     case Success =>
-      if (messages.nonEmpty)
-        new java.util.LinkedList(java.util.Arrays.asList(DaffodilCTDMLMessages(messages)))
-      else new java.util.ArrayList[api.Diagnostic]()
-    case Failure(cause) => new java.util.LinkedList(java.util.Arrays.asList(cause))
+      if (messages.nonEmpty) List(DaffodilCTDMLMessages(messages)) else Nil
+    case Failure(cause) => List(cause)
   }
 
   override def bitPos0b: Long = finalBitPos0b
   override def isScannable: Boolean = false // binary data is not scannable
   override def encodingName: String = "" // encoding needed only if scannable
-  override def isValidationError: Boolean = diagnostics.asScala.exists(_.isValidation)
+  override def isValidationError: Boolean = diagnostics.exists(_.isValidation)
   override def isProcessingError: Boolean = processorResult.isFailure
-  override def getDiagnostics: java.util.List[api.Diagnostic] = diagnostics
+  override def getDiagnostics: java.util.List[api.Diagnostic] = diagnostics.asJava
 }

--- a/daffodil-tdml-processor/src/main/scala/org/apache/daffodil/processor/tdml/DaffodilTDMLDFDLProcessor.scala
+++ b/daffodil-tdml-processor/src/main/scala/org/apache/daffodil/processor/tdml/DaffodilTDMLDFDLProcessor.scala
@@ -441,7 +441,7 @@ final class DaffodilTDMLParseResult(actual: ParseResult, outputter: TDMLInfosetO
 
   override def getResult: Node = outputter.getResult
 
-  override def getBlobPaths: java.util.List[Path] = outputter.getBlobPaths()
+  override def getBlobPaths: java.util.List[Path] = outputter.getBlobPaths
 
   def inputter = outputter.toInfosetInputter
 
@@ -455,7 +455,7 @@ final class DaffodilTDMLParseResult(actual: ParseResult, outputter: TDMLInfosetO
 
   override def addDiagnostic(diag: Diagnostic): Unit = actual.addDiagnostic(diag)
 
-  override def cleanUp(): Unit = getBlobPaths.forEach { Files.delete }
+  override def cleanUp(): Unit = getBlobPaths.forEach { Files.delete(_) }
 }
 
 final class DaffodilTDMLUnparseResult(
@@ -481,28 +481,26 @@ final class DaffodilTDMLUnparseResult(
 }
 
 class DaffodilTDMLSAXErrorHandler extends ErrorHandler with WithDiagnostics {
-  private var diagnostics: java.util.List[api.Diagnostic] = java.util.Collections.emptyList()
+  private var diagnostics: Seq[api.Diagnostic] = Nil
   private var errorStatus: Boolean = false
 
   override def warning(exception: SAXParseException): Unit = {
     errorStatus = false
     val embeddedDiagnostic = exception.getCause.asInstanceOf[Diagnostic]
-    diagnostics = new java.util.LinkedList[api.Diagnostic](diagnostics)
-    diagnostics.add(embeddedDiagnostic)
+    diagnostics = embeddedDiagnostic +: diagnostics
   }
 
   override def error(exception: SAXParseException): Unit = {
     errorStatus = true
     val embeddedDiagnostic = exception.getCause.asInstanceOf[Diagnostic]
-    diagnostics = new java.util.LinkedList[api.Diagnostic](diagnostics)
-    diagnostics.add(embeddedDiagnostic)
+    diagnostics = embeddedDiagnostic +: diagnostics
   }
 
   override def fatalError(exception: SAXParseException): Unit = {
     error(exception)
   }
 
-  override def getDiagnostics: java.util.List[api.Diagnostic] = diagnostics
+  override def getDiagnostics: java.util.List[api.Diagnostic] = diagnostics.asJava
 
   override def isError: Boolean = errorStatus
 }


### PR DESCRIPTION
- the Java API uses Java Lists, but we need immutability and O(1) prepends in the scala code, so we update to use seqs internally and leverage .asJava/.asScala wrappers as necessary. For getBlobPaths/getDiagnostics, we keep those as lists internally as well since they override the java functions.

DAFFODIL-3014