### PR TITLE
Change withValidation API to accept a URL instead of URI

### DIFF
--- a/daffodil-cli/src/main/scala/org/apache/daffodil/cli/Main.scala
+++ b/daffodil-cli/src/main/scala/org/apache/daffodil/cli/Main.scala
@@ -1051,7 +1051,12 @@ class Main(
           Logger.log.debug(s"Unparser = ${processorImpl.ssrd.unparser.toString}")
         }
         val (validationKind, validationConfig) = validate
-        Some(processor.withValidation(validationKind, validationConfig.getOrElse(null)))
+        Some(
+          processor.withValidation(
+            validationKind,
+            validationConfig.map(_.toURL).getOrElse(null)
+          )
+        )
       } else {
         None
       }
@@ -1126,7 +1131,7 @@ class Main(
           val (validationKind, validationConfig) = validate
           val processor = processorFactory
             .onPath(path.getOrElse("/"))
-            .withValidation(validationKind, validationConfig.getOrElse(null))
+            .withValidation(validationKind, validationConfig.map(_.toURL).getOrElse(null))
             // needed to access SchemaSetRuntimeData
             .asInstanceOf[DataProcessor]
           if (processor.isError) {

--- a/daffodil-core/src/main/java/org/apache/daffodil/api/DataProcessor.java
+++ b/daffodil-core/src/main/java/org/apache/daffodil/api/DataProcessor.java
@@ -27,7 +27,7 @@ import org.apache.daffodil.api.validation.ValidatorNotRegisteredException;
 
 import java.io.File;
 import java.io.Serializable;
-import java.net.URI;
+import java.net.URL;
 import java.nio.channels.WritableByteChannel;
 import java.util.Map;
 
@@ -64,17 +64,17 @@ public interface DataProcessor extends WithDiagnostics, Serializable {
    * @param kind   Kind of validation to use. Can be a custom validator name available via the
    *               {@link org.apache.daffodil.api.validation.ValidatorFactory} SPI or one of the built-in validators
    *               ("xerces", "daffodil", "off", "schematron")
-   * @param config Absolute URI to use for validation configuration. If the URI ends with .conf
+   * @param config URL to use for validation configuration. If the URL path ends with .conf
    *               or .properties it is treated as a java.util.Properties file that is loaded and
-   *               provided to the validator. Otherwise, the URI is provided as a single property to
-   *               the validator. Can be null if a URI is not known or the validator does not need
+   *               provided to the validator. Otherwise, the URL is provided as a single property to
+   *               the validator. Can be null if a URL is not known or the validator does not need
    *               additional configuration--this could cause an exception if a validator requires
    *               properties.
    * @return a new {@link DataProcessor} with a specified validator.
    * @throws ValidatorNotRegisteredException  if the validator cannot be found
    * @throws ValidatorInitializationException if initializing the validator fails
    */
-  DataProcessor withValidation(String kind, URI config) throws ValidatorNotRegisteredException, ValidatorInitializationException;
+  DataProcessor withValidation(String kind, URL config) throws ValidatorNotRegisteredException, ValidatorInitializationException;
 
   /**
    * Obtain a new {@link DataProcessor} with external variables read from a Daffodil configuration file

--- a/daffodil-core/src/main/java/org/apache/daffodil/api/validation/package-info.java
+++ b/daffodil-core/src/main/java/org/apache/daffodil/api/validation/package-info.java
@@ -20,7 +20,7 @@
  *
  * <p>
  * Daffodil provides a number of built-in validators for use with {@link
- * org.apache.daffodil.api.DataProcessor#withValidation(String, URI)}. For each
+ * org.apache.daffodil.api.DataProcessor#withValidation(String, URL)}. For each
  * built-in validator, the following contains the validator name, a
  * description, and validator specific properties. The {@code String} parameter
  * should be the name of the validator. If the URI parameter ends in
@@ -65,7 +65,7 @@
  *     <p><b>Example:</b></p>
  *     <pre>{@code
  * // enable XML schema validation, setting the "xerces" property to the schema.xsd file
- * dataProcessor.withValidation("xerces", URI.create("file:///path/to/schema.xsd"))
+ * dataProcessor.withValidation("xerces", new URL("file:///path/to/schema.xsd"))
  * }</pre>
  *   </dd>
  *
@@ -92,10 +92,10 @@
  *     <p><b>Example:</b></p>
  *     <pre>{@code
  * // enable schematron validation, setting the "schematron" property to the schematron.sch file
- * dataProcessor.withValidation("schematron", URI.create("file:///path/to/schematron.sch"))
+ * dataProcessor.withValidation("schematron", new URL("file:///path/to/schematron.sch"))
  *
  * // use schematron validation, reading the schematron.properties file to set "schematron" or other schematron properties
- * dataProcessor.withValidation("schematron", URI.create("file:///path/to/schematron.properties"))
+ * dataProcessor.withValidation("schematron", new URL("file:///path/to/schematron.properties"))
  * }</pre>
  *   </dd>
  * </dl>
@@ -111,7 +111,7 @@
  *  returns the custom Validator from the previous step</li>
  *  <li>Register the custom ValidatorFactory by creating a {@link org.apache.daffodil.api.validation.ValidatorFactory}
  *  file in {@code META-INF/services/}, its contents being the fully qualified name of the custom validator factory</li>
- *  <li>Call the {@link org.apache.daffodil.api.DataProcessor#withValidation(String, URI)} function, providing the name
+ *  <li>Call the {@link org.apache.daffodil.api.DataProcessor#withValidation(String, URL)} function, providing the name
  *  of the validator and optional URI.</li>
  * </ol>
  */

--- a/daffodil-core/src/main/scala/org/apache/daffodil/core/util/TestUtils.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/core/util/TestUtils.scala
@@ -19,7 +19,7 @@ package org.apache.daffodil.core.util
 
 import java.io.ByteArrayInputStream
 import java.io.InputStream
-import java.net.URI
+import java.net.URL
 import java.nio.channels.Channels
 import java.nio.channels.ReadableByteChannel
 import java.nio.channels.WritableByteChannel
@@ -359,7 +359,7 @@ class Fakes private () {
     override def withExternalVariables(
       extVars: java.util.Map[String, String]
     ): DFDL.DataProcessor = this
-    override def withValidation(kind: String, config: URI): DFDL.DataProcessor = this
+    override def withValidation(kind: String, config: URL): DFDL.DataProcessor = this
     override def withDebugger(dbg: api.debugger.Debugger): DFDL.DataProcessor = this
 
     override def newXMLReaderInstance: api.DaffodilParseXMLReader = null
@@ -435,7 +435,7 @@ class StreamParser private (val schema: Node) {
       .onPath("/")
     val schemaTempFile = Files.createTempFile("streamparser", ".test")
     FileUtils.write(schemaTempFile.toFile, schema.toString(), Charset.defaultCharset())
-    val dataproc = dataproc1.withValidation("xerces", schemaTempFile.toUri)
+    val dataproc = dataproc1.withValidation("xerces", schemaTempFile.toUri.toURL)
     // .withDebuggerRunner(new TraceDebuggerRunner()) // DAFFODIL-2624 - cannot trace in streaming SAPI
     // .withDebugging(true)
     if (dataproc.isError)

--- a/daffodil-core/src/main/scala/org/apache/daffodil/lib/xml/DaffodilXMLLoader.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/lib/xml/DaffodilXMLLoader.scala
@@ -736,7 +736,7 @@ class DaffodilXMLLoader(val errorHandler: org.xml.sax.ErrorHandler)
     optSchemaURI.foreach { schemaURI =>
       val validator =
         try {
-          XercesValidator.fromURI(schemaURI)
+          XercesValidator.fromURL(schemaURI.toURL())
         } catch {
           case e: org.xml.sax.SAXParseException =>
             Assert.invariantFailed(

--- a/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/processors/DataProcessor.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/processors/DataProcessor.scala
@@ -20,7 +20,7 @@ package org.apache.daffodil.runtime1.processors
 import java.io.File
 import java.io.IOException
 import java.io.ObjectOutputStream
-import java.net.URI
+import java.net.URL
 import java.nio.CharBuffer
 import java.nio.LongBuffer
 import java.nio.channels.Channels
@@ -137,18 +137,18 @@ class DataProcessor(
    */
   override def clone(): DataProcessor = copy()
 
-  override def withValidation(kind: String, config: URI): api.DataProcessor = {
+  override def withValidation(kind: String, config: URL): api.DataProcessor = {
     val properties = new Properties()
     if (config != null) {
-      val configStr = config.toString
-      if (configStr.endsWith(".conf") || configStr.endsWith(".properties")) {
+      val configPath = config.getPath()
+      if (configPath.endsWith(".conf") || configPath.endsWith(".properties")) {
         try {
-          properties.load(config.toURL.openStream())
+          properties.load(config.openStream())
         } catch {
           case e: Exception => throw new ValidatorInitializationException(e.getMessage)
         }
       } else {
-        properties.setProperty(kind, configStr)
+        properties.setProperty(kind, config.toString())
       }
     }
     val v = Validators.get(kind).make(properties)

--- a/daffodil-core/src/main/scala/org/apache/daffodil/validation/XercesValidator.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/validation/XercesValidator.scala
@@ -18,7 +18,7 @@
 package org.apache.daffodil.validation
 
 import java.io.IOException
-import java.net.URI
+import java.net.URL
 import java.util.Properties
 import javax.xml.XMLConstants
 import javax.xml.transform.stream.StreamSource
@@ -40,7 +40,7 @@ import org.xml.sax.SAXParseException
  * 
  * Configuration requirements.
  *   <ul>
- *    <li>xerces=schema_file_uri_string</li>
+ *    <li>xerces=schema_file_url_string</li>
  *   </ul>
  */
 class XercesValidatorFactory extends api.validation.ValidatorFactory {
@@ -60,8 +60,8 @@ object XercesValidatorFactory {
           "invalid configuration: xerces property is empty or not defined"
         )
     }
-    val uri = new URI(schemaFile)
-    XercesValidator.fromURI(uri)
+    val url = new URL(schemaFile)
+    XercesValidator.fromURL(url)
   }
 }
 
@@ -132,17 +132,17 @@ object XercesValidator {
   private type XercesValidatorImpl = javax.xml.validation.Validator
   val name = "xerces"
 
-  def fromURI(schemaURI: URI) = new XercesValidator({
+  def fromURL(schemaURL: URL) = new XercesValidator({
     val is =
       try {
-        schemaURI.toURL.openStream()
+        schemaURL.openStream()
       } catch {
         case e: IOException =>
           throw new api.validation.ValidatorInitializationException(e.getMessage)
       }
     val stream = new StreamSource(is)
     stream.setSystemId(
-      schemaURI.toString
+      schemaURL.toString
     ) // must set this so that relative URIs will be created for import/include files.
     stream
   })

--- a/daffodil-core/src/test/java/org/apache/daffodil/jexample/TestAPI.java
+++ b/daffodil-core/src/test/java/org/apache/daffodil/jexample/TestAPI.java
@@ -239,7 +239,7 @@ public class TestAPI {
     org.apache.daffodil.api.Compiler compiler = Daffodil.compiler();
     DataProcessor parser = compiler.reload(input);
     assertNotNull(schemaFile);
-    parser = parser.withValidation("xerces", schemaFile.toURI());
+    parser = parser.withValidation("xerces", schemaFile.toURI().toURL());
     assertNotNull(parser);
   }
 
@@ -788,7 +788,7 @@ public class TestAPI {
     java.io.File schemaFile = getResource("/test/api/mySchema1.dfdl.xsd");
     ProcessorFactory pf = c.compileFile(schemaFile);
     DataProcessor dp = pf.onPath("/");
-    dp = dp.withValidation("xerces", schemaFile.toURI());
+    dp = dp.withValidation("xerces", schemaFile.toURI().toURL());
 
     java.io.File file = getResource("/test/api/myData.dat");
     java.io.FileInputStream fis = new java.io.FileInputStream(file);
@@ -1352,7 +1352,7 @@ public class TestAPI {
     java.io.File schemaFile = getResource("/test/api/blob.dfdl.xsd");
     ProcessorFactory pf = c.compileFile(schemaFile);
     DataProcessor dp = pf.onPath("/");
-    dp = dp.withValidation("xerces", schemaFile.toURI());
+    dp = dp.withValidation("xerces", schemaFile.toURI().toURL());
 
     byte[] data = new byte[]{0x00, 0x00, 0x00, 0x04, 0x01, 0x02, 0x03, 0x04};
     ByteArrayInputStream bis = new ByteArrayInputStream(data);
@@ -1465,7 +1465,7 @@ public class TestAPI {
     URI uri = new URI("/test/api/mySchema1.dfdl.xsd");
     ProcessorFactory pf = c.compileSource(uri);
     DataProcessor dp1 = pf.onPath("/");
-    DataProcessor dp = dp1.withValidation("xerces", getResource(uri.getPath()).toURI());
+    DataProcessor dp = dp1.withValidation("xerces", getResource(uri.getPath()).toURI().toURL());
 
     java.io.File file = getResource("/test/api/myDataBroken.dat");
     java.io.FileInputStream fis = new java.io.FileInputStream(file);

--- a/daffodil-core/src/test/java/org/apache/daffodil/jexample/ValidatorApiExample.java
+++ b/daffodil-core/src/test/java/org/apache/daffodil/jexample/ValidatorApiExample.java
@@ -87,7 +87,7 @@ public class ValidatorApiExample {
       System.err.println(d.toString());
     }
     DataProcessor dp1 = pf.onPath("/");
-    DataProcessor dp = dp1.withValidation("xerces", schemaFile.toURI());
+    DataProcessor dp = dp1.withValidation("xerces", schemaFile.toURI().toURL());
 
     java.io.InputStream fis = new ByteArrayInputStream("0".getBytes());
     try (InputSourceDataInputStream dis = Daffodil.newInputSourceDataInputStream(fis)) {

--- a/daffodil-core/src/test/scala/org/apache/daffodil/sexample/TestAPI.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/sexample/TestAPI.scala
@@ -718,7 +718,7 @@ class TestAPI {
     val input = Channels.newChannel(is)
     val compiler = Daffodil.compiler()
     val parser = compiler.reload(input)
-    val p = parser.withValidation("xerces", schemaFile.toURI)
+    val p = parser.withValidation("xerces", schemaFile.toURI.toURL)
     assertNotNull(p)
   }
 
@@ -784,7 +784,7 @@ class TestAPI {
     val schemaFile = getResource("/test/api/mySchema1.dfdl.xsd")
     val pf = c.compileFile(schemaFile)
     val dp1 = pf.onPath("/")
-    val dp = dp1.withValidation("xerces", schemaFile.toURI)
+    val dp = dp1.withValidation("xerces", schemaFile.toURI.toURL)
     val file = getResource("/test/api/myData.dat")
     val fis = new java.io.FileInputStream(file)
     Using.resource(Daffodil.newInputSourceDataInputStream(fis)) { input =>
@@ -1294,7 +1294,7 @@ class TestAPI {
     val schemaFile = getResource("/test/api/blob.dfdl.xsd")
     val pf = c.compileFile(schemaFile)
     val dp1 = pf.onPath("/")
-    val dp = dp1.withValidation("xerces", schemaFile.toURI)
+    val dp = dp1.withValidation("xerces", schemaFile.toURI.toURL)
 
     val data = Array[Byte](0x00, 0x00, 0x00, 0x04, 0x01, 0x02, 0x03, 0x04)
     val bis = new ByteArrayInputStream(data)
@@ -1401,7 +1401,7 @@ class TestAPI {
     val uri = new URI("/test/api/mySchema1.dfdl.xsd")
     val pf = c.compileSource(uri)
     val dp1 = pf.onPath("/")
-    val dp = dp1.withValidation("xerces", getResource(uri.getPath).toURI)
+    val dp = dp1.withValidation("xerces", getResource(uri.getPath).toURI.toURL)
 
     val file = getResource("/test/api/myDataBroken.dat")
     val fis = new java.io.FileInputStream(file)

--- a/daffodil-schematron/src/main/scala/org/apache/daffodil/validation/schematron/SchematronValidatorFactory.scala
+++ b/daffodil-schematron/src/main/scala/org/apache/daffodil/validation/schematron/SchematronValidatorFactory.scala
@@ -19,6 +19,7 @@ package org.apache.daffodil.validation.schematron
 
 import java.io.InputStream
 import java.net.URI
+import java.net.URL
 import java.util.Properties
 
 import org.apache.daffodil.api
@@ -36,14 +37,14 @@ import net.sf.saxon.TransformerFactoryImpl
  * Configuration
  *
  * <ul>
- *  <li>schematron=uri_string_to_schematron_file</li>
- *  <li>schematron.svrl.file=uri_string_to_output_file</li>
+ *  <li>schematron=url_string_to_schematron_file</li>
+ *  <li>schematron.svrl.file=url_string_to_output_file</li>
  * </ul>
  */
 object SchematronValidatorFactory {
   def makeValidator(config: Properties): SchematronValidator = {
     val schPathValue = config.getProperty(SchematronValidator.name)
-    val schUri = new URI({
+    val schUrl = new URL({
       if (!Misc.isNullOrBlank(schPathValue)) schPathValue
       else
         throw new api.validation.ValidatorInitializationException(
@@ -52,11 +53,11 @@ object SchematronValidatorFactory {
     })
     val schStream =
       try {
-        schUri.toURL.openStream()
+        schUrl.openStream()
       } catch {
         case _: Exception =>
           throw new api.validation.ValidatorInitializationException(
-            s"schematron resource not found: $schUri"
+            s"schematron resource not found: $schUrl"
           )
       }
     val svrlOutPath: Option[URI] = {
@@ -66,7 +67,7 @@ object SchematronValidatorFactory {
       else None
     }
 
-    makeValidator(schStream, schUri.toString, SchSource.from(schUri), svrlOutPath)
+    makeValidator(schStream, schUrl.toString, SchSource.from(schUrl), svrlOutPath)
   }
 
   def makeValidator(

--- a/daffodil-schematron/src/main/scala/org/apache/daffodil/validation/schematron/Transforms.scala
+++ b/daffodil-schematron/src/main/scala/org/apache/daffodil/validation/schematron/Transforms.scala
@@ -18,7 +18,7 @@
 package org.apache.daffodil.validation.schematron
 
 import java.io.InputStream
-import java.net.URI
+import java.net.URL
 import javax.xml.transform.ErrorListener
 import javax.xml.transform.Source
 import javax.xml.transform.Templates
@@ -78,7 +78,7 @@ sealed trait SchSource {
   def stages: Seq[String]
 }
 object SchSource {
-  def from(p: URI): SchSource = p.toString.split("\\.").last match {
+  def from(url: URL): SchSource = url.getPath.split("\\.").last match {
     case "sch" => Sch
     case _ => Xsd
   }

--- a/daffodil-schematron/src/test/scala/org/apache/daffodil/validation/schematron/EmbeddedTesting.scala
+++ b/daffodil-schematron/src/test/scala/org/apache/daffodil/validation/schematron/EmbeddedTesting.scala
@@ -73,7 +73,7 @@ trait EmbeddedTesting {
     if (pf.isError()) pf.getDiagnostics.forEach(println)
     assertFalse("Schema did not compile", pf.isError())
 
-    val dp = pf.onPath("/").withValidation("schematron", schema)
+    val dp = pf.onPath("/").withValidation("schematron", schema.toURL())
 
     f(Validation(dp))
   }

--- a/daffodil-tdml-processor/src/main/scala/org/apache/daffodil/processor/tdml/DaffodilTDMLDFDLProcessor.scala
+++ b/daffodil-tdml-processor/src/main/scala/org/apache/daffodil/processor/tdml/DaffodilTDMLDFDLProcessor.scala
@@ -197,7 +197,7 @@ class DaffodilTDMLDFDLProcessor private[tdml] (
       case "limited" => "daffodil"
       case _ => validation
     }
-    copy(dp = dp.withValidation(validatorName, schemaURI))
+    copy(dp = dp.withValidation(validatorName, schemaURI.toURL))
   }
 
   override def withExternalDFDLVariables(

--- a/daffodil-test/src/test/scala/org/apache/daffodil/infoset/TestStringAsXml.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/infoset/TestStringAsXml.scala
@@ -43,7 +43,7 @@ class TestStringAsXml {
     )
     val dp = pf.onPath("/")
     val schema = if (validatingSchema != null) validatingSchema else dfdlSchemaURI
-    dp.withValidation("xerces", schema)
+    dp.withValidation("xerces", schema.toURL)
 
   }
 


### PR DESCRIPTION
The implementation of withValidation currently converts the URI parameter to a URL and then opens it as a stream to provide to the validator. But this conversion implicitly requires the URI to be a valid URL (e.g. has a scheme, can be opened as a stream). We could add documentation to make this more clear, but changing it to a URL makes it much more explicit and ensures our invariants hold.

DAFFODIL-3035