### PR TITLE
Ensure we set elements as final only once and when they have values

### DIFF
--- a/daffodil-cli/src/test/resources/org/apache/daffodil/cli/cli_schema_05.dfdl.xsd
+++ b/daffodil-cli/src/test/resources/org/apache/daffodil/cli/cli_schema_05.dfdl.xsd
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<schema
+  xmlns="http://www.w3.org/2001/XMLSchema"
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/"
+  xmlns:ex="http://example.com"
+  targetNamespace="http://example.com" >
+
+  <include schemaLocation="/org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+
+  <annotation>
+    <appinfo source="http://www.ogf.org/dfdl/">
+      <dfdl:format ref="ex:GeneralFormat" representation="binary" />
+    </appinfo>
+  </annotation>
+
+  <element name="root">
+    <complexType>
+      <sequence>
+        <element name="dispatch" type="xs:int" />
+        <choice dfdl:choiceDispatchKey="{ xs:string(./dispatch) }">
+          <sequence dfdl:choiceBranchKey="1">
+            <element name="i1" type="xs:int" />
+            <element name="i2" type="xs:int" />
+          </sequence>
+          <sequence dfdl:choiceBranchKey="2">
+            <element name="l1" type="xs:long" />
+            <element name="l2" type="xs:long" />
+          </sequence>
+        </choice>
+      </sequence>
+    </complexType>
+  </element>
+
+</schema>

--- a/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/processors/DataProcessor.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/processors/DataProcessor.scala
@@ -368,12 +368,9 @@ class DataProcessor(
         state.setMaybeProcessor(Maybe(p))
 
         if (state.processorStatus == Success) {
-          // At this point all infoset nodes have been set final, all infoset
-          // walker blocks released, and all elements walked. The one exception
-          // is the root node has not been set final because isFinal is handled
-          // by the sequence parser and there is no sequence around the root
-          // node. So mark it final and do one last walk to end the document.
-          state.infoset.child(0).isFinal = true
+          // At this point all infoset nodes have been set final, all PoUs
+          // resolved, and all infoset walker blocks released. Do one last walk
+          // to project any unwalked elements to the target infoset
           state.walker.walk(lastWalk = true)
           Assert.invariant(state.walker.isFinished)
         }

--- a/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/ElementCombinator1.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/ElementCombinator1.scala
@@ -206,6 +206,13 @@ abstract class ElementParserBase(
         validate(pstate)
       }
 
+      // We successfully finished parsing this element. There are no more changes expected to be
+      // made so we can mark it as final and allow the InfosetWalker to project it to the target
+      // infoset. Note that the InfosetWalker will not walk past active points of uncertainty,
+      // so even though this is final we don't have to worry that it might we might backtrack
+      // and remove it--setFinal is just about local finality.
+      pstate.infoset.setFinal()
+
     } finally {
       parseEnd(pstate)
       if (pstate.dataProc.isDefined) pstate.dataProc.value.endElement(pstate, this)

--- a/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/ElementKindParsers.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/ElementKindParsers.scala
@@ -213,17 +213,6 @@ abstract class ChoiceDispatchCombinatorParserBase(
 
           if (pstate.processorStatus eq Success) {
             Logger.log.debug(s"Choice dispatch success: ${parser}")
-
-            // We usually rely on the sequence parser to set elements as final.
-            // But choices with scalar elements do not necessarily have a
-            // sequence surrounding them and so they aren't set final. In order
-            // to set these elements final, we do it here as well. We will
-            // attempt to walk the infoset after the PoU is discarded.
-            val newLastChildNode = pstate.infoset.maybeLastChild
-            if (newLastChildNode.isDefined) {
-              newLastChildNode.get.isFinal = true
-            }
-
           } else {
             Logger.log.debug(s"Choice dispatch failed: ${parser}")
             val diag =

--- a/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/Parser.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/Parser.scala
@@ -276,17 +276,6 @@ class ChoiceParser(ctxt: RuntimeData, val childParsers: Array[Parser])
           // Choice branch was successfull. Break out of the loop and let
           // withPointOfUncertainty discard the pou
           successfullyParsedChildBranch = true
-
-          // We usually rely on the sequence parser to set elements as final.
-          // But choices with scalar elements do not necessarily have a
-          // sequence surrounding them and so they aren't set final. In order
-          // to set these elements final, we do it here as well. We will
-          // attempt to walk the infoset after the PoU is discarded.
-          val newLastChildNode = pstate.infoset.maybeLastChild
-          if (newLastChildNode.isDefined) {
-            newLastChildNode.get.isFinal = true
-          }
-
         } else {
           // Failed to parse this branch alternative. Create diagnostic and
           // check if anything resolved the associated point of uncertainty
@@ -310,8 +299,6 @@ class ChoiceParser(ctxt: RuntimeData, val childParsers: Array[Parser])
           }
         }
       }
-
-      pstate.walker.walk()
     }
 
     if (!successfullyParsedChildBranch) {

--- a/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/SequenceParserBases.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/SequenceParserBases.scala
@@ -114,9 +114,6 @@ abstract class SequenceParserBase(
       //
       while (!isDone && (scpIndex < limit) && (pstate.processorStatus eq Success)) {
 
-        // keep track of the current last child node. If the last child changes
-        // while parsing, we know a new child was added in this loop
-
         child = children(scpIndex).asInstanceOf[SequenceChildParser]
 
         child match {
@@ -216,29 +213,9 @@ abstract class SequenceParserBase(
                 pstate.mpstate.moveOverOneGroupIndexOnly()
               }
 
-              val newLastChildNode = pstate.infoset.maybeLastChild
-              if (newLastChildNode.isDefined) {
-                // We have potentially added a child to to this complex during
-                // this array loop.
-                //
-                // If the new child is a DIArray, we know this DIArray has at
-                // least one element, but we don't know if we actually added a
-                // new one in this loop or not. So just get the last array
-                // element and set it as final anyways.
-                //
-                // If it's not a DIArray, that means it's just an optional
-                // simple/complex and that will get set final below where all
-                // other non-array elements get set as final.
-                val lastChild = newLastChildNode.get
-                if (lastChild.isArray) {
-                  // not simple or complex, must be an array
-                  val lastArrayElem = lastChild.maybeLastChild
-                  if (lastArrayElem.isDefined) {
-                    lastArrayElem.get.isFinal = true
-                    pstate.walker.walk()
-                  }
-                }
-              }
+              // we might have added a new instance to the array. Attempt to project it to an
+              // infoset if there are no PoU's or anything blocking it
+              pstate.walker.walk()
 
             } // end while for each repeat
             parser.endArray(pstate)
@@ -335,50 +312,9 @@ abstract class SequenceParserBase(
           } // end case scalarParser
         } // end match case parser
 
-        // now that we have finished parsing a single instance of this sequence,
-        // we need to potentially set things as final, get the last child to
-        // determine if it changed from the saved last child, which lets us know
-        // if a new child was actually added.
-        val newLastChildNode = pstate.infoset.maybeLastChild
-
-        if (!isOrdered) {
-          // In the special case of unordered sequences with arrays, we do not
-          // use the RepatingChildParser. Instead we parse on instance at a time
-          // in this loop. So array elements aren't set final above like normal
-          // arrays are.
-          //
-          // So if the last child node is a DIArray, we must set new array
-          // elements as final here. We can't know if we actually added a new
-          // DIArray element or not, so just set the last one as final
-          // regardless.
-          //
-          // Note that we do not need to do a null check because in an unordered
-          // sequence we are blocking, so we can't possibly walk/free any of
-          // these newly added elements.
-          if (newLastChildNode.isDefined && newLastChildNode.get.isArray) {
-            // we have a new last child, and it's not simple or complex, so must
-            // be an array. Set its last child final
-            newLastChildNode.get.maybeLastChild.get.isFinal = true
-          }
-        }
-
-        // We finished parsing one part of a sequence, which could either be an
-        // array, simple, or complex. We aren't sure if we actually added a new
-        // element or not, but in case we did, mark the last node as final.
-        //
-        // Additionally, if this is an ordered sequence, try to walk the infoset
-        // to output events for this potentially new element. If this is an
-        // unordered sequence, walking is unnecessary. This is because we may
-        // need to reorder the infoset once this unordered sequence is complete
-        // (via flattenAndValidateChildNodes below) and cannot walk until that
-        // happens. To ensure we don't walk even if a child parser tries to call
-        // walk() we incremented infosetWalkerBlockCount at the beginning of this
-        // function, so the walker is effectively blocked from making any
-        // progress. So we don't even bother calling walk() in this case.
-        if (newLastChildNode.isDefined) {
-          newLastChildNode.get.isFinal = true
-          if (isOrdered) pstate.walker.walk()
-        }
+        // we finished parsing one whole thing (scalar element, entire array, etc). Attempt to
+        // project it to an infoset if there are no PoU's or anything blocking it
+        pstate.walker.walk()
 
         scpIndex += 1
 


### PR DESCRIPTION
> [!NOTE]
> This is an alternate approach to PR #1504. I started adding assertions as suggested in that PR but many of them actually failed and couldn't be easily fixed. I realized that our logic to set elements as final was actually pretty broken and we just got lucky that things were mostly working. This required reworking the solution, but I think this is now easier to make sense of when things are marked as final and allows all the invariants to hold.

Our current logic to handle setting elements as final during parse is pretty broken. The core issue is that we primarily call setFinal in the sequence parser where it is difficult to know which elements are actually final--we had to make assumptions based on the results of the things actualy parsing elements. This usually worked, but in some cases could lead to setting an element final multiple times, or setting an element as final when it wasn't actually final.

A case where this flawed logic could lead to issues is with InfosetInputters that aren't designed to receive invalid infosets, such as JDOM or SAX inputters. Note that InfosetInputters aren't required to handle invalid infosets, except for those that are used by the debugger. This could lead to incomplete error diagnostics or misleading reasons for an error.

To make the final logic more clear and avoid these kinds of errors, DINode.isFinal is made private with new getFinal and setFinal method used instead. These functions allow us to place a number of assertions throughout the infoset logic to ensure we set things as final appropriately.

This also moves where we set elements as final. DISimple and DIComplex elements are set final in the ElementCombinatorParser and only when they successfully parse. This avoids cases where an element could be set final even though it failed to parse and removes any ambiguities about what sholud be set final. DIArrays are set final in the sequence parser that handles the ending of arrays, with special logic to handle arrays in unordered sequences. Note that the sequence parser is still responsible for attempting to walk the infoset to project the internal infoset into the target infoset--keeping all the walk logic in one place.

DAFFODIL-3006