### PR TITLE
Replace usage of java.util.Optional in api

### DIFF
--- a/daffodil-core/src/main/java/org/apache/daffodil/api/Compiler.java
+++ b/daffodil-core/src/main/java/org/apache/daffodil/api/Compiler.java
@@ -24,7 +24,6 @@ import java.io.IOException;
 import java.net.URI;
 import java.nio.channels.ReadableByteChannel;
 import java.util.Map;
-import java.util.Optional;
 
 /**
  * Compile DFDL schemas into {@link ProcessorFactory}'s or
@@ -43,7 +42,7 @@ public interface Compiler {
    * @return {@link ProcessorFactory} used to create {@link DataProcessor}(s). Must check {@code ProcessorFactory.isError} before using it.
    */
   default ProcessorFactory compileFile(File schemaFile) {
-    return compileFile(schemaFile, Optional.empty(), Optional.empty());
+    return compileFile(schemaFile, null, null);
   }
 
   /**
@@ -57,22 +56,7 @@ public interface Compiler {
    * @return {@link ProcessorFactory} used to create {@link DataProcessor}(s). Must check {@code ProcessorFactory.isError} before using it.
    */
   default ProcessorFactory compileFile(File schemaFile, String rootName) {
-    return compileFile(schemaFile, Optional.ofNullable(rootName), Optional.empty());
-  }
-
-  /**
-   * Compile DFDL schema file into a {@link ProcessorFactory}
-   * <p>
-   * To allow jar-file packaging, (where schema files might be part of a jar),
-   * it is recommended to use {@code Compiler.compileSource} instead.
-   *
-   * @param schemaFile  DFDL schema file used to create a {@link ProcessorFactory}.
-   * @param optRootName Optional for name of root element, or Optional.empty() to choose automatically from first element of schema.
-   *                    Defaults to Optional.empty().
-   * @return {@link ProcessorFactory} used to create {@link DataProcessor}(s). Must check {@code ProcessorFactory.isError} before using it.
-   */
-  default ProcessorFactory compileFile(File schemaFile, Optional<String> optRootName) {
-    return compileFile(schemaFile, optRootName, Optional.empty());
+    return compileFile(schemaFile, rootName, null);
   }
 
   /**
@@ -88,24 +72,7 @@ public interface Compiler {
    *                      when unambiguous. Pass "" (empty string) for No Namespace.*
    * @return {@link ProcessorFactory} used to create {@link DataProcessor}(s). Must check {@code ProcessorFactory.isError} before using it.
    */
-  default ProcessorFactory compileFile(File schemaFile, String rootName, String rootNamespace) {
-    return compileFile(schemaFile, Optional.ofNullable(rootName), Optional.ofNullable(rootNamespace));
-  }
-
-  /**
-   * Compile DFDL schema file into a {@link ProcessorFactory}
-   * <p>
-   * To allow jar-file packaging, (where schema files might be part of a jar),
-   * it is recommended to use {@code Compiler.compileSource} instead.
-   *
-   * @param schemaFile       DFDL schema file used to create a {@link ProcessorFactory}.
-   * @param optRootName      Optional for name of root element, or Optional.empty() to choose automatically from first element of schema.
-   *                         Defaults to Optional.empty().
-   * @param optRootNamespace Optional for string of namespace of the root element, or Optional.empty() to infer automatically when
-   *                         unambiguous. Pass Some("") (empty string) for No Namespace. Defaults to Optional.empty().
-   * @return {@link ProcessorFactory} used to create {@link DataProcessor}(s). Must check {@code ProcessorFactory.isError} before using it.
-   */
-  ProcessorFactory compileFile(File schemaFile, Optional<String> optRootName, Optional<String> optRootNamespace);
+  ProcessorFactory compileFile(File schemaFile, String rootName, String rootNamespace);
 
   /**
    * Compile DFDL schema source into a {@link ProcessorFactory}
@@ -114,7 +81,7 @@ public interface Compiler {
    * @return {@link ProcessorFactory} used to create {@link DataProcessor}(s). Must check {@code ProcessorFactory.isError} before using it.
    */
   default ProcessorFactory compileSource(URI uri) {
-    return compileSource(uri, Optional.empty(), Optional.empty());
+    return compileSource(uri, null, null);
   }
 
   /**
@@ -125,19 +92,7 @@ public interface Compiler {
    * @return {@link ProcessorFactory} used to create {@link DataProcessor}(s). Must check {@code ProcessorFactory.isError} before using it.
    */
   default ProcessorFactory compileSource(URI uri, String rootName) {
-    return compileSource(uri, Optional.ofNullable(rootName), Optional.empty());
-  }
-
-  /**
-   * Compile DFDL schema source into a {@link ProcessorFactory}
-   *
-   * @param uri         URI of DFDL schema file used to create a {@link ProcessorFactory}.
-   * @param optRootName Optional for name of root element, or Optional.empty() to choose automatically from first
-   *                    element of schema. Defaults to Optional.empty().
-   * @return {@link ProcessorFactory} used to create {@link DataProcessor}(s). Must check {@code ProcessorFactory.isError} before using it.
-   */
-  default ProcessorFactory compileSource(URI uri, Optional<String> optRootName) {
-    return compileSource(uri, optRootName, Optional.empty());
+    return compileSource(uri, rootName, null);
   }
 
   /**
@@ -149,22 +104,7 @@ public interface Compiler {
    *                      when unambiguous. Pass "" (empty string) for No Namespace.
    * @return {@link ProcessorFactory} used to create {@link DataProcessor}(s). Must check {@code ProcessorFactory.isError} before using it.
    */
-  default ProcessorFactory compileSource(URI uri, String rootName, String rootNamespace) {
-    return compileSource(uri, Optional.ofNullable(rootName), Optional.ofNullable(rootNamespace));
-  }
-
-  /**
-   * Compile DFDL schema source into a {@link ProcessorFactory}
-   *
-   * @param uri              URI of DFDL schema file used to create a {@link ProcessorFactory}.
-   * @param optRootName      Optional for name of root element, or Optional.empty() to choose automatically from first
-   *                         element of schema. Defaults to Optional.empty().
-   * @param optRootNamespace Optional for string of namespace of the root element, or Optional.empty() to infer
-   *                         automatically when unambiguous. Pass Some("") (empty string) for No Namespace.
-   *                         Defaults to Optional.empty().
-   * @return {@link ProcessorFactory} used to create {@link DataProcessor}(s). Must check {@code ProcessorFactory.isError} before using it.
-   */
-  ProcessorFactory compileSource(URI uri, Optional<String> optRootName, Optional<String> optRootNamespace);
+  ProcessorFactory compileSource(URI uri, String rootName, String rootNamespace);
 
   /**
    * Compile DFDL resource name into a {@link ProcessorFactory}
@@ -174,7 +114,20 @@ public interface Compiler {
    * @throws IOException if resource cannot be found
    */
   default ProcessorFactory compileResource(String name) throws IOException {
-    return compileResource(name, Optional.empty(), Optional.empty());
+    return compileResource(name, null, null);
+  }
+
+  /**
+   * Compile DFDL resource name into a {@link ProcessorFactory}
+   *
+   * @param name     Resource name of a DFDL schema used to create a {@link ProcessorFactory}.
+   * @param rootName name of root element, or null to choose automatically from first element
+   *                 of schema.
+   * @return {@link ProcessorFactory} used to create {@link DataProcessor}(s). Must check {@code ProcessorFactory.isError} before using it.
+   * @throws IOException if resource cannot be found
+   */
+  default ProcessorFactory compileResource(String name, String rootName) throws IOException {
+    return compileResource(name, rootName, null);
   }
 
   /**
@@ -188,23 +141,7 @@ public interface Compiler {
    * @return {@link ProcessorFactory} used to create {@link DataProcessor}(s). Must check {@code ProcessorFactory.isError} before using it.
    * @throws IOException if resource cannot be found
    */
-  default ProcessorFactory compileResource(String name, String rootName, String rootNamespace) throws IOException {
-    return compileResource(name, Optional.ofNullable(rootName), Optional.ofNullable(rootNamespace));
-  }
-
-  /**
-   * Compile DFDL resource name into a {@link ProcessorFactory}
-   *
-   * @param name             Resource name of a DFDL schema used to create a {@link ProcessorFactory}.
-   * @param optRootName      Optional for name of root element, or Optional.empty() to choose automatically from first
-   *                         element of schema. Defaults to Optional.empty().
-   * @param optRootNamespace Optional for string of namespace of the root element, or Optional.empty() to infer
-   *                         automatically when unambiguous. Pass Some("") (empty string) for No Namespace.
-   *                         Defaults to Optional.empty().
-   * @return {@link ProcessorFactory} used to create {@link DataProcessor}(s). Must check {@code ProcessorFactory.isError} before using it.
-   * @throws IOException if resource cannot be found
-   */
-  ProcessorFactory compileResource(String name, Optional<String> optRootName, Optional<String> optRootNamespace) throws IOException;
+  ProcessorFactory compileResource(String name, String rootName, String rootNamespace) throws IOException;
 
   /**
    * Reload a saved parser from a file

--- a/daffodil-core/src/main/java/org/apache/daffodil/api/infoset/InfosetInputter.java
+++ b/daffodil-core/src/main/java/org/apache/daffodil/api/infoset/InfosetInputter.java
@@ -20,7 +20,6 @@ package org.apache.daffodil.api.infoset;
 import org.apache.daffodil.runtime1.dpath.NodeInfo;
 
 import java.util.Map;
-import java.util.Optional;
 
 /**
  * Abstract class used to determine how the infoset representation should be
@@ -104,11 +103,11 @@ public abstract class InfosetInputter {
    * Determine if the current event is nilled. This will only be called when
    * the current event type is StartElement.
    *
-   * @return Optional.empty if no nil property is set, which implies the element is not nilled
-   * or Optional.of(false) if the nil property is set, but it is set to false or Optional.of(true)
+   * @return null if no nil property is set, which implies the element is not nilled
+   * or false if the nil property is set, but it is set to false or true
    * if the nil property is set to true.
    */
-  public abstract Optional<Boolean> isNilled();
+  public abstract Boolean isNilled();
 
   /**
    * @return true if there are remaining events. False otherwise.

--- a/daffodil-core/src/main/java/org/apache/daffodil/api/validation/Validators.java
+++ b/daffodil-core/src/main/java/org/apache/daffodil/api/validation/Validators.java
@@ -19,8 +19,6 @@ package org.apache.daffodil.api.validation;
 
 import org.apache.daffodil.lib.util.SimpleNamedServiceLoader;
 
-import java.util.Optional;
-
 /**
  * Access SPI registered {@link org.apache.daffodil.api.validation.ValidatorFactory} instances.
  * <p>
@@ -55,13 +53,13 @@ public class Validators {
   }
 
   /**
-   * Optionally find the factory
+   * Attempt to find the factory
    *
    * @param name registered name of the validator factory
-   * @return {@link org.apache.daffodil.api.validation.ValidatorFactory} optional factory instance
+   * @return {@link org.apache.daffodil.api.validation.ValidatorFactory} factory instance or null if not found
    */
-  public static Optional<ValidatorFactory> find(String name) {
-    return Optional.ofNullable(impls.get(name));
+  public static ValidatorFactory find(String name) {
+    return impls.get(name);
   }
 
   /**

--- a/daffodil-core/src/main/scala/org/apache/daffodil/core/compiler/Compiler.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/core/compiler/Compiler.scala
@@ -29,7 +29,6 @@ import java.util.zip.GZIPInputStream
 import java.util.zip.ZipException
 import scala.collection.mutable.ArrayBuffer
 import scala.jdk.CollectionConverters.*
-import scala.jdk.OptionConverters.*
 import scala.util.Try
 import scala.xml.Node
 
@@ -428,24 +427,24 @@ class Compiler private (
 
   override def compileFile(
     schemaFile: File,
-    optRootName: java.util.Optional[String],
-    optRootNamespace: java.util.Optional[String]
+    rootName: String,
+    rootNamespace: String
   ): api.ProcessorFactory =
-    compileFile(schemaFile, optRootName.toScala, optRootNamespace.toScala)
+    compileFile(schemaFile, Option(rootName), Option(rootNamespace))
 
   override def compileSource(
     uri: URI,
-    optRootName: java.util.Optional[String],
-    optRootNamespace: java.util.Optional[String]
+    rootName: String,
+    rootNamespace: String
   ): api.ProcessorFactory =
-    compileSource(uri, optRootName.toScala, optRootNamespace.toScala)
+    compileSource(uri, Option(rootName), Option(rootNamespace))
 
   override def compileResource(
     name: String,
-    optRootName: java.util.Optional[String],
-    optRootNamespace: java.util.Optional[String]
+    rootName: String,
+    rootNamespace: String
   ): api.ProcessorFactory =
-    compileResource(name, optRootName.toScala, optRootNamespace.toScala)
+    compileResource(name, Option(rootName), Option(rootNamespace))
 
   override def withTunables(tunables: java.util.Map[String, String]): api.Compiler =
     withTunables(

--- a/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/infoset/InfosetInputter.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/infoset/InfosetInputter.scala
@@ -17,8 +17,6 @@
 
 package org.apache.daffodil.runtime1.infoset
 
-import scala.jdk.OptionConverters.*
-
 import org.apache.daffodil.api
 import org.apache.daffodil.api.infoset.Infoset.InfosetInputterEventType
 import org.apache.daffodil.lib.exceptions.Assert
@@ -348,7 +346,7 @@ final class InfosetInputter(delegate: api.infoset.InfosetInputter)
   private def createElement(erd: ERD) = {
     val elem = if (erd.isSimpleType) new DISimple(erd) else new DIComplex(erd)
 
-    val optNilled = delegate.isNilled.toScala
+    val optNilled = Option(delegate.isNilled)
 
     if (optNilled.isDefined) {
       if (!erd.isNillable) {

--- a/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/infoset/JDOMInfosetInputter.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/infoset/JDOMInfosetInputter.scala
@@ -19,7 +19,6 @@ package org.apache.daffodil.runtime1.infoset
 
 import java.lang.Boolean as JBoolean
 import java.util.Iterator
-import scala.jdk.OptionConverters.*
 
 import org.apache.daffodil.api
 import org.apache.daffodil.api.infoset.Infoset.InfosetInputterEventType
@@ -112,22 +111,22 @@ class JDOMInfosetInputter(doc: Document) extends api.infoset.InfosetInputter {
     text
   }
 
-  override def isNilled(): java.util.Optional[JBoolean] = {
+  override def isNilled(): JBoolean = {
     val elem = stack.top._1
     val nilAttrValue = elem.getAttributeValue("nil", JDOMInfosetInputter.JDOM_XSI_NAMESPACE)
-    val res: Option[JBoolean] =
+    val res: JBoolean =
       if (nilAttrValue == null) {
-        None
+        null
       } else if (nilAttrValue == "true" || nilAttrValue == "1") {
-        Some(true)
+        true
       } else if (nilAttrValue == "false" || nilAttrValue == "0") {
-        Some(false)
+        false
       } else {
         throw new InvalidInfosetException(
           "xsi:nil property is not a valid boolean: '" + nilAttrValue + "' for element " + elem.getQualifiedName
         )
       }
-    res.toJava
+    res
   }
 
   override def hasNext(): Boolean = {

--- a/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/infoset/JsonInfosetInputter.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/infoset/JsonInfosetInputter.scala
@@ -18,7 +18,6 @@
 package org.apache.daffodil.runtime1.infoset
 
 import java.lang.Boolean as JBoolean
-import scala.jdk.OptionConverters.*
 
 import org.apache.daffodil.api
 import org.apache.daffodil.api.infoset.Infoset.InfosetInputterEventType
@@ -138,13 +137,13 @@ class JsonInfosetInputter(input: java.io.InputStream) extends api.infoset.Infose
     }
   }
 
-  override def isNilled(): java.util.Optional[JBoolean] = {
+  override def isNilled(): JBoolean = {
     val opt = if (jsp.getCurrentToken() == JsonToken.VALUE_NULL) {
-      Some(java.lang.Boolean.valueOf(true))
+      java.lang.Boolean.valueOf(true)
     } else {
-      None
+      null
     }
-    opt.toJava
+    opt
   }
 
   override def fini(): Unit = {

--- a/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/infoset/NullInfosetInputter.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/infoset/NullInfosetInputter.scala
@@ -20,7 +20,6 @@ package org.apache.daffodil.runtime1.infoset
 import java.io.InputStream
 import java.lang.Boolean as JBoolean
 import scala.collection.mutable.ArrayBuffer
-import scala.jdk.OptionConverters.*
 import scala.xml.Elem
 import scala.xml.SAXParser
 import scala.xml.Text
@@ -40,7 +39,7 @@ object NullInfosetInputter {
     localName: String = null,
     namespaceURI: String = null,
     simpleText: String = null,
-    isNilled: Option[JBoolean] = None
+    isNilled: JBoolean = null
   )
 
   def toEvents(is: InputStream): Array[Event] = {
@@ -81,9 +80,10 @@ object NullInfosetInputter {
           val value = str == "true" || str == "1"
           value.asInstanceOf[JBoolean]
         }
+        .orNull
       (text, isNilled)
     } else {
-      (null, None)
+      (null, null)
     }
 
     events += Event(StartElement, localName, namespaceURI, simpleText, isNilled)
@@ -114,7 +114,7 @@ class NullInfosetInputter(events: Array[NullInfosetInputter.Event])
     primType: NodeInfo.Kind,
     runtimeProperties: java.util.Map[String, String]
   ): String = curEvent.simpleText
-  def isNilled(): java.util.Optional[JBoolean] = curEvent.isNilled.toJava
+  def isNilled(): JBoolean = curEvent.isNilled
 
   def hasNext(): Boolean = curIndex + 1 < events.length
   def next(): Unit = {

--- a/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/infoset/SAXInfosetInputter.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/infoset/SAXInfosetInputter.scala
@@ -20,7 +20,6 @@ package org.apache.daffodil.runtime1.infoset
 import java.lang.Boolean as JBoolean
 import java.net.URI
 import java.net.URISyntaxException
-import scala.jdk.OptionConverters.*
 
 import org.apache.daffodil.api
 import org.apache.daffodil.api.infoset.Infoset.InfosetInputterEventType
@@ -107,13 +106,13 @@ class SAXInfosetInputter(
     }
   }
 
-  override def isNilled(): java.util.Optional[JBoolean] = {
-    val _isNilled: Option[JBoolean] = if (currentEvent.nilValue.isDefined) {
+  override def isNilled(): JBoolean = {
+    val _isNilled: JBoolean = if (currentEvent.nilValue.isDefined) {
       val nilValue = currentEvent.nilValue.get
       if (nilValue == "true" || nilValue == "1") {
-        Some(true)
+        true
       } else if (nilValue == "false" || nilValue == "0") {
-        Some(false)
+        false
       } else {
         throw new InvalidInfosetException(
           "xsi:nil property is not a valid boolean: '" + nilValue +
@@ -121,9 +120,9 @@ class SAXInfosetInputter(
         )
       }
     } else {
-      None
+      null
     }
-    _isNilled.toJava
+    _isNilled
   }
 
   override def hasNext(): Boolean = {

--- a/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/infoset/ScalaXMLInfosetInputter.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/infoset/ScalaXMLInfosetInputter.scala
@@ -18,7 +18,6 @@
 package org.apache.daffodil.runtime1.infoset
 
 import java.lang.Boolean as JBoolean
-import scala.jdk.OptionConverters.*
 import scala.xml.Comment
 import scala.xml.Elem
 import scala.xml.Node
@@ -119,12 +118,12 @@ class ScalaXMLInfosetInputter(rootNode: Node) extends api.infoset.InfosetInputte
     result
   }
 
-  override def isNilled(): java.util.Optional[JBoolean] = {
+  override def isNilled(): JBoolean = {
     val elem = stack.top._1
     val nilAttrValueOpt = elem.attribute(XMLUtils.XSI_NAMESPACE, "nil")
-    val res: Option[JBoolean] =
+    val res: JBoolean =
       if (nilAttrValueOpt.isEmpty) {
-        None
+        null
       } else {
         val nilAttrValueSeq = nilAttrValueOpt.get
         if (nilAttrValueSeq.length > 1) {
@@ -134,16 +133,16 @@ class ScalaXMLInfosetInputter(rootNode: Node) extends api.infoset.InfosetInputte
         }
         val nilAttrValue = nilAttrValueSeq.head.toString
         if (nilAttrValue == "true" || nilAttrValue == "1") {
-          Some(true)
+          true
         } else if (nilAttrValue == "false" || nilAttrValue == "0") {
-          Some(false)
+          false
         } else {
           throw new InvalidInfosetException(
             "xsi:nil property is not a valid boolean: '" + nilAttrValue + "' for element " + elem.label
           )
         }
       }
-    res.toJava
+    res
   }
 
   override def hasNext(): Boolean = {

--- a/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/infoset/W3CDOMInfosetInputter.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/infoset/W3CDOMInfosetInputter.scala
@@ -114,22 +114,22 @@ class W3CDOMInfosetInputter(doc: Document) extends api.infoset.InfosetInputter {
     text
   }
 
-  override def isNilled(): java.util.Optional[JBoolean] = {
+  override def isNilled(): JBoolean = {
     val elem = stack.top._1
     val nilAttrValue = elem.getAttributeNS(XMLConstants.W3C_XML_SCHEMA_INSTANCE_NS_URI, "nil")
-    val res: Option[JBoolean] =
+    val res: JBoolean =
       if (nilAttrValue == "") {
-        None
+        null
       } else if (nilAttrValue == "true" || nilAttrValue == "1") {
-        Some(true)
+        true
       } else if (nilAttrValue == "false" || nilAttrValue == "0") {
-        Some(false)
+        false
       } else {
         throw new InvalidInfosetException(
           "xsi:nil property is not a valid boolean: '" + nilAttrValue + "' for element " + elem.getNodeName
         )
       }
-    res.toJava
+    res
   }
 
   override def hasNext(): Boolean = {

--- a/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/infoset/XMLTextInfosetInputter.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/infoset/XMLTextInfosetInputter.scala
@@ -27,7 +27,6 @@ import javax.xml.stream.XMLStreamException
 import javax.xml.stream.XMLStreamReader
 import javax.xml.stream.XMLStreamWriter
 import javax.xml.stream.util.XMLEventAllocator
-import scala.jdk.OptionConverters.*
 
 import org.apache.daffodil.api
 import org.apache.daffodil.api.infoset.Infoset.InfosetInputterEventType
@@ -342,17 +341,17 @@ class XMLTextInfosetInputter(input: java.io.InputStream) extends api.infoset.Inf
     txt
   }
 
-  override def isNilled(): java.util.Optional[JBoolean] = {
+  override def isNilled(): JBoolean = {
     Assert.invariant(xsr.getEventType() == START_ELEMENT)
     // this should use a fast hash lookup
     val nilAttrValue = xsr.getAttributeValue(XMLConstants.W3C_XML_SCHEMA_INSTANCE_NS_URI, "nil")
-    val res: Option[JBoolean] =
+    val res: JBoolean =
       if (nilAttrValue == null) {
-        None
+        null
       } else if (nilAttrValue == "true" || nilAttrValue == "1") {
-        Some(true)
+        true
       } else if (nilAttrValue == "false" || nilAttrValue == "0") {
-        Some(false)
+        false
       } else {
         throw new InvalidInfosetException(
           "xsi:nil property is not a valid boolean: '" + nilAttrValue + "' on line " + evAlloc
@@ -361,7 +360,7 @@ class XMLTextInfosetInputter(input: java.io.InputStream) extends api.infoset.Inf
             .getLineNumber
         )
       }
-    res.toJava
+    res
   }
 
   override def fini(): Unit = {

--- a/daffodil-core/src/test/java/org/apache/daffodil/jexample/TestInfosetInputter.java
+++ b/daffodil-core/src/test/java/org/apache/daffodil/jexample/TestInfosetInputter.java
@@ -22,8 +22,6 @@ import org.apache.daffodil.api.infoset.InfosetInputter;
 import org.apache.daffodil.runtime1.dpath.NodeInfo;
 
 import java.util.Map;
-import java.util.Optional;
-
 
 public class TestInfosetInputter extends InfosetInputter {
 
@@ -56,9 +54,8 @@ public class TestInfosetInputter extends InfosetInputter {
   }
 
   @Override
-  public Optional<Boolean> isNilled() {
-    Boolean isNilled = events[curEventIndex].isNilled;
-    return Optional.ofNullable(isNilled);
+  public Boolean isNilled() {
+    return events[curEventIndex].isNilled;
   }
 
   @Override

--- a/daffodil-core/src/test/scala/org/apache/daffodil/lib/validation/TestValidatorsSPI.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/lib/validation/TestValidatorsSPI.scala
@@ -25,6 +25,8 @@ import org.apache.daffodil.validation.XercesValidator
 
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertThrows
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -38,7 +40,7 @@ class TestValidatorsSPI {
   }
 
   @Test def testValidatorFindNotFoundNone(): Unit = {
-    assertFalse(Validators.find("dont exist").isPresent)
+    assertNull(Validators.find("dont exist"))
   }
 
   @Test def testValidatorNonExists(): Unit = {
@@ -50,7 +52,7 @@ class TestValidatorsSPI {
     val defaultF = Validators.get(defaultName)
 
     assertEquals(defaultName, defaultF.name())
-    assertTrue(Validators.find(defaultName).isPresent)
+    assertNotNull(Validators.find(defaultName))
     assertTrue(Validators.isRegistered(defaultName))
   }
 

--- a/daffodil-core/src/test/scala/org/apache/daffodil/sexample/TestAPI.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/sexample/TestAPI.scala
@@ -28,7 +28,6 @@ import java.nio.channels.Channels
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.nio.file.Paths
-import java.util.Optional
 import javax.xml.XMLConstants
 import scala.collection.immutable.ArraySeq
 import scala.jdk.CollectionConverters.*
@@ -347,7 +346,7 @@ class TestAPI {
     val c = Daffodil.compiler()
 
     val schemaFileName = getResource("/test/api/mySchema3.dfdl.xsd")
-    val pf = c.compileFile(schemaFileName, Optional.of("e4"), Optional.empty[String]())
+    val pf = c.compileFile(schemaFileName, "e4")
     val dp1 = pf.onPath("/")
     val dp = reserializeDataProcessor(dp1)
 
@@ -376,11 +375,7 @@ class TestAPI {
 
     val schemaFileName = getResource("/test/api/mySchema3.dfdl.xsd")
     // element
-    val pf = c.compileFile(
-      schemaFileName,
-      Optional.of("e4"),
-      Optional.empty[String]()
-    ) // e4 is a 4-byte long string
+    val pf = c.compileFile(schemaFileName, "e4") // e4 is a 4-byte long string
     val dp1 = pf.onPath("/")
     val dp = reserializeDataProcessor(dp1)
 
@@ -440,7 +435,7 @@ class TestAPI {
     val c = Daffodil.compiler()
 
     val schemaFile = getResource("/test/api/TopLevel.dfdl.xsd")
-    val pf = c.compileFile(schemaFile, Optional.of("TopLevel"), Optional.empty[String]())
+    val pf = c.compileFile(schemaFile, "TopLevel")
     val dp1 = pf.onPath("/")
     val dp = reserializeDataProcessor(dp1)
 
@@ -475,7 +470,7 @@ class TestAPI {
     val c = Daffodil.compiler()
 
     val schemaFile = getResource("/test/api/TopLevel.dfdl.xsd")
-    val pf = c.compileFile(schemaFile, Optional.of("TopLevel2"), Optional.empty[String]())
+    val pf = c.compileFile(schemaFile, "TopLevel2")
     val dp1 = pf.onPath("/")
     val dp = reserializeDataProcessor(dp1)
 
@@ -506,7 +501,7 @@ class TestAPI {
     val c = Daffodil.compiler()
 
     val schemaFile = getResource("/test/api/TopLevel.dfdl.xsd")
-    val pf = c.compileFile(schemaFile, Optional.of("TopLevel2"), Optional.empty[String]())
+    val pf = c.compileFile(schemaFile, "TopLevel2")
     val dp1 = pf.onPath("/")
     val dp = reserializeDataProcessor(dp1)
 
@@ -822,7 +817,7 @@ class TestAPI {
     val c = Daffodil.compiler()
 
     val schemaFile = getResource("/test/api/mySchema3.dfdl.xsd")
-    val pf = c.compileFile(schemaFile, Optional.of("e4"), Optional.empty[String]())
+    val pf = c.compileFile(schemaFile, "e4")
     val dp1 = pf.onPath("/")
     val dp = reserializeDataProcessor(dp1)
 
@@ -862,7 +857,7 @@ class TestAPI {
     val c = Daffodil.compiler()
 
     val schemaFile = getResource("/test/api/ambig_elt.dfdl.xsd")
-    val pf = c.compileFile(schemaFile, Optional.of("root"), Optional.empty[String]())
+    val pf = c.compileFile(schemaFile, "root")
     val dp1 = pf.onPath("/")
     val dp = reserializeDataProcessor(dp1)
 
@@ -1275,7 +1270,7 @@ class TestAPI {
   def doXMLTextEscapeStyleTest(expect: String, data: String, schemaType: String): Unit = {
     val c = Daffodil.compiler()
     val schemaFile = getResource("/test/api/mySchemaCDATA.dfdl.xsd")
-    val pf = c.compileFile(schemaFile, Optional.of(schemaType), Optional.empty[String]())
+    val pf = c.compileFile(schemaFile, schemaType)
     var dp = pf.onPath("/")
 
     val is = new ByteArrayInputStream(data.getBytes(StandardCharsets.UTF_8))

--- a/daffodil-core/src/test/scala/org/apache/daffodil/sexample/TestInfosetInputterOutputter.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/sexample/TestInfosetInputterOutputter.scala
@@ -19,7 +19,6 @@ package org.apache.daffodil.sexample
 
 import java.lang.Boolean as JBoolean
 import scala.collection.mutable.ArrayBuffer
-import scala.jdk.OptionConverters.*
 
 import org.apache.daffodil.api.infoset.Infoset.InfosetInputterEventType
 import org.apache.daffodil.api.infoset.Infoset.InfosetInputterEventType.*
@@ -35,7 +34,7 @@ case class TestInfosetEvent(
   localName: String = null,
   namespaceURI: String = null,
   simpleText: String = null,
-  isNilled: Option[JBoolean] = None
+  isNilled: JBoolean = null
 )
 
 object TestInfosetEvent {
@@ -46,7 +45,7 @@ object TestInfosetEvent {
   def startComplex(
     name: String,
     namespace: String,
-    isNilled: Option[JBoolean] = None
+    isNilled: JBoolean = null
   ) =
     TestInfosetEvent(StartElement, name, namespace, null, isNilled)
 
@@ -54,7 +53,7 @@ object TestInfosetEvent {
     name: String,
     namespace: String,
     text: String,
-    isNilled: Option[JBoolean] = None
+    isNilled: JBoolean = null
   ) =
     TestInfosetEvent(StartElement, name, namespace, text, isNilled)
 
@@ -79,7 +78,7 @@ case class TestInfosetInputter(events: TestInfosetEvent*) extends InfosetInputte
     primType: NodeInfo.Kind,
     runtimeProperties: java.util.Map[String, String]
   ) = events(curEventIndex).simpleText
-  override def isNilled(): java.util.Optional[JBoolean] = events(curEventIndex).isNilled.toJava
+  override def isNilled(): JBoolean = events(curEventIndex).isNilled
 
   override def hasNext(): Boolean = curEventIndex + 1 < events.length
   override def next(): Unit = curEventIndex += 1
@@ -111,7 +110,7 @@ case class TestInfosetOutputter() extends InfosetOutputter {
         simple.metadata.name,
         simple.metadata.namespace,
         simple.getText,
-        if (simple.metadata.isNillable) Some(simple.isNilled) else None
+        if (simple.metadata.isNillable) simple.isNilled else null
       )
     )
   }
@@ -127,7 +126,7 @@ case class TestInfosetOutputter() extends InfosetOutputter {
       TestInfosetEvent.startComplex(
         complex.metadata.name,
         complex.metadata.namespace,
-        if (complex.metadata.isNillable) Some(complex.isNilled) else None
+        if (complex.metadata.isNillable) complex.isNilled else null
       )
     )
   }

--- a/daffodil-tdml-processor/src/main/scala/org/apache/daffodil/processor/tdml/TDMLInfosetInputter.scala
+++ b/daffodil-tdml-processor/src/main/scala/org/apache/daffodil/processor/tdml/TDMLInfosetInputter.scala
@@ -125,7 +125,7 @@ class TDMLInfosetInputter(
     }
   }
 
-  override def isNilled(): java.util.Optional[JBoolean] = {
+  override def isNilled(): JBoolean = {
     val res = scalaInputter.isNilled()
     if (!others.forall(_.isNilled() == res))
       throw TDMLException("isNilled does not match", Some(implString))


### PR DESCRIPTION
- use null instead to offer the same functionality ex, instead of Optional.of(tue), Optional.of(false) or Optional.empty(), we have just true, false or null.
- update documentation/tests

DAFFODIL-3019