### PR TITLE
Remove Diagnostic.getMessageOnly API

### DIFF
--- a/daffodil-core/src/main/java/org/apache/daffodil/api/Diagnostic.java
+++ b/daffodil-core/src/main/java/org/apache/daffodil/api/Diagnostic.java
@@ -38,23 +38,16 @@ public abstract class Diagnostic extends Exception {
   }
 
   /**
-   * Get all diagnostic information, including mode name, schema context, and data location
+   * Get the diagnostic message
    * <p>
-   * Future versions of Daffodil will change getMessage to return only the message portion of a
-   * diagnostic, matching the behavior of getMessageOnly--users should call toString() instead.
+   * This does not include any additional details about the Diagnostic, such as
+   * mode name, schema context, or data location. For a human-readable
+   * representation of this diagnostic, including the message and all context
+   * information, use {@link #toString()}.
    *
    * @return diagnostic message in string form
    */
   public abstract String getMessage();
-
-  /**
-   * Get only the message part of a diagnostic.
-   * <p>
-   * This does not include mode name, schema context, or data location information
-   *
-   * @return diagnostic message in string form
-   */
-  public abstract String getMessageOnly();
 
   /**
    * Get the diagnostic mode name

--- a/daffodil-core/src/main/scala/org/apache/daffodil/lib/iapi/Diagnostic.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/lib/iapi/Diagnostic.scala
@@ -121,15 +121,17 @@ abstract class Diagnostic protected (
   }
 
   /**
-   * Turns the diagnostic object into a string.
+   * Return just the message portion of the diagnostic.
    *
-   * Should utilize locale information to properly internationalize. But if that is
-   * unavailable, will still construct an English-language string.
+   * This should be localized but Daffodil does not currently support localized error
+   * messages--only english is supported.
    */
   override def getMessage(): String = message
 
-  override def getMessageOnly: String = message
-
+  /**
+   * Turns the diagnostic object into a human-readable string containing all available
+   * diagnostic information, including mode, message, schema context, and data location
+   */
   override def toString() =
     getModeName() + ": " + getMessage + schemaContextString + dataLocationString
 


### PR DESCRIPTION
Daffodil 3.11.0 added the getMessageOnly API function to support a way to get just the message portion of a Diagnostic. This maintained the behavior of getMessage, which returned the message as well as the mode and schema context, but the intention was for a future release to drop getMessageOnly and change getMessage to return only the message.

The changes to the Daffodil API in commit c9a35ce2bd for Daffodil 4.0.0 modified getMessage to only return the message, so this removes getMessageOnly now that getMessage has that behavior.

DAFFODIL-2999