### PR TITLE
Sign release-candidate windows convenience binaries with ssl.com credentials

### DIFF
--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -54,6 +54,8 @@ jobs:
           svn_password: ${{ secrets.DAFFODIL_SVN_DEV_PASSWORD }}
           nexus_username: ${{ secrets.NEXUS_STAGE_DEPLOYER_USER }}
           nexus_password: ${{ secrets.NEXUS_STAGE_DEPLOYER_PW }}
+          esigner_storepass: ${{ secrets.ESIGNER_ASF_STOREPASS  }}
+          esigner_keypass: ${{ secrets.ESIGNER_ASF_KEYPASS  }}
           publish: true
 
       - name: Install Dependencies


### PR DESCRIPTION
Note, INFRA has not set up these secrets yet. These are just placeholders until we get the actual secret names but allows review now. For reference, the INFRA issue is https://issues.apache.org/jira/browse/INFRA-28208. Once that is resolved, this PR will be updated with the actual secrets.