### PR TITLE
Replace deprecated URL constructor globally

### DIFF
--- a/daffodil-core/src/main/java/org/apache/daffodil/api/validation/package-info.java
+++ b/daffodil-core/src/main/java/org/apache/daffodil/api/validation/package-info.java
@@ -65,7 +65,7 @@
  *     <p><b>Example:</b></p>
  *     <pre>{@code
  * // enable XML schema validation, setting the "xerces" property to the schema.xsd file
- * dataProcessor.withValidation("xerces", new URL("file:///path/to/schema.xsd"))
+ * dataProcessor.withValidation("xerces", new URI("file:///path/to/schema.xsd").toURL)
  * }</pre>
  *   </dd>
  *
@@ -92,10 +92,10 @@
  *     <p><b>Example:</b></p>
  *     <pre>{@code
  * // enable schematron validation, setting the "schematron" property to the schematron.sch file
- * dataProcessor.withValidation("schematron", new URL("file:///path/to/schematron.sch"))
+ * dataProcessor.withValidation("schematron", new URI("file:///path/to/schematron.sch").toURL)
  *
  * // use schematron validation, reading the schematron.properties file to set "schematron" or other schematron properties
- * dataProcessor.withValidation("schematron", new URL("file:///path/to/schematron.properties"))
+ * dataProcessor.withValidation("schematron", new URI("file:///path/to/schematron.properties").toURL)
  * }</pre>
  *   </dd>
  * </dl>

--- a/daffodil-core/src/main/scala/org/apache/daffodil/validation/XercesValidator.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/validation/XercesValidator.scala
@@ -18,6 +18,7 @@
 package org.apache.daffodil.validation
 
 import java.io.IOException
+import java.net.URI
 import java.net.URL
 import java.util.Properties
 import javax.xml.XMLConstants
@@ -60,7 +61,7 @@ object XercesValidatorFactory {
           "invalid configuration: xerces property is empty or not defined"
         )
     }
-    val url = new URL(schemaFile)
+    val url = new URI(schemaFile).toURL
     XercesValidator.fromURL(url)
   }
 }

--- a/daffodil-core/src/test/scala/org/apache/daffodil/lib/util/TestXMLCatalogAndValidate.scala
+++ b/daffodil-core/src/test/scala/org/apache/daffodil/lib/util/TestXMLCatalogAndValidate.scala
@@ -291,9 +291,6 @@ object XMLLoaderFactory {
     val loader = new SchemaAwareFactoryAdapter()
     loader
   }
-
-  //  val doc = loader.load(new URL("http://horstmann.com/index.html"))
-  //  println(doc);
 }
 
 // From http://stackoverflow.com/questions/1627111/how-does-one-validate-the-schema-of-an-xml-file-using-scala

--- a/daffodil-schematron/src/main/scala/org/apache/daffodil/validation/schematron/SchematronValidatorFactory.scala
+++ b/daffodil-schematron/src/main/scala/org/apache/daffodil/validation/schematron/SchematronValidatorFactory.scala
@@ -19,7 +19,6 @@ package org.apache.daffodil.validation.schematron
 
 import java.io.InputStream
 import java.net.URI
-import java.net.URL
 import java.util.Properties
 
 import org.apache.daffodil.api
@@ -44,13 +43,13 @@ import net.sf.saxon.TransformerFactoryImpl
 object SchematronValidatorFactory {
   def makeValidator(config: Properties): SchematronValidator = {
     val schPathValue = config.getProperty(SchematronValidator.name)
-    val schUrl = new URL({
+    val schUrl = new URI({
       if (!Misc.isNullOrBlank(schPathValue)) schPathValue
       else
         throw new api.validation.ValidatorInitializationException(
           "invalid configuration: schematron property is empty or not defined"
         )
-    })
+    }).toURL
     val schStream =
       try {
         schUrl.openStream()

--- a/daffodil-test/src/test/scala/org/apache/daffodil/infoset/TestStringAsXmlValidator.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/infoset/TestStringAsXmlValidator.scala
@@ -17,7 +17,7 @@
 package org.apache.daffodil.infoset
 
 import java.io.InputStream
-import java.net.URL
+import java.net.URI
 import java.util.Properties
 
 import org.apache.daffodil.api.validation.ValidationHandler
@@ -30,7 +30,7 @@ object TestStringAsXmlValidator {
 }
 
 class TestStringAsXmlValidator(schemaURL: String) extends Validator {
-  private lazy val xercesValidator = XercesValidator.fromURL(new URL(schemaURL))
+  private lazy val xercesValidator = XercesValidator.fromURL(new URI(schemaURL).toURL)
 
   override def validateXML(document: InputStream, vh: ValidationHandler): Unit = {
     xercesValidator.validateXML(document, vh)


### PR DESCRIPTION
java.net.URL(String) has been deprecated since JDK 20, and causes the build to fail in some instances. Use the new URI(schemaFile).toURL instead, which is non-deprecated and available on all supported JDK versions.

DAFFODIL-3083