### PR TITLE
Add "dependencies" label to scala steward PRs

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -13,4 +13,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-dependencies: ['update/*']
+dependencies:
+ - head-branch: ['^update/']

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -15,13 +15,13 @@
 
 name: PR Labeler
 on:
-  pull_request:
-    types: [opened]
+- pull_request_target
 
 jobs:
   pr-labeler:
+    permissions:
+      contents: read
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: TimonVS/pr-labeler-action@f9c084306ce8b3f488a8f3ee1ccedc6da131d1af # v5.0.0
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5.0.0


### PR DESCRIPTION
Commit 549ac81deb used the TimonVS/pr-labeler-action action to label pull requests from scala-steward, but it did not actually add labels.

I think we could get the existing action to work by switching to "push_request_target" as the action type (which this PR does). But this also switches to the official GitHub actions/labeler, which is more comnmonly used, is probably safer from a security standpoint, and has better documentation.

This requires minor modifications to the config file name and format.

DAFFODIL-2995