### PR TITLE
Small changes attempting to increase unparse performance

### DIFF
--- a/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/processors/EncodingRuntimeData.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/processors/EncodingRuntimeData.scala
@@ -122,7 +122,7 @@ final class EncodingRuntimeData(
   with ImplementsThrowsSDE
   with Serializable {
 
-  def runtimeDependencies = Vector(charsetEv)
+  val runtimeDependencies = Array[Evaluatable[AnyRef]](charsetEv)
 
   def getDecoderInfo(state: ParseOrUnparseState) = {
     val cs = charsetEv.evaluate(state)

--- a/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/processors/EvBinaryFloat.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/processors/EvBinaryFloat.scala
@@ -24,6 +24,6 @@ class BinaryFloatRepEv(expr: CompiledExpression[String], eci: DPathElementCompil
   extends EvaluatableConvertedExpression[String, BinaryFloatRep](expr, BinaryFloatRep, eci)
   with InfosetCachedEvaluatable[BinaryFloatRep] {
 
-  override def runtimeDependencies = Vector()
+  override val runtimeDependencies = Array()
 
 }

--- a/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/processors/EvByteOrder.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/processors/EvByteOrder.scala
@@ -28,7 +28,7 @@ import org.apache.daffodil.runtime1.dsom.*
 class ByteOrderEv(override val expr: CompiledExpression[String], eci: DPathElementCompileInfo)
   extends EvaluatableConvertedExpression[String, ByteOrder](expr, ByteOrder, eci)
   with InfosetCachedEvaluatable[ByteOrder] {
-  override def runtimeDependencies = Vector()
+  override val runtimeDependencies = Array()
 
 }
 
@@ -48,7 +48,7 @@ class CheckByteAndBitOrderEv(
 ) extends Evaluatable[Ok](t)
   with InfosetCachedEvaluatable[Ok] { // can't use unit here, not <: AnyRef
 
-  override def runtimeDependencies = Vector()
+  override val runtimeDependencies = Array()
 
   override final protected def compute(state: ParseOrUnparseState): Ok = {
     t match {
@@ -78,7 +78,7 @@ class CheckBitOrderAndCharsetEv(t: DPathCompileInfo, bitOrder: BitOrder, charset
   extends Evaluatable[Ok](t)
   with InfosetCachedEvaluatable[Ok] { // can't use unit here, not <: AnyRef
 
-  override def runtimeDependencies = Vector(charsetEv)
+  override val runtimeDependencies = Array(charsetEv)
 
   override final protected def compute(state: ParseOrUnparseState): Ok = {
     val bitsCharset = charsetEv.evaluate(state)

--- a/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/processors/EvCalendarLanguage.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/processors/EvCalendarLanguage.scala
@@ -58,7 +58,7 @@ class CalendarLanguageEv(
     eci
   )
   with InfosetCachedEvaluatable[ULocale] {
-  override def runtimeDependencies = Vector()
+  override val runtimeDependencies = Array()
 }
 
 class CalendarEv(
@@ -71,7 +71,7 @@ class CalendarEv(
 ) extends Evaluatable[Calendar](eci)
   with InfosetCachedEvaluatable[Calendar] {
 
-  override def runtimeDependencies = Seq(localeEv)
+  override val runtimeDependencies = Array(localeEv)
 
   override def compute(state: ParseOrUnparseState) = {
     // Used to configure the dataFormatter
@@ -107,7 +107,7 @@ class DateTimeFormatterEv(
 ) extends Evaluatable[ThreadSafePool[SimpleDateFormat]](eci)
   with InfosetCachedEvaluatable[ThreadSafePool[SimpleDateFormat]] {
 
-  override def runtimeDependencies = Seq(localeEv)
+  override val runtimeDependencies = Array(localeEv)
 
   override def compute(state: ParseOrUnparseState) = {
     val calendar = calendarEv.evaluate(state)

--- a/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/processors/EvDelimiters.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/processors/EvDelimiters.scala
@@ -60,7 +60,7 @@ abstract class DelimiterParseEv(
   with InfosetCachedEvaluatable[Array[DFADelimiter]]
   with DelimiterEvMixin[Array[DFADelimiter]] {
 
-  override def runtimeDependencies = Vector()
+  override val runtimeDependencies = Array()
 
   override protected def compute(state: ParseOrUnparseState): Array[DFADelimiter] = {
     if (state.isInstanceOf[UState]) {
@@ -85,7 +85,7 @@ abstract class DelimiterUnparseEv(
   with InfosetCachedEvaluatable[Array[DFADelimiter]]
   with DelimiterEvMixin[Array[DFADelimiter]] {
 
-  override def runtimeDependencies = Seq(outputNewLine)
+  override val runtimeDependencies = Array(outputNewLine)
 
   override protected def compute(state: ParseOrUnparseState): Array[DFADelimiter] = {
     if (state.isInstanceOf[PState]) {

--- a/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/processors/EvElement.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/processors/EvElement.scala
@@ -36,7 +36,7 @@ class ExplicitLengthEv(expr: CompiledExpression[JLong], ci: DPathCompileInfo)
   extends EvaluatableExpression[JLong](expr, ci)
   with LengthEv
   with InfosetCachedEvaluatable[JLong] {
-  override def runtimeDependencies = Vector()
+  override val runtimeDependencies = Array()
 
   /**
    * Length is special. For the dfdl:length property, when it's an expression
@@ -61,7 +61,7 @@ class ImplicitLengthEv(lengthValue: Long, ci: DPathElementCompileInfo)
   with LengthEv
   with NoCacheEvaluatable[JLong] {
 
-  override def runtimeDependencies = Vector()
+  override val runtimeDependencies = Array()
 
   private val jLength = JLong.valueOf(lengthValue)
 
@@ -161,7 +161,7 @@ class LengthInBitsEv(
   ci: DPathCompileInfo
 ) extends LengthInBitsEvBase(ci, lengthUnits, lengthKind) {
 
-  override def runtimeDependencies = maybeCharsetEv.toList :+ lengthEv
+  override val runtimeDependencies = Array(lengthEv) ++ maybeCharsetEv.toList
 
   override protected def lengthInLengthUnits(state: ParseOrUnparseState) =
     lengthEv.evaluate(state).longValue()
@@ -183,7 +183,7 @@ class MinLengthInBitsEv(
   ci: DPathCompileInfo
 ) extends LengthInBitsEvBase(ci, lengthUnits, lengthKind) {
 
-  override def runtimeDependencies = maybeCharsetEv.toList
+  override val runtimeDependencies = maybeCharsetEv.toList.toArray
 
   override protected def lengthInLengthUnits(state: ParseOrUnparseState) = minLen
 }
@@ -206,7 +206,7 @@ class UnparseTargetLengthInBitsEv(
 ) extends Evaluatable[MaybeJULong](ci)
   with InfosetCachedEvaluatable[MaybeJULong] {
 
-  override def runtimeDependencies = Vector(this.lengthInBitsEv, this.minLengthInBitsEv)
+  override val runtimeDependencies = Array(this.lengthInBitsEv, this.minLengthInBitsEv)
 
   /**
    * Note: use of MaybeJULong type. New Maybe type added which can be stored in
@@ -242,7 +242,7 @@ class UnparseTargetLengthInCharactersEv(
 ) extends Evaluatable[MaybeJULong](ci)
   with InfosetCachedEvaluatable[MaybeJULong] {
 
-  override def runtimeDependencies = Vector(this.lengthEv, charsetEv)
+  override val runtimeDependencies = Array(this.lengthEv, charsetEv)
 
   /**
    * Note: use of MaybeJULong type. New Maybe type added which can be stored in
@@ -268,17 +268,17 @@ class UnparseTargetLengthInCharactersEv(
 class OccursCountEv(expr: CompiledExpression[JLong], ci: DPathElementCompileInfo)
   extends EvaluatableExpression[JLong](expr, ci)
   with InfosetCachedEvaluatable[JLong] {
-  override def runtimeDependencies = Vector()
+  override val runtimeDependencies = Array()
 }
 
 class OutputNewLineEv(expr: CompiledExpression[String], ci: DPathCompileInfo)
   extends EvaluatableConvertedExpression[String, String](expr, OutputNewLineCooker, ci)
   with InfosetCachedEvaluatable[String] {
-  override def runtimeDependencies = Vector()
+  override val runtimeDependencies = Array()
 }
 
 class ChoiceDispatchKeyEv(expr: CompiledExpression[String], ci: DPathCompileInfo)
   extends EvaluatableConvertedExpression[String, String](expr, ChoiceDispatchKeyCooker, ci)
   with InfosetCachedEvaluatable[String] {
-  override def runtimeDependencies = Vector()
+  override val runtimeDependencies = Array()
 }

--- a/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/processors/EvEncoding.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/processors/EvEncoding.scala
@@ -58,7 +58,7 @@ abstract class EncodingEvBase(
     tci
   )
   with InfosetCachedEvaluatable[String] {
-  override def runtimeDependencies = Vector()
+  override val runtimeDependencies = Array()
 
   override protected def compute(state: ParseOrUnparseState): String = {
     // compute via the cooker first
@@ -85,7 +85,7 @@ abstract class CharsetEvBase(encodingEv: EncodingEvBase, tci: DPathCompileInfo)
   extends Evaluatable[BitsCharset](tci)
   with InfosetCachedEvaluatable[BitsCharset] {
 
-  override def runtimeDependencies = Seq(encodingEv)
+  override val runtimeDependencies = Array(encodingEv)
 
   private def checkCharset(state: ParseOrUnparseState, bitsCharset: BitsCharset): Unit = {
     if (bitsCharset.bitWidthOfACodeUnit != 8) {
@@ -120,7 +120,7 @@ class FillByteEv(fillByteRaw: String, charsetEv: CharsetEv, tci: DPathCompileInf
   extends Evaluatable[Integer](tci)
   with InfosetCachedEvaluatable[Integer] {
 
-  override def runtimeDependencies = Seq(charsetEv)
+  override val runtimeDependencies = Array(charsetEv)
 
   private val maybeSingleRawByteValue: MaybeInt = {
     val RawByte = """\%\#r([0-9a-fA-F]{2})\;""".r

--- a/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/processors/EvEscapeSchemes.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/processors/EvEscapeSchemes.scala
@@ -33,13 +33,13 @@ import org.apache.daffodil.runtime1.processors.unparsers.UState
 class EscapeCharEv(expr: CompiledExpression[String], ci: DPathCompileInfo)
   extends EvaluatableConvertedExpression[String, String](expr, EscapeCharacterCooker, ci)
   with InfosetCachedEvaluatable[String] {
-  override def runtimeDependencies = Vector()
+  override val runtimeDependencies = Array()
 }
 
 class EscapeEscapeCharEv(expr: CompiledExpression[String], ci: DPathCompileInfo)
   extends EvaluatableConvertedExpression[String, String](expr, EscapeEscapeCharacterCooker, ci)
   with InfosetCachedEvaluatable[String] {
-  override def runtimeDependencies = Vector()
+  override val runtimeDependencies = Array()
 }
 class ExtraEscapedCharsEv(expr: CompiledExpression[String], ci: DPathCompileInfo)
   extends EvaluatableConvertedExpression[String, Seq[String]](
@@ -48,7 +48,7 @@ class ExtraEscapedCharsEv(expr: CompiledExpression[String], ci: DPathCompileInfo
     ci
   )
   with InfosetCachedEvaluatable[Seq[String]] {
-  override def runtimeDependencies = Vector()
+  override val runtimeDependencies = Array()
 }
 
 trait EscapeSchemeCommonEv {
@@ -103,7 +103,7 @@ class EscapeSchemeCharParseEv(
   ci: DPathCompileInfo
 ) extends EscapeSchemeParseEv(ci) {
 
-  override def runtimeDependencies = Vector(escapeChar) ++ optEscapeEscapeChar.toList
+  override val runtimeDependencies = Array(escapeChar) ++ optEscapeEscapeChar.toList
 
   def compute(state: ParseOrUnparseState) = {
     val escChar = escapeChar.evaluate(state).charAt(0)
@@ -119,8 +119,8 @@ class EscapeSchemeCharUnparseEv(
   ci: DPathCompileInfo
 ) extends EscapeSchemeUnparseEv(ci) {
 
-  override def runtimeDependencies =
-    Vector(escapeChar) ++ optEscapeEscapeChar.toList ++ extraEscapedChars.toList
+  override val runtimeDependencies =
+    Array(escapeChar) ++ optEscapeEscapeChar.toList ++ extraEscapedChars.toList
 
   def compute(state: ParseOrUnparseState) = {
     val escChar = escapeChar.evaluate(state).charAt(0)
@@ -142,7 +142,7 @@ class EscapeSchemeBlockParseEv(
   ci: DPathCompileInfo
 ) extends EscapeSchemeParseEv(ci) {
 
-  override def runtimeDependencies = optEscapeEscapeChar.toList
+  override val runtimeDependencies = optEscapeEscapeChar.toList.toArray
 
   val bs = EscapeBlockStartCooker.convertConstant(blockStart, ci, forUnparse = false)
   val be = EscapeBlockEndCooker.convertConstant(blockEnd, ci, forUnparse = false)
@@ -162,7 +162,8 @@ class EscapeSchemeBlockUnparseEv(
   ci: DPathCompileInfo
 ) extends EscapeSchemeUnparseEv(ci) {
 
-  override def runtimeDependencies = optEscapeEscapeChar.toList ++ extraEscapedChars.toList
+  override val runtimeDependencies =
+    (optEscapeEscapeChar.toList ++ extraEscapedChars.toList).toArray
 
   val bs = EscapeBlockStartCooker.convertConstant(blockStart, ci, forUnparse = true)
   val be = EscapeBlockEndCooker.convertConstant(blockEnd, ci, forUnparse = true)

--- a/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/processors/EvFieldDFA.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/processors/EvFieldDFA.scala
@@ -26,7 +26,7 @@ class FieldDFAParseEv(val escapeSchemeEv: Maybe[EscapeSchemeParseEv], ci: DPathC
   extends Evaluatable[DFAField](ci)
   with InfosetCachedEvaluatable[DFAField] {
 
-  override def runtimeDependencies = escapeSchemeEv.toList
+  override val runtimeDependencies = escapeSchemeEv.toList.toArray
 
   def compute(state: ParseOrUnparseState) = {
 

--- a/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/processors/EvTextNumber.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/processors/EvTextNumber.scala
@@ -45,7 +45,7 @@ class TextStandardDecimalSeparatorEv(expr: CompiledExpression[String], tci: DPat
     tci
   )
   with InfosetCachedEvaluatable[List[String]] {
-  override def runtimeDependencies = Vector()
+  override val runtimeDependencies = Array()
 }
 
 class TextStandardGroupingSeparatorEv(expr: CompiledExpression[String], tci: DPathCompileInfo)
@@ -55,7 +55,7 @@ class TextStandardGroupingSeparatorEv(expr: CompiledExpression[String], tci: DPa
     tci
   )
   with InfosetCachedEvaluatable[String] {
-  override def runtimeDependencies = Vector()
+  override val runtimeDependencies = Array()
 }
 
 class TextStandardExponentRepEv(expr: CompiledExpression[String], tci: DPathCompileInfo)
@@ -65,7 +65,7 @@ class TextStandardExponentRepEv(expr: CompiledExpression[String], tci: DPathComp
     tci
   )
   with InfosetCachedEvaluatable[String] {
-  override def runtimeDependencies = Vector()
+  override val runtimeDependencies = Array()
 }
 
 class TextNumberFormatEv(
@@ -86,8 +86,8 @@ class TextNumberFormatEv(
 ) extends Evaluatable[DecimalFormat](tci)
   with InfosetCachedEvaluatable[DecimalFormat] {
 
-  override def runtimeDependencies =
-    (decimalSepEv.toList ++ groupingSepEv.toList ++ exponentRepEv.toList).toVector
+  override val runtimeDependencies =
+    (decimalSepEv.toList ++ groupingSepEv.toList ++ exponentRepEv.toList).toArray
 
   private def checkUnique(
     decimalSep: MaybeChar,
@@ -245,7 +245,7 @@ class TextBooleanTrueRepEv(
     tci
   )
   with InfosetCachedEvaluatable[List[String]] {
-  override def runtimeDependencies = Vector()
+  override val runtimeDependencies = Array()
 
   override final protected def compute(state: ParseOrUnparseState): List[String] = {
     if (mustBeSameLength) {
@@ -279,5 +279,5 @@ class TextBooleanFalseRepEv(expr: CompiledExpression[String], tci: DPathCompileI
     tci
   )
   with InfosetCachedEvaluatable[List[String]] {
-  override def runtimeDependencies = Vector()
+  override val runtimeDependencies = Array()
 }

--- a/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/processors/Evaluatable.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/processors/Evaluatable.scala
@@ -175,7 +175,7 @@ abstract class Evaluatable[+T <: AnyRef](
    * Important - Evalutables MUST declare all evaluatables they depend on. But only those
    * they directly depend on. (Not the dependents of the dependents...)
    */
-  def runtimeDependencies: Seq[Evaluatable[AnyRef]]
+  val runtimeDependencies: Array[Evaluatable[AnyRef]]
 
   /**
    * Been compiled yet?
@@ -453,7 +453,7 @@ abstract class EvaluatableExpression[ExprType <: AnyRef](
 ) extends Evaluatable[ExprType](ci)
   with ExprEvalMixin[ExprType] {
 
-  override def runtimeDependencies = Vector()
+  override val runtimeDependencies = Array()
 
   override final def toBriefXML(depth: Int = -1) =
     "<EvaluatableExpression eName='" + ci.diagnosticDebugName + "' expr=" + expr
@@ -475,7 +475,7 @@ trait EvaluatableConvertedExpressionMixin[ExprType <: AnyRef, +ConvertedType <: 
 
   protected def converter: Converter[ExprType, ConvertedType]
 
-  override def runtimeDependencies = Vector()
+  override val runtimeDependencies = Array[Evaluatable[AnyRef]]()
 
   override final def toBriefXML(depth: Int = -1) =
     if (this.isConstant) this.constValue.toString else expr.toBriefXML(depth)

--- a/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/processors/PackedBinaryTraits.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/processors/PackedBinaryTraits.scala
@@ -93,7 +93,7 @@ abstract class PackedBinaryDecimalBaseParser(
 ) extends PrimParser
   with PackedBinaryConversion[JBigDecimal]
   with PackedBinaryLengthCheck {
-  override def runtimeDependencies = Vector()
+  override val runtimeDependencies = Array()
 
   protected def getBitLength(s: ParseOrUnparseState): Int
 
@@ -138,7 +138,7 @@ abstract class PackedBinaryIntegerBaseParser(
 ) extends PrimParser
   with PackedBinaryConversion[JBigInteger]
   with PackedBinaryLengthCheck {
-  override def runtimeDependencies = Vector()
+  override val runtimeDependencies = Array()
 
   protected def getBitLength(s: ParseOrUnparseState): Int
 

--- a/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/processors/ProcessorBases.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/processors/ProcessorBases.scala
@@ -51,7 +51,7 @@ trait Processor extends ToBriefXMLImpl with Serializable {
   // things common to both unparser and parser go here.
   def context: RuntimeData
   override def childProcessors: Vector[Processor]
-  def runtimeDependencies: Vector[Evaluatable[AnyRef]]
+  val runtimeDependencies: Array[Evaluatable[AnyRef]]
 
   var isInitialized: Boolean = false
 

--- a/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/processors/VariableMap1.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/processors/VariableMap1.scala
@@ -121,7 +121,7 @@ class VariableInstance private (val rd: VariableRuntimeData) extends Serializabl
   }
 
   override def toString: String =
-    "VariableInstance(%s,%s,%s,%s)".format(state, value, rd, rd.maybeDefaultValueExpr)
+    s"VariableInstance($state,$value,$rd,${rd.maybeDefaultValueExpr})"
 
   def copy(
     state: VariableState = state,
@@ -164,8 +164,7 @@ class VariableHasNoValue(qname: NamedQName, context: VariableRuntimeData)
   extends VariableException(
     qname,
     context,
-    "Variable map (runtime): variable %s has no value. It was not set, and has no default value."
-      .format(qname)
+    s"Variable map (runtime): variable $qname has no value. It was not set, and has no default value."
   )
   with RetryableException
 
@@ -173,7 +172,7 @@ class VariableSuspended(qname: NamedQName, context: VariableRuntimeData)
   extends VariableException(
     qname,
     context,
-    "Variable map (runtime): variable %s is currently suspended".format(qname)
+    s"Variable map (runtime): variable $qname is currently suspended"
   )
   with RetryableException
 
@@ -186,8 +185,7 @@ class VariableCircularDefinition(qname: NamedQName, context: VariableRuntimeData
   extends VariableException(
     qname,
     context,
-    "Variable map (runtime): variable %s is part of a circular definition with other variables"
-      .format(qname)
+    s"Variable map (runtime): variable $qname is part of a circular definition with other variables"
   )
 
 /**
@@ -367,15 +365,11 @@ class VariableMap private (
     vrd.direction match {
       case VariableDirection.ParseOnly if (!state.isInstanceOf[PState]) =>
         state.SDE(
-          "Attempting to read variable %s which is marked as parseOnly during unparsing".format(
-            varQName
-          )
+          s"Attempting to read variable $varQName which is marked as parseOnly during unparsing"
         )
       case VariableDirection.UnparseOnly if (!state.isInstanceOf[UState]) =>
         state.SDE(
-          "Attempting to read variable %s which is marked as unparseOnly during parsing".format(
-            varQName
-          )
+          s"Attempting to read variable $varQName which is marked as unparseOnly during parsing"
         )
       case _ => // Do nothing
     }
@@ -538,8 +532,7 @@ class VariableMap private (
           case 1 => Some(vTable(candidates.head.vmapIndex))
           case _ => {
             val msg =
-              "External variable binding %s is ambiguous. A namespace is required to resolve the ambiguity. Found variables: %s"
-                .format(bindingQName, candidates.map(_.globalQName.toString).mkString(", "))
+              s"External variable binding $bindingQName is ambiguous. A namespace is required to resolve the ambiguity. Found variables: ${candidates.map(_.globalQName.toString).mkString(", ")}"
             throw new ExternalVariableException(msg)
           }
         }
@@ -570,11 +563,8 @@ class VariableMap private (
                 variable.rd.primType.fromXMLString(newValue)
               } catch {
                 case e: InvalidPrimitiveDataException => {
-                  val msg = "Value for variable %s is not a valid %s: %s".format(
-                    variable.rd.globalQName,
-                    variable.rd.primType.globalQName,
-                    newValue
-                  )
+                  val msg =
+                    s"Value for variable ${variable.rd.globalQName} is not a valid ${variable.rd.primType.globalQName}: $newValue"
                   throw new ExternalVariableException(msg)
                 }
               }

--- a/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/AssertPatternParsers.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/AssertPatternParsers.scala
@@ -73,7 +73,7 @@ class AssertPatternParser(
   override val failureType: FailureType
 ) extends PrimParser
   with AssertParserMixin {
-  override def runtimeDependencies = Vector()
+  override val runtimeDependencies = Array()
 
   override def toBriefXML(depthLimit: Int = -1) = {
     val kindString = if (discrim) "Discriminator" else "Assertion"

--- a/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/BinaryBooleanParsers.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/BinaryBooleanParsers.scala
@@ -93,7 +93,7 @@ class BinaryBooleanParser(
   lengthKind: LengthKind
 ) extends BinaryBooleanParserBase(binaryBooleanTrueRep, binaryBooleanFalseRep, lengthUnits) {
 
-  override def runtimeDependencies = Vector(lengthEv)
+  override val runtimeDependencies = Array(lengthEv)
 
   override def getBitLength(state: PState): Int = {
     val nBytesAsJLong = lengthEv.evaluate(state)
@@ -113,7 +113,7 @@ class BinaryBooleanBitLimitLengthParser(
 ) extends BinaryBooleanParserBase(binaryBooleanTrueRep, binaryBooleanFalseRep, lengthUnits)
   with BitLengthFromBitLimitMixin {
 
-  override def runtimeDependencies = Vector()
+  override val runtimeDependencies = Array()
 
   override def getBitLength(state: PState): Int = {
     getLengthInBits(state).toInt

--- a/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/BinaryNumberParsers.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/BinaryNumberParsers.scala
@@ -31,7 +31,7 @@ import org.apache.daffodil.runtime1.processors.ParseOrUnparseState
 import org.apache.daffodil.runtime1.processors.unparsers.UState
 
 class BinaryFloatParser(override val context: ElementRuntimeData) extends PrimParser {
-  override def runtimeDependencies = Vector()
+  override val runtimeDependencies = Array()
 
   def parse(start: PState): Unit = {
     val dis = start.dataInputStream
@@ -47,7 +47,7 @@ class BinaryFloatParser(override val context: ElementRuntimeData) extends PrimPa
 }
 
 class BinaryDoubleParser(override val context: ElementRuntimeData) extends PrimParser {
-  override def runtimeDependencies = Vector()
+  override val runtimeDependencies = Array()
 
   def parse(start: PState): Unit = {
     val dis = start.dataInputStream
@@ -92,7 +92,7 @@ abstract class BinaryDecimalParserBase(
   binaryDecimalVirtualPoint: Int
 ) extends PrimParser
   with BinaryNumberCheckWidth {
-  override def runtimeDependencies = Vector()
+  override val runtimeDependencies = Array()
 
   protected def getBitLength(s: ParseOrUnparseState): Int
 
@@ -138,7 +138,7 @@ abstract class BinaryIntegerBaseParser(
   override val context: ElementRuntimeData
 ) extends PrimParser
   with BinaryNumberCheckWidth {
-  override def runtimeDependencies = Vector()
+  override val runtimeDependencies = Array()
 
   protected def getBitLength(s: ParseOrUnparseState): Int
 

--- a/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/BlobLengthParsers.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/BlobLengthParsers.scala
@@ -105,7 +105,7 @@ sealed abstract class BlobLengthParser(override val context: ElementRuntimeData)
 final class BlobSpecifiedLengthParser(erd: ElementRuntimeData, lengthEv: LengthInBitsEv)
   extends BlobLengthParser(erd) {
 
-  override def runtimeDependencies = Vector(lengthEv)
+  override val runtimeDependencies = Array(lengthEv)
 
   override def getLengthInBits(pstate: PState): Long = {
     lengthEv.evaluate(pstate).get

--- a/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/ConvertTextStandardNumberParser.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/ConvertTextStandardNumberParser.scala
@@ -43,7 +43,7 @@ case class ConvertTextCombinatorParser(
   converterParser: Parser
 ) extends CombinatorParser(rd) {
 
-  override def runtimeDependencies = Vector()
+  override val runtimeDependencies = Array()
 
   override def childProcessors = Vector(valueParser, converterParser)
 
@@ -166,7 +166,7 @@ case class ConvertTextStandardNumberParser(
 ) extends TextPrimParser
   with TextDecimalVirtualPointMixin {
 
-  override def runtimeDependencies = Vector(textNumberFormatEv)
+  override val runtimeDependencies = Array(textNumberFormatEv)
 
   private val primNumeric = context.optPrimType.get.asInstanceOf[NodeInfo.PrimType.PrimNumeric]
 

--- a/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/DelimitedParsers.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/DelimitedParsers.scala
@@ -50,7 +50,7 @@ class StringDelimitedParser(
 ) extends TextPrimParser
   with CaptureParsingValueLength {
 
-  override def runtimeDependencies = Vector(fieldDFAEv, context.encInfo.charsetEv)
+  override val runtimeDependencies = Array(fieldDFAEv, context.encInfo.charsetEv)
 
   override val charsetEv = context.encInfo.charsetEv
 

--- a/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/DelimiterParsers.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/DelimiterParsers.scala
@@ -51,7 +51,7 @@ class DelimiterTextParser(
   mustMatchNonZeroData: Boolean
 ) extends TextPrimParser {
 
-  override def runtimeDependencies = rd.encodingInfo.runtimeDependencies
+  override val runtimeDependencies = rd.encodingInfo.runtimeDependencies
   override def context = rd
 
   override val nom = delimiterType.toString

--- a/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/ElementCombinator1.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/ElementCombinator1.scala
@@ -44,7 +44,7 @@ abstract class ElementParserBase(
   eRepTypeParser: Maybe[Parser]
 ) extends CombinatorParser(erd) {
 
-  override def runtimeDependencies = Vector()
+  override val runtimeDependencies = Array()
 
   def move(pstate: PState): Unit // implement for different kinds of "moving over to next thing"
   def parseBegin(pstate: PState): Unit

--- a/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/ElementKindParsers.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/ElementKindParsers.scala
@@ -34,7 +34,7 @@ import org.apache.daffodil.runtime1.processors.TermRuntimeData
 class ComplexTypeParser(rd: RuntimeData, bodyParser: Parser) extends CombinatorParser(rd) {
   override def nom = "ComplexType"
 
-  override def runtimeDependencies = Vector()
+  override val runtimeDependencies = Array()
 
   override def childProcessors = Vector(bodyParser)
 
@@ -61,7 +61,7 @@ class DelimiterStackParser(
 
   override def childProcessors = Vector(bodyParser)
 
-  override def runtimeDependencies = delimiters.toVector
+  override val runtimeDependencies = delimiters.toArray
 
   def parse(start: PState): Unit = {
 
@@ -105,7 +105,7 @@ class DynamicEscapeSchemeParser(
 
   override def childProcessors = Vector(bodyParser)
 
-  override def runtimeDependencies = Vector(escapeScheme)
+  override val runtimeDependencies = Array(escapeScheme)
 
   def parse(start: PState): Unit = {
     // evaluate the dynamic escape scheme in the correct scope. the resulting
@@ -131,7 +131,7 @@ class DynamicEscapeSchemeParser(
  */
 class ChoiceBranchEmptyParser(val context: RuntimeData) extends PrimParserNoData {
 
-  override def runtimeDependencies = Vector()
+  override val runtimeDependencies = Array()
 
   def parse(state: PState): Unit = {
     // do nothing
@@ -150,7 +150,7 @@ abstract class ChoiceDispatchCombinatorParserBase(
 
   override def nom = "ChoiceDispatch"
 
-  override def runtimeDependencies = Vector()
+  override val runtimeDependencies = Array()
 
   override def childProcessors =
     dispatchBranchKeyMap.values.iterator.asScala.map(_._1).toVector ++

--- a/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/ExpressionEvaluatingParsers.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/ExpressionEvaluatingParsers.scala
@@ -42,7 +42,7 @@ abstract class ExpressionEvaluationParser(
 
   override val context: RuntimeData = contextParam
 
-  override def runtimeDependencies = Vector()
+  override val runtimeDependencies = Array()
 
   override def childProcessors = Vector()
 
@@ -90,7 +90,7 @@ final class NewVariableInstanceStartParser(vrd: VariableRuntimeData, trd: TermRu
 
   override def context = trd
 
-  override def runtimeDependencies = Vector()
+  override val runtimeDependencies = Array()
 
   def parse(start: PState): Unit = {
     val nvi = start.newVariableInstance(vrd)
@@ -111,7 +111,7 @@ final class NewVariableInstanceEndParser(vrd: VariableRuntimeData, trd: TermRunt
   extends PrimParser {
 
   override def context = trd
-  override def runtimeDependencies = Vector()
+  override val runtimeDependencies = Array()
 
   def parse(start: PState) = {
     start.removeVariableInstance(vrd)

--- a/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/FramingParsers.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/FramingParsers.scala
@@ -23,7 +23,7 @@ import org.apache.daffodil.runtime1.processors.TextProcessor
 class SkipRegionParser(skipInBits: Int, override val context: TermRuntimeData)
   extends PrimParser {
 
-  override def runtimeDependencies = Vector()
+  override val runtimeDependencies = Array()
 
   override def parse(pstate: PState) = {
     val dis = pstate.dataInputStream
@@ -34,7 +34,7 @@ class SkipRegionParser(skipInBits: Int, override val context: TermRuntimeData)
 class AlignmentFillParser(alignmentInBits: Int, override val context: TermRuntimeData)
   extends PrimParser {
 
-  override def runtimeDependencies = Vector()
+  override val runtimeDependencies = Array()
 
   override def parse(pstate: PState): Unit = {
     val dis = pstate.dataInputStream

--- a/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/HexBinaryLengthParsers.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/HexBinaryLengthParsers.scala
@@ -75,7 +75,7 @@ sealed abstract class HexBinaryLengthParser(override val context: ElementRuntime
 final class HexBinarySpecifiedLengthParser(erd: ElementRuntimeData, lengthEv: LengthInBitsEv)
   extends HexBinaryLengthParser(erd) {
 
-  override def runtimeDependencies = Vector(lengthEv)
+  override val runtimeDependencies = Array(lengthEv)
 
   override def getLengthInBits(pstate: PState): Long = {
     lengthEv.evaluate(pstate).get
@@ -86,7 +86,7 @@ final class HexBinarySpecifiedLengthParser(erd: ElementRuntimeData, lengthEv: Le
 final class HexBinaryEndOfBitLimitParser(erd: ElementRuntimeData)
   extends HexBinaryLengthParser(erd) {
 
-  override def runtimeDependencies = Vector()
+  override val runtimeDependencies = Array()
 
   override def getLengthInBits(pstate: PState): Long = {
     pstate.bitLimit0b.get - pstate.bitPos0b

--- a/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/HiddenGroupCombinatorParser.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/HiddenGroupCombinatorParser.scala
@@ -30,7 +30,7 @@ class HiddenGroupCombinatorParser(ctxt: ModelGroupRuntimeData, bodyParser: Parse
 
   override def childProcessors = Vector(bodyParser)
 
-  override def runtimeDependencies = Vector()
+  override val runtimeDependencies = Array()
 
   def parse(start: PState): Unit = {
     try {

--- a/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/InitiatedContentParsers.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/InitiatedContentParsers.scala
@@ -24,7 +24,7 @@ final class InitiatedContentDiscrimOnIndexGreaterThanMinParser(
   min: Int,
   override val context: ElementRuntimeData
 ) extends PrimParser {
-  override def runtimeDependencies = Vector()
+  override val runtimeDependencies = Array()
 
   final def parse(start: PState): Unit = {
     if (start.arrayIterationPos > min)
@@ -34,7 +34,7 @@ final class InitiatedContentDiscrimOnIndexGreaterThanMinParser(
 
 final class InitiatedContentDiscrimChoiceParser(override val context: TermRuntimeData)
   extends PrimParser {
-  override def runtimeDependencies = Vector()
+  override val runtimeDependencies = Array()
 
   final def parse(start: PState): Unit = {
     start.resolvePointOfUncertainty()
@@ -44,7 +44,7 @@ final class InitiatedContentDiscrimChoiceParser(override val context: TermRuntim
 final class InitiatedContentDiscrimChoiceOnlyOnFirstIndexParser(
   override val context: TermRuntimeData
 ) extends PrimParser {
-  override def runtimeDependencies = Vector()
+  override val runtimeDependencies = Array()
 
   final def parse(start: PState): Unit = {
     if (start.arrayIterationPos == 1)
@@ -56,7 +56,7 @@ final class InitiatedContentDiscrimChoiceAndIndexGreaterThanMinParser(
   min: Int,
   override val context: ElementRuntimeData
 ) extends PrimParser {
-  override def runtimeDependencies = Vector()
+  override val runtimeDependencies = Array()
 
   final def parse(start: PState): Unit = {
     // Resolves PoUs associated with arrays with some minimum number of

--- a/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/NilEmptyCombinatorParsers.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/NilEmptyCombinatorParsers.scala
@@ -24,7 +24,7 @@ abstract class NilOrValueParser(ctxt: TermRuntimeData, nilParser: Parser, valueP
   extends CombinatorParser(ctxt) {
 
   override def childProcessors = Vector(nilParser, valueParser)
-  override def runtimeDependencies = Vector()
+  override val runtimeDependencies = Array()
 
   def parse(pstate: PState): Unit = {
 

--- a/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/NilParsers.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/NilParsers.scala
@@ -28,7 +28,7 @@ abstract class LiteralNilOfSpecifiedLengthParserBase(erd: ElementRuntimeData)
 
   private val eName = erd.name
 
-  override def runtimeDependencies = Vector(erd.encInfo.charsetEv)
+  override val runtimeDependencies = Array(erd.encInfo.charsetEv)
   override val context = erd
 
   override val charsetEv = erd.encInfo.charsetEv

--- a/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/NonBaseTenTextNumberParser.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/NonBaseTenTextNumberParser.scala
@@ -26,7 +26,7 @@ import org.apache.daffodil.runtime1.processors.ElementRuntimeData
 class ConvertNonBaseTenTextNumberParser(override val context: ElementRuntimeData, base: Int)
   extends TextPrimParser {
 
-  override def runtimeDependencies = Vector()
+  override val runtimeDependencies = Array()
 
   private val primNumeric = context.optPrimType.get.asInstanceOf[NodeInfo.PrimType.PrimNumeric]
 

--- a/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/Parser.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/Parser.scala
@@ -212,7 +212,7 @@ trait TextPrimParser extends PrimParser with TextProcessor
  * optimized out.
  */
 final class NadaParser(override val context: RuntimeData) extends PrimParserNoData {
-  override def runtimeDependencies: Vector[Evaluatable[AnyRef]] = Vector()
+  override val runtimeDependencies: Array[Evaluatable[AnyRef]] = Array()
 
   override def isEmpty = true
 
@@ -232,7 +232,7 @@ final class SeqCompParser(
   val childParsers: Array[Parser],
   testAssert: Array[Parser]
 ) extends CombinatorParser(context) {
-  override def runtimeDependencies = Vector()
+  override val runtimeDependencies = Array()
   override def childProcessors = childParsers.toVector
 
   override def nom = "seq"
@@ -265,7 +265,7 @@ final class SeqCompParser(
 
 class ChoiceParser(ctxt: RuntimeData, val childParsers: Array[Parser])
   extends CombinatorParser(ctxt) {
-  override def runtimeDependencies = Vector()
+  override val runtimeDependencies = Array()
   override def childProcessors = childParsers.toVector
 
   override def nom = "choice"
@@ -325,7 +325,7 @@ class ChoiceParser(ctxt: RuntimeData, val childParsers: Array[Parser])
 }
 
 case class DummyParser(override val context: TermRuntimeData) extends PrimParserNoData {
-  override def runtimeDependencies: Vector[Evaluatable[AnyRef]] = Vector()
+  override val runtimeDependencies: Array[Evaluatable[AnyRef]] = Array()
 
   def parse(pstate: PState): Unit =
     pstate.SDE("Parser for " + context + " is not yet implemented.")
@@ -349,5 +349,5 @@ case class NotParsableParser(context: ElementRuntimeData) extends PrimParserNoDa
   }
 
   override def childProcessors = Vector()
-  override def runtimeDependencies = Vector()
+  override val runtimeDependencies = Array()
 }

--- a/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/PrimitivesDateTime1.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/PrimitivesDateTime1.scala
@@ -41,7 +41,7 @@ case class ConvertTextCalendarParser(
   dateTimeFormatterEv: DateTimeFormatterEv
 ) extends TextPrimParser {
 
-  override def runtimeDependencies = Vector(calendarEv, dateTimeFormatterEv)
+  override val runtimeDependencies = Array(calendarEv, dateTimeFormatterEv)
 
   def parse(start: PState): Unit = {
     val node = start.simpleElement
@@ -135,7 +135,7 @@ case class ConvertBinaryCalendarSecMilliParser(
   lengthInBits: Int
 ) extends PrimParser {
 
-  override def runtimeDependencies = Vector()
+  override val runtimeDependencies = Array()
 
   def parse(start: PState): Unit = {
 

--- a/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/RepTypeParsers.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/RepTypeParsers.scala
@@ -100,7 +100,7 @@ class RepTypeParser(
   with WithDetachedParser {
 
   override def childProcessors = Vector(repTypeParser)
-  override def runtimeDependencies = Vector()
+  override val runtimeDependencies = Array()
 
   override def parse(pstate: PState): Unit = {
     val repValue =

--- a/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/SeparatedSequenceParsers.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/SeparatedSequenceParsers.scala
@@ -131,7 +131,7 @@ final class OrderedSeparatedSequenceParser(
   override val childParsers: Array[SequenceChildParser]
 ) extends SequenceParserBase(rd, isOrdered = true) {
 
-  override def runtimeDependencies = Vector()
+  override val runtimeDependencies = Array()
   override def childProcessors = (sep +: childParsers).toVector
 }
 
@@ -142,6 +142,6 @@ final class UnorderedSeparatedSequenceParser(
   override val childParsers: Array[SequenceChildParser]
 ) extends SequenceParserBase(rd, isOrdered = false) {
 
-  override def runtimeDependencies = Vector()
+  override val runtimeDependencies = Array()
   override def childProcessors = (sep +: childParsers).toVector
 }

--- a/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/SequenceChildBases.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/SequenceChildBases.scala
@@ -202,7 +202,7 @@ abstract class SequenceChildParser(
 
   override def childProcessors: Vector[Processor] = Vector(childParser)
 
-  override def runtimeDependencies: Vector[Evaluatable[AnyRef]] = Vector()
+  override val runtimeDependencies: Array[Evaluatable[AnyRef]] = Array()
 
   final override def parse(pstate: PState): Unit =
     Assert.usageError("Not to be called on sequence child parsers")
@@ -473,7 +473,7 @@ abstract class OccursCountExpressionParser(
 
   final override def pouStatus = PoUStatus.NoPoU
 
-  final override def runtimeDependencies = Vector(occursCountEv)
+  final override val runtimeDependencies = Array(occursCountEv)
 
   final override def isBoundedMax = true
 

--- a/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/SpecifiedLengthParsers.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/SpecifiedLengthParsers.scala
@@ -38,7 +38,7 @@ sealed abstract class SpecifiedLengthParserBase(eParser: Parser, erd: RuntimeDat
   extends CombinatorParser(erd)
   with CaptureParsingValueLength {
 
-  override def runtimeDependencies = Vector()
+  override val runtimeDependencies = Array()
 
   override def childProcessors = Vector(eParser)
 
@@ -283,7 +283,7 @@ final class SpecifiedLengthPrefixedCharactersParser(
 class CaptureStartOfContentLengthParser(override val context: ElementRuntimeData)
   extends PrimParser {
 
-  override def runtimeDependencies = Vector()
+  override val runtimeDependencies = Array()
 
   override def parse(state: PState): Unit = {
     val dis = state.dataInputStream
@@ -295,7 +295,7 @@ class CaptureStartOfContentLengthParser(override val context: ElementRuntimeData
 class CaptureEndOfContentLengthParser(override val context: ElementRuntimeData)
   extends PrimParser {
 
-  override def runtimeDependencies = Vector()
+  override val runtimeDependencies = Array()
 
   override def parse(state: PState): Unit = {
     val dis = state.dataInputStream
@@ -307,7 +307,7 @@ class CaptureEndOfContentLengthParser(override val context: ElementRuntimeData)
 class CaptureStartOfValueLengthParser(override val context: ElementRuntimeData)
   extends PrimParser {
 
-  override def runtimeDependencies = Vector()
+  override val runtimeDependencies = Array()
 
   override def parse(state: PState): Unit = {
     val dis = state.dataInputStream
@@ -319,7 +319,7 @@ class CaptureStartOfValueLengthParser(override val context: ElementRuntimeData)
 class CaptureEndOfValueLengthParser(override val context: ElementRuntimeData)
   extends PrimParser {
 
-  override def runtimeDependencies = Vector()
+  override val runtimeDependencies = Array()
 
   override def parse(state: PState): Unit = {
     val dis = state.dataInputStream

--- a/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/StringLengthParsers.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/StringLengthParsers.scala
@@ -40,7 +40,7 @@ final class StringOfSpecifiedLengthParser(
 ) extends TextPrimParser
   with StringOfSpecifiedLengthMixin {
 
-  override def runtimeDependencies = Vector(erd.encInfo.charsetEv)
+  override val runtimeDependencies = Array(erd.encInfo.charsetEv)
 
   override lazy val charsetEv = erd.encInfo.charsetEv
 

--- a/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/TextBooleanParser.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/TextBooleanParser.scala
@@ -31,7 +31,7 @@ case class ConvertTextBooleanParser(
   ignoreCase: Boolean
 ) extends TextPrimParser {
 
-  override def runtimeDependencies = Vector(textBooleanTrueRepEv, textBooleanFalseRepEv)
+  override val runtimeDependencies = Array(textBooleanTrueRepEv, textBooleanFalseRepEv)
 
   private def matches(str1: String, str2: String): Boolean = {
     if (ignoreCase) str1.equalsIgnoreCase(str2) else str1 == str2

--- a/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/UnseparatedSequenceParsers.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/UnseparatedSequenceParsers.scala
@@ -83,7 +83,7 @@ class OrderedUnseparatedSequenceParser(
   override val childParsers: Array[SequenceChildParser]
 ) extends SequenceParserBase(rd, isOrdered = true) {
 
-  override def runtimeDependencies = Vector()
+  override val runtimeDependencies = Array()
 
   override def childProcessors: Vector[Processor] = childParsers.toVector
 }
@@ -92,7 +92,7 @@ class UnorderedUnseparatedSequenceParser(
   rd: SequenceRuntimeData,
   override val childParsers: Array[SequenceChildParser]
 ) extends SequenceParserBase(rd, isOrdered = false) {
-  override def runtimeDependencies = Vector()
+  override val runtimeDependencies = Array()
 
   override def childProcessors: Vector[Processor] = childParsers.toVector
 }

--- a/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/ZonedTextParsers.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/ZonedTextParsers.scala
@@ -37,7 +37,7 @@ case class ConvertZonedCombinatorParser(
   converterParser: Parser
 ) extends CombinatorParser(rd) {
 
-  override def runtimeDependencies = Vector()
+  override val runtimeDependencies = Array()
 
   override def childProcessors = Vector(valueParser, converterParser)
 
@@ -58,7 +58,7 @@ case class ConvertZonedNumberParser(
 ) extends TextPrimParser
   with TextDecimalVirtualPointMixin {
 
-  override def runtimeDependencies = Vector(textNumberFormatEv)
+  override val runtimeDependencies = Array(textNumberFormatEv)
 
   private val primNumeric = context.optPrimType.get.asInstanceOf[NodeInfo.PrimType.PrimNumeric]
 

--- a/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/processors/unparsers/UState.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/processors/unparsers/UState.scala
@@ -626,21 +626,21 @@ final class UStateMain private (
    * that is what has gone wrong.
    */
   override def inspectOrError = {
-    val m = inspectMaybe
-    if (m.isEmpty)
+    if (inspect)
+      inspectAccessor
+    else
       Assert.invariantFailed(
         "An InfosetEvent was required for unparsing, but no InfosetEvent was available."
       )
-    m.get
   }
 
   override def advanceOrError = {
-    val m = advanceMaybe
-    if (m.isEmpty)
+    if (advance)
+      advanceAccessor
+    else
       Assert.invariantFailed(
         "An InfosetEvent was required for unparsing, but no InfosetEvent was available."
       )
-    m.get
   }
 
   override def isInspectArrayEnd = {
@@ -668,24 +668,24 @@ final class UStateMain private (
   override val arrayIterationIndexStack = MStackOfLong()
   arrayIterationIndexStack.push(1L)
   override def moveOverOneArrayIterationIndexOnly() =
-    arrayIterationIndexStack.push(arrayIterationIndexStack.pop() + 1)
+    arrayIterationIndexStack.setTop(arrayIterationIndexStack.top + 1)
   override def arrayIterationPos = arrayIterationIndexStack.top
 
   override val occursIndexStack = MStackOfLong()
   occursIndexStack.push(1L)
-  override def moveOverOneOccursIndexOnly() = occursIndexStack.push(occursIndexStack.pop() + 1)
+  override def moveOverOneOccursIndexOnly() = occursIndexStack.setTop(occursIndexStack.top + 1)
   override def occursPos = occursIndexStack.top
 
   override val groupIndexStack = MStackOfLong()
   groupIndexStack.push(1L)
-  override def moveOverOneGroupIndexOnly() = groupIndexStack.push(groupIndexStack.pop() + 1)
+  override def moveOverOneGroupIndexOnly() = groupIndexStack.setTop(groupIndexStack.top + 1)
   override def groupPos = groupIndexStack.top
 
   // TODO: it doesn't look anything is actually reading the value of childindex
   // stack. Can we get rid of it?
   override val childIndexStack = MStackOfLong()
   childIndexStack.push(1L)
-  override def moveOverOneElementChildOnly() = childIndexStack.push(childIndexStack.pop() + 1)
+  override def moveOverOneElementChildOnly() = childIndexStack.setTop(childIndexStack.top + 1)
   override def childPos = childIndexStack.top
 
   override lazy val escapeSchemeEVCache = new MStackOfMaybe[EscapeSchemeUnparserHelper]

--- a/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/processors/unparsers/Unparser.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/processors/unparsers/Unparser.scala
@@ -30,7 +30,7 @@ sealed trait Unparser extends Processor {
 
   protected def unparse(ustate: UState): Unit
 
-  final def unparse1(ustate: UState, ignore: AnyRef = null) = {
+  final def unparse1(ustate: UState) = {
     Assert.invariant(isInitialized)
     val savedProc = ustate.maybeProcessor
     ustate.setProcessor(this)
@@ -134,7 +134,7 @@ trait SuspendableUnparser extends PrimUnparser {
 final class ErrorUnparser(override val context: TermRuntimeData = null)
   extends PrimUnparserNoData {
 
-  override def runtimeDependencies = Vector()
+  override val runtimeDependencies = Array()
 
   def unparse(ustate: UState): Unit = {
     Assert.abort("Error Unparser")
@@ -149,7 +149,7 @@ final class SeqCompUnparser(context: RuntimeData, val childUnparsers: Array[Unpa
   extends CombinatorUnparser(context)
   with ToBriefXMLImpl {
 
-  override def runtimeDependencies = Vector()
+  override val runtimeDependencies = Array()
 
   override def childProcessors = childUnparsers.toVector
 
@@ -174,7 +174,7 @@ case class DummyUnparser(primitiveName: String) extends PrimUnparserNoData {
 
   override def context = null
 
-  override def runtimeDependencies = Vector()
+  override val runtimeDependencies = Array()
 
   override def isEmpty = true
 
@@ -202,5 +202,5 @@ case class NotUnparsableUnparser(override val context: ElementRuntimeData)
   }
 
   override def childProcessors = Vector()
-  override def runtimeDependencies = Vector()
+  override val runtimeDependencies = Array()
 }

--- a/daffodil-core/src/main/scala/org/apache/daffodil/unparsers/runtime1/BCDUnparsers.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/unparsers/runtime1/BCDUnparsers.scala
@@ -47,7 +47,7 @@ class BCDIntegerRuntimeLengthUnparser(
 ) extends BCDIntegerBaseUnparser(e)
   with HasRuntimeExplicitLength {
 
-  override def runtimeDependencies = Vector(lengthEv)
+  override val runtimeDependencies = Array(lengthEv)
 }
 
 final class BCDIntegerDelimitedUnparser(e: ElementRuntimeData)
@@ -59,7 +59,7 @@ final class BCDIntegerDelimitedUnparser(e: ElementRuntimeData)
 final class BCDIntegerMinimumLengthUnparser(e: ElementRuntimeData)
   extends BCDIntegerBaseUnparser(e) {
 
-  override def runtimeDependencies = Vector()
+  override val runtimeDependencies = Array()
 
   override def getBitLength(s: ParseOrUnparseState): Int = {
     val number = getNumberToPut(s.asInstanceOf[UState])
@@ -91,7 +91,7 @@ class BCDDecimalRuntimeLengthUnparser(
 ) extends BCDDecimalBaseUnparser(e, binaryDecimalVirtualPoint)
   with HasRuntimeExplicitLength {
 
-  override def runtimeDependencies = Vector(lengthEv)
+  override val runtimeDependencies = Array(lengthEv)
 }
 
 final class BCDDecimalDelimitedUnparser(e: ElementRuntimeData, binaryDecimalVirtualPoint: Int)
@@ -105,7 +105,7 @@ final class BCDDecimalMinimumLengthUnparser(
   binaryDecimalVirtualPoint: Int
 ) extends BCDDecimalBaseUnparser(e, binaryDecimalVirtualPoint) {
 
-  override def runtimeDependencies = Vector()
+  override val runtimeDependencies = Array()
 
   override def getBitLength(s: ParseOrUnparseState): Int = {
     val number = getNumberToPut(s.asInstanceOf[UState])

--- a/daffodil-core/src/main/scala/org/apache/daffodil/unparsers/runtime1/BinaryBooleanUnparsers.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/unparsers/runtime1/BinaryBooleanUnparsers.scala
@@ -116,7 +116,7 @@ class BinaryBooleanUnparser(
     lengthUnits
   ) {
 
-  override def runtimeDependencies = Vector(lengthEv)
+  override val runtimeDependencies = Array(lengthEv)
 
   override def getBitLength(s: ParseOrUnparseState): Int = {
     val nBytesAsJLong = lengthEv.evaluate(s)
@@ -140,7 +140,7 @@ class BinaryBooleanMinimumLengthUnparser(
     lengthUnits
   ) {
 
-  override def runtimeDependencies = Vector()
+  override val runtimeDependencies = Array()
 
   override def getBitLength(s: ParseOrUnparseState): Int = 32
 

--- a/daffodil-core/src/main/scala/org/apache/daffodil/unparsers/runtime1/BinaryNumberUnparsers.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/unparsers/runtime1/BinaryNumberUnparsers.scala
@@ -112,7 +112,7 @@ class BinaryIntegerKnownLengthUnparser(
 ) extends BinaryIntegerBaseUnparser(e)
   with HasKnownLengthInBits {
 
-  override def runtimeDependencies = Vector()
+  override val runtimeDependencies = Array()
 
 }
 
@@ -123,7 +123,7 @@ class BinaryIntegerRuntimeLengthUnparser(
 ) extends BinaryIntegerBaseUnparser(e)
   with HasRuntimeExplicitLength {
 
-  override def runtimeDependencies = Vector(lengthEv)
+  override val runtimeDependencies = Array(lengthEv)
 }
 
 class BinaryIntegerMinimumLengthUnparser(
@@ -133,7 +133,7 @@ class BinaryIntegerMinimumLengthUnparser(
 
   private val primNumeric = e.optPrimType.get.asInstanceOf[NodeInfo.PrimType.PrimNumeric]
 
-  override def runtimeDependencies = Vector()
+  override val runtimeDependencies = Array()
 
   override def getBitLength(s: ParseOrUnparseState): Int = {
     if (maybeNBits.isDefined) {
@@ -152,7 +152,7 @@ class BinaryIntegerMinimumLengthUnparser(
 
 class BinaryFloatUnparser(e: ElementRuntimeData) extends BinaryNumberBaseUnparser(e) {
 
-  override def runtimeDependencies = Vector()
+  override val runtimeDependencies = Array()
 
   override def getBitLength(s: ParseOrUnparseState) = 32
 
@@ -169,7 +169,7 @@ class BinaryFloatUnparser(e: ElementRuntimeData) extends BinaryNumberBaseUnparse
 
 class BinaryDoubleUnparser(e: ElementRuntimeData) extends BinaryNumberBaseUnparser(e) {
 
-  override def runtimeDependencies = Vector()
+  override val runtimeDependencies = Array()
 
   override def getBitLength(s: ParseOrUnparseState) = 64
 
@@ -191,7 +191,7 @@ class BinaryDecimalKnownLengthUnparser(
 ) extends BinaryDecimalUnparserBase(e, signed, binaryDecimalVirtualPoint)
   with HasKnownLengthInBits {
 
-  override def runtimeDependencies = Vector()
+  override val runtimeDependencies = Array()
 
 }
 
@@ -204,7 +204,7 @@ class BinaryDecimalRuntimeLengthUnparser(
 ) extends BinaryDecimalUnparserBase(e, signed, binaryDecimalVirtualPoint)
   with HasRuntimeExplicitLength {
 
-  override def runtimeDependencies = Vector(lengthEv)
+  override val runtimeDependencies = Array(lengthEv)
 }
 
 class BinaryDecimalMinimumLengthUnparser(
@@ -213,7 +213,7 @@ class BinaryDecimalMinimumLengthUnparser(
   binaryDecimalVirtualPoint: Int
 ) extends BinaryDecimalUnparserBase(e, signed, binaryDecimalVirtualPoint) {
 
-  override def runtimeDependencies = Vector()
+  override val runtimeDependencies = Array()
 
   override def getBitLength(s: ParseOrUnparseState): Int = {
     // type is xs:decimal, the length is determined by the minimum number of

--- a/daffodil-core/src/main/scala/org/apache/daffodil/unparsers/runtime1/BlobLengthUnparser.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/unparsers/runtime1/BlobLengthUnparser.scala
@@ -28,7 +28,7 @@ import org.apache.daffodil.runtime1.processors.unparsers.*
 
 abstract class BlobUnparserBase(override val context: ElementRuntimeData) extends PrimUnparser {
 
-  override def runtimeDependencies = Vector()
+  override val runtimeDependencies = Array()
 
   protected def getLengthInBits(state: UState): Long
 

--- a/daffodil-core/src/main/scala/org/apache/daffodil/unparsers/runtime1/ChoiceAndOtherVariousUnparsers.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/unparsers/runtime1/ChoiceAndOtherVariousUnparsers.scala
@@ -66,7 +66,7 @@ case class ChoiceBranchMap(
  */
 class ChoiceBranchEmptyUnparser(val context: RuntimeData) extends PrimUnparserNoData {
 
-  override def runtimeDependencies = Vector()
+  override val runtimeDependencies = Array()
 
   def unparse(state: UState): Unit = {
     // do nothing
@@ -81,7 +81,7 @@ class ChoiceCombinatorUnparser(
   with ToBriefXMLImpl {
   override def nom = "Choice"
 
-  override def runtimeDependencies = Vector()
+  override val runtimeDependencies = Array()
 
   override def childProcessors = choiceBranchMap.childProcessors
 
@@ -160,8 +160,8 @@ class DelimiterStackUnparser(
 
   override def childProcessors = Vector(bodyUnparser)
 
-  override def runtimeDependencies =
-    (initiatorOpt.toList ++ separatorOpt.toList ++ terminatorOpt.toList).toVector
+  override val runtimeDependencies =
+    (initiatorOpt.toList ++ separatorOpt.toList ++ terminatorOpt.toList).toArray
 
   def unparse(state: UState): Unit = {
     // Evaluate Delimiters
@@ -194,7 +194,7 @@ class DynamicEscapeSchemeUnparser(
 
   override def childProcessors = Vector(bodyUnparser)
 
-  override def runtimeDependencies = Vector(escapeScheme)
+  override val runtimeDependencies = Array(escapeScheme)
 
   def unparse(state: UState): Unit = {
     // evaluate the dynamic escape scheme in the correct scope. the resulting

--- a/daffodil-core/src/main/scala/org/apache/daffodil/unparsers/runtime1/ConvertBinaryCalendarUnparser.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/unparsers/runtime1/ConvertBinaryCalendarUnparser.scala
@@ -40,7 +40,7 @@ case class ConvertBinaryCalendarSecMilliUnparser(
   /**
    * Primitive unparsers must override runtimeDependencies
    */
-  override def runtimeDependencies = Vector()
+  override val runtimeDependencies = Array()
 
   protected def putNumber(
     dos: DataOutputStream,

--- a/daffodil-core/src/main/scala/org/apache/daffodil/unparsers/runtime1/ConvertNonBaseTenTextNumberUnparser.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/unparsers/runtime1/ConvertNonBaseTenTextNumberUnparser.scala
@@ -29,7 +29,7 @@ case class ConvertNonBaseTenTextNumberUnparser(
   base: Int
 ) extends TextPrimUnparser {
 
-  override def runtimeDependencies = Vector()
+  override val runtimeDependencies = Array()
 
   override def unparse(state: UState): Unit = {
 

--- a/daffodil-core/src/main/scala/org/apache/daffodil/unparsers/runtime1/ConvertTextBooleanUnparser.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/unparsers/runtime1/ConvertTextBooleanUnparser.scala
@@ -35,7 +35,7 @@ case class ConvertTextBooleanUnparser(
   /**
    * Primitive unparsers must override runtimeDependencies
    */
-  override def runtimeDependencies = Vector(textBooleanTrueRepEv, textBooleanFalseRepEv)
+  override val runtimeDependencies = Array(textBooleanTrueRepEv, textBooleanFalseRepEv)
 
   def unparse(state: UState): Unit = {
 

--- a/daffodil-core/src/main/scala/org/apache/daffodil/unparsers/runtime1/ConvertTextCalendarUnparser.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/unparsers/runtime1/ConvertTextCalendarUnparser.scala
@@ -37,7 +37,7 @@ case class ConvertTextCalendarUnparser(
   /**
    * Primitive unparsers must override runtimeDependencies
    */
-  override def runtimeDependencies = Vector(calendarEv, dateTimeFormatterEv)
+  override val runtimeDependencies = Array(calendarEv, dateTimeFormatterEv)
 
   def unparse(state: UState): Unit = {
 

--- a/daffodil-core/src/main/scala/org/apache/daffodil/unparsers/runtime1/ConvertTextStandardNumberUnparser.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/unparsers/runtime1/ConvertTextStandardNumberUnparser.scala
@@ -34,7 +34,7 @@ case class ConvertTextCombinatorUnparser(
   converterUnparser: Unparser
 ) extends CombinatorUnparser(rd) {
 
-  override def runtimeDependencies = Vector()
+  override val runtimeDependencies = Array()
 
   override def childProcessors = Vector(converterUnparser, valueUnparser)
 
@@ -56,7 +56,7 @@ case class ConvertTextNumberUnparser(
   with TextDecimalVirtualPointMixin
   with ToBriefXMLImpl {
 
-  override def runtimeDependencies = Vector(textNumberFormatEv)
+  override val runtimeDependencies = Array(textNumberFormatEv)
 
   override def unparse(state: UState): Unit = {
 

--- a/daffodil-core/src/main/scala/org/apache/daffodil/unparsers/runtime1/ConvertZonedNumberUnparser.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/unparsers/runtime1/ConvertZonedNumberUnparser.scala
@@ -30,7 +30,7 @@ case class ConvertZonedCombinatorUnparser(
   converterUnparser: Unparser
 ) extends CombinatorUnparser(rd) {
 
-  override def runtimeDependencies = Vector()
+  override val runtimeDependencies = Array()
 
   override def childProcessors = Vector(converterUnparser, valueUnparser)
 
@@ -52,7 +52,7 @@ case class ConvertZonedNumberUnparser(
   with TextDecimalVirtualPointMixin
   with ToBriefXMLImpl {
 
-  override def runtimeDependencies = Vector()
+  override val runtimeDependencies = Array()
 
   override def unparse(state: UState): Unit = {
 

--- a/daffodil-core/src/main/scala/org/apache/daffodil/unparsers/runtime1/DelimitedUnparsers.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/unparsers/runtime1/DelimitedUnparsers.scala
@@ -40,7 +40,7 @@ sealed class StringDelimitedUnparser(
   isDelimRequired: Boolean
 ) extends TextPrimUnparser {
 
-  override def runtimeDependencies = Vector()
+  override val runtimeDependencies = Array()
 
   val fieldDFA = CreateFieldDFA()
   val textUnparser = new TextDelimitedUnparser(context)

--- a/daffodil-core/src/main/scala/org/apache/daffodil/unparsers/runtime1/DelimiterUnparsers.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/unparsers/runtime1/DelimiterUnparsers.scala
@@ -35,7 +35,7 @@ class DelimiterTextUnparser(
 
   private def erd = context
 
-  override def runtimeDependencies = Vector()
+  override val runtimeDependencies = Array()
 
   override lazy val nom = {
     if (delimiterType == DelimiterTextType.Initiator) "InitiatorUnparser"

--- a/daffodil-core/src/main/scala/org/apache/daffodil/unparsers/runtime1/ElementUnparser.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/unparsers/runtime1/ElementUnparser.scala
@@ -55,14 +55,13 @@ class ElementUnspecifiedLengthUnparser(
   with RegularElementUnparserStartEndStrategy
   with RepMoveMixin {
 
-  override def runtimeDependencies = Vector()
+  override val runtimeDependencies = Array[Evaluatable[AnyRef]]()
 
 }
 
 sealed trait RepMoveMixin {
   def move(start: UState): Unit = {
-    val childIndex = start.childIndexStack.pop()
-    start.childIndexStack.push(childIndex + 1)
+    start.childIndexStack.setTop(start.childIndexStack.top + 1)
   }
 }
 
@@ -79,15 +78,14 @@ class ElementUnparserInputValueCalc(erd: ElementRuntimeData, setVarUnparsers: Ar
   extends ElementUnparserBase(erd, setVarUnparsers, Nope, Nope, Nope, Nope)
   with RegularElementUnparserStartEndStrategy {
 
-  override def runtimeDependencies = Vector()
+  override val runtimeDependencies = Array()
 
   /**
    * Move over in the element children, but not in the group.
    * This avoids separators for this IVC element.
    */
   override def move(state: UState): Unit = {
-    val childIndex = state.childIndexStack.pop()
-    state.childIndexStack.push(childIndex + 1)
+    state.childIndexStack.setTop(state.childIndexStack.top + 1)
   }
 }
 
@@ -108,7 +106,7 @@ class ElementOVCUnspecifiedLengthUnparser(
   with OVCStartEndStrategy
   with RepMoveMixin {
 
-  override def runtimeDependencies = Vector()
+  override val runtimeDependencies = Array()
 
 }
 
@@ -298,7 +296,7 @@ class ElementSpecifiedLengthUnparser(
   with RegularElementUnparserStartEndStrategy
   with ElementSpecifiedLengthMixin {
 
-  override def runtimeDependencies = maybeTargetLengthEv.toList.toVector
+  override val runtimeDependencies = maybeTargetLengthEv.toList.toArray
 
   override def runContentUnparser(state: UState): Unit = {
     computeTargetLength(
@@ -357,7 +355,7 @@ class ElementOVCSpecifiedLengthUnparser(
   with OVCStartEndStrategy
   with ElementSpecifiedLengthMixin {
 
-  override def runtimeDependencies = maybeTargetLengthEv.toList.toVector
+  override val runtimeDependencies = maybeTargetLengthEv.toList.toArray
 
   private def suspendableExpression =
     new ElementOVCSpecifiedLengthUnparserSuspendableExpression(this, expr)
@@ -396,7 +394,7 @@ sealed trait ElementUnparserStartEndStrategy {
 
   protected def erd: ElementRuntimeData
 
-  def runtimeDependencies: Vector[Evaluatable[AnyRef]]
+  val runtimeDependencies: Array[Evaluatable[AnyRef]]
 }
 
 sealed trait RegularElementUnparserStartEndStrategy extends ElementUnparserStartEndStrategy {

--- a/daffodil-core/src/main/scala/org/apache/daffodil/unparsers/runtime1/ExpressionEvaluatingUnparsers.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/unparsers/runtime1/ExpressionEvaluatingUnparsers.scala
@@ -60,7 +60,7 @@ final class SetVariableUnparser(
   referencingContext: NonTermRuntimeData
 ) extends PrimUnparserNoData {
 
-  override def runtimeDependencies = Vector()
+  override val runtimeDependencies = Array()
 
   override def childProcessors = Vector()
 
@@ -95,7 +95,7 @@ class NewVariableInstanceStartUnparser(vrd: VariableRuntimeData, trd: TermRuntim
   extends PrimUnparserNoData {
 
   override def context = trd
-  override def runtimeDependencies = Vector()
+  override val runtimeDependencies = Array()
 
   override def childProcessors = Vector()
 
@@ -120,7 +120,7 @@ class NewVariableInstanceEndUnparser(vrd: VariableRuntimeData, trd: TermRuntimeD
   extends PrimUnparserNoData {
 
   override def context = trd
-  override def runtimeDependencies = Vector()
+  override val runtimeDependencies = Array()
 
   override def childProcessors = Vector()
 

--- a/daffodil-core/src/main/scala/org/apache/daffodil/unparsers/runtime1/FramingUnparsers.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/unparsers/runtime1/FramingUnparsers.scala
@@ -26,7 +26,7 @@ import org.apache.daffodil.runtime1.processors.unparsers.*
 class SkipRegionUnparser(skipInBits: Int, override val context: TermRuntimeData)
   extends AlignmentPrimUnparser {
 
-  override def runtimeDependencies = Vector()
+  override val runtimeDependencies = Array()
 
   override def unparse(state: UState) = {
     val dos = state.getDataOutputStream
@@ -73,7 +73,7 @@ class AlignmentFillUnparser(alignmentInBits: Int, override val context: TermRunt
   extends AlignmentPrimUnparser
   with SuspendableUnparser {
 
-  override def runtimeDependencies = Vector()
+  override val runtimeDependencies = Array()
 
   override def suspendableOperation =
     new AlignmentFillUnparserSuspendableOperation(alignmentInBits, context)

--- a/daffodil-core/src/main/scala/org/apache/daffodil/unparsers/runtime1/HexBinaryLengthUnparser.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/unparsers/runtime1/HexBinaryLengthUnparser.scala
@@ -27,7 +27,7 @@ import org.apache.daffodil.runtime1.processors.unparsers.*
 abstract class HexBinaryUnparserBase(override val context: ElementRuntimeData)
   extends PrimUnparser {
 
-  override def runtimeDependencies = Vector()
+  override val runtimeDependencies = Array()
 
   protected def getLengthInBits(state: UState): Long
 

--- a/daffodil-core/src/main/scala/org/apache/daffodil/unparsers/runtime1/HiddenGroupCombinatorUnparser.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/unparsers/runtime1/HiddenGroupCombinatorUnparser.scala
@@ -31,7 +31,7 @@ class HiddenGroupCombinatorUnparser(ctxt: ModelGroupRuntimeData, bodyUnparser: U
 
   override def childProcessors = Vector(bodyUnparser)
 
-  override def runtimeDependencies = Vector()
+  override val runtimeDependencies = Array()
 
   def unparse(start: UState): Unit = {
     try {

--- a/daffodil-core/src/main/scala/org/apache/daffodil/unparsers/runtime1/IBM4690PackedDecimalUnparsers.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/unparsers/runtime1/IBM4690PackedDecimalUnparsers.scala
@@ -50,7 +50,7 @@ class IBM4690PackedIntegerRuntimeLengthUnparser(
 ) extends IBM4690PackedIntegerBaseUnparser(e)
   with HasRuntimeExplicitLength {
 
-  override def runtimeDependencies = Vector(lengthEv)
+  override val runtimeDependencies = Array(lengthEv)
 }
 
 final class IBM4690PackedIntegerDelimitedUnparser(e: ElementRuntimeData)
@@ -62,7 +62,7 @@ final class IBM4690PackedIntegerDelimitedUnparser(e: ElementRuntimeData)
 final class IBM4690PackedIntegerMinimumLengthUnparser(e: ElementRuntimeData)
   extends IBM4690PackedIntegerBaseUnparser(e) {
 
-  override def runtimeDependencies = Vector()
+  override val runtimeDependencies = Array()
 
   override def getBitLength(s: ParseOrUnparseState): Int = {
     val number = getNumberToPut(s.asInstanceOf[UState])
@@ -101,7 +101,7 @@ class IBM4690PackedDecimalRuntimeLengthUnparser(
 ) extends IBM4690PackedDecimalBaseUnparser(e, binaryDecimalVirtualPoint, decimalSigned)
   with HasRuntimeExplicitLength {
 
-  override def runtimeDependencies = Vector(lengthEv)
+  override val runtimeDependencies = Array(lengthEv)
 }
 
 final class IBM4690PackedDecimalDelimitedUnparser(
@@ -119,7 +119,7 @@ final class IBM4690PackedDecimalMinimumLengthUnparser(
   decimalSigned: YesNo
 ) extends IBM4690PackedDecimalBaseUnparser(e, binaryDecimalVirtualPoint, decimalSigned) {
 
-  override def runtimeDependencies = Vector()
+  override val runtimeDependencies = Array()
 
   override def getBitLength(s: ParseOrUnparseState): Int = {
     val number = getNumberToPut(s.asInstanceOf[UState])

--- a/daffodil-core/src/main/scala/org/apache/daffodil/unparsers/runtime1/NadaUnparser.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/unparsers/runtime1/NadaUnparser.scala
@@ -27,7 +27,7 @@ class NadaUnparser(override val context: RuntimeData) extends PrimUnparser {
 
   override def toString = "Nada"
 
-  override def runtimeDependencies = Vector()
+  override val runtimeDependencies = Array()
 
   override def unparse(start: UState) = {
     Assert.abort("NadaUnparsers are all supposed to optimize out!")

--- a/daffodil-core/src/main/scala/org/apache/daffodil/unparsers/runtime1/NilEmptyCombinatorUnparsers.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/unparsers/runtime1/NilEmptyCombinatorUnparsers.scala
@@ -28,7 +28,7 @@ case class SimpleNilOrValueUnparser(
   valueUnparser: Unparser
 ) extends CombinatorUnparser(ctxt) {
 
-  override def runtimeDependencies = Vector()
+  override val runtimeDependencies = Array()
 
   override def childProcessors = Vector(nilUnparser, valueUnparser)
 
@@ -54,7 +54,7 @@ case class ComplexNilOrContentUnparser(
   contentUnparser: Unparser
 ) extends CombinatorUnparser(ctxt) {
 
-  override def runtimeDependencies = Vector()
+  override val runtimeDependencies = Array()
 
   override def childProcessors = Vector(nilUnparser, contentUnparser)
 

--- a/daffodil-core/src/main/scala/org/apache/daffodil/unparsers/runtime1/NilUnparsers.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/unparsers/runtime1/NilUnparsers.scala
@@ -26,7 +26,7 @@ class LiteralValueNilOfSpecifiedLengthUnparser(
   isForPattern: Boolean
 ) extends StringNoTruncateUnparser(erd) {
 
-  override def runtimeDependencies = Vector(slEv)
+  override val runtimeDependencies = Array(slEv)
 
   override protected def contentString(state: UState) = {
     slEv.evaluate(state)

--- a/daffodil-core/src/main/scala/org/apache/daffodil/unparsers/runtime1/PackedBinaryUnparserTraits.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/unparsers/runtime1/PackedBinaryUnparserTraits.scala
@@ -41,7 +41,7 @@ abstract class PackedBinaryBaseUnparser(override val context: ElementRuntimeData
   extends PrimUnparser
   with PackedBinaryConversion {
 
-  override def runtimeDependencies: Vector[Evaluatable[AnyRef]] = Vector()
+  override val runtimeDependencies: Array[Evaluatable[AnyRef]] = Array()
 
   protected def getBitLength(s: ParseOrUnparseState): Int
 

--- a/daffodil-core/src/main/scala/org/apache/daffodil/unparsers/runtime1/PackedDecimalUnparsers.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/unparsers/runtime1/PackedDecimalUnparsers.scala
@@ -55,7 +55,7 @@ class PackedIntegerRuntimeLengthUnparser(
 ) extends PackedIntegerBaseUnparser(e, packedSignCodes)
   with HasRuntimeExplicitLength {
 
-  override def runtimeDependencies = Vector(lengthEv)
+  override val runtimeDependencies = Array(lengthEv)
 }
 
 final class PackedIntegerDelimitedUnparser(
@@ -71,7 +71,7 @@ final class PackedIntegerMinimumLengthUnparser(
   packedSignCodes: PackedSignCodes
 ) extends PackedIntegerBaseUnparser(e, packedSignCodes) {
 
-  override def runtimeDependencies = Vector()
+  override val runtimeDependencies = Array()
 
   override def getBitLength(s: ParseOrUnparseState): Int = {
     val number = getNumberToPut(s.asInstanceOf[UState])
@@ -121,7 +121,7 @@ class PackedDecimalRuntimeLengthUnparser(
   )
   with HasRuntimeExplicitLength {
 
-  override def runtimeDependencies = Vector(lengthEv)
+  override val runtimeDependencies = Array(lengthEv)
 }
 
 final class PackedDecimalDelimitedUnparser(
@@ -151,7 +151,7 @@ final class PackedDecimalMinimumLengthUnparser(
     decimalSigned
   ) {
 
-  override def runtimeDependencies = Vector()
+  override val runtimeDependencies = Array()
 
   override def getBitLength(s: ParseOrUnparseState): Int = {
     val number = getNumberToPut(s.asInstanceOf[UState])

--- a/daffodil-core/src/main/scala/org/apache/daffodil/unparsers/runtime1/RepTypeUnparsers.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/unparsers/runtime1/RepTypeUnparsers.scala
@@ -36,7 +36,7 @@ class RepTypeUnparser(
 
   override def childProcessors = Vector(repTypeUnparser)
 
-  override def runtimeDependencies = Vector()
+  override val runtimeDependencies = Array()
 
   protected def unparse(ustate: UState): Unit = {
     Assert.invariant(ustate.currentInfosetNodeMaybe.isDefined)

--- a/daffodil-core/src/main/scala/org/apache/daffodil/unparsers/runtime1/SeparatedSequenceUnparsers.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/unparsers/runtime1/SeparatedSequenceUnparsers.scala
@@ -125,7 +125,7 @@ class OrderedSeparatedSequenceUnparser(
   // have been optimized away
   Assert.invariant(childUnparsers.length > 0)
 
-  override def runtimeDependencies = Vector()
+  override val runtimeDependencies = Array()
 
   override def childProcessors = childUnparsers.toVector
 

--- a/daffodil-core/src/main/scala/org/apache/daffodil/unparsers/runtime1/SequenceChildUnparsers.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/unparsers/runtime1/SequenceChildUnparsers.scala
@@ -40,7 +40,7 @@ abstract class SequenceChildUnparser(
   val trd: TermRuntimeData
 ) extends CombinatorUnparser(srd) {
 
-  override def runtimeDependencies = Vector()
+  override val runtimeDependencies = Array()
 
 }
 
@@ -67,7 +67,7 @@ abstract class RepeatingChildUnparser(
     childUnparser.unparse1(state)
   }
 
-  override def runtimeDependencies = Vector()
+  override val runtimeDependencies = Array()
 
   override def toString = "RepUnparser(" + childUnparser.toString + ")"
 

--- a/daffodil-core/src/main/scala/org/apache/daffodil/unparsers/runtime1/SpecifiedLength2.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/unparsers/runtime1/SpecifiedLength2.scala
@@ -210,7 +210,7 @@ class SimpleTypeRetryUnparser(
 ) extends PrimUnparser
   with SuspendableUnparser {
 
-  override final def runtimeDependencies = maybeUnparserTargetLengthInBitsEv.toSeq.toVector
+  override final val runtimeDependencies = maybeUnparserTargetLengthInBitsEv.toList.toArray
 
   final override def childProcessors = Vector(vUnparser)
 
@@ -225,7 +225,7 @@ class SimpleTypeRetryUnparser(
 class CaptureStartOfContentLengthUnparser(override val context: ElementRuntimeData)
   extends PrimUnparser {
 
-  override def runtimeDependencies = Vector()
+  override val runtimeDependencies = Array()
 
   override def unparse(state: UState): Unit = {
     val dos = state.getDataOutputStream
@@ -243,7 +243,7 @@ class CaptureEndOfContentLengthUnparser(
   maybeFixedLengthInBits: MaybeULong
 ) extends PrimUnparser {
 
-  override def runtimeDependencies = Vector()
+  override val runtimeDependencies = Array()
 
   override def unparse(state: UState): Unit = {
     val dos = state.getDataOutputStream
@@ -274,7 +274,7 @@ class CaptureEndOfContentLengthUnparser(
 class CaptureStartOfValueLengthUnparser(override val context: ElementRuntimeData)
   extends PrimUnparser {
 
-  override def runtimeDependencies = Vector()
+  override val runtimeDependencies = Array()
 
   override def unparse(state: UState): Unit = {
     val dos = state.getDataOutputStream
@@ -290,7 +290,7 @@ class CaptureStartOfValueLengthUnparser(override val context: ElementRuntimeData
 class CaptureEndOfValueLengthUnparser(override val context: ElementRuntimeData)
   extends PrimUnparser {
 
-  override def runtimeDependencies = Vector()
+  override val runtimeDependencies = Array()
 
   override def unparse(state: UState): Unit = {
     val dos = state.getDataOutputStream
@@ -479,7 +479,7 @@ class ElementUnusedUnparser(
 ) extends PrimUnparser
   with SuspendableUnparser {
 
-  override def runtimeDependencies = Vector(targetLengthEv)
+  override val runtimeDependencies = Array(targetLengthEv)
 
   override def suspendableOperation =
     new ElementUnusedUnparserSuspendableOperation(
@@ -583,7 +583,7 @@ class ChoiceUnusedUnparser(
 ) extends PrimUnparser
   with SuspendableUnparser {
 
-  override def runtimeDependencies = Vector()
+  override val runtimeDependencies = Array()
 
   override def suspendableOperation = suspendableOp
 }
@@ -677,7 +677,7 @@ class OnlyPaddingUnparser(
 ) extends TextPrimUnparser
   with SuspendableUnparser {
 
-  override def runtimeDependencies = Vector(targetLengthEv)
+  override val runtimeDependencies = Array(targetLengthEv)
 
   override def suspendableOperation =
     new OnlyPaddingUnparserSuspendableOperation(
@@ -734,7 +734,7 @@ class NilLiteralCharacterUnparser(
 ) extends TextPrimUnparser
   with SuspendableUnparser {
 
-  override def runtimeDependencies = Vector(targetLengthEv)
+  override val runtimeDependencies = Array(targetLengthEv)
 
   override def suspendableOperation = new NilLiteralCharacterUnparserSuspendableOperation(
     context,

--- a/daffodil-core/src/main/scala/org/apache/daffodil/unparsers/runtime1/SpecifiedLengthUnparsers.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/unparsers/runtime1/SpecifiedLengthUnparsers.scala
@@ -37,7 +37,7 @@ final class SpecifiedLengthExplicitImplicitUnparser(
   targetLengthInBitsEv: UnparseTargetLengthInBitsEv
 ) extends CombinatorUnparser(erd) {
 
-  override def runtimeDependencies = Vector()
+  override val runtimeDependencies = Array()
 
   override def childProcessors = Vector(eUnparser)
 
@@ -141,7 +141,7 @@ class SpecifiedLengthPrefixedUnparser(
 ) extends CombinatorUnparser(erd)
   with CalculatedPrefixedLengthUnparserMixin {
 
-  override def runtimeDependencies = Vector()
+  override val runtimeDependencies = Array()
 
   override def childProcessors = Vector(prefixedLengthUnparser, eUnparser)
 

--- a/daffodil-core/src/main/scala/org/apache/daffodil/unparsers/runtime1/StreamSplitterMixin.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/unparsers/runtime1/StreamSplitterMixin.scala
@@ -88,7 +88,7 @@ class RegionSplitUnparser(override val context: TermRuntimeData)
 
   override def childProcessors: Vector[Processor] = Vector()
 
-  override def runtimeDependencies = Vector()
+  override val runtimeDependencies = Array()
 
   override lazy val suspendableOperation = new RegionSplitSuspendableOperation(context)
 

--- a/daffodil-core/src/main/scala/org/apache/daffodil/unparsers/runtime1/StringLengthUnparsers.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/unparsers/runtime1/StringLengthUnparsers.scala
@@ -46,7 +46,7 @@ sealed abstract class StringSpecifiedLengthUnparserBase(val erd: ElementRuntimeD
 class StringNoTruncateUnparser(erd: ElementRuntimeData)
   extends StringSpecifiedLengthUnparserBase(erd) {
 
-  override def runtimeDependencies: Vector[Evaluatable[AnyRef]] = Vector()
+  override val runtimeDependencies: Array[Evaluatable[AnyRef]] = Array()
 
   override def unparse(state: UState): Unit = {
     val dos = state.getDataOutputStream
@@ -120,7 +120,7 @@ class StringMaybeTruncateBitsUnparser(
   charsetEv: CharsetEv
 ) extends StringSpecifiedLengthUnparserTruncateBase(stringTruncationType, erd) {
 
-  override def runtimeDependencies = Vector(targetLengthInBitsEv, charsetEv)
+  override val runtimeDependencies = Array(targetLengthInBitsEv, charsetEv)
 
   private def getLengthInBits(str: String, state: UState): (Long, Long) = {
     val cs = charsetEv.evaluate(state)
@@ -257,7 +257,7 @@ class StringMaybeTruncateCharactersUnparser(
   erd: ElementRuntimeData
 ) extends StringSpecifiedLengthUnparserTruncateBase(stringTruncationType, erd) {
 
-  override def runtimeDependencies = Vector(lengthInCharactersEv)
+  override val runtimeDependencies = Array(lengthInCharactersEv)
 
   override def unparse(state: UState): Unit = {
     val dos = state.getDataOutputStream

--- a/daffodil-core/src/main/scala/org/apache/daffodil/unparsers/runtime1/StringLiteralForUnparser.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/unparsers/runtime1/StringLiteralForUnparser.scala
@@ -33,7 +33,7 @@ class NilStringLiteralForUnparserEv(
 ) extends Evaluatable[String](tci)
   with InfosetCachedEvaluatable[String] {
 
-  override def runtimeDependencies = maybeOutputNewLineEv.toList
+  override val runtimeDependencies = maybeOutputNewLineEv.toList.toArray
 
   override protected def compute(state: ParseOrUnparseState): String = {
     val endMarker = "__daffodil_stringLiteralForUnparser_endMarker__"

--- a/daffodil-core/src/main/scala/org/apache/daffodil/unparsers/runtime1/SuppressableSeparatorUnparser.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/unparsers/runtime1/SuppressableSeparatorUnparser.scala
@@ -205,7 +205,7 @@ final class SuppressableSeparatorUnparser private (
 
   override def childProcessors: Vector[Processor] = Vector(sepUnparser)
 
-  override def runtimeDependencies = Vector()
+  override val runtimeDependencies = Array()
 }
 
 object SuppressableSeparatorUnparser {

--- a/daffodil-core/src/main/scala/org/apache/daffodil/unparsers/runtime1/UnseparatedSequenceUnparsers.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/unparsers/runtime1/UnseparatedSequenceUnparsers.scala
@@ -62,14 +62,14 @@ class OrderedUnseparatedSequenceUnparser(
   // have been optimized away
   Assert.invariant(childUnparsers.length > 0)
 
-  override def runtimeDependencies = Vector()
+  override val runtimeDependencies = Array()
 
   override def childProcessors = childUnparsers.toVector
 
   /**
    * Unparses one iteration of an array/optional element
    */
-  protected def unparseOne(
+  inline protected def unparseOne(
     unparser: SequenceChildUnparser,
     trd: TermRuntimeData,
     state: UState


### PR DESCRIPTION
This series of commits are the result of analyzing profiling data with the goal of increasing unparse performance

- Avoid calling Maybe.toList.toVector
- Removing some unnecessary Maybe's
- Avoid MStack.push(MStack.pop + 1) calls
- Removed an unused default parameter
- Inlining a function
- Change some uses of String.format to String interpolation

These changes seem to provide a couple percentage points of improvement in performance, but it's still pretty close to the margin of error.  Future unparse performance improvements will likely require some significant architecture changes, namely around how deeply nested our unparse code ends up being.