### PR TITLE
Add DeterministicGZIPOutputStream with BEST_COMPRESSION for consistent gzip output across JDKs

### DIFF
--- a/daffodil-core/src/main/java/org/apache/daffodil/layers/runtime1/DeterministicGZIPOutputStream.java
+++ b/daffodil-core/src/main/java/org/apache/daffodil/layers/runtime1/DeterministicGZIPOutputStream.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.daffodil.layers.runtime1;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.zip.Deflater;
+import java.util.zip.GZIPOutputStream;
+
+/**
+ * A GZIPOutputStream that uses Deflater BEST_COMPRESSION to produce 
+ * output that is consistent across JDKs linked against different zlib
+ * implementations (e.g. stock zlib vs. zlib-ng).
+ *
+ * According to the zlib documentation/logic from deflate.c, 
+ * compression levels range from 0 to 9:
+ *   Level 0: fastest, no compression
+ *   Level 1: some compression but faster than all other compression levels
+ *   Level 9: best compression but slowest
+ * 
+ * As the compression level number increases, speed decreases. BEST_COMPRESSION
+ * corresponds to level 9, which is at the slowest end of the spectrum.
+ *
+ * At DEFAULT_COMPRESSION(level 6) compression level, stock zlib and zlib-ng produce byte-different
+ * gzip output for the same input, but with BEST_COMPRESSION(level 9) they produce identical output.
+ */
+public final class DeterministicGZIPOutputStream extends GZIPOutputStream {
+    public DeterministicGZIPOutputStream(OutputStream out) throws IOException {
+        super(out);
+        // Force maximum compression so that stock zlib and zlib-ng converge
+        // on the same output bytes.
+        this.def.setLevel(Deflater.BEST_COMPRESSION);
+    }
+}

--- a/daffodil-core/src/main/java/org/apache/daffodil/layers/runtime1/GZipLayer.java
+++ b/daffodil-core/src/main/java/org/apache/daffodil/layers/runtime1/GZipLayer.java
@@ -24,7 +24,6 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.Objects;
 import java.util.zip.GZIPInputStream;
-import java.util.zip.GZIPOutputStream;
 
 public final class GZipLayer extends Layer {
 
@@ -63,7 +62,7 @@ public final class GZipLayer extends Layer {
   @Override
   public OutputStream wrapLayerOutput(OutputStream jos) throws Exception {
     OutputStream fixedOS = fixIsNeeded() ? new GZIPFixedOutputStream(jos) : jos;
-    return new GZIPOutputStream(fixedOS);
+    return new DeterministicGZIPOutputStream(fixedOS);
   }
 
 }
@@ -149,3 +148,4 @@ class GZIPFixedOutputStream extends OutputStream {
     }
   }
 }
+

--- a/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/processors/DataProcessor.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/processors/DataProcessor.scala
@@ -28,7 +28,6 @@ import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.nio.file.Path
 import java.util.Properties
-import java.util.zip.GZIPOutputStream
 import scala.jdk.CollectionConverters.*
 
 import org.apache.daffodil.api
@@ -37,6 +36,7 @@ import org.apache.daffodil.api.layers.exceptions.LayerFatalException
 import org.apache.daffodil.api.metadata.MetadataHandler
 import org.apache.daffodil.api.validation.ValidatorInitializationException
 import org.apache.daffodil.api.validation.Validators
+import org.apache.daffodil.layers.runtime1.DeterministicGZIPOutputStream
 import org.apache.daffodil.lib.equality.*
 import org.apache.daffodil.lib.iapi.DaffodilTunables
 import org.apache.daffodil.lib.iapi.WithDiagnostics
@@ -227,7 +227,7 @@ class DataProcessor(
     os.write(headerString.getBytes(StandardCharsets.UTF_8))
 
     // serialize and compress the data processor to the outputstream
-    val oos = new ObjectOutputStream(new GZIPOutputStream(os))
+    val oos = new ObjectOutputStream(new DeterministicGZIPOutputStream(os))
 
     //
     // Make a copy of this object so that we can make its saved state

--- a/daffodil-core/src/test/scala/org/apache/daffodil/core/layers/TestGzipErrors.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/core/layers/TestGzipErrors.scala
@@ -27,6 +27,7 @@ import org.apache.daffodil.core.util.FuzzRandomSingleByte
 import org.apache.daffodil.core.util.FuzzZeroBits
 import org.apache.daffodil.core.util.LayerParseTester
 import org.apache.daffodil.core.util.TestUtils
+import org.apache.daffodil.layers.runtime1.DeterministicGZIPOutputStream
 import org.apache.daffodil.lib.util.*
 import org.apache.daffodil.lib.xml.XMLUtils
 
@@ -85,7 +86,7 @@ a few lines of pointless text like this.""".replace("\r\n", "\n").replace("\n", 
 
   def makeGZIPData(text: String) = {
     val baos = new ByteArrayOutputStream()
-    val gzos = new java.util.zip.GZIPOutputStream(baos)
+    val gzos = new DeterministicGZIPOutputStream(baos)
     IOUtils.write(text, gzos, StandardCharsets.UTF_8)
     gzos.close()
     val data = baos.toByteArray()

--- a/daffodil-core/src/test/scala/org/apache/daffodil/core/layers/TestLayers.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/core/layers/TestLayers.scala
@@ -24,6 +24,7 @@ import java.nio.charset.StandardCharsets
 import scala.jdk.CollectionConverters.*
 
 import org.apache.daffodil.core.util.TestUtils
+import org.apache.daffodil.layers.runtime1.DeterministicGZIPOutputStream
 import org.apache.daffodil.lib.util.*
 import org.apache.daffodil.lib.xml.XMLUtils
 
@@ -174,7 +175,7 @@ class TestLayers {
 
   def makeGZIPData(text: String) = {
     val baos = new ByteArrayOutputStream()
-    val gzos = new java.util.zip.GZIPOutputStream(baos)
+    val gzos = new DeterministicGZIPOutputStream(baos)
     IOUtils.write(text, gzos, StandardCharsets.UTF_8)
     gzos.close()
     val data = baos.toByteArray()

--- a/daffodil-core/src/test/scala/org/apache/daffodil/layers/TestJavaIOStreams.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/layers/TestJavaIOStreams.scala
@@ -24,6 +24,7 @@ import java.nio.charset.StandardCharsets
 import java.util.Scanner
 import scala.jdk.CollectionConverters.*
 
+import org.apache.daffodil.layers.runtime1.DeterministicGZIPOutputStream
 import org.apache.daffodil.lib.exceptions.Assert
 
 import org.apache.commons.io.IOUtils
@@ -73,7 +74,7 @@ ZyBzb2x1dGlvbnMuCg=="""
 
   val zipped = {
     val baos = new ByteArrayOutputStream()
-    val gzs = new java.util.zip.GZIPOutputStream(baos)
+    val gzs = new DeterministicGZIPOutputStream(baos)
     IOUtils.write(text, gzs, StandardCharsets.ISO_8859_1)
     gzs.close()
     val bytes = baos.toByteArray()

--- a/daffodil-core/src/test/scala/org/apache/daffodil/layers/TestLimitingJavaIOStreams.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/layers/TestLimitingJavaIOStreams.scala
@@ -23,6 +23,7 @@ import java.nio.charset.StandardCharsets
 
 import org.apache.daffodil.io.BoundaryMarkLimitingInputStream
 import org.apache.daffodil.io.RegexLimitingInputStream
+import org.apache.daffodil.layers.runtime1.DeterministicGZIPOutputStream
 import org.apache.daffodil.lib.exceptions.Assert
 
 import org.apache.commons.io.IOUtils
@@ -70,7 +71,7 @@ ZyBzb2x1dGlvbnMuCg=="""
 
   val zipped = {
     val baos = new ByteArrayOutputStream()
-    val gzs = new java.util.zip.GZIPOutputStream(baos)
+    val gzs = new DeterministicGZIPOutputStream(baos)
     IOUtils.write(text, gzs, iso8859)
     gzs.close()
     val bytes = baos.toByteArray()

--- a/daffodil-core/src/test/scala/org/apache/daffodil/layers/runtime1/TestGzipLayer.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/layers/runtime1/TestGzipLayer.scala
@@ -18,7 +18,6 @@
 package org.apache.daffodil.layers.runtime1
 
 import java.io.ByteArrayOutputStream
-import java.util.zip.GZIPOutputStream
 
 import org.apache.commons.io.IOUtils
 import org.junit.Assert.*
@@ -40,7 +39,7 @@ class TestGzipLayer {
     val baos = new ByteArrayOutputStream()
     val baosRaw = new ByteArrayOutputStream()
     val gzos = gl.wrapLayerOutput(baos)
-    val gzosRaw = new GZIPOutputStream(baosRaw)
+    val gzosRaw = new DeterministicGZIPOutputStream(baosRaw)
     val data = "testing 1, 2, 3"
     IOUtils.write(data, gzos, "ascii")
     IOUtils.write(data, gzosRaw, "ascii")


### PR DESCRIPTION

- Add DeterministicGZIPOutputStream subclass that sets Deflater.BEST_COMPRESSION (level 9)
- At DEFAULT_COMPRESSION (level 6), stock zlib and zlib-ng produce byte-different gzip output due to different match-finding heuristics
- At BEST_COMPRESSION (level 9), both implementations produce identical output.
- Note: BEST_COMPRESSION is slower than DEFAULT_COMPRESSION