### PR TITLE
Add "dependencies" label to scala steward PRs

### DIFF
--- a/.github/pr-labeler.yml
+++ b/.github/pr-labeler.yml
@@ -13,6 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# https://github.com/scala-steward-org/scala-steward/blob/main/docs/repo-specific-configuration.md
-
-pullRequests.customLabels = [ "dependencies" ]
+dependencies: ['update/*']

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,0 +1,27 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: PR Labeler
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  pr-labeler:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: TimonVS/pr-labeler-action@f9c084306ce8b3f488a8f3ee1ccedc6da131d1af # v5.0.0
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Commit 6d60986a53 added a scala steward configuration to apply the "dependencies" label to PRs it created, but that didn't actually work as expected--it only adds the text "labels: depenencies" to the PR message without actually labeling anything. Turns out scala steward doesn't have the ability to add actual labels.

To fix this, we now use the TimonVS/pr-labeler-action action (usage is approved by ASF) which allows assigning labels based on branch names. Scala steward uses an "update/" prefix for its branches so we specify that in the config.

This also removes the .scala-steward.conf file--it doesn't provide any value since the only thing it was used for was labeling, which didn't work.

DAFFODIL-2995