### PR TITLE
Update LICENSE/NOTICE files

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -210,8 +210,8 @@ is subject to the terms and conditions of the following licenses.
 
   This product bundles source from 'Passera', including all files under the
   following directories:
-    - daffodil-lib/src/test/scala/passera/
-    - daffodil-lib/src/main/scala/passera/
+    - daffodil-core/src/test/scala/passera/
+    - daffodil-core/src/main/scala/passera/
   These files are available under the BSD-2-Clause license:
 
     Copyright (c) 2011-2013, Nate Nystrom
@@ -240,11 +240,11 @@ is subject to the terms and conditions of the following licenses.
 
   This product bundles material copied or derived from W3C, including the
   following files:
-    - daffodil-lib/src/main/resources/org/apache/daffodil/xsd/XMLSchema.dtd (https://www.w3.org/2001/XMLSchema.dtd)
-    - daffodil-lib/src/main/resources/org/apache/daffodil/xsd/XMLSchema.xsd (https://www.w3.org/2001/XMLSchema.xsd)
-    - daffodil-lib/src/main/resources/org/apache/daffodil/xsd/XMLSchema_for_DFDL.xsd (https://www.w3.org/2001/XMLSchema.dtd)
-    - daffodil-lib/src/main/resources/org/apache/daffodil/xsd/datatypes.dtd (https://www.w3.org/2001/datatypes.dtd)
-    - daffodil-lib/src/main/resources/org/apache/daffodil/xsd/xml.xsd (https://www.w3.org/2001/xml.xsd)
+    - daffodil-core/src/main/resources/org/apache/daffodil/xsd/XMLSchema.dtd (https://www.w3.org/2001/XMLSchema.dtd)
+    - daffodil-core/src/main/resources/org/apache/daffodil/xsd/XMLSchema.xsd (https://www.w3.org/2001/XMLSchema.xsd)
+    - daffodil-core/src/main/resources/org/apache/daffodil/xsd/XMLSchema_for_DFDL.xsd (https://www.w3.org/2001/XMLSchema.dtd)
+    - daffodil-core/src/main/resources/org/apache/daffodil/xsd/datatypes.dtd (https://www.w3.org/2001/datatypes.dtd)
+    - daffodil-core/src/main/resources/org/apache/daffodil/xsd/xml.xsd (https://www.w3.org/2001/xml.xsd)
   These files are available under the W3C Software and Document Licnese:
 
     By obtaining and/or copying this work, you (the licensee) agree that you have
@@ -386,10 +386,10 @@ is subject to the terms and conditions of the following licenses.
     OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
     SOFTWARE.
 
-    This product bundles content from the Schematron converters, including
-    the following files:
-      - daffodil-schematron/src/main/resources/iso-schematron-xslt2/ExtractSchFromXSD-2.xsl
-    The content is available under the MIT License:
+  This product bundles content from the Schematron converters, including
+  the following files:
+    - daffodil-schematron/src/main/resources/iso-schematron-xslt2/ExtractSchFromXSD-2.xsl
+  The content is available under the MIT License:
 
     Copyright (c) 2002-2010 Rick Jelliffe and Topologi Pty. Ltd.
 

--- a/NOTICE
+++ b/NOTICE
@@ -23,4 +23,4 @@ This product includes derived works from Scala
   The derived work is adapted from scala/src/library/scala/Symbol.scala:
     https://github.com/scala/scala/blob/904e3a5d2b9616b9c533d77d0c51652b138e8659/src/library/scala/Symbol.scala
   and can be found in:
-    daffodil-lib/src/main/scala/org/apache/daffodil/lib/util/UniquenessCache.scala
+    daffodil-core/src/main/scala/org/apache/daffodil/lib/util/UniquenessCache.scala

--- a/daffodil-cli/bin.LICENSE
+++ b/daffodil-cli/bin.LICENSE
@@ -217,7 +217,7 @@ is subject to the terms and conditions of the following licenses.
 
     COPYRIGHT AND PERMISSION NOTICE
 
-    Copyright © 2016-2023 Unicode, Inc.
+    Copyright © 2016-2025 Unicode, Inc.
 
     NOTICE TO USER: Carefully read the following legal agreement. BY
     DOWNLOADING, INSTALLING, COPYING OR OTHERWISE USING DATA FILES, AND/OR
@@ -252,6 +252,8 @@ is subject to the terms and conditions of the following licenses.
     not be used in advertising or otherwise to promote the sale, use or other
     dealings in these Data Files or Software without prior written
     authorization of the copyright holder.
+
+    SPDX-License-Identifier: Unicode-3.0
 
     ----------------------------------------------------------------------
 
@@ -643,6 +645,32 @@ is subject to the terms and conditions of the following licenses.
     THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
     (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
     OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+    ----------------------------------------------------------------------
+
+    File: sorttable.js (only for ICU4J)
+
+    The MIT Licence, for code from kryogenix.org
+
+    Code downloaded from the Browser Experiments section of kryogenix.org is
+    licenced under the so-called MIT licence. The licence is below.
+
+    Copyright (c) 1997-date Stuart Langridge
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
 
 - com.fasterxml.jackson.core.jackson-core-2.13.4.jar
   This product bundles 'Jackson JSON processor' which bundles a shaded copy of FastDoubleParser <https://github.com/wrandelshofer/FastDoubleParser>.
@@ -1516,7 +1544,7 @@ is subject to the terms and conditions of the following licenses.
       other dealings in this Software without prior written authorization
       from James Clark.
 
-- org.apache.daffodil.daffodil-lib-<VERSION>.jar with:
+- org.apache.daffodil.daffodil-core-<VERSION>.jar with:
   org/apache/daffodil/xsd/XMLSchema.dtd (https://www.w3.org/2001/XMLSchema.dtd)
   org/apache/daffodil/xsd/XMLSchema.xsd (https://www.w3.org/2001/XMLSchema.xsd)
   org/apache/daffodil/xsd/XMLSchema_for_DFDL.xsd (https://www.w3.org/2001/XMLSchema.dtd)
@@ -1563,7 +1591,7 @@ is subject to the terms and conditions of the following licenses.
     permission. Title to copyright in this work will at all times remain with
     copyright holders.
 
-- org.apache.daffodil.daffodil-lib-<VERSION>.jar with:
+- org.apache.daffodil.daffodil-core-<VERSION>.jar with:
   passera/ directory
   This product bundles 'Passera' compiled source from the above files.
   These files are available under the BSD-2-Clause license:

--- a/daffodil-cli/bin.NOTICE
+++ b/daffodil-cli/bin.NOTICE
@@ -46,29 +46,13 @@ The following NOTICE information applies to binary components distributed with t
   and the licenses and copyrights that apply to that code.
 
 - com.typesafe.scala-logging.scala-logging_<VERSION>.jar
-  Copyright 2014-2021 Lightbend, Inc.
-
-- commons-codec.commons-codec-<VERSION>.jar
-  Apache Commons Codec
-  Copyright 2002-2020 The Apache Software Foundation
-
-  src/test/org/apache/commons/codec/language/DoubleMetaphoneTest.java
-  contains test data from http://aspell.net/test/orig/batch0.tab.
-  Copyright (C) 2002 Kevin Atkinson (kevina@gnu.org)
-
-  ===============================================================================
-
-  The content of package org.apache.commons.codec.language.bm has been translated
-  from the original php source code available at http://stevemorse.org/phoneticinfo.htm
-  with permission from the original authors.
-  Original source copyright:
-  Copyright (c) 2008 Alexander Beider & Stephen P. Morse.
+  Copyright 2014-2025 Lightbend, Inc. dba Akka
 
 - commons-io.commons-io-<VERSION>.jar
   Apache Commons IO
-  Copyright 2002-2021 The Apache Software Foundation
+  Copyright 2002-2025 The Apache Software Foundation
 
-- org.apache.daffodil.daffodil-lib-<VERSION>.jar
+- org.apache.daffodil.daffodil-core-<VERSION>.jar
   Apache Daffodil
   Copyright 2025 The Apache Software Foundation
 
@@ -91,19 +75,7 @@ The following NOTICE information applies to binary components distributed with t
     The derived work is adapted from scala/src/library/scala/Symbol.scala:
       https://github.com/scala/scala/blob/904e3a5d2b9616b9c533d77d0c51652b138e8659/src/library/scala/Symbol.scala
     and can be found in:
-      daffodil-lib/src/main/scala/org/apache/daffodil/util/UniquenessCache.scala
-
-- org.apache.httpcomponents.client5.httpclient5-<VERSION>.jar
-  Apache HttpClient
-  Copyright 1999-2020 The Apache Software Foundation
-
-- org.apache.httpcomponents.core5.httpcore5-<VERSION>.jar
-  Apache HttpComponents Core HTTP/1.1
-  Copyright 2005-2020 The Apache Software Foundation
-
-- org.apache.httpcomponents.core5.httpcore5-h2-<VERSION>.jar
-  Apache HttpComponents Core HTTP/2
-  Copyright 2005-2020 The Apache Software Foundation
+      daffodil-core/src/main/scala/org/apache/daffodil/lib/util/UniquenessCache.scala
 
 - org.jdom.jdom2-<VERSION>.jar
   Copyright (C) 2000-2012 Jason Hunter & Brett McLaughlin.
@@ -114,31 +86,33 @@ The following NOTICE information applies to binary components distributed with t
 
 - org.scala-lang.modules.scala-parser-combinators_<VERSION>.jar
   Scala parser combinators
-  Copyright (c) 2002-2022 EPFL
-  Copyright (c) 2011-2022 Lightbend, Inc.
+  Copyright (c) 2002-2025 EPFL
+  Copyright (c) 2011-2025 Lightbend, Inc. dba Akka
 
   Scala includes software developed at
   LAMP/EPFL (https://lamp.epfl.ch/) and
-  Lightbend, Inc. (https://www.lightbend.com/).
+  Akka (https://akka.io/).
 
 - org.scala-lang.modules.scala-xml_<VERSION>.jar
   scala-xml
-  Copyright (c) 2002-2022 EPFL
-  Copyright (c) 2011-2022 Lightbend, Inc.
+  Copyright (c) 2002-2025 EPFL
+  Copyright (c) 2011-2025 Lightbend, Inc. dba Akka
 
   scala-xml includes software developed at
   LAMP/EPFL (https://lamp.epfl.ch/) and
-  Lightbend, Inc. (https://www.lightbend.com/).
+  Akka (https://akka.io).
 
-- org.scala-lang.scala-library-<VERSION>.jar
-- org.scala-lang.scala-reflect-<VERSION>.jar
-  Scala
-  Copyright (c) 2002-2023 EPFL
-  Copyright (c) 2011-2023 Lightbend, Inc.
+- org.scala-lang.scala3-library-<VERSION>.jar
+  Scala 3 (https://www.scala-lang.org)
+  Copyright (c) 2012-2025 EPFL
+  Copyright (c) 2012-2025 Lightbend, Inc. dba Akka
 
   Scala includes software developed at
   LAMP/EPFL (https://lamp.epfl.ch/) and
-  Lightbend, Inc. (https://www.lightbend.com/).
+  Akka (https://akka.io).
+
+- org.xmlresolver.xmlresolver-<VERSION>.jar:
+  Copyright 2015-2023 Norman Walsh and contributors. http://nwalsh.com/
 
 - xerces.xercesImpl-<VERSION>.jar
   Apache Xerces Java

--- a/daffodil-core/src/main/resources/META-INF/LICENSE
+++ b/daffodil-core/src/main/resources/META-INF/LICENSE
@@ -211,7 +211,6 @@ is subject to the terms and conditions of the following licenses.
   This product bundles source from 'Passera', including all files under the
   following directories:
     - passera/
-    - passera/
   These files are available under the BSD-2-Clause license:
 
     Copyright (c) 2011-2013, Nate Nystrom

--- a/daffodil-core/src/main/resources/META-INF/NOTICE
+++ b/daffodil-core/src/main/resources/META-INF/NOTICE
@@ -23,4 +23,4 @@ This product includes derived works from Scala
   The derived work is adapted from scala/src/library/scala/Symbol.scala:
     https://github.com/scala/scala/blob/904e3a5d2b9616b9c533d77d0c51652b138e8659/src/library/scala/Symbol.scala
   and can be found in:
-    daffodil-core/src/main/scala/org/apache/daffodil/util/UniquenessCache.scala
+    daffodil-core/src/main/scala/org/apache/daffodil/lib/util/UniquenessCache.scala


### PR DESCRIPTION
- Replace references to daffodil-lib with daffodil-core
- Update dependency licenses to latest, usually just updating a copyright year or company name
- Removed mentions of transitive dependencies we no longer have, includes: commons-codec, httplient5, httpcore5, httpcore5-h2
- Correct inconsistent indentation in some places

DAFFODIL-3025