### PR TITLE
Add Validators.list() API

### DIFF
--- a/daffodil-core/src/main/java/org/apache/daffodil/api/validation/ValidatorNotRegisteredException.java
+++ b/daffodil-core/src/main/java/org/apache/daffodil/api/validation/ValidatorNotRegisteredException.java
@@ -27,6 +27,12 @@ public class ValidatorNotRegisteredException extends Exception {
    * @param name the requested validator factory name
    */
   ValidatorNotRegisteredException(String name) {
-    super("No api.validation.ValidatorFactory is registered as " + name);
+    super(
+      String.format(
+        "No Daffodil ValidatorFactory is registered with name '%s'. Available validators: %s",
+        name,
+        String.join(", ", Validators.list())
+      )
+    );
   }
 }

--- a/daffodil-core/src/main/java/org/apache/daffodil/api/validation/Validators.java
+++ b/daffodil-core/src/main/java/org/apache/daffodil/api/validation/Validators.java
@@ -19,6 +19,9 @@ package org.apache.daffodil.api.validation;
 
 import org.apache.daffodil.lib.util.SimpleNamedServiceLoader;
 
+import java.util.List;
+import java.util.ArrayList;
+
 /**
  * Access SPI registered {@link org.apache.daffodil.api.validation.ValidatorFactory} instances.
  * <p>
@@ -70,5 +73,14 @@ public class Validators {
    */
   public static boolean isRegistered(String name) {
     return impls.containsKey(name);
+  }
+
+  /**
+   * Get a list of available validator names
+   *
+   * @return array of validator names
+   */
+  public static List<String> list() {
+    return new ArrayList<String>(impls.keySet());
   }
 }

--- a/daffodil-core/src/test/scala/org/apache/daffodil/lib/validation/TestValidatorsSPI.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/lib/validation/TestValidatorsSPI.scala
@@ -21,6 +21,9 @@ import java.util.Properties
 
 import org.apache.daffodil.api.validation.ValidatorNotRegisteredException
 import org.apache.daffodil.api.validation.Validators
+import org.apache.daffodil.core.util.TestUtils.intercept
+import org.apache.daffodil.validation.DaffodilValidator
+import org.apache.daffodil.validation.NoValidator
 import org.apache.daffodil.validation.XercesValidator
 
 import org.junit.Assert.assertEquals
@@ -45,6 +48,10 @@ class TestValidatorsSPI {
 
   @Test def testValidatorNonExists(): Unit = {
     assertFalse(Validators.isRegistered("dont exist"))
+    val e = intercept[ValidatorNotRegisteredException] {
+      Validators.get("dont exist")
+    }
+    assertTrue(e.getMessage.contains("dont exist"))
   }
 
   @Test def testDefaultIsRegistered(): Unit = {
@@ -76,5 +83,12 @@ class TestValidatorsSPI {
     assertFalse(validationHandler.errors.isEmpty)
 
     assertEquals(validationHandler.errors.head, "boom")
+  }
+
+  @Test def testListValidators(): Unit = {
+    val vs = Validators.list()
+    assertTrue(vs.contains(NoValidator.name))
+    assertTrue(vs.contains(DaffodilValidator.name))
+    assertTrue(vs.contains(XercesValidator.name))
   }
 }


### PR DESCRIPTION
Allows listing names of all validators avilable via SPI.

Also use the new function to improve the ValidatorNotRegisteredException to contain the list of available validators.

DAFFODIL-3034