### PR TITLE
Exclude xml-apis dependency

### DIFF
--- a/daffodil-cli/bin.NOTICE
+++ b/daffodil-cli/bin.NOTICE
@@ -126,15 +126,6 @@ The following NOTICE information applies to binary components distributed with t
       Apache Software Foundation that were originally developed at iClick, Inc.,
       software copyright (c) 1999.
 
-- xml-apis.xml-apis-<VERSION>.jar
-  Apache XML Commons XML APIs
-  Copyright 1999-2009 The Apache Software Foundation.
-
-  Portions of this software were originally based on the following:
-    - software copyright (c) 1999, IBM Corporation., http://www.ibm.com.
-    - software copyright (c) 1999, Sun Microsystems., http://www.sun.com.
-    - software copyright (c) 2000 World Wide Web Consortium, http://www.w3.org
-
 - xml-resolver.xml-resolver-<VERSION>.jar
   Apache XML Commons Resolver
   Copyright 2006 The Apache Software Foundation.

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -26,7 +26,7 @@ object Dependencies {
     "org.scala-lang.modules" %% "scala-xml" % "2.4.0",
     "org.scala-lang.modules" %% "scala-parser-combinators" % "2.4.0",
     "com.ibm.icu" % "icu4j" % "77.1",
-    "xerces" % "xercesImpl" % "2.12.2",
+    ("xerces" % "xercesImpl" % "2.12.2").exclude("xml-apis", "xml-apis"),
     "xml-resolver" % "xml-resolver" % "1.2",
     "commons-io" % "commons-io" % "2.20.0",
     "com.typesafe.scala-logging" %% "scala-logging" % "3.9.5"


### PR DESCRIPTION
XercesImpl depends on xml-apis, but all versions of Java that Daffodil supports (i.e. 17+) already include the APIs provided by this jar. Including xml-apis on such systems can lead to split packages, which although has not cause problems so far, should be avoided. Its removal also reduces our dependencies which is always a good thing.

This modifies our dependency config to exclude xml-apis as a transitive dependency form XercesImpl.

DAFFODIL-2812