### PR TITLE
Drop Java 8 and 11 support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,17 +39,15 @@ jobs:
       fail-fast: false
       matrix:
         java_distribution: [ temurin ]
-        java_version: [ 8, 11, 17, 21 ]
+        java_version: [ 17, 21, 24 ]
         scala_version: [ 3.3.6 ]
         os: [ ubuntu-22.04, windows-2022, macos-14 ]
         exclude:
           # only run macos on java 17
           - os: macos-14
-            java_version: 8
-          - os: macos-14
-            java_version: 11
-          - os: macos-14
             java_version: 21
+          - os: macos-14
+            java_version: 24
         include:
           # configure shell/cc/ar for all OSes
           - os: ubuntu-22.04
@@ -68,13 +66,13 @@ jobs:
           - lang: en_US
           - encoding: UTF-8
           - os: ubuntu-22.04
-            java_version: 8
+            java_version: 17
             lang: de_DE
           - os: ubuntu-22.04
-            java_version: 11
+            java_version: 21
             lang: ja_JP
           - os: windows-2022
-            java_version: 8
+            java_version: 21
             encoding: US-ASCII
 
 

--- a/build.sbt
+++ b/build.sbt
@@ -175,11 +175,8 @@ lazy val testStdLayout = Project("daffodil-test-stdLayout", file("test-stdLayout
   .dependsOn(tdmlJunit % "test")
   .settings(commonSettings, nopublish)
 
-// Choices here are Java LTS versions, 8, 11, 17, 21,...
-// However 8 is deprecated as of Java 21, so will be phased out.
-val minSupportedJavaVersion: String =
-  if (scala.util.Properties.isJavaAtLeast("21")) "11"
-  else "8"
+// Choices here are Java LTS versions, 17, 21,...
+val minSupportedJavaVersion: String = "17"
 
 lazy val commonSettings = Seq(
   organization := "org.apache.daffodil",
@@ -217,7 +214,7 @@ lazy val commonSettings = Seq(
 
 def buildScalacOptions(scalaVersion: String) = {
   val commonOptions = Seq(
-    s"-release:$minSupportedJavaVersion", // scala 2.12 can only do Java 8, regardless of this setting.
+    s"-release:$minSupportedJavaVersion",
     "-feature",
     "-deprecation",
     "-unchecked"
@@ -247,18 +244,6 @@ def buildTestScalacOptions(scalaVersion: String) = {
   commonOptions ++ scalaVersionSpecificOptions
 }
 
-val javaVersionSpecificOptions = {
-  val releaseOption = // as of Java 11, they no longer accept "-release". Must use "--release".
-    if (scala.util.Properties.isJavaAtLeast("11")) "--release" else "-release"
-
-  // Java 21 deprecates Java 8 and warns about it.
-  // So if you are using Java 21, Java code compilation will specify a newer Java version
-  // to avoid warnings.
-  if (scala.util.Properties.isJavaAtLeast("11")) Seq(releaseOption, minSupportedJavaVersion)
-  else if (scala.util.Properties.isJavaAtLeast("9")) Seq(releaseOption, "8")
-  else Nil // for Java 8 compilation
-}
-
 // Workaround issue that some options are valid for javac, not javadoc.
 // These javacOptions are for code compilation only. (Issue sbt/sbt#355)
 def buildJavacOptions() = {
@@ -267,10 +252,12 @@ def buildJavacOptions() = {
     "-Xlint:deprecation",
     "-deprecation",
     "-Xlint:dep-ann",
-    "-Xlint:unchecked"
+    "-Xlint:unchecked",
+    "--release",
+    minSupportedJavaVersion
   )
 
-  commonOptions ++ javaVersionSpecificOptions
+  commonOptions
 }
 
 lazy val nopublish = Seq(


### PR DESCRIPTION
- update GitHub Actions workflows to use Java 17 and 21 only
- set minimum supported Java version to 17 in build script
- clean up Java version-specific options for compatibility
- add non-LTS tracking version java 24 for now with plans to replace with LTS 25 and next future non-LTS version

DAFFODIL-3017