### PR TITLE
Add Maybe[T].toArray and fix DelimiterTextParser array aliasing

### DIFF
--- a/daffodil-core/src/main/scala/org/apache/daffodil/lib/util/Maybe.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/lib/util/Maybe.scala
@@ -48,6 +48,8 @@ final class Maybe[+T <: AnyRef](val v: AnyRef) extends AnyVal with Serializable 
   //  @inline final def iterator: Iterator[T] = if (isEmpty) collection.Iterator.empty else collection.Iterator.single(get)
   @inline final def toList: List[T] = if (isEmpty) List() else new ::(get, Nil)
   @inline final def toSeq: Seq[T] = toList
+  @inline final def toArray[U >: T: scala.reflect.ClassTag]: Array[U] =
+    if (isEmpty) Array.empty[U] else Array[U](value)
   // @inline final def getOrElse[U >: T](default: U): U = if (isEmpty) default else get
 
   /**

--- a/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/processors/EvElement.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/processors/EvElement.scala
@@ -183,7 +183,7 @@ class MinLengthInBitsEv(
   ci: DPathCompileInfo
 ) extends LengthInBitsEvBase(ci, lengthUnits, lengthKind) {
 
-  override val runtimeDependencies = maybeCharsetEv.toList.toArray
+  override val runtimeDependencies = maybeCharsetEv.toArray
 
   override protected def lengthInLengthUnits(state: ParseOrUnparseState) = minLen
 }

--- a/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/processors/EvEscapeSchemes.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/processors/EvEscapeSchemes.scala
@@ -142,7 +142,7 @@ class EscapeSchemeBlockParseEv(
   ci: DPathCompileInfo
 ) extends EscapeSchemeParseEv(ci) {
 
-  override val runtimeDependencies = optEscapeEscapeChar.toList.toArray
+  override val runtimeDependencies = optEscapeEscapeChar.toArray
 
   val bs = EscapeBlockStartCooker.convertConstant(blockStart, ci, forUnparse = false)
   val be = EscapeBlockEndCooker.convertConstant(blockEnd, ci, forUnparse = false)

--- a/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/processors/EvFieldDFA.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/runtime1/processors/EvFieldDFA.scala
@@ -26,7 +26,7 @@ class FieldDFAParseEv(val escapeSchemeEv: Maybe[EscapeSchemeParseEv], ci: DPathC
   extends Evaluatable[DFAField](ci)
   with InfosetCachedEvaluatable[DFAField] {
 
-  override val runtimeDependencies = escapeSchemeEv.toList.toArray
+  override val runtimeDependencies = escapeSchemeEv.toArray
 
   def compute(state: ParseOrUnparseState) = {
 

--- a/daffodil-core/src/main/scala/org/apache/daffodil/unparsers/runtime1/ElementUnparser.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/unparsers/runtime1/ElementUnparser.scala
@@ -296,7 +296,7 @@ class ElementSpecifiedLengthUnparser(
   with RegularElementUnparserStartEndStrategy
   with ElementSpecifiedLengthMixin {
 
-  override val runtimeDependencies = maybeTargetLengthEv.toList.toArray
+  override val runtimeDependencies = maybeTargetLengthEv.toArray
 
   override def runContentUnparser(state: UState): Unit = {
     computeTargetLength(
@@ -355,7 +355,7 @@ class ElementOVCSpecifiedLengthUnparser(
   with OVCStartEndStrategy
   with ElementSpecifiedLengthMixin {
 
-  override val runtimeDependencies = maybeTargetLengthEv.toList.toArray
+  override val runtimeDependencies = maybeTargetLengthEv.toArray
 
   private def suspendableExpression =
     new ElementOVCSpecifiedLengthUnparserSuspendableExpression(this, expr)

--- a/daffodil-core/src/main/scala/org/apache/daffodil/unparsers/runtime1/SpecifiedLength2.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/unparsers/runtime1/SpecifiedLength2.scala
@@ -210,7 +210,7 @@ class SimpleTypeRetryUnparser(
 ) extends PrimUnparser
   with SuspendableUnparser {
 
-  override final val runtimeDependencies = maybeUnparserTargetLengthInBitsEv.toList.toArray
+  override final val runtimeDependencies = maybeUnparserTargetLengthInBitsEv.toArray
 
   final override def childProcessors = Vector(vUnparser)
 

--- a/daffodil-core/src/main/scala/org/apache/daffodil/unparsers/runtime1/StringLiteralForUnparser.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/unparsers/runtime1/StringLiteralForUnparser.scala
@@ -33,7 +33,7 @@ class NilStringLiteralForUnparserEv(
 ) extends Evaluatable[String](tci)
   with InfosetCachedEvaluatable[String] {
 
-  override val runtimeDependencies = maybeOutputNewLineEv.toList.toArray
+  override val runtimeDependencies = maybeOutputNewLineEv.toArray
 
   override protected def compute(state: ParseOrUnparseState): String = {
     val endMarker = "__daffodil_stringLiteralForUnparser_endMarker__"


### PR DESCRIPTION
Added Maybe[T].toArray, replacing seven hand-rolled .toList.toArray call sites across the runtimeDependencies migration to Array (EvElement, EvEscapeSchemes, EvFieldDFA, StringLiteralForUnparser, SpecifiedLength2, ElementUnparser x2) with a single reusable method.

DelimiterTextParser.runtimeDependencies now .clone()s EncodingRuntimeData's array instead of aliasing the same mutable instance: Array is invariant and mutable, unlike the Vector this used to be, so sharing the identical instance would let a future in-place mutation (e.g. dedupe or append) silently corrupt every sibling delimiter parser's dependency list along with EncodingRuntimeData's own.

DAFFODIL-3065