### PR TITLE
Remove many uses of ThreadLocals

### DIFF
--- a/daffodil-core/src/main/scala/org/apache/daffodil/io/FormatInfo.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/io/FormatInfo.scala
@@ -30,6 +30,7 @@ import org.apache.daffodil.lib.schema.annotation.props.gen.EncodingErrorPolicy
 import org.apache.daffodil.lib.schema.annotation.props.gen.UTF16Width
 import org.apache.daffodil.lib.util.Maybe
 import org.apache.daffodil.lib.util.MaybeInt
+import org.apache.daffodil.lib.util.ThreadSafePool
 
 /**
  * Abstract interface to obtain format properties or values derived from
@@ -119,6 +120,5 @@ trait FormatInfo {
   /**
    * Buffers used for regex matching
    */
-  def regexMatchBuffer: CharBuffer
-  def regexMatchBitPositionBuffer: LongBuffer
+  def regexMatchStatePool: ThreadSafePool[(CharBuffer, LongBuffer)]
 }

--- a/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/processors/ProcessorStateBases.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/processors/ProcessorStateBases.scala
@@ -49,6 +49,7 @@ import org.apache.daffodil.lib.util.Maybe.Nope
 import org.apache.daffodil.lib.util.Maybe.One
 import org.apache.daffodil.lib.util.MaybeInt
 import org.apache.daffodil.lib.util.MaybeULong
+import org.apache.daffodil.lib.util.ThreadSafePool
 import org.apache.daffodil.runtime1.dpath.DState
 import org.apache.daffodil.runtime1.dsom.DPathCompileInfo
 import org.apache.daffodil.runtime1.dsom.RuntimeSchemaDefinitionError
@@ -699,8 +700,8 @@ final class CompileState(
     // do nothing
   }
 
-  def regexMatchBuffer: CharBuffer = Assert.usageError("Not to be used.")
-  def regexMatchBitPositionBuffer: LongBuffer = Assert.usageError("Not to be used.")
+  def regexMatchStatePool: ThreadSafePool[(CharBuffer, LongBuffer)] =
+    Assert.usageError("Not to be used.")
 
   // $COVERAGE-OFF$
   override def setVariable(

--- a/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/PState.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/PState.scala
@@ -528,8 +528,7 @@ final class PState private (
     }
   }
 
-  override lazy val (regexMatchBuffer, regexMatchBitPositionBuffer) =
-    dataProcArg.regexMatchState.get
+  override lazy val regexMatchStatePool = dataProcArg.regexMatchStatePool
 
   /**
    * Verify that the state is left where we expect it to be after

--- a/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/PrimitivesDateTime1.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/PrimitivesDateTime1.scala
@@ -62,8 +62,6 @@ case class ConvertTextCalendarParser(
     // the case.
     calendarOrig.clear()
 
-    val df = dateTimeFormatterEv.evaluate(start).get
-
     // When we evaluate calendarEV, if it is a constant we will always get back
     // the same Calendar object. Because of this it is important here to clone
     // this calendar and always use the clone below for two reasons:
@@ -78,8 +76,11 @@ case class ConvertTextCalendarParser(
     //    cloning, we ensure that they modify different objects.
     val calendar = calendarOrig.clone().asInstanceOf[Calendar]
 
-    df.setCalendar(calendar)
-    df.parse(str, calendar, pos);
+    val dateTimeFormatterPool = dateTimeFormatterEv.evaluate(start)
+    dateTimeFormatterPool.withInstance { df =>
+      df.setCalendar(calendar)
+      df.parse(str, calendar, pos);
+    }
 
     // Verify that we did not fail to parse and that we consumed the entire string. Note that
     // getErrorIndex is never set and is always -1. Only a getIndex value of zero means there

--- a/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/processors/unparsers/UState.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/processors/unparsers/UState.scala
@@ -41,6 +41,7 @@ import org.apache.daffodil.lib.util.MStackOfMaybe
 import org.apache.daffodil.lib.util.Maybe
 import org.apache.daffodil.lib.util.Maybe.Nope
 import org.apache.daffodil.lib.util.Maybe.One
+import org.apache.daffodil.lib.util.ThreadSafePool
 import org.apache.daffodil.runtime1.dpath.UnparserBlocking
 import org.apache.daffodil.runtime1.iapi.DFDL
 import org.apache.daffodil.runtime1.infoset.DIArray
@@ -398,8 +399,8 @@ abstract class UState(
     }
   }
 
-  def regexMatchBuffer: CharBuffer = Assert.usageError("Not to be used.")
-  def regexMatchBitPositionBuffer: LongBuffer = Assert.usageError("Not to be used.")
+  def regexMatchStatePool: ThreadSafePool[(CharBuffer, LongBuffer)] =
+    Assert.usageError("Not to be used.")
 
   def documentElement: DIDocument
 

--- a/daffodil-core/src/main/scala/org/apache/daffodil/unparsers/runtime1/ConvertTextCalendarUnparser.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/unparsers/runtime1/ConvertTextCalendarUnparser.scala
@@ -67,8 +67,6 @@ case class ConvertTextCalendarUnparser(
     // the case.
     calendarOrig.clear()
 
-    val df = dateTimeFormatterEv.evaluate(state).get
-
     // When we evaluate calendarEV, if it is a constant we will always get back
     // the same Calendar object. Because of this it is important here to clone
     // this calendar and always use the clone below for two reasons:
@@ -105,8 +103,11 @@ case class ConvertTextCalendarUnparser(
     calendar.set(Calendar.MILLISECOND, infosetCalendar.get(Calendar.MILLISECOND))
     calendar.setTimeZone(infosetCalendar.getTimeZone)
 
-    df.setCalendar(calendar)
-    val str = df.format(calendar)
+    val dateFormatterPool = dateTimeFormatterEv.evaluate(state)
+    val str = dateFormatterPool.withInstance { df =>
+      df.setCalendar(calendar)
+      df.format(calendar)
+    }
 
     node.overwriteDataValue(str)
   }

--- a/daffodil-core/src/test/scala/org/apache/daffodil/io/FormatInfoForUnitTest.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/io/FormatInfoForUnitTest.scala
@@ -34,6 +34,7 @@ import org.apache.daffodil.lib.schema.annotation.props.gen.EncodingErrorPolicy
 import org.apache.daffodil.lib.schema.annotation.props.gen.UTF16Width
 import org.apache.daffodil.lib.util.Maybe
 import org.apache.daffodil.lib.util.MaybeInt
+import org.apache.daffodil.lib.util.ThreadSafePool
 
 object FormatInfoForUnitTest {
   def apply() = {
@@ -58,8 +59,11 @@ class FormatInfoForUnitTest private () extends FormatInfo {
   var encodingMandatoryAlignmentInBits: Int = 8
   var encodingErrorPolicy: EncodingErrorPolicy = EncodingErrorPolicy.Replace
   var tunable: DaffodilTunables = DaffodilTunables()
-  var regexMatchBuffer = CharBuffer.allocate(1024)
-  var regexMatchBitPositionBuffer = LongBuffer.allocate(1024)
+  var regexMatchStatePool = new ThreadSafePool[(CharBuffer, LongBuffer)] {
+    override def allocate() = {
+      (CharBuffer.allocate(1024), LongBuffer.allocate(1024))
+    }
+  }
 
   def reset(cs: BitsCharset): Unit = {
     priorEncoding = cs
@@ -107,8 +111,7 @@ class FakeFormatInfo(val bitOrder: BitOrder, val byteOrder: ByteOrder) extends F
   def encodingMandatoryAlignmentInBits: Int = ???
   def encodingErrorPolicy: EncodingErrorPolicy = ???
   def tunable: DaffodilTunables = ???
-  def regexMatchBuffer: CharBuffer = ???
-  def regexMatchBitPositionBuffer: LongBuffer = ???
+  def regexMatchStatePool: ThreadSafePool[(CharBuffer, LongBuffer)] = ???
 }
 
 object FakeFormatInfo_MSBF_BE

--- a/daffodil-tdml-lib/src/main/scala/org/apache/daffodil/tdml/TDMLRunner.scala
+++ b/daffodil-tdml-lib/src/main/scala/org/apache/daffodil/tdml/TDMLRunner.scala
@@ -71,6 +71,7 @@ import org.apache.daffodil.lib.util.Misc.bits2Bytes
 import org.apache.daffodil.lib.util.Misc.hex2Bits
 import org.apache.daffodil.lib.util.Misc.uriToDiagnosticFile
 import org.apache.daffodil.lib.util.SchemaUtils
+import org.apache.daffodil.lib.util.ThreadSafePool
 import org.apache.daffodil.lib.xml.DaffodilXMLLoader
 import org.apache.daffodil.lib.xml.XMLUtils
 import org.apache.daffodil.tdml.DiagnosticType.DiagnosticType
@@ -1966,9 +1967,7 @@ object VerifyTestCase {
 
       override def tunable: DaffodilTunables = doNotUse
 
-      override def regexMatchBuffer: CharBuffer = doNotUse
-
-      override def regexMatchBitPositionBuffer: LongBuffer = doNotUse
+      override def regexMatchStatePool: ThreadSafePool[(CharBuffer, LongBuffer)] = doNotUse
     }
 
     Using.resource(InputSourceDataInputStream(bytes)) { dis =>

--- a/daffodil-test/src/test/scala/org/apache/daffodil/runtime1/layers/AISPayloadArmoringLayer.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/runtime1/layers/AISPayloadArmoringLayer.scala
@@ -38,6 +38,7 @@ import org.apache.daffodil.lib.schema.annotation.props.gen.EncodingErrorPolicy
 import org.apache.daffodil.lib.schema.annotation.props.gen.UTF16Width
 import org.apache.daffodil.lib.util.Maybe
 import org.apache.daffodil.lib.util.MaybeInt
+import org.apache.daffodil.lib.util.ThreadSafePool
 
 import org.apache.commons.io.IOUtils
 
@@ -107,8 +108,7 @@ class AISPayloadArmoringOutputStream(jos: java.io.OutputStream) extends OutputSt
     override def maybeUTF16Width: Maybe[UTF16Width] = doNotUse
     override def encodingMandatoryAlignmentInBits: Int = doNotUse
     override def tunable: DaffodilTunables = doNotUse
-    override def regexMatchBuffer: CharBuffer = doNotUse
-    override def regexMatchBitPositionBuffer: LongBuffer = doNotUse
+    override def regexMatchStatePool: ThreadSafePool[(CharBuffer, LongBuffer)] = doNotUse
   }
 
   override def close(): Unit = {


### PR DESCRIPTION
Currently we make use of ThreadLocal's as a way to create a per-thread instance of a class that is not thread safe. One major drawback with this approach is that values stored in ThreadLocals are never guaranteed to be garbage collected unless you call ThreadLocal.remove, even if the ThreadLocal has no more direct strong references--this is beacause the Thread iself has a table of strong references to ThreadLocal values. And few of our ThreadLocal uses ever call remove(). This can lead to pretty significant memory leaks in some edge cases.

The reason we don't call remove is because in most cases we use ThreadLocals as an efficient pool, where each thread gets its own slot from the pool, and we don't necessarily know when a thread will no longer need that instance. But that means these instances can leak.

To resolve this, this adds a new ThreadSafePool class, which is close to a drop-in replacement for ThreadLocal. The only real difference is this uses defines `allocate()` instead of `initialValue()`, and a `withInstance` function must be used to get an instance and automatically return it to the pool when withInstance ends.

The ThreadSafePool implementation makes use of a ConcurrentLinkedQueue to support thread safe pool access--note that this does allow for an unbounded number of pool instances, but in practice each pool should never contain more than the number of threads. And unlike ThreadLocal, this does allow different threads to reuse the same instance, so it could potentially reduce memory. Additionally, if a pool no longer has strong reference then its values can be garbage collected, so there is no need to call `remove()` to avoid memory leaks.

The main drawback is that the ConcurrentLinkedQueue could add some overhead since it does have to deal with potential thread contention, and it does require allocations for the backing list. But hopefully this is all relatively minor.

DAFFODIL-3030