### PR TITLE
Make codecov patch coverage check informational-only on main

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -16,10 +16,12 @@
 coverage:
   status:
     project: off
-    patch: 
+    patch:
       default:
         target: auto
+        only_pulls: true
       main:
+        target: auto
         branches:
           - main
         informational: true


### PR DESCRIPTION
The strict patch coverage check now only runs in the context of pull requests (only_pulls: true), so merges to main no longer trigger it. A separate, branch-scoped check for main remains informational so coverage is still reported on merge but never fails the build.

The target for the main block is also explicitly made auto to make it clear it's the same checks as the default block.

DAFFODIL-3081