### PR TITLE
Make codecov patch stats informational on the main branch

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -19,5 +19,9 @@ coverage:
     patch: 
       default:
         target: auto
+      main:
+        branches:
+          - main
+        informational: true
 
 comment: false


### PR DESCRIPTION
Sometimes we merge PRs that do not meet the codecov patch threshold, usually because it is not possible or requires too much effort to meet. This leads to a CI failure on the main branch when these PRs are merged.

But by merging a PR we are tacitly agreeing to accept whatever coverage it has and so we don't need to report CI failures that might hide actual failures.

This changes the codecov patch configuration for the main branch so it is informational only. CI will still run coverage and report the stats, but it should not cause CI to indicate coverage failures even if the patch threshold is not met.

DAFFODIL-3081