### PR TITLE
Expose `UnparseResult.location` in the API

### DIFF
--- a/daffodil-core/src/main/java/org/apache/daffodil/api/UnparseResult.java
+++ b/daffodil-core/src/main/java/org/apache/daffodil/api/UnparseResult.java
@@ -22,5 +22,10 @@ package org.apache.daffodil.api;
  * containing diagnostic information
  */
 public interface UnparseResult extends Result, WithDiagnostics {
-
+  /**
+   * Get the current unparse {@link org.apache.daffodil.api.DataLocation}
+   *
+   * @return the current infoset location
+   */
+  DataLocation location();
 }

--- a/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/processors/DataProcessor.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/processors/DataProcessor.scala
@@ -603,6 +603,8 @@ class UnparseResult(dp: DataProcessor, ustate: UState)
 
   override def resultState = ustate
 
+  override def location(): api.DataLocation = resultState.currentLocation
+
   private def maybeEncodingInfo =
     if (Maybe.WithNulls.isDefined(ustate.currentInfosetNode))
       One(ustate.currentInfosetNode.asInstanceOf[DIElement].runtimeData.encodingInfo)


### PR DESCRIPTION
- Added a `location` method to the `UnparseResult` interface for retrieving the current `DataLocation`.
- Updated `DataProcessor` to support the new `location` method.

DAFFODIL-3031